### PR TITLE
Adding CORSIKA to FindMCPrimary

### DIFF
--- a/CommonMC/fcl/prolog.fcl
+++ b/CommonMC/fcl/prolog.fcl
@@ -38,8 +38,8 @@ CommonMC: {
     GenParticles : "compressDigiMCs"
     SimParticles : "compressDigiMCs"
     PrimaryGenIds : ["CeEndpoint", "CeLeadingLog", "dioTail",
-	"cosmicDYB", "CosmicCRY", 
-	"InternalRPC" , "InternalRMC", "ExternalRPC", "ExternalRMC"  ]
+	"cosmicDYB", "CosmicCRY", "CosmicCORSIKA", 
+ 	"InternalRPC" , "InternalRMC", "ExternalRPC", "ExternalRMC"  ]
   }
   SelectRecoMC : {
     module_type : SelectRecoMC

--- a/CommonMC/src/FindMCPrimary_module.cc
+++ b/CommonMC/src/FindMCPrimary_module.cc
@@ -97,9 +97,9 @@ namespace mu2e {
 	}
       }
     }
-    // handle CRY separately: it simulates secondaries and we have to create the primary ourselves.
+    // handle CRY and CORSIKA separately: it simulates secondaries and we have to create the primary ourselves.
     // This should be done in the generator FIXME!
-    if(pgps.size() >0 && pgps.front()->generatorId() == GenId::cosmicCRY){
+    if(pgps.size() >0 && (pgps.front()->generatorId() == GenId::cosmicCRY || pgps.front()->generatorId() == GenId::cosmicCORSIKA )){
       HepLorentzVector pmom;
       Hep3Vector ppos;
       double ptime(FLT_MAX);

--- a/TrkDiag/src/InfoMCStructHelper.cc
+++ b/TrkDiag/src/InfoMCStructHelper.cc
@@ -108,6 +108,10 @@ namespace mu2e {
 
     // go through the SimParticles of this primary, and find the one most related to the
     // downstream fit (KalSeedMC)
+
+    if (primary.primarySimParticles().empty()) {
+      throw cet::exception("Simulation")<<"InfoMCStructHelper: No Primary Particle found" << std::endl;
+    }
     auto bestprimarysp = primary.primarySimParticles().front();
     MCRelationship bestrel;
     for(auto const& spp : primary.primarySimParticles()){


### PR DESCRIPTION
I added the CORSIKA GenId to the list of GenIds for the FindMCPrimary module. Also, I've added a check in InfoMCStructHelper in case there are no primaries in the event: in the previous version it was throwing a Segmentation Fault because it was calling .front() without checking the size of the vector.