### PR TITLE
GenerateProtonTimes bug fix: applyToGenIds configuration piece should…

### DIFF
--- a/CommonMC/src/GenerateProtonTimes_module.cc
+++ b/CommonMC/src/GenerateProtonTimes_module.cc
@@ -111,14 +111,14 @@ namespace mu2e {
 
     typedef std::vector<std::string> VS;
 
-    const auto ig(conf().ignoredGenIds());
-    for(const auto i: ig) {
+    for(const auto i: conf().ignoredGenIds()) {
       ignoredGenIds_.insert(GenId::findByName(i).id());
     }
 
-    const auto ia(conf().applyToGenIds());
-    for(const auto i: ia) {
-      applyToGenIds_.insert(GenId::findByName(i).id());
+    if(ignoredGenIds_.empty()) {
+      for(const auto i: conf().applyToGenIds()) {
+        applyToGenIds_.insert(GenId::findByName(i).id());
+      }
     }
 
     conf().randPDFparameters(protonPulseConf_);


### PR DESCRIPTION
… be used conditionally per its declaration.

This fix addresses the proton time map change caught by the nightly validation.
