### PR TITLE
Strengthen this check after digi compression

### DIFF
--- a/Filters/src/CompressDigiMCsCheck_module.cc
+++ b/Filters/src/CompressDigiMCsCheck_module.cc
@@ -173,9 +173,13 @@ namespace mu2e {
 	      }
 
 	      if ( (i_stepPointPtr->volumeId() == j_stepPointPtr->volumeId()) &&
-		   (i_stepPointPtr->totalEDep() == j_stepPointPtr->totalEDep())
+		   (i_stepPointPtr->totalEDep() == j_stepPointPtr->totalEDep()) && 
+		   (i_stepPointPtr->simParticle() == j_stepPointPtr->simParticle())
 		   ) {
-		throw cet::exception("CompressDigiMCsCheck") << "Two StepPointMCs in StrawDigiMC waveform are identical" << std::endl;
+		throw cet::exception("CompressDigiMCsCheck") 
+		  << "Two StepPointMCs in StrawDigiMC waveform are identical: " << std::endl
+		  << "\ti_stepPointPtr: volumeId = " << i_stepPointPtr->volumeId() << ", EDep = " << i_stepPointPtr->totalEDep() << ", SimPart = " << i_stepPointPtr->simParticle() << std::endl
+		  << "\tj_stepPointPtr: volumeId = " << j_stepPointPtr->volumeId() << ", EDep = " << j_stepPointPtr->totalEDep() << ", SimPart = " << j_stepPointPtr->simParticle() << std::endl;
 	      }
 	    }
 	  }


### PR DESCRIPTION
We found an event that was failing this check. It turned out there were two steps in the same volume with the same energy deposit but they were from different SimParticles. Both were low energy photons from the neutron background frame. I've just updated this check to include this as a requirement. With the new StrawGasStep, we will no longer have a vector of waveforms and so this check can be removed at that time.