### PR TITLE
fixing of bugs which wouldn't allow stage 2 types of jobs to run

### DIFF
--- a/JobConfig/cosmic/dsstops_resampler_lo.fcl
+++ b/JobConfig/cosmic/dsstops_resampler_lo.fcl
@@ -6,4 +6,4 @@ physics.filters.filterS1.cutEDepMax: 14
 //Drop truncated stream
 physics.outputs: [DSVacuumOut]
 //Events that deposited lower than 14 MeV in CRV
-//physics.filters.dsResample.fileNames: ["/pnfs/mu2e/persistent/users/oksuzian/workflow/cry_rs1_1019_g4_10_5/outstage/25394938.fcllist_191106224859/00/00053/sim.oksuzian.minedep-filter.cry-minedep_filter-10-5.002701_00007722.art"]
+physics.filters.dsResample.fileNames: ["/pnfs/mu2e/persistent/users/oksuzian/workflow/cry_rs1_1019_g4_10_5/outstage/25394938.fcllist_191106224859/00/00053/sim.oksuzian.minedep-filter.cry-minedep_filter-10-5.002701_00007722.art"]

--- a/Mu2eG4/inc/Mu2eG4PerThreadStorage.hh
+++ b/Mu2eG4/inc/Mu2eG4PerThreadStorage.hh
@@ -64,10 +64,10 @@ struct Mu2eG4PerThreadStorage
             artEvent->getByLabel(generatorModuleLabel, gensHandle);
         }
         
-        if ( !gensHandle.isValid() )
+        if ( !gensHandle.isValid() && genInputHits == nullptr )
         {
             throw cet::exception("CONFIG")
-            << "Error in PerThreadStorage::initializeEventInfo.  You are trying to run in MT mode and there is no GenParticleCollection!\n";
+            << "Error in PerThreadStorage::initializeEventInfo.  You are trying to run a G4job without an input for G4.\n";
         }
         
     }

--- a/Mu2eG4/src/Mu2eG4MT_module.cc
+++ b/Mu2eG4/src/Mu2eG4MT_module.cc
@@ -328,16 +328,6 @@ void Mu2eG4MT::beginSubRun(art::SubRun& sr, art::ProcessingFrame const& procFram
 // Create one G4 event and copy its output to the art::event.
 void Mu2eG4MT::produce(art::Event& event, art::ProcessingFrame const& procFrame) {
     
-    
-    if (num_schedules>1) {
-        if (   multiStagePars_.inputSimParticles() != art::InputTag()
-                || multiStagePars_.inputMCTrajectories() != art::InputTag()
-                || !(multiStagePars_.genInputHits().empty()) ) {
-                throw cet::exception("CONFIG")
-                << "Error: You are trying to run in MT mode with input from previous stages.  This is an invalid configuration!\n";
-        }
-    }
-    
     art::Handle<GenParticleCollection> gensHandle;
     if(!(_generatorModuleLabel == art::InputTag())) {
         event.getByLabel(_generatorModuleLabel, gensHandle);

--- a/Mu2eG4/src/Mu2eG4WorkerRunManager.cc
+++ b/Mu2eG4/src/Mu2eG4WorkerRunManager.cc
@@ -79,11 +79,14 @@ namespace mu2e {
     stackingCuts_(createMu2eG4Cuts(pset_.get<fhicl::ParameterSet>("Mu2eG4StackingOnlyCut", fhicl::ParameterSet()), mu2elimits_)),
     steppingCuts_(createMu2eG4Cuts(pset_.get<fhicl::ParameterSet>("Mu2eG4SteppingOnlyCut",fhicl::ParameterSet()), mu2elimits_)),
     commonCuts_(createMu2eG4Cuts(pset_.get<fhicl::ParameterSet>("Mu2eG4CommonCut", fhicl::ParameterSet()), mu2elimits_))
-{}
+{
+    std::cout << "WorkerRM on thread " << workerID_ << " is being created\n!";
+    
+}
   
 // Destructor of base is called automatically.  No need to do anything.
 Mu2eG4WorkerRunManager::~Mu2eG4WorkerRunManager(){
-  std::cout << "This WorkerRM is being destroyed!\n";
+    std::cout << "WorkerRM on thread " << workerID_ << " is being destroyed\n!";
 }
     
 
@@ -285,7 +288,7 @@ void Mu2eG4WorkerRunManager::processEvent(art::Event* event){
     numberOfEventProcessed = 0;
     ConstructScoringWorlds();
     
-    std::cout << "WorkerRM::ProcessEvent:" << event->id().event() << " on thread " << workerID_ << std::endl;
+//    std::cout << "WorkerRM::ProcessEvent:" << event->id().event() << " on thread " << workerID_ << std::endl;
     
     eventLoopOnGoing = true;
     while(seedsQueue.size()>0)


### PR DESCRIPTION
In testing some stage 2 jobs for a proposal for ALCC, I encountered a bug that caused stage 2 jobs to fail. Two files needed to be changed, Mu2eG4/inc/Mu2eG4PerThreadStorage.hh and  Mu2eG4/src/Mu2eG4MT_module.cc to fix this.  The non-MT Mu2eG4/src/Mu2eG4_module.cc did not need any changes.  I have also removed some unnecessary printout from the WorkerRunManager and modified a fcl file for the resampling jobs I am testing.

I have tested Validation/fcl/ceSimReco.fcl, Validation/fcl/POTSim.fcl, Mu2eG4/fcl/g4test_03.fcl to entire that these configurations run.  