### PR TITLE
TrkAna config change

### DIFF
--- a/TrkDiag/fcl/TrkAnaDigisReco.fcl
+++ b/TrkDiag/fcl/TrkAnaDigisReco.fcl
@@ -46,3 +46,7 @@ services.TFileService.fileName: "nts.owner.TrkAnaDigisReco.version.sequencer.roo
 physics.analyzers.TrkAnaNeg.SelectEvents : [RecoPath]
 physics.analyzers.TrkAnaPos.SelectEvents : [RecoPath]
 
+# Include more information (MC, full TrkQual and TrkPID branches)
+physics.analyzers.TrkAnaNeg.candidate.options : @local::AllOpt
+physics.analyzers.TrkAnaPos.candidate.options : @local::AllOpt
+

--- a/TrkDiag/fcl/TrkAnaReco.fcl
+++ b/TrkDiag/fcl/TrkAnaReco.fcl
@@ -18,6 +18,10 @@ physics :
 physics.TrkAnaTrigPath : [ @sequence::TrkAnaReco.TrigSequence ]
 physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequence ]
 
+# Include more information (MC, full TrkQual and TrkPID branches)
+physics.analyzers.TrkAnaNeg.candidate.options : @local::AllOpt
+physics.analyzers.TrkAnaPos.candidate.options : @local::AllOpt
+
 # for hit level diagnostics, set diagLevel to 2
 physics.analyzers.TrkAnaNeg.diagLevel : 1
 physics.analyzers.TrkAnaNeg.FillMCInfo : true

--- a/TrkDiag/fcl/TrkAnaReco_Upstream.fcl
+++ b/TrkDiag/fcl/TrkAnaReco_Upstream.fcl
@@ -23,6 +23,12 @@ physics.analyzers.TrkAnaNeg.supplements : [ @local::DeM, @local::UmuM ]
 physics.analyzers.TrkAnaPos.candidate : @local::UeP
 physics.analyzers.TrkAnaPos.supplements : [ @local::DeP, @local::UmuP ]
 
+# Include more information (MC and full TrkQual branches)
+physics.analyzers.TrkAnaNeg.candidate.options : @local::AllOpt
+physics.analyzers.TrkAnaNeg.candidate.options.fillTrkPID : false
+physics.analyzers.TrkAnaPos.candidate.options : @local::AllOpt
+physics.analyzers.TrkAnaPos.candidate.options.fillTrkPID : false
+
 # for hit level diagnostics, set diagLevel to 2
 physics.analyzers.TrkAnaNeg.diagLevel : 1
 physics.analyzers.TrkAnaNeg.FillMCInfo : true

--- a/TrkDiag/fcl/prolog.fcl
+++ b/TrkDiag/fcl/prolog.fcl
@@ -158,14 +158,16 @@ BEGIN_PROLOG
   genCountLogger: { module_type: GenEventCountReader }
 
 # candidate configuration for TrkAna
+  AllOpt : { fillMC : true 
+	     trkqual : "TrkQual"
+	     fillTrkQual : true 
+	     trkpid : "TrkPID"
+	     fillTrkPID : true
+  }
+
   DeM : { input : "KFF" 
       	  branch : "de" 
 	  suffix : "DeM" 
-	  fillMC : true 
-	  trkqual : "TrkQual"
-	  fillTrkQual : true 
-	  trkpid : "TrkPID"
-	  fillTrkPID : true
   }
   UeM : { input : "KFF" 
       	  branch : "ue" 
@@ -182,11 +184,6 @@ BEGIN_PROLOG
   DeP : { input : "KFF" 
       	  branch : "de" 
 	  suffix : "DeP" 
-	  fillMC : true 
-	  trkqual : "TrkQual"
-	  fillTrkQual : true 
-	  trkpid : "TrkPID"
-	  fillTrkPID : true
   }
   UeP : { input : "KFF" 
       	  branch : "ue" 


### PR DESCRIPTION
I've changed the TrkAna config a little bit. Now the scripts write out the MC information for the "candidate" track (i.e. de for most scripts, but ue for the upstream script). I also fixed a big with TrkAna trying to get a TrkPID object when TrkPID writing had been turned off.