### PR TITLE
Added CosmicLivetime data product; Clean-up of CORSIKA code

### DIFF
--- a/EventGenerator/src/CORSIKAEventGenerator_module.cc
+++ b/EventGenerator/src/CORSIKAEventGenerator_module.cc
@@ -31,6 +31,7 @@
 #include "GeometryService/inc/DetectorSystem.hh"
 #include "GeometryService/inc/Mu2eEnvelope.hh"
 #include "MCDataProducts/inc/GenParticle.hh"
+#include "MCDataProducts/inc/CosmicLivetime.hh"
 #include "MCDataProducts/inc/GenParticleCollection.hh"
 #include "CalorimeterGeom/inc/Calorimeter.hh"
 #include "ExtinctionMonitorFNAL/Geometry/inc/ExtMonFNAL.hh"
@@ -60,19 +61,13 @@ namespace mu2e {
         fhicl::Atom<std::string> corsikaModuleLabel{Name("corsikaModuleLabel"), Comment("Reference point in the coordinate system"), "FromCorsikaBinary"};
         fhicl::Atom<std::string> refPointChoice{Name("refPointChoice"), Comment("Reference point in the coordinate system"), "UNDEFINED"};
         fhicl::Atom<bool> projectToTargetBox{Name("projectToTargetBox"), Comment("Store only events that cross the target box"), false};
-        fhicl::Atom<float> targetBoxXmin{Name("targetBoxXmin"), Comment("Extension of the generation plane"), -5000};
-        fhicl::Atom<float> targetBoxXmax{Name("targetBoxXmax"), Comment("Extension of the generation plane"), 5000};
-        fhicl::Atom<float> targetBoxYmin{Name("targetBoxYmin"), Comment("Extension of the generation plane"), -5000};
-        fhicl::Atom<float> targetBoxYmax{Name("targetBoxYmax"), Comment("Extension of the generation plane"), 5000};
-        fhicl::Atom<float> targetBoxZmin{Name("targetBoxZmin"), Comment("Extension of the generation plane"), -5000};
-        fhicl::Atom<float> targetBoxZmax{Name("targetBoxZmax"), Comment("Extension of the generation plane"), 5000};
       };
       typedef art::EDProducer::Table<Config> Parameters;
 
       explicit CorsikaEventGenerator(const Parameters &conf);
       // Accept compiler written d'tor.  Modules are never moved or copied.
       virtual void produce (art::Event& e);
-      virtual void beginSubRun(art::SubRun &sr);
+      virtual void endSubRun(art::SubRun &sr);
 
     private:
 
@@ -89,12 +84,7 @@ namespace mu2e {
       float _worldYmax = 0;
       float _worldZmin = 0;
       float _worldZmax = 0;
-      float _targetBoxXmin = 0;
-      float _targetBoxXmax = 0;
-      float _targetBoxYmin = 0;
-      float _targetBoxYmax = 0;
-      float _targetBoxZmin = 0;
-      float _targetBoxZmax = 0;
+
       bool _projectToTargetBox = false;
       Hep3Vector _cosmicReferencePointInMu2e;
       std::string _refPointChoice;
@@ -104,21 +94,17 @@ namespace mu2e {
   CorsikaEventGenerator::CorsikaEventGenerator(const Parameters &conf) : EDProducer{conf},
                                                                          _conf(conf()),
                                                                          _corsikaModuleLabel(_conf.corsikaModuleLabel()),
-                                                                         _targetBoxXmin(_conf.targetBoxXmin()),
-                                                                         _targetBoxXmax(_conf.targetBoxXmax()),
-                                                                         _targetBoxYmin(_conf.targetBoxYmin()),
-                                                                         _targetBoxYmax(_conf.targetBoxYmax()),
-                                                                         _targetBoxZmin(_conf.targetBoxZmin()),
-                                                                         _targetBoxZmax(_conf.targetBoxZmax()),
                                                                          _projectToTargetBox(_conf.projectToTargetBox()),
                                                                          _refPointChoice(_conf.refPointChoice())
   {
     produces<GenParticleCollection>();
   }
 
-
-  void CorsikaEventGenerator::beginSubRun( art::SubRun &subrun){
-
+  void CorsikaEventGenerator::endSubRun(art::SubRun &subrun)
+  {
+    art::Handle<mu2e::CosmicLivetime> livetime;
+    subrun.getByLabel(_corsikaModuleLabel, livetime);
+    std::cout << *livetime << std::endl;
   }
 
   void CorsikaEventGenerator::produce(art::Event &evt)

--- a/EventGenerator/test/corsikaTest.fcl
+++ b/EventGenerator/test/corsikaTest.fcl
@@ -17,7 +17,7 @@ targetParams: {
 
 source: {
     module_type: FromCorsikaBinary
-    fileNames: ["/mu2e/data/users/srsoleti/DAT110001"]
+    fileNames: ["/pnfs/mu2e/persistent/users/srsoleti/corsika/DAT110001"]
     runNumber          : 1
     firstSubRunNumber  : 0
     firstEventNumber   : 1

--- a/EventGenerator/test/corsikaTest.fcl
+++ b/EventGenerator/test/corsikaTest.fcl
@@ -25,6 +25,7 @@ source: {
     maxEvents: -1
     @table::targetParams
     seed: 1
+    resample: false
     fluxConstant: 1.8e4
     lowE: 1.3
     highE: 1e6
@@ -133,7 +134,7 @@ physics : {
 
   }
 
-  trigFilter: [corsikaGen, g4run, g4run, randomsaver]
+  trigFilter: [corsikaGen, g4run, randomsaver]
   e1 : [outfile]
   ana : [corsikaGenPlots]
 

--- a/EventGenerator/test/corsikaTest.fcl
+++ b/EventGenerator/test/corsikaTest.fcl
@@ -24,6 +24,7 @@ source: {
     showerAreaExtension  : 10000
     maxEvents: -1
     @table::targetParams
+    seed: 1
     fluxConstant: 1.8e4
     lowE: 1.3
     highE: 1e6
@@ -73,6 +74,8 @@ physics : {
       corsikaModuleLabel: "FromCorsikaBinary"
       refPointChoice: "UNDEFINED"
       projectToTargetBox : true
+      targetBoxYmax : 5000
+      intDist: -1
     }
 
     g4run :

--- a/EventGenerator/test/corsikaTest.fcl
+++ b/EventGenerator/test/corsikaTest.fcl
@@ -17,7 +17,7 @@ targetParams: {
 
 source: {
     module_type: FromCorsikaBinary
-    fileNames: ["/mu2e/app/users/srsoleti/corsika-77100/run/DAT110001"]
+    fileNames: ["/mu2e/data/users/srsoleti/DAT110001"]
     runNumber          : 1
     firstSubRunNumber  : 0
     firstEventNumber   : 1
@@ -25,6 +25,8 @@ source: {
     maxEvents: -1
     @table::targetParams
     fluxConstant: 1.8e4
+    lowE: 1.3
+    highE: 1e6
 }
 
 customCutPhoton: {
@@ -70,7 +72,7 @@ physics : {
       module_type : CORSIKAEventGenerator
       corsikaModuleLabel: "FromCorsikaBinary"
       refPointChoice: "UNDEFINED"
-      @table::targetParams
+      projectToTargetBox : true
     }
 
     g4run :

--- a/MCDataProducts/inc/CosmicLivetime.hh
+++ b/MCDataProducts/inc/CosmicLivetime.hh
@@ -1,0 +1,78 @@
+#ifndef MCDataProducts_CosmicLivetime_hh
+#define MCDataProducts_CosmicLivetime_hh
+
+// Original author Stefano Roberto Soleti
+
+// C++ includes
+#include <iostream>
+#include <vector>
+#include <math.h>
+
+// Mu2e includes
+
+namespace mu2e {
+
+  struct CosmicLivetime{
+
+  public:
+
+    CosmicLivetime():
+      _primaries(0),
+      _area(0),
+      _lowE(0),
+      _highE(0),
+      _fluxConstant(0)  {
+    }
+
+    CosmicLivetime( unsigned int primaries,
+                    float area,
+                    float lowE,
+                    float highE,
+                    float fluxConstant ):
+      _primaries(primaries),
+      _area(area),
+      _lowE(lowE),
+      _highE(highE),
+      _fluxConstant(fluxConstant) {
+        const float eslope = -2.7;
+
+        const float EiToOneMinusGamma = pow(_lowE, 1 + eslope);
+        const float EfToOneMinusGamma = pow(_highE, 1 + eslope);
+        // http://pdg.lbl.gov/2018/reviews/rpp2018-rev-cosmic-rays.pdf eq. 29.2
+        _livetime = _primaries / (M_PI * _area * _fluxConstant * (EfToOneMinusGamma - EiToOneMinusGamma) / (1. + eslope));
+    }
+
+    // Accessors
+    unsigned int primaries() const { return _primaries; }
+    float area()             const { return _area; }
+    float lowE()             const { return _lowE;}
+    float highE()            const { return _highE; }
+    float fluxConstant()     const { return _fluxConstant; }
+    float liveTime()         const { return _livetime; }
+
+
+    // Accept compiler generated versions of d'tor, copy c'tor, assignment operator.
+
+    // Print contents of the object.
+    void print( std::ostream& ost = std::cout, bool doEndl = true ) const;
+
+  private:
+
+    unsigned int _primaries;
+    float _area;             // m2
+    float _lowE;             // (GeV)
+    float _highE;            // (GeV)
+    float _fluxConstant;
+    float _livetime;         // s
+
+  };
+
+  inline std::ostream& operator<<( std::ostream& ost,
+                                   CosmicLivetime const& lt){
+    lt.print(ost,false);
+    return ost;
+  }
+
+} // namespace mu2e
+
+#endif /* MCDataProducts_CosmicLivetime_hh */

--- a/MCDataProducts/src/CosmicLivetime.cc
+++ b/MCDataProducts/src/CosmicLivetime.cc
@@ -1,0 +1,34 @@
+//
+// Original author Stefano Roberto Soleti
+//
+
+// C++ includes
+#include <ostream>
+
+// Framework includes.
+#include "cetlib_except/exception.h"
+
+// Mu2e includes
+#include "MCDataProducts/inc/CosmicLivetime.hh"
+
+using namespace std;
+
+namespace mu2e {
+
+  // Print the information found in this hit.
+  void CosmicLivetime::print( ostream& ost, bool doEndl ) const {
+
+    ost << "Cosmic livetime: " << _livetime << " s" << endl
+        << " primaries: " << _primaries << endl
+        << " area: "      << _area << " m^2" << endl
+        << " lowE: "       << _lowE << " GeV" << endl
+        << " highE: "  << _highE << " GeV" << endl
+        << " fluxConstant: "     << _fluxConstant;
+
+    if ( doEndl ){
+      ost << endl;
+    }
+
+  }
+
+} // namespace mu2e

--- a/MCDataProducts/src/classes.h
+++ b/MCDataProducts/src/classes.h
@@ -32,6 +32,7 @@
 #include "MCDataProducts/inc/SimParticleTimeMap.hh"
 #include "MCDataProducts/inc/SimParticleRemapping.hh"
 #include "MCDataProducts/inc/VisibleGenElTrackCollection.hh"
+#include "MCDataProducts/inc/CosmicLivetime.hh"
 
 // simulation bookeeping
 #include "MCDataProducts/inc/PhysicalVolumeInfo.hh"

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -172,6 +172,9 @@
  <class name="mu2e::CaloHitMCTruthCollection"/>
  <class name="art::Wrapper<mu2e::CaloHitMCTruthCollection>"/>
 
+ <class name="mu2e::CosmicLivetime"/>
+ <class name="art::Wrapper<mu2e::CosmicLivetime>"/>
+
  <class name="mu2e::CaloDigiMC"/>
  <class name="mu2e::CaloDigiMCCollection"/>
  <class name="art::Wrapper<mu2e::CaloDigiMCCollection>"/>

--- a/Sources/inc/CosmicCORSIKA.hh
+++ b/Sources/inc/CosmicCORSIKA.hh
@@ -54,7 +54,7 @@ struct Config
   fhicl::Atom<std::string> module_label{Name("module_label"), Comment("Art module label"), ""};
   fhicl::Atom<std::string> module_type{Name("module_type"), Comment("Art module type"), ""};
   fhicl::Atom<bool> projectToTargetBox{Name("projectToTargetBox"), Comment("Store only events that cross the target box"), false};
-  fhicl::Atom<float> showerAreaExtension{Name("showerAreaExtension"), Comment("Extension of the generation box on the xz plane");
+  fhicl::Atom<float> showerAreaExtension{Name("showerAreaExtension"), Comment("Extension of the generation box on the xz plane")};
   fhicl::Atom<float> tOffset{Name("tOffset"), Comment("Time offset"), 0};
   fhicl::Atom<float> lowE{Name("lowE"), Comment("lowE"), 1.3};
   fhicl::Atom<float> highE{Name("highE"), Comment("highE"), 1e6};

--- a/Sources/inc/CosmicCORSIKA.hh
+++ b/Sources/inc/CosmicCORSIKA.hh
@@ -66,6 +66,7 @@ struct Config
   fhicl::Atom<float> targetBoxZmin{Name("targetBoxZmin"), Comment("Target box z min")};
   fhicl::Atom<float> targetBoxZmax{Name("targetBoxZmax"), Comment("Target box z max")};
   fhicl::Atom<int> seed{Name("seed"), Comment("Seed for particle random offset")};
+  fhicl::Atom<bool> resample{Name("resample"), Comment("Resampling flag")};
 };
 typedef fhicl::WrappedTable<Config> Parameters;
 
@@ -79,7 +80,6 @@ namespace mu2e {
       CosmicCORSIKA(const Config& conf);
       // CosmicCORSIKA(art::Run &run, CLHEP::HepRandomEngine &engine);
       ~CosmicCORSIKA();
-      const unsigned int getNumShowers();
 
       const std::map<unsigned int, int> corsikaToPdgId = {
         {1, 22}, // gamma
@@ -202,7 +202,7 @@ namespace mu2e {
         {195, -5332} // Omega+_bbar
       };
 
-      virtual bool generate(GenParticleCollection &);
+      virtual bool generate(GenParticleCollection &, unsigned int &);
       void openFile(FILE *f);
 
     private:
@@ -239,6 +239,8 @@ namespace mu2e {
       float _garbage;
 
       unsigned int _primaries = 0;
+
+      bool _resample = false;
 
       CLHEP::HepJamesRandom _engine;
       CLHEP::RandFlat _randFlatX;

--- a/Sources/inc/CosmicCORSIKA.hh
+++ b/Sources/inc/CosmicCORSIKA.hh
@@ -10,7 +10,6 @@
 #include "GlobalConstantsService/inc/ParticleDataTable.hh"
 
 // Framework includes
-#include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Core/ModuleMacros.h"
 #include "art/Framework/Principal/Event.h"
 #include "fhiclcpp/ParameterSet.h"
@@ -47,22 +46,24 @@ struct Config
   using Name = fhicl::Name;
   using Comment = fhicl::Comment;
   fhicl::Sequence<std::string> showerInputFiles{Name("fileNames"),Comment("List of CORSIKA binary output paths")};
-  fhicl::Atom<int> firstEventNumber{Name("firstEventNumber"), Comment("Reference point on the Y axis"), 0};
-  fhicl::Atom<int> firstSubRunNumber{Name("firstSubRunNumber"), Comment("Reference point on the Y axis"), 0};
-  fhicl::Atom<int> maxEvents{Name("maxEvents"), Comment("Reference point on the Y axis"), 0};
-  fhicl::Atom<unsigned int> runNumber{Name("runNumber"), Comment("Reference point on the Y axis"), 0};
-  fhicl::Atom<std::string> module_label{Name("module_label"), Comment("Reference point on the Y axis"), ""};
-  fhicl::Atom<std::string> module_type{Name("module_type"), Comment("Reference point on the Y axis"), ""};
+  fhicl::Atom<int> firstEventNumber{Name("firstEventNumber"), Comment("First event number"), 0};
+  fhicl::Atom<int> firstSubRunNumber{Name("firstSubRunNumber"), Comment("First subrun number"), 0};
+  fhicl::Atom<int> maxEvents{Name("maxEvents"), Comment("Max number of events"), 0};
+  fhicl::Atom<unsigned int> runNumber{Name("runNumber"), Comment("First run number"), 0};
+  fhicl::Atom<std::string> module_label{Name("module_label"), Comment("Art module label"), ""};
+  fhicl::Atom<std::string> module_type{Name("module_type"), Comment("Art module type"), ""};
   fhicl::Atom<bool> projectToTargetBox{Name("projectToTargetBox"), Comment("Store only events that cross the target box"), false};
-  fhicl::Atom<float> showerAreaExtension{Name("showerAreaExtension"), Comment("Reference point on the Y axis"), 10000};
+  fhicl::Atom<float> showerAreaExtension{Name("showerAreaExtension"), Comment("Extension of the generation box on the xz plane"), 10000};
   fhicl::Atom<float> tOffset{Name("tOffset"), Comment("Time offset"), 0};
+  fhicl::Atom<float> lowE{Name("lowE"), Comment("lowE"), 1.3};
+  fhicl::Atom<float> highE{Name("highE"), Comment("highE"), 1e6};
   fhicl::Atom<float> fluxConstant{Name("fluxConstant"), Comment("Flux constant"), 1.8e4};
-  fhicl::Atom<float> targetBoxXmin{Name("targetBoxXmin"), Comment("Extension of the generation plane"), -5000};
-  fhicl::Atom<float> targetBoxXmax{Name("targetBoxXmax"), Comment("Extension of the generation plane"), 5000};
-  fhicl::Atom<float> targetBoxYmin{Name("targetBoxYmin"), Comment("Extension of the generation plane"), -5000};
-  fhicl::Atom<float> targetBoxYmax{Name("targetBoxYmax"), Comment("Extension of the generation plane"), 5000};
-  fhicl::Atom<float> targetBoxZmin{Name("targetBoxZmin"), Comment("Extension of the generation plane"), -5000};
-  fhicl::Atom<float> targetBoxZmax{Name("targetBoxZmax"), Comment("Extension of the generation plane"), 5000};
+  fhicl::Atom<float> targetBoxXmin{Name("targetBoxXmin"), Comment("Target box x min"), -5000};
+  fhicl::Atom<float> targetBoxXmax{Name("targetBoxXmax"), Comment("Target box x max"), 5000};
+  fhicl::Atom<float> targetBoxYmin{Name("targetBoxYmin"), Comment("Target box y min"), -5000};
+  fhicl::Atom<float> targetBoxYmax{Name("targetBoxYmax"), Comment("Target box y max"), 5000};
+  fhicl::Atom<float> targetBoxZmin{Name("targetBoxZmin"), Comment("Target box z min"), -5000};
+  fhicl::Atom<float> targetBoxZmax{Name("targetBoxZmax"), Comment("Target box z max"), 5000};
 
 };
 typedef fhicl::WrappedTable<Config> Parameters;
@@ -71,13 +72,12 @@ class GenParticleCollection;
 
 namespace mu2e {
 
-  class CosmicCORSIKA{
+  class CosmicCORSIKA {
 
     public:
       CosmicCORSIKA(const Config& conf);
       // CosmicCORSIKA(art::Run &run, CLHEP::HepRandomEngine &engine);
       ~CosmicCORSIKA();
-      const float getLiveTime();
       const unsigned int getNumShowers();
 
       const std::map<unsigned int, int> corsikaToPdgId = {
@@ -208,7 +208,7 @@ namespace mu2e {
 
       bool genEvent(std::map<std::pair<int,int>, GenParticleCollection> &particles_map);
       float wrapvarBoxNo(const float var, const float low, const float high, int &boxno);
-      static float wrapvar(const float var, const float low, const float high);
+
       std::vector<CLHEP::Hep3Vector> _targetBoxIntersections;
       std::vector<CLHEP::Hep3Vector> _worldIntersections;
       std::map<std::pair<int,int>, GenParticleCollection> _particles_map;
@@ -216,7 +216,6 @@ namespace mu2e {
       GlobalConstantsHandle<ParticleDataTable> pdt;
 
       const float _GeV2MeV = CLHEP::GeV / CLHEP::MeV;
-      const float _ns2s = CLHEP::ns / CLHEP::s;
       const float _cm2mm = CLHEP::cm / CLHEP::mm;
 
       CLHEP::Hep3Vector _cosmicReferencePointInMu2e;

--- a/Sources/inc/CosmicCORSIKA.hh
+++ b/Sources/inc/CosmicCORSIKA.hh
@@ -30,6 +30,7 @@
 #include "CLHEP/Units/SystemOfUnits.h"
 #include "CLHEP/Vector/ThreeVector.h"
 #include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/Randomize.h"
 
 #include "fhiclcpp/types/ConfigurationTable.h"
 
@@ -53,18 +54,18 @@ struct Config
   fhicl::Atom<std::string> module_label{Name("module_label"), Comment("Art module label"), ""};
   fhicl::Atom<std::string> module_type{Name("module_type"), Comment("Art module type"), ""};
   fhicl::Atom<bool> projectToTargetBox{Name("projectToTargetBox"), Comment("Store only events that cross the target box"), false};
-  fhicl::Atom<float> showerAreaExtension{Name("showerAreaExtension"), Comment("Extension of the generation box on the xz plane"), 10000};
+  fhicl::Atom<float> showerAreaExtension{Name("showerAreaExtension"), Comment("Extension of the generation box on the xz plane");
   fhicl::Atom<float> tOffset{Name("tOffset"), Comment("Time offset"), 0};
   fhicl::Atom<float> lowE{Name("lowE"), Comment("lowE"), 1.3};
   fhicl::Atom<float> highE{Name("highE"), Comment("highE"), 1e6};
-  fhicl::Atom<float> fluxConstant{Name("fluxConstant"), Comment("Flux constant"), 1.8e4};
-  fhicl::Atom<float> targetBoxXmin{Name("targetBoxXmin"), Comment("Target box x min"), -10000};
-  fhicl::Atom<float> targetBoxXmax{Name("targetBoxXmax"), Comment("Target box x max"), 3000};
-  fhicl::Atom<float> targetBoxYmin{Name("targetBoxYmin"), Comment("Target box y min"), -5000};
-  fhicl::Atom<float> targetBoxYmax{Name("targetBoxYmax"), Comment("Target box y max"), 5000};
-  fhicl::Atom<float> targetBoxZmin{Name("targetBoxZmin"), Comment("Target box z min"), -5000};
-  fhicl::Atom<float> targetBoxZmax{Name("targetBoxZmax"), Comment("Target box z max"), 21000};
-
+  fhicl::Atom<float> fluxConstant{Name("fluxConstant"), Comment("Primary cosmic nucleon flux constant")};
+  fhicl::Atom<float> targetBoxXmin{Name("targetBoxXmin"), Comment("Target box x min")};
+  fhicl::Atom<float> targetBoxXmax{Name("targetBoxXmax"), Comment("Target box x max")};
+  fhicl::Atom<float> targetBoxYmin{Name("targetBoxYmin"), Comment("Target box y min")};
+  fhicl::Atom<float> targetBoxYmax{Name("targetBoxYmax"), Comment("Target box y max")};
+  fhicl::Atom<float> targetBoxZmin{Name("targetBoxZmin"), Comment("Target box z min")};
+  fhicl::Atom<float> targetBoxZmax{Name("targetBoxZmax"), Comment("Target box z max")};
+  fhicl::Atom<int> seed{Name("seed"), Comment("Seed for particle random offset")};
 };
 typedef fhicl::WrappedTable<Config> Parameters;
 
@@ -238,6 +239,10 @@ namespace mu2e {
       float _garbage;
 
       unsigned int _primaries = 0;
+
+      CLHEP::HepJamesRandom _engine;
+      CLHEP::RandFlat _randFlatX;
+      CLHEP::RandFlat _randFlatZ;
   };  // CosmicCORSIKA
 
 }

--- a/Sources/inc/CosmicCORSIKA.hh
+++ b/Sources/inc/CosmicCORSIKA.hh
@@ -58,12 +58,12 @@ struct Config
   fhicl::Atom<float> lowE{Name("lowE"), Comment("lowE"), 1.3};
   fhicl::Atom<float> highE{Name("highE"), Comment("highE"), 1e6};
   fhicl::Atom<float> fluxConstant{Name("fluxConstant"), Comment("Flux constant"), 1.8e4};
-  fhicl::Atom<float> targetBoxXmin{Name("targetBoxXmin"), Comment("Target box x min"), -5000};
-  fhicl::Atom<float> targetBoxXmax{Name("targetBoxXmax"), Comment("Target box x max"), 5000};
+  fhicl::Atom<float> targetBoxXmin{Name("targetBoxXmin"), Comment("Target box x min"), -10000};
+  fhicl::Atom<float> targetBoxXmax{Name("targetBoxXmax"), Comment("Target box x max"), 3000};
   fhicl::Atom<float> targetBoxYmin{Name("targetBoxYmin"), Comment("Target box y min"), -5000};
   fhicl::Atom<float> targetBoxYmax{Name("targetBoxYmax"), Comment("Target box y max"), 5000};
   fhicl::Atom<float> targetBoxZmin{Name("targetBoxZmin"), Comment("Target box z min"), -5000};
-  fhicl::Atom<float> targetBoxZmax{Name("targetBoxZmax"), Comment("Target box z max"), 5000};
+  fhicl::Atom<float> targetBoxZmax{Name("targetBoxZmax"), Comment("Target box z max"), 21000};
 
 };
 typedef fhicl::WrappedTable<Config> Parameters;

--- a/Sources/src/CosmicCORSIKA.cc
+++ b/Sources/src/CosmicCORSIKA.cc
@@ -35,21 +35,9 @@ namespace mu2e {
     fread(&_garbage, 4, 1, in);
   }
 
-  const float CosmicCORSIKA::getLiveTime()
-  {
-    const float area = (_targetBoxXmax + 2 * _showerAreaExtension - _targetBoxXmin) * (_targetBoxZmax + 2 * _showerAreaExtension - _targetBoxZmin) * 1e-6; //m^2
-    const float eslope = -2.7;
-    const float lowE = 1.3;     // GeV
-    const float highE = 1e6; // GeV
-    const float EiToOneMinusGamma = pow(lowE, 1 + eslope);
-    const float EfToOneMinusGamma = pow(highE, 1 + eslope);
-    // http://pdg.lbl.gov/2018/reviews/rpp2018-rev-cosmic-rays.pdf eq. 29.2
-    return _primaries / (M_PI * area * _fluxConstant * (EfToOneMinusGamma - EiToOneMinusGamma) / (1. + eslope));
-  }
 
   CosmicCORSIKA::~CosmicCORSIKA(){
-    std::cout << "Total number of primaries: " << getNumShowers() << std::endl;
-    std::cout << "Simulated live-time: " << getLiveTime() << std::endl;
+
   }
 
 
@@ -58,11 +46,6 @@ namespace mu2e {
     //wrap variable so that it's always between low and high
     boxno = int(floor(var / (high - low)));
     return (var - (high - low) * floor(var / (high - low))) + low;
-  }
-
-  float CosmicCORSIKA::wrapvar( const float var, const float low, const float high){
-    //wrap variable so that it's always between low and high
-    return (var - (high - low) * floor(var/(high-low))) + low;
   }
 
 

--- a/Sources/src/FromCorsikaBinary_source.cc
+++ b/Sources/src/FromCorsikaBinary_source.cc
@@ -11,6 +11,7 @@
 
 #include "CLHEP/Vector/LorentzVector.h"
 #include "CLHEP/Vector/ThreeVector.h"
+#include "CLHEP/Units/SystemOfUnits.h"
 
 #include "art/Framework/IO/Sources/Source.h"
 #include "art/Framework/Core/InputSourceMacros.h"
@@ -32,6 +33,7 @@
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "MCDataProducts/inc/GenParticle.hh"
 #include "MCDataProducts/inc/GenParticleCollection.hh"
+#include "MCDataProducts/inc/CosmicLivetime.hh"
 
 #include "Sources/inc/CosmicCORSIKA.hh"
 #include "SeedService/inc/SeedService.hh"
@@ -70,6 +72,13 @@ namespace mu2e {
 
       art::ProductID particlesPID_;
 
+      float _area;
+      float _lowE;  // GeV
+      float _highE; // GeV
+      float _fluxConstant;
+
+      const float _mm22m2 = CLHEP::mm2 / CLHEP::m2;
+
     public:
       CorsikaBinaryDetail(const Parameters &conf,
                           art::ProductRegistryHelper &,
@@ -98,6 +107,9 @@ namespace mu2e {
       , runNumber_(conf().runNumber())
       , currentSubRunNumber_(-1U)
       , currentEventNumber_(0)
+      , _lowE(conf().lowE())
+      , _highE(conf().highE())
+      , _fluxConstant(conf().fluxConstant())
       , _corsikaGen(conf())
     {
       if(!art::RunID(runNumber_).isValid()) {
@@ -106,19 +118,9 @@ namespace mu2e {
       }
 
       rh.reconstitutes<mu2e::GenParticleCollection,art::InEvent>(myModuleLabel_);
-
-      // auto get_ProductID = [](auto const& typeLabel, auto const& processName) {
-      //   if (!typeLabel.hasEmulatedModule()) {
-      //     throw cet::exception("BADCONFIG", " FromCorsikaBinary: ")
-      //     << " Must provided emulated module name for reconstituted product.\n";
-      //   }
-      //   auto const canonical_product_name = art::canonicalProductName(typeLabel.friendlyClassName(),
-      //                                                                 typeLabel.emulatedModule(),
-      //                                                                 typeLabel.productInstanceName(),
-      //                                                                 processName);
-      //   return art::ProductID{canonical_product_name};
-      // };
-      // particlesPID_ = get_ProductID(gpcTypeLabel, art::Globals::instance()->processName());
+      rh.reconstitutes<mu2e::CosmicLivetime,art::InSubRun>(myModuleLabel_);
+      _area = (conf().targetBoxXmax() + 2 * conf().showerAreaExtension() - conf().targetBoxXmin())
+            * (conf().targetBoxZmax() + 2 * conf().showerAreaExtension() - conf().targetBoxZmin()) * _mm22m2; // m^2
 
     }
 
@@ -196,6 +198,8 @@ namespace mu2e {
       outSR = pm_.makeSubRunPrincipal(runNumber,
                                       subRunNumber,
                                       ts);
+      std::unique_ptr<CosmicLivetime> livetime(new CosmicLivetime(_corsikaGen.getNumShowers(), _area, _lowE, _highE, _fluxConstant));
+      art::put_product_in_principal(std::move(livetime), *outSR, myModuleLabel_);
     }
     lastSubRunID_ = newID;
 


### PR DESCRIPTION
The live-time of a cosmic sample can be calculated from 5 parameters, according to the cosmic-ray primary nucleon intensity formula (eq. 29.2 of http://pdg.lbl.gov/2018/reviews/rpp2018-rev-cosmic-rays.pdf). These parameters are:
- the number of primary nucleons
- the sampled area (in m2)
- the minimum energy (in GeV)
- the maximum energy (in GeV)
- the flux constant (1.8e4 by default).

This pull request includes a new data product with these 5 parameters, plus the calculated live-time. The data product is stored for each subrun. 