### PR TITLE
turn off verbose info and warnings

### DIFF
--- a/Mu2eG4/fcl/prolog.fcl
+++ b/Mu2eG4/fcl/prolog.fcl
@@ -103,7 +103,7 @@ mu2eg4DefaultTrajectories: {
 }
 #----------------
 mu2eg4DefaultDebug: {
-    stepLimitKillerVerbose: true
+    stepLimitKillerVerbose: false
     printPhysicsProcessSummary : false
     PiENuPolicyVerbosity : 0
     printTrackTiming: false

--- a/fcl/standardMessageDestinations.fcl
+++ b/fcl/standardMessageDestinations.fcl
@@ -139,6 +139,7 @@ mf_coutInfo:
    GEOM_MINRANGECUT : { limit : 0 }
    GEOM_PARTICLECUT : { limit : 0 }
    Configuration : { limit : 0 }
+   HITS : { limit : 0 }
  } # end categories
 } # end mf_coutInfo
 mf_coutInfoStats : 


### PR DESCRIPTION
Turn off two sources of unnecessary prints. (would also assign to Krzysztof
if I could see him in the list)

1) We had turned this off before, now it is back, so try again

%MSG-i HITS:  StrawDigisFromStepPointMCs:makeSD@BeginModule  26-Nov-2019 17:26:03 CST run: 1 subRun: 0 event: 1
StrawDigisFromStepPointMCs::fillHitMap will use StepPointMCs from: 
   mu2e::StepPointMCs_g4run_tracker_ceSimReco.

2) This comes from 6/6/19 when Krzysztof modified the stepper code. Before
that, this message almost never printed, now it prints every 100 events in ceSimReco.fcl
In current production it is most of the log file. It is possible to also turn this off in code,
if it is useful to keep the flag on for other reasons.

isTrackKilledByFieldPropagator WARNING: particle killed by the Field Propagator in TrackerStrawGas_0_0_0_36
printKilledTrackInfo Track info: ID: 3 pdgid: 11 name: e-, CurrentStepNumber: 8, TrackStatus: 2, step length: 0.02848704, currentRange: 0.00000000, track length: 0.35858597, KE: 0.00000000e+00, mom: (-0.00000000e+00,0.00000000e+00,-0.00000000e+00), mag: 0.00000000e+00, TrackCreationCode: ( 17: eIoni )


