### PR TITLE
Added support for compact CORSIKA binaries (40x smaller files)

### DIFF
--- a/EventGenerator/test/corsikaTest.fcl
+++ b/EventGenerator/test/corsikaTest.fcl
@@ -17,7 +17,7 @@ targetParams: {
 
 source: {
     module_type: FromCorsikaBinary
-    fileNames: ["/pnfs/mu2e/persistent/users/srsoleti/corsika/DAT110001"]
+    fileNames: ["/mu2e/app/users/srsoleti/corsika-77100/run/DAT110001"]
     runNumber          : 1
     firstSubRunNumber  : 0
     firstEventNumber   : 1
@@ -26,7 +26,7 @@ source: {
     @table::targetParams
     seed: 1
     resample: false
-    compact: false
+    compact: true
     fluxConstant: 1.8e4
     lowE: 1.3
     highE: 1e6

--- a/EventGenerator/test/corsikaTest.fcl
+++ b/EventGenerator/test/corsikaTest.fcl
@@ -26,6 +26,7 @@ source: {
     @table::targetParams
     seed: 1
     resample: false
+    compact: false
     fluxConstant: 1.8e4
     lowE: 1.3
     highE: 1e6

--- a/Sources/inc/CosmicCORSIKA.hh
+++ b/Sources/inc/CosmicCORSIKA.hh
@@ -242,7 +242,7 @@ namespace mu2e {
       unsigned int _primaries = 0;
 
       bool _resample = false;
-      bool _compact = false;
+      bool _compact = true;
 
       CLHEP::HepJamesRandom _engine;
       CLHEP::RandFlat _randFlatX;

--- a/Sources/inc/CosmicCORSIKA.hh
+++ b/Sources/inc/CosmicCORSIKA.hh
@@ -67,6 +67,7 @@ struct Config
   fhicl::Atom<float> targetBoxZmax{Name("targetBoxZmax"), Comment("Target box z max")};
   fhicl::Atom<int> seed{Name("seed"), Comment("Seed for particle random offset")};
   fhicl::Atom<bool> resample{Name("resample"), Comment("Resampling flag")};
+  fhicl::Atom<bool> compact{Name("compact"), Comment("CORSIKA compact output flag")};
 };
 typedef fhicl::WrappedTable<Config> Parameters;
 
@@ -206,8 +207,8 @@ namespace mu2e {
       void openFile(FILE *f);
 
     private:
-
       bool genEvent(std::map<std::pair<int,int>, GenParticleCollection> &particles_map);
+      bool genEventCompact(std::map<std::pair<int,int>, GenParticleCollection> &particles_map);
       float wrapvarBoxNo(const float var, const float low, const float high, int &boxno);
 
       std::vector<CLHEP::Hep3Vector> _targetBoxIntersections;
@@ -241,6 +242,7 @@ namespace mu2e {
       unsigned int _primaries = 0;
 
       bool _resample = false;
+      bool _compact = false;
 
       CLHEP::HepJamesRandom _engine;
       CLHEP::RandFlat _randFlatX;

--- a/Sources/src/CosmicCORSIKA.cc
+++ b/Sources/src/CosmicCORSIKA.cc
@@ -24,6 +24,7 @@ namespace mu2e {
         _targetBoxZmin(conf.targetBoxZmin()), // mm
         _targetBoxZmax(conf.targetBoxZmax()),  // mm
         _resample(conf.resample()),
+        _compact(conf.compact()),
         _engine(conf.seed()),
         _randFlatX(_engine, -(_targetBoxXmax-_targetBoxXmin+_showerAreaExtension)/2, +(_targetBoxXmax-_targetBoxXmin+_showerAreaExtension)/2),
         _randFlatZ(_engine, -(_targetBoxZmax-_targetBoxZmin+_showerAreaExtension)/2, +(_targetBoxZmax-_targetBoxZmin+_showerAreaExtension)/2)
@@ -47,8 +48,137 @@ namespace mu2e {
     return (var - (high - low) * floor(var / (high - low))) + low;
   }
 
+  bool CosmicCORSIKA::genEventCompact(std::map<std::pair<int,int>, GenParticleCollection> &particles_map) {
+    bool running = true;
+    int particleDataSubBlockCounter = 0;
+    const float xOffset = _randFlatX.fire();
+    const float zOffset = _randFlatZ.fire();
+    char word[5];
 
- bool CosmicCORSIKA::genEvent(std::map<std::pair<int,int>, GenParticleCollection> &particles_map) {
+    if (feof(in))
+      return false;
+
+    while (running)
+    {
+
+      fread(word, sizeof(char)*4, 1, in);
+			word[4] = '\0';
+
+			// Compact event blocks start with the EVHW word
+      if (strcmp(word, "EVHW") == 0) {
+        // The size of the event block is 12 4-byte words, EVHW + 11 floats
+				float eventBlock[11];
+				fread(eventBlock, sizeof(eventBlock), 1, in);
+        _primaries++;
+        if (particleDataSubBlockCounter > 0)
+        {
+          running = false;
+        }
+        particleDataSubBlockCounter = 0;
+      }
+      else
+			{
+        // We didn't find EVHW, so go back by 4 chars in the file
+        fseek(in, -sizeof(char)*4, SEEK_CUR);
+
+        // The first number in the block is the size of the block
+        int blockSize;
+        fread(&blockSize, sizeof(blockSize), 1, in);
+
+        // The blocks have multiple of 7 size
+        // see https://web.ikp.kit.edu/corsika/physics_description/corsika_phys.pdf
+        if (blockSize % 7 == 0 && blockSize > 0 && blockSize / 7 <= 39) {
+					unsigned int n_particles = blockSize / 7;
+
+          // Maximum size of the block is 7*39=273
+					float block[273];
+					fread(block, sizeof(float)*blockSize, 1, in);
+          fread(&_garbage, 4, 1, in);
+
+					char blockName[5];
+					memcpy(blockName, block, 4);
+					blockName[4] = '\0';
+
+					// End of run
+					if (strcmp(blockName, "RUNE") == 0)
+					{
+            // If resampling is on, we go back to the beginning of the file
+            if (_resample) {
+              std::cout << "Resampling file..." << std::endl;
+              fseek(in, 0, SEEK_SET);
+              fread(&_garbage, 4, 1, in);
+              continue;
+            } else {
+              _primaries = 0;
+              return false;
+            }
+					}
+          // Run header, we don't use it
+					else if (strcmp(blockName, "RUNH") == 0)
+					{
+						continue;
+					}
+          // Only the first event has a full size block
+					else if (strcmp(blockName, "EVTH") == 0)
+					{
+            _primaries++;
+          }
+          else
+					{
+            // We are inside a particle data block
+            particleDataSubBlockCounter++;
+            for (unsigned int i = 0; i < n_particles; i++)
+						{
+              unsigned int k = i * 7;
+              if (block[k] != 0)
+              {
+                const int id = (int)(block[k] / 1000);
+                const int pdgId = corsikaToPdgId.at(id);
+                const float P_x = block[k + 2] * _GeV2MeV;
+                const float P_y = -block[k + 3] * _GeV2MeV;
+                const float P_z = block[k + 1] * _GeV2MeV;
+
+                int boxnox = 0, boxnoz = 0;
+
+                const float x = wrapvarBoxNo(block[k + 5] * _cm2mm + xOffset, _targetBoxXmin - _showerAreaExtension, _targetBoxXmax + _showerAreaExtension, boxnox);
+                const float z = wrapvarBoxNo(-block[k + 4] * _cm2mm + zOffset, _targetBoxZmin - _showerAreaExtension, _targetBoxZmax + _showerAreaExtension, boxnoz);
+                std::pair xz(boxnox, boxnoz);
+                const float m = pdt->particle(pdgId).ref().mass(); // to MeV
+
+                const float energy = safeSqrt(P_x * P_x + P_y * P_y + P_z * P_z + m * m);
+
+                const Hep3Vector position(x, _targetBoxYmax, z);
+                const HepLorentzVector mom4(P_x, P_y, P_z, energy);
+
+                const float particleTime = block[k + 6];
+
+                GenParticle part(static_cast<PDGCode::type>(pdgId),
+                                  GenId::cosmicCORSIKA, position, mom4,
+                                  particleTime);
+
+                if (particles_map.count(xz) == 0)
+                {
+                  GenParticleCollection parts;
+                  parts.push_back(part);
+                  particles_map.insert({xz, parts});
+                }
+                else
+                {
+                  particles_map[xz].push_back(part);
+                }
+              }
+						}
+					}
+				}
+
+			}
+
+		}
+
+    return true;
+  }
+
+  bool CosmicCORSIKA::genEvent(std::map<std::pair<int,int>, GenParticleCollection> &particles_map) {
     float block[273]; // all data blocks have this size
     // static TDatabasePDG *pdgt = TDatabasePDG::Instance();
 
@@ -142,9 +272,7 @@ namespace mu2e {
             {
               if (id < 75000)
               {
-                // float dxyz[3] = {-block[k + 1], -block[k + 3], block[k + 2]};
-                // float xyz[3] = {-block[k + 4], FDHalfHeight, block[k + 5]};
-                // if (CheckTPCIntersection(xyz, dxyz)) {
+
                 if (block[k + 1] != 0)
                 {
                   id = (int)(id / 1000);
@@ -200,15 +328,21 @@ namespace mu2e {
   {
 
     // loop over particles in the truth object
-
     bool passed = false;
     while (!passed) {
 
       if (_particles_map.size() == 0)
       {
-        if (!genEvent(_particles_map))
-        {
-          return false;
+        if (_compact) {
+          if (!genEventCompact(_particles_map))
+          {
+            return false;
+          }
+        } else {
+          if (!genEvent(_particles_map))
+          {
+            return false;
+          }
         }
       }
 
@@ -216,7 +350,6 @@ namespace mu2e {
       GenParticleCollection crossingParticles;
 
       float timeOffset = std::numeric_limits<float>::max();
-
       primaries = _primaries;
 
       for (unsigned int i = 0; i < particles.size(); i++) {


### PR DESCRIPTION
Now it is possible to read from CORSIKA binary files produced with the "compact" option, which produces files on average 40x smaller. With this option the electromagnetic interactions are calculated analytically with the non-linear Klein-Gordon equations and are not simulated with EGS4. This affects only the Cherenkov radiation in the GeV range. This should speed up the processing, especially when the resampling option is on. 