### PR TITLE
move to art v3_04_00 and python 3

### DIFF
--- a/Mu2eG4/src/SConscript
+++ b/Mu2eG4/src/SConscript
@@ -26,7 +26,7 @@ if g4_version[2] == '9':
 else:
     g4_version = g4_version[1:5]
 
-# print "GEANT4_VERSION ",  g4_version
+# print("GEANT4_VERSION ",  g4_version)
 
 # Compiler switches needed by the default G4 build.
 G4CPPFLAGS = [ '-DG4OPTIMISE',           '-DG4VERBOSE',    '-DG4GMAKE',
@@ -54,8 +54,8 @@ elif  g4vis == 'none':
 else:
     G4GS_CPPFLAGS = [ '-DG4VIS_USE_OPENGLX',    '-DG4VIS_USE_OPENGL' ]
 
-# print "mu2eopts      ",  mu2eopts
-# print "G4GS_CPPFLAGS ",  G4GS_CPPFLAGS
+# print("mu2eopts      ",  mu2eopts)
+# print("G4GS_CPPFLAGS ",  G4GS_CPPFLAGS)
 
 # The granular version of the G4 libraries.
 G4GRANULARLIBS = [

--- a/scripts/build/python/mu2e_helper.py
+++ b/scripts/build/python/mu2e_helper.py
@@ -29,10 +29,10 @@ class mu2e_helper:
         # where dictionaries go: tmp/src/package/subdir
         self.tmpdir = "tmp/src/"+self.relpath
         # change string package/subdir/src to package_subdir
-        tokens = string.split(self.relpath,'/')
+        tokens = self.relpath.split('/')
         if len(tokens) > 1:
             if tokens[-1] == 'src': tokens.pop()
-        self.libstub = string.join(tokens,'_')
+        self.libstub = '_'.join(tokens)
 
         # A few places we use ClassDef in order to enable a class
         # to be fully capable at the root prompt

--- a/scripts/build/python/sconstruct_helper.py
+++ b/scripts/build/python/sconstruct_helper.py
@@ -15,12 +15,12 @@ import subprocess
 # return a dictionary with mu2eOpts
 def mu2eEnvironment():
     mu2eOpts = {}
-    if not os.environ.has_key('MU2E_BASE_RELEASE'):
+    if 'MU2E_BASE_RELEASE' not in os.environ:
         raise Exception('You have not specified MU2E_BASE_RELEASE for this build')
     primaryBase = os.environ['MU2E_BASE_RELEASE']
     mu2eOpts["primaryBase"] = primaryBase
 
-    if os.environ.has_key("MU2E_SATELLITE_RELEASE"):
+    if "MU2E_SATELLITE_RELEASE" in os.environ:
         mu2eOpts["satellite"] = True
         mu2eOpts["satelliteBase"] = os.environ["MU2E_SATELLITE_RELEASE"]
         base = mu2eOpts["satelliteBase"]
@@ -35,12 +35,12 @@ def mu2eEnvironment():
     mu2eOpts['tmpdir'] = base+'/tmp'
 
     envopts = os.environ['MU2E_SETUP_BUILDOPTS'].strip()
-    fsopts  = subprocess.check_output(primaryBase+"/buildopts",shell=True).strip()
+    fsopts  = subprocess.check_output(primaryBase+"/buildopts",shell=True).strip().decode() # decode to convert byte string to text
     if envopts != fsopts:
         raise Exception("ERROR: Inconsistent build options: (MU2E_SETUP_BUILDOPTS vs ./buildopts)\n"
              +"Please source setup.sh after setting new options with buildopts.\n")
 
-    # copy the buildopts to the dicitonary
+    # copy the buildopts to the dictionary
     mu2eOpts["buildopts"] = fsopts
     for line in fsopts.split():
         pp = line.split("=")
@@ -204,17 +204,17 @@ def extraCleanup():
     for top, dirs, files in os.walk("./lib"):
         for name in files:
             ff =  os.path.join(top, name)
-            print "removing file ", ff
+            print("removing file ", ff)
             os.unlink (ff)
 
     for top, dirs, files in os.walk("./tmp"):
         for name in files:
             ff =  os.path.join(top, name)
-            print "removing file ", ff
+            print("removing file ", ff)
             os.unlink (ff)
 
     for top, dirs, files in os.walk("./gen"):
         for name in files:
             ff =  os.path.join(top, name)
-            print "removing file ", ff
+            print("removing file ", ff)
             os.unlink (ff)

--- a/setup.sh
+++ b/setup.sh
@@ -103,7 +103,7 @@ build=$($MU2E_BASE_RELEASE/buildopts --build)
 # and is therefore different from the value shown in
 # SETUP_<productname> environment vars, or by the "ups active" command.
 export MU2E_UPS_QUALIFIERS=+e19:+${build}
-export MU2E_ART_SQUALIFIER=s89
+export MU2E_ART_SQUALIFIER=s94
 
 MU2E_G4_GRAPHICS_QUALIFIER=''
 if [[ $($MU2E_BASE_RELEASE/buildopts --g4vis) == qt ]]; then
@@ -118,8 +118,8 @@ fi
 export MU2E_G4_EXTRA_QUALIFIER=''
 
 # Setup the framework and its dependent products
-setup -B art v3_03_01 -q${MU2E_UPS_QUALIFIERS}
-setup -B art_root_io v1_01_03 -q${MU2E_UPS_QUALIFIERS}
+setup -B art v3_04_00 -q${MU2E_UPS_QUALIFIERS}
+setup -B art_root_io v1_02_00 -q${MU2E_UPS_QUALIFIERS}
 
 # Geant4 and its cross-section files.
 if [[ $($MU2E_BASE_RELEASE/buildopts --trigger) == "off" ]]; then
@@ -129,19 +129,19 @@ else
 fi
 
 # Get access to raw data formats.
-setup -B mu2e_artdaq_core v1_02_30 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
+setup -B mu2e_artdaq_core v1_02_30a -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
 
 # Other libraries we need.
-setup -B pcie_linux_kernel_module v2_02_07a -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}
+setup -B pcie_linux_kernel_module v2_02_07b -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}
 
 setup -B heppdt   v3_04_01j -q${MU2E_UPS_QUALIFIERS}
-setup -B BTrk   v1_02_18c  -q${MU2E_UPS_QUALIFIERS}
+setup -B BTrk   v1_02_21  -q${MU2E_UPS_QUALIFIERS}
 setup -B cry   v1_7m  -q${MU2E_UPS_QUALIFIERS}
 setup -B gsl v2_5  -q${build}
 setup curl v7_64_1
 
 # The build system.
-setup -B scons v3_0_5  -q p2715a
+setup -B scons v3_1_1  -q +p372
 
 # The debugger
 setup -B gdb v8_2_1


### PR DESCRIPTION
- move from art v3_03_01 to v3_04_00
- move setups from python 2.7 to python 3.7
We are making both art and python moves at the same time in order to avoid creating new setup methods that would only be used a short time.

The art change:
- fix module names in error messages
- enable MixMaxRng random engine 
- fix problem with finding products when module label is re-used

We expect all products we usually use to setup and work with python3, except jobsub.
jobsub will be fixed, but it will take a while longer.  Meanwhile, users will have to setup
jobsub (usually via setup mu2egrid) in a different process.

