### PR TITLE
make validation bit positions permanent

### DIFF
--- a/Validation/src/ValBkgCluster.cc
+++ b/Validation/src/ValBkgCluster.cc
@@ -26,10 +26,8 @@ int mu2e::ValBkgCluster::fill(const mu2e::BkgClusterCollection & coll,
     for(auto const& h : bc.hits()) {
       _hd->Fill(h.distance());
     }
-    int i=0;
     for(auto sn: bc.flag().bitNames()) { 
-      if(bc.flag().hasAnyProperty(BkgClusterFlag(sn.first))) _hBits->Fill(i); 
-      i++;
+      if(bc.flag().hasAnyProperty(BkgClusterFlag(sn.first))) _hBits->Fill(std::log2(sn.second)); 
     }
 
   }

--- a/Validation/src/ValHelixSeed.cc
+++ b/Validation/src/ValHelixSeed.cc
@@ -36,10 +36,8 @@ int mu2e::ValHelixSeed::fill(const mu2e::HelixSeedCollection & coll,
     _hNStrHit->Fill(nstrawhits);
     const TrkFitFlag& tff = hs.status();
 
-    int i=0;
     for(auto sn: tff.bitNames()) { 
-      if(tff.hasAnyProperty(TrkFitFlag(sn.first))) _hStatus->Fill(i); 
-      i++;
+      if(tff.hasAnyProperty(TrkFitFlag(sn.first))) _hStatus->Fill(std::log2(sn.second)); 
     }
 
     _ht0->Fill(hs.t0().t0());

--- a/Validation/src/ValKalSeed.cc
+++ b/Validation/src/ValKalSeed.cc
@@ -75,10 +75,8 @@ int mu2e::ValKalSeed::fill(const mu2e::KalSeedCollection & coll,
     //    for(mu2e::TrkFitFlagDetail::bit_type i=0; i<f.size(); i++) 
     //  if(f.hasAnyProperty(i)) _hStatus->Fill(i); 
 
-    int i=0;
     for(auto sn: tff.bitNames()) { 
-      if(tff.hasAnyProperty(TrkFitFlag(sn.first))) _hStatus->Fill(i); 
-      i++;
+      if(tff.hasAnyProperty(TrkFitFlag(sn.first))) _hStatus->Fill(std::log2(sn.second)); 
     }
 
     _hflt0->Fill(ks.flt0());


### PR DESCRIPTION
Plot bits by their mask, not alphabetically (implied by map order).
Dave fixed StrawHitFlag plot last year, this fixes the other three bit plots in validation.
This change will probably trigger a validation alert.