### PR TITLE
Sequential Event Mixing

### DIFF
--- a/EventMixing/src/MixBackgroundFrames_module.cc
+++ b/EventMixing/src/MixBackgroundFrames_module.cc
@@ -141,6 +141,7 @@ namespace mu2e {
 
   //================================================================
   size_t MixBackgroundFramesDetail::eventsToSkip() {
+    //FIXME: Ideally, we would know the number of events in the secondary input file
     std::uniform_int_distribution<size_t> uniform(minSkip_, maxSkip_);
     size_t result = uniform(urbg_);
     if(debugLevel_ > 0) { 

--- a/EventMixing/src/MixBackgroundFrames_module.cc
+++ b/EventMixing/src/MixBackgroundFrames_module.cc
@@ -53,6 +53,14 @@ namespace mu2e {
           Comment("control the level of debug output"),
           0u
           };
+      Atom<int> minSkip { Name("minSkip"),
+	  Comment("minimum number of background events to skip at the start of a file"),
+	  0
+	  };
+      Atom<int> maxSkip { Name("maxSkip"),
+	  Comment("maximum number of background events to skip at the start of a file"),
+	  10000
+	  };
     };
 
     // The following hack will hopefully go away after
@@ -87,6 +95,9 @@ namespace mu2e {
     artURBG urbg_;
 
     ProtonBunchIntensity pbi_;
+    int totalBkgCount_;
+    int minSkip_;
+    int maxSkip_;
 
   public:
     MixBackgroundFramesDetail(const fhicl::ParameterSet& pset, art::MixHelper &helper);
@@ -94,6 +105,10 @@ namespace mu2e {
     void startEvent(const art::Event& event);
 
     size_t nSecondaries();
+
+    size_t eventsToSkip();
+
+    void processEventIDs(art::EventIDSequence const& seq);
   };
 
   //================================================================
@@ -104,6 +119,9 @@ namespace mu2e {
     , debugLevel_{ retrieveConfiguration("mu2e", pset).debugLevel() }
     , engine_{helper.createEngine(art::ServiceHandle<SeedService>()->getSeed())}
     , urbg_{ engine_ }
+    , totalBkgCount_(0)
+    , minSkip_{ retrieveConfiguration("mu2e", pset).minSkip() }
+    , maxSkip_{ retrieveConfiguration("mu2e", pset).maxSkip() }
   {}
 
   //================================================================
@@ -119,6 +137,32 @@ namespace mu2e {
     auto res = poisson(urbg_);
     if(debugLevel_ > 0)std::cout << " Mixing " << res  << " Secondaries " << std::endl;
     return res;
+  }
+
+  //================================================================
+  size_t MixBackgroundFramesDetail::eventsToSkip() {
+    std::uniform_int_distribution<size_t> uniform(minSkip_, maxSkip_);
+    size_t result = uniform(urbg_);
+    if(debugLevel_ > 0) { 
+      std::cout << " Skipping " << result << " Secondaries " << std::endl; 
+    }
+    return result;
+  }
+
+  //================================================================
+  void MixBackgroundFramesDetail::processEventIDs(art::EventIDSequence const& seq) {
+
+    if (debugLevel_ > 4) {
+      std::cout << "The following bkg events were mixed in (START)" << std::endl;
+      int counter = 0;
+      for (const auto& i_eid : seq) {
+	std::cout << "Run: " << i_eid.run() << " SubRun: " << i_eid.subRun() << " Event: " << i_eid.event() << std::endl;
+	++counter;
+      }
+      totalBkgCount_ += counter;
+      std::cout << "Bkg Event Count  (this microbunch) = " << counter << std::endl;
+      std::cout << "Bkg Event Count  (all microbunches) = " << totalBkgCount_ << " (END)" << std::endl;
+    }
   }
 
   //================================================================

--- a/JobConfig/mixing/prolog.fcl
+++ b/JobConfig/mixing/prolog.fcl
@@ -14,13 +14,15 @@ mixerTemplateCommon: {
 #     randomLimReplace -- events unique within a primary event
 #     randomNoReplace -- events guaranteed to be used once only.
 #   readMode            : randomNoReplace
-   readMode            : randomLimReplace
+   readMode            : sequential
    wrapFiles           : true
 
    mu2e: {
       protonBunchIntensityTag: "protonBunchIntensity"
       meanEventsPerProton: @nil
       products: @nil
+      minSkip : 0
+      maxSkip : 10000
    }
 }
 


### PR DESCRIPTION
I have added the code to skip a random number of background events when reading a new secondary input file. I have tested that it works with some debug statements on a single background frame.

There is one issue. I have set the min and max offset to be 0 and 10000 in fcl, this causes an exception to be thrown for certain background frames. I'm not sure whether we want to configure each background frame individually or find a smarter way to select the range (as far as I can tell, there is no way to get the number of events in a secondary input file)