### PR TITLE
Added --as-needed flag to the link.

### DIFF
--- a/scripts/build/python/sconstruct_helper.py
+++ b/scripts/build/python/sconstruct_helper.py
@@ -128,7 +128,7 @@ def libPath(mu2eOpts):
 def mergeFlags(mu2eOpts):
     build = mu2eOpts['build']
     flags = ['-std=c++17','-Wall','-Wno-unused-local-typedefs','-g',
-             '-Werror','-Wl,--no-undefined','-gdwarf-2',
+             '-Werror','-Wl,--no-undefined','-gdwarf-2', '-Wl,--as-needed',
              '-Werror=return-type','-Winit-self','-Woverloaded-virtual']
     if build == 'prof':
         flags = flags + [ '-O3', '-fno-omit-frame-pointer', '-DNDEBUG' ]


### PR DESCRIPTION
Fixme:
 scons env.MergeFlags did not correctly add this only to the link commands.
So I had to use the -Wl, syntax to tell the compile lines to ignore it.  It
would be good to figure out how to teach MergeFlags to add it only the link
commands.