### PR TITLE
Ensuring aligned Straws are placed correctly by AlignedTrackerMaker (+ non-const Straw accessor)

### DIFF
--- a/GeneralUtilities/inc/HepTransform.hh
+++ b/GeneralUtilities/inc/HepTransform.hh
@@ -9,70 +9,44 @@
 
 #include <ostream>
 
-namespace mu2e
-{
+namespace mu2e {
 
-    class HepTransform
-    {
-    public:
-        HepTransform() : _displacement(0, 0, 0),
-                         _rotation(CLHEP::HepRotation::IDENTITY) {}
+  class HepTransform {
+  public:
+    HepTransform():_displacement(0,0,0),
+		   _rotation(CLHEP::HepRotation::IDENTITY) {}
+    HepTransform( CLHEP::Hep3Vector & disp, CLHEP::HepRotation & rot ) :
+      _displacement(disp),
+      _rotation(rot) {}
+    HepTransform( double dx, double dy, double dz,  
+		  double rx, double ry, double rz):
+      _displacement(dx,dy,dz) {
+      _rotation.rotateX(rx);
+      _rotation.rotateY(ry);
+      _rotation.rotateZ(rz);
+    }
 
+    CLHEP::Hep3Vector  displacement() const { return _displacement;}
+    CLHEP::HepRotation rotation()     const { return _rotation;    }
 
-        HepTransform(CLHEP::Hep3Vector const& disp, CLHEP::HepRotation const& rot) :
-                _displacement(disp),
-                _rotation(rot) {}
+    void  setDisplacement ( CLHEP::Hep3Vector & aDisp ) { 
+                                   _displacement = aDisp;}
+    void  setRotation ( CLHEP::HepRotation & aRot ) { _rotation = aRot; }
 
-        HepTransform(double dx, double dy, double dz,
-                     double rx, double ry, double rz) :
-                _displacement(dx, dy, dz)
-        {
-            _rotation.rotateX(rx);
-            _rotation.rotateY(ry);
-            _rotation.rotateZ(rz);
-        }
+    // combine HepTransform
+    HepTransform& operator*=(HepTransform const& b);
+    friend HepTransform operator*(HepTransform const& a, HepTransform const& b);
 
-        HepTransform(HepTransform const& other) :
-            _displacement(other._displacement), _rotation(other._rotation) { }
+    // apply to a vector
+    friend CLHEP::Hep3Vector operator*(HepTransform const& a, 
+				CLHEP::Hep3Vector const& v);
 
+  private:
+    CLHEP::Hep3Vector  _displacement;
+    CLHEP::HepRotation _rotation;
+  };
 
-        CLHEP::Hep3Vector displacement() const { return _displacement; }
-
-        CLHEP::HepRotation rotation() const { return _rotation; }
-
-        void setDisplacement(CLHEP::Hep3Vector &aDisp)
-        {
-            _displacement = aDisp;
-        }
-
-        void setRotation(CLHEP::HepRotation &aRot) { _rotation = aRot; }
-
-        HepTransform &operator=(HepTransform const &other)
-        {
-            if(&other == this)
-                return *this;
-
-            _displacement = other._displacement;
-            _rotation = other._rotation;
-
-            return *this;
-        }
-
-        // combine HepTransform
-        HepTransform &operator*=(HepTransform const &b);
-
-        friend HepTransform operator*(HepTransform const &a, HepTransform const &b);
-
-        // apply to a vector
-        friend CLHEP::Hep3Vector operator*(HepTransform const &a,
-                                           CLHEP::Hep3Vector const &v);
-
-    private:
-        CLHEP::Hep3Vector _displacement;
-        CLHEP::HepRotation _rotation;
-    };
-
-    std::ostream &operator<<(std::ostream &os, const HepTransform &rhs);
+  std::ostream& operator<<(std::ostream& os, const HepTransform& rhs );
 
 } // end of namespace mu2e
 

--- a/GeneralUtilities/inc/HepTransform.hh
+++ b/GeneralUtilities/inc/HepTransform.hh
@@ -32,8 +32,9 @@ namespace mu2e
             _rotation.rotateZ(rz);
         }
 
-        HepTransform(HepTransform const&other) :
+        HepTransform(HepTransform const& other) :
             _displacement(other._displacement), _rotation(other._rotation) { }
+
 
         CLHEP::Hep3Vector displacement() const { return _displacement; }
 
@@ -45,6 +46,17 @@ namespace mu2e
         }
 
         void setRotation(CLHEP::HepRotation &aRot) { _rotation = aRot; }
+
+        HepTransform &operator=(HepTransform const &other)
+        {
+            if(&other == this)
+                return *this;
+
+            _displacement = other._displacement;
+            _rotation = other._rotation;
+
+            return *this;
+        }
 
         // combine HepTransform
         HepTransform &operator*=(HepTransform const &b);

--- a/GeneralUtilities/inc/HepTransform.hh
+++ b/GeneralUtilities/inc/HepTransform.hh
@@ -9,44 +9,58 @@
 
 #include <ostream>
 
-namespace mu2e {
+namespace mu2e
+{
 
-  class HepTransform {
-  public:
-    HepTransform():_displacement(0,0,0),
-		   _rotation(CLHEP::HepRotation::IDENTITY) {}
-    HepTransform( CLHEP::Hep3Vector & disp, CLHEP::HepRotation & rot ) :
-      _displacement(disp),
-      _rotation(rot) {}
-    HepTransform( double dx, double dy, double dz,  
-		  double rx, double ry, double rz):
-      _displacement(dx,dy,dz) {
-      _rotation.rotateX(rx);
-      _rotation.rotateY(ry);
-      _rotation.rotateZ(rz);
-    }
+    class HepTransform
+    {
+    public:
+        HepTransform() : _displacement(0, 0, 0),
+                         _rotation(CLHEP::HepRotation::IDENTITY) {}
 
-    CLHEP::Hep3Vector  displacement() const { return _displacement;}
-    CLHEP::HepRotation rotation()     const { return _rotation;    }
 
-    void  setDisplacement ( CLHEP::Hep3Vector & aDisp ) { 
-                                   _displacement = aDisp;}
-    void  setRotation ( CLHEP::HepRotation & aRot ) { _rotation = aRot; }
+        HepTransform(CLHEP::Hep3Vector const& disp, CLHEP::HepRotation const& rot) :
+                _displacement(disp),
+                _rotation(rot) {}
 
-    // combine HepTransform
-    HepTransform& operator*=(HepTransform const& b);
-    friend HepTransform operator*(HepTransform const& a, HepTransform const& b);
+        HepTransform(double dx, double dy, double dz,
+                     double rx, double ry, double rz) :
+                _displacement(dx, dy, dz)
+        {
+            _rotation.rotateX(rx);
+            _rotation.rotateY(ry);
+            _rotation.rotateZ(rz);
+        }
 
-    // apply to a vector
-    friend CLHEP::Hep3Vector operator*(HepTransform const& a, 
-				CLHEP::Hep3Vector const& v);
+        HepTransform(HepTransform const&other) :
+            _displacement(other._displacement), _rotation(other._rotation) { }
 
-  private:
-    CLHEP::Hep3Vector  _displacement;
-    CLHEP::HepRotation _rotation;
-  };
+        CLHEP::Hep3Vector displacement() const { return _displacement; }
 
-  std::ostream& operator<<(std::ostream& os, const HepTransform& rhs );
+        CLHEP::HepRotation rotation() const { return _rotation; }
+
+        void setDisplacement(CLHEP::Hep3Vector &aDisp)
+        {
+            _displacement = aDisp;
+        }
+
+        void setRotation(CLHEP::HepRotation &aRot) { _rotation = aRot; }
+
+        // combine HepTransform
+        HepTransform &operator*=(HepTransform const &b);
+
+        friend HepTransform operator*(HepTransform const &a, HepTransform const &b);
+
+        // apply to a vector
+        friend CLHEP::Hep3Vector operator*(HepTransform const &a,
+                                           CLHEP::Hep3Vector const &v);
+
+    private:
+        CLHEP::Hep3Vector _displacement;
+        CLHEP::HepRotation _rotation;
+    };
+
+    std::ostream &operator<<(std::ostream &os, const HepTransform &rhs);
 
 } // end of namespace mu2e
 

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -64,7 +64,7 @@ namespace mu2e {
 
       // make an intermediate multiplication
       HepTransform plane_temp = align_tracker
-	* plane_to_tracker * align_plane;
+	* (plane_to_tracker * align_plane);
 
       for(auto panel_p : plane.getPanels()) {
 	auto& panel = *panel_p;
@@ -80,13 +80,13 @@ namespace mu2e {
 	HepTransform panel_to_plane(dv.x(),dv.y(),dv.z(),0.0,0.0,rz);
 
 	// make an intermediate multiplication
-	HepTransform panel_temp = plane_temp * panel_to_plane * align_panel;
+	HepTransform panel_temp = plane_temp * (panel_to_plane * align_panel);
 
 	for(size_t istr=0; istr< StrawId::_nstraws; istr++) {
-	  // need to const cast so we can update geometry - fixme
-	  Straw& straw = const_cast<Straw &>(panel.getStraw(istr));
-
-	  // how to place the straw in the panel
+          // access strawId from Panel since it performs necessary checks
+          Straw &straw = tracker.getStraw(panel.getStraw(istr).id());
+	  
+          // how to place the straw in the panel
 	  double dx = straw.getMidPoint().perp()
 	    - panel.straw0MidPoint().perp();
 	  double dz = ( straw.getMidPoint()

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -9,105 +9,109 @@
 using namespace std;
 using namespace CLHEP;
 
-namespace mu2e
-{
+namespace mu2e {
 
 
-    Tracker::ptr_t AlignedTrackerMaker::fromFcl()
-    {
-        GeomHandle<Tracker> trk_h;
+  Tracker::ptr_t AlignedTrackerMaker::fromFcl() {
 
-        // make shared_ptr to a copy of the GeomHandle Tracker object
-        // made via copy constructor.  AlignedTracker leaves the
-        // nominal Geometry untouched.
-        Tracker::ptr_t ptr = std::make_shared<Tracker>(*trk_h);
+    GeomHandle<Tracker> trk_h;
 
-        if (_config.verbose() > 0) {
-            cout << "AlignedTrackerMaker::fromFcl made Tracker with nStraws = "
-                 << ptr->nStraws() << endl;
-        }
+    // make shared_ptr to a copy of the GeomHandle Tracker object
+    // made via copy constructor.  AlignedTracker leaves the
+    // nominal Geometry untouched.
+    Tracker::ptr_t  ptr = std::make_shared<Tracker>(*trk_h);
 
-        return ptr;
+    if ( _config.verbose() > 0 ) {
+      cout << "AlignedTrackerMaker::fromFcl made Tracker with nStraws = "
+	   << ptr->nStraws() << endl;
     }
 
-    Tracker::ptr_t AlignedTrackerMaker::fromDb(
-            TrkAlignTracker::cptr_t tatr_p,
-            TrkAlignPlane::cptr_t tapl_p,
-            TrkAlignPanel::cptr_t tapa_p)
-    {
-        // get standard geometry
-        auto align_trk_ptr = fromFcl();
-        Tracker &tracker = *align_trk_ptr;
+    return ptr;
+  }
 
-        if (_config.verbose() > 0)
-            cout << "AlignedTrackerMaker::fromDb now aligning Tracker " << endl;
-
-        // Align the entire Tracker
-        // the whole tracker has nominal center on 0,0,0
-        auto const &rowtr = tatr_p->rowAt(0);
-        HepTransform align_tracker(rowtr.dx(), rowtr.dy(), rowtr.dz(),
-                                   rowtr.rx(), rowtr.ry(), rowtr.rz());
-
-        for (auto &plane : tracker.getPlanes())
-        {
-            auto const &rowpl = tapl_p->rowAt(plane.id().plane());
-            HepTransform align_plane(rowpl.dx(), rowpl.dy(), rowpl.dz(),
-                                     rowpl.rx(), rowpl.ry(), rowpl.rz());
+  Tracker::ptr_t AlignedTrackerMaker::fromDb(
+			  TrkAlignTracker::cptr_t tatr_p,
+			  TrkAlignPlane::cptr_t   tapl_p,
+			  TrkAlignPanel::cptr_t   tapa_p ) {
 
 
-            if (_config.verbose() > 0)
-            {
-                cout << "AlignedTrackerMaker::fromDb plane ID " << plane.id().plane() << " alignment constants: "
-                     << align_plane << endl;
-            }
-            // how to place the plane in the tracker
-            HepTransform plane_to_tracker(0.0, 0.0, plane.origin().z(), 0.0, 0.0, 0.0);
 
-            // make an intermediate multiplication
-            HepTransform plane_temp = align_plane * plane_to_tracker * align_tracker;
+    // get standard geometry
+    auto ptr = fromFcl();
+    Tracker& tracker = *ptr;
 
-
-            for (auto panel_p : plane.getPanels())
-            {
-                auto &panel = *panel_p;
-                auto const &rowpa = tapa_p->rowAt(panel.id().uniquePanel());
-                HepTransform align_panel(rowpa.dx(), rowpa.dy(), rowpa.dz(),
-                                         rowpa.rx(), rowpa.ry(), rowpa.rz());
-
-                // how to place the panel in the plane
-                Hep3Vector dv = panel.straw0MidPoint() - plane_to_tracker.displacement();
-                double rz = dv.phi();
-
-                HepTransform panel_to_plane(dv.x(), dv.y(), dv.z(), 0.0, 0.0, rz);
-
-                    // make an intermediate multiplication
-                HepTransform panel_temp = align_panel * panel_to_plane * plane_temp;
-
-                for (size_t istr = 0; istr < StrawId::_nstraws; istr++)
-                {
-                    // access strawId from Panel since it performs necessary checks
-                    Straw &straw = tracker.getStraw(panel.getStraw(istr).id());
-
-                    // how to place the straw in the panel
-                    double dx = straw.getMidPoint().perp()
-                                - panel.straw0MidPoint().perp();
-                    double dz = (straw.getMidPoint()
-                                 - panel.straw0MidPoint()).z();
-
-                    Hep3Vector straw_to_panel = Hep3Vector(dx, 0.0, dz);
-                    Hep3Vector straw_dir = Hep3Vector(0.0, 1.0, 0.0);
-
-                    Hep3Vector aligned_straw = panel_temp * straw_to_panel;
-                    Hep3Vector aligned_straw_dir = panel_temp.rotation() * straw_dir;
-
-                    straw._c = aligned_straw;
-                    straw._w = aligned_straw_dir;
-
-                } // straw loop
-            } // panel loop
-        } // plane loop
-
-        return align_trk_ptr;
+    if ( _config.verbose() > 0 ) {
+      cout << "AlignedTrackerMaker::fromDb now aligning Tracker " << endl;
     }
+
+    // the whole tracker has nominal center on 0,0,0
+    auto const& rowtr = tatr_p->rowAt(0);
+    HepTransform align_tracker(rowtr.dx(),rowtr.dy(),rowtr.dz(),
+			       rowtr.rx(),rowtr.ry(),rowtr.rz());
+
+    for(auto& plane : tracker.getPlanes()) {
+
+      auto const& rowpl = tapl_p->rowAt( plane.id().plane() );
+      HepTransform align_plane(rowpl.dx(),rowpl.dy(),rowpl.dz(),
+			       rowpl.rx(),rowpl.ry(),rowpl.rz());
+
+
+	if ( _config.verbose() > 0 ) {
+	  cout << "AlignedTrackerMaker::fromDb plane ID " << plane.id().plane() << " alignment constants: " << align_plane << endl;
+	}
+      // how to place the plane in the tracker
+      HepTransform plane_to_tracker(0.0,0.0,plane.origin().z(),0.0,0.0,0.0);
+
+      // make an intermediate multiplication
+      HepTransform plane_temp = align_tracker
+	* plane_to_tracker * align_plane;
+
+      for(auto panel_p : plane.getPanels()) {
+	auto& panel = *panel_p;
+	auto const& rowpa = tapa_p->rowAt( panel.id().uniquePanel() );
+	HepTransform align_panel(rowpa.dx(),rowpa.dy(),rowpa.dz(),
+				 rowpa.rx(),rowpa.ry(),rowpa.rz());
+
+	// how to place the panel in the plane
+	Hep3Vector dv = panel.straw0MidPoint()
+	  - plane_to_tracker.displacement();
+	double rz = dv.phi();
+
+	HepTransform panel_to_plane(dv.x(),dv.y(),dv.z(),0.0,0.0,rz);
+
+	// make an intermediate multiplication
+	HepTransform panel_temp = plane_temp * panel_to_plane * align_panel;
+
+	for(size_t istr=0; istr< StrawId::_nstraws; istr++) {
+	  // need to const cast so we can update geometry - fixme
+	  Straw& straw = const_cast<Straw &>(panel.getStraw(istr));
+
+	  // how to place the straw in the panel
+	  double dx = straw.getMidPoint().perp()
+	    - panel.straw0MidPoint().perp();
+	  double dz = ( straw.getMidPoint()
+			- panel.straw0MidPoint() ).z();
+
+	  Hep3Vector straw_to_panel = Hep3Vector(dx,0.0,dz);
+	  Hep3Vector straw_dir = Hep3Vector(0.0,1.0,0.0);
+
+	  Hep3Vector aligned_straw = panel_temp*straw_to_panel;
+	  Hep3Vector aligned_straw_dir = panel_temp.rotation()*straw_dir;
+
+	  // aligned straw position inserted in the Tracker object
+	  //we need to go the long way to get non-const access
+
+	  Hep3Vector pdif = aligned_straw - straw.getMidPoint();
+	  Hep3Vector ddif = aligned_straw_dir - straw.getDirection();
+
+	  straw._c = aligned_straw;
+	  straw._w = aligned_straw_dir;
+
+	} // straw loop
+      } // panel loop
+    } // plane loop
+
+    return ptr;
+  }
 
 } // namespace mu2e

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -83,7 +83,6 @@ namespace mu2e {
 	HepTransform panel_temp = plane_temp * (panel_to_plane * align_panel);
 
 	for(size_t istr=0; istr< StrawId::_nstraws; istr++) {
-          // access strawId from Panel since it performs necessary checks
           Straw &straw = tracker.getStraw(panel.getStraw(istr).id());
 	  
           // how to place the straw in the panel

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -9,109 +9,105 @@
 using namespace std;
 using namespace CLHEP;
 
-namespace mu2e {
+namespace mu2e
+{
 
 
-  Tracker::ptr_t AlignedTrackerMaker::fromFcl() {
+    Tracker::ptr_t AlignedTrackerMaker::fromFcl()
+    {
+        GeomHandle<Tracker> trk_h;
 
-    GeomHandle<Tracker> trk_h;
+        // make shared_ptr to a copy of the GeomHandle Tracker object
+        // made via copy constructor.  AlignedTracker leaves the
+        // nominal Geometry untouched.
+        Tracker::ptr_t ptr = std::make_shared<Tracker>(*trk_h);
 
-    // make shared_ptr to a copy of the GeomHandle Tracker object
-    // made via copy constructor.  AlignedTracker leaves the
-    // nominal Geometry untouched.
-    Tracker::ptr_t  ptr = std::make_shared<Tracker>(*trk_h);
+        if (_config.verbose() > 0) {
+            cout << "AlignedTrackerMaker::fromFcl made Tracker with nStraws = "
+                 << ptr->nStraws() << endl;
+        }
 
-    if ( _config.verbose() > 0 ) {
-      cout << "AlignedTrackerMaker::fromFcl made Tracker with nStraws = "
-	   << ptr->nStraws() << endl;
+        return ptr;
     }
 
-    return ptr;
-  }
+    Tracker::ptr_t AlignedTrackerMaker::fromDb(
+            TrkAlignTracker::cptr_t tatr_p,
+            TrkAlignPlane::cptr_t tapl_p,
+            TrkAlignPanel::cptr_t tapa_p)
+    {
+        // get standard geometry
+        auto align_trk_ptr = fromFcl();
+        Tracker &tracker = *align_trk_ptr;
 
-  Tracker::ptr_t AlignedTrackerMaker::fromDb(
-			  TrkAlignTracker::cptr_t tatr_p,
-			  TrkAlignPlane::cptr_t   tapl_p,
-			  TrkAlignPanel::cptr_t   tapa_p ) {
+        if (_config.verbose() > 0)
+            cout << "AlignedTrackerMaker::fromDb now aligning Tracker " << endl;
+
+        // Align the entire Tracker
+        // the whole tracker has nominal center on 0,0,0
+        auto const &rowtr = tatr_p->rowAt(0);
+        HepTransform align_tracker(rowtr.dx(), rowtr.dy(), rowtr.dz(),
+                                   rowtr.rx(), rowtr.ry(), rowtr.rz());
+
+        for (auto &plane : tracker.getPlanes())
+        {
+            auto const &rowpl = tapl_p->rowAt(plane.id().plane());
+            HepTransform align_plane(rowpl.dx(), rowpl.dy(), rowpl.dz(),
+                                     rowpl.rx(), rowpl.ry(), rowpl.rz());
 
 
+            if (_config.verbose() > 0)
+            {
+                cout << "AlignedTrackerMaker::fromDb plane ID " << plane.id().plane() << " alignment constants: "
+                     << align_plane << endl;
+            }
+            // how to place the plane in the tracker
+            HepTransform plane_to_tracker(0.0, 0.0, plane.origin().z(), 0.0, 0.0, 0.0);
 
-    // get standard geometry
-    auto ptr = fromFcl();
-    Tracker& tracker = *ptr;
+            // make an intermediate multiplication
+            HepTransform plane_temp = align_plane * plane_to_tracker * align_tracker;
 
-    if ( _config.verbose() > 0 ) {
-      cout << "AlignedTrackerMaker::fromDb now aligning Tracker " << endl;
+
+            for (auto panel_p : plane.getPanels())
+            {
+                auto &panel = *panel_p;
+                auto const &rowpa = tapa_p->rowAt(panel.id().uniquePanel());
+                HepTransform align_panel(rowpa.dx(), rowpa.dy(), rowpa.dz(),
+                                         rowpa.rx(), rowpa.ry(), rowpa.rz());
+
+                // how to place the panel in the plane
+                Hep3Vector dv = panel.straw0MidPoint() - plane_to_tracker.displacement();
+                double rz = dv.phi();
+
+                HepTransform panel_to_plane(dv.x(), dv.y(), dv.z(), 0.0, 0.0, rz);
+
+                    // make an intermediate multiplication
+                HepTransform panel_temp = align_panel * panel_to_plane * plane_temp;
+
+                for (size_t istr = 0; istr < StrawId::_nstraws; istr++)
+                {
+                    // access strawId from Panel since it performs necessary checks
+                    Straw &straw = tracker.getStraw(panel.getStraw(istr).id());
+
+                    // how to place the straw in the panel
+                    double dx = straw.getMidPoint().perp()
+                                - panel.straw0MidPoint().perp();
+                    double dz = (straw.getMidPoint()
+                                 - panel.straw0MidPoint()).z();
+
+                    Hep3Vector straw_to_panel = Hep3Vector(dx, 0.0, dz);
+                    Hep3Vector straw_dir = Hep3Vector(0.0, 1.0, 0.0);
+
+                    Hep3Vector aligned_straw = panel_temp * straw_to_panel;
+                    Hep3Vector aligned_straw_dir = panel_temp.rotation() * straw_dir;
+
+                    straw._c = aligned_straw;
+                    straw._w = aligned_straw_dir;
+
+                } // straw loop
+            } // panel loop
+        } // plane loop
+
+        return align_trk_ptr;
     }
-
-    // the whole tracker has nominal center on 0,0,0
-    auto const& rowtr = tatr_p->rowAt(0);
-    HepTransform align_tracker(rowtr.dx(),rowtr.dy(),rowtr.dz(),
-			       rowtr.rx(),rowtr.ry(),rowtr.rz());
-
-    for(auto& plane : tracker.getPlanes()) {
-
-      auto const& rowpl = tapl_p->rowAt( plane.id().plane() );
-      HepTransform align_plane(rowpl.dx(),rowpl.dy(),rowpl.dz(),
-			       rowpl.rx(),rowpl.ry(),rowpl.rz());
-
-
-	if ( _config.verbose() > 0 ) {
-	  cout << "AlignedTrackerMaker::fromDb plane ID " << plane.id().plane() << " alignment constants: " << align_plane << endl;
-	}
-      // how to place the plane in the tracker
-      HepTransform plane_to_tracker(0.0,0.0,plane.origin().z(),0.0,0.0,0.0);
-
-      // make an intermediate multiplication
-      HepTransform plane_temp = align_tracker
-	* plane_to_tracker * align_plane;
-
-      for(auto panel_p : plane.getPanels()) {
-	auto& panel = *panel_p;
-	auto const& rowpa = tapa_p->rowAt( panel.id().uniquePanel() );
-	HepTransform align_panel(rowpa.dx(),rowpa.dy(),rowpa.dz(),
-				 rowpa.rx(),rowpa.ry(),rowpa.rz());
-
-	// how to place the panel in the plane
-	Hep3Vector dv = panel.straw0MidPoint()
-	  - plane_to_tracker.displacement();
-	double rz = dv.phi();
-
-	HepTransform panel_to_plane(dv.x(),dv.y(),dv.z(),0.0,0.0,rz);
-
-	// make an intermediate multiplication
-	HepTransform panel_temp = plane_temp * panel_to_plane * align_panel;
-
-	for(size_t istr=0; istr< StrawId::_nstraws; istr++) {
-	  // need to const cast so we can update geometry - fixme
-	  Straw& straw = const_cast<Straw &>(panel.getStraw(istr));
-
-	  // how to place the straw in the panel
-	  double dx = straw.getMidPoint().perp()
-	    - panel.straw0MidPoint().perp();
-	  double dz = ( straw.getMidPoint()
-			- panel.straw0MidPoint() ).z();
-
-	  Hep3Vector straw_to_panel = Hep3Vector(dx,0.0,dz);
-	  Hep3Vector straw_dir = Hep3Vector(0.0,1.0,0.0);
-
-	  Hep3Vector aligned_straw = panel_temp*straw_to_panel;
-	  Hep3Vector aligned_straw_dir = panel_temp.rotation()*straw_dir;
-
-	  // aligned straw position inserted in the Tracker object
-	  //we need to go the long way to get non-const access
-
-	  Hep3Vector pdif = aligned_straw - straw.getMidPoint();
-	  Hep3Vector ddif = aligned_straw_dir - straw.getDirection();
-
-	  straw._c = aligned_straw;
-	  straw._w = aligned_straw_dir;
-
-	} // straw loop
-      } // panel loop
-    } // plane loop
-
-    return ptr;
-  }
 
 } // namespace mu2e

--- a/TrackerGeom/inc/Tracker.hh
+++ b/TrackerGeom/inc/Tracker.hh
@@ -36,6 +36,7 @@ namespace mu2e {
   class Tracker : public Detector, public ProditionsEntity {
 
         friend class TrackerMaker;
+        friend class AlignedTrackerMaker;
 
   public:
 
@@ -181,6 +182,13 @@ namespace mu2e {
     TubsParams strawWirePlate(StrawId const& id) const;
 
   protected:
+
+      Straw &getStraw(StrawId const& strawId)
+      {
+          // private accessor for non-const Straws
+          // via the const-accessor for getStraw so as to avoid code duplication
+          return const_cast<Straw &>(static_cast<const Tracker &>(*this).getStraw(strawId));
+      }
 
     std::string _name;
 

--- a/TrackerGeom/inc/Tracker.hh
+++ b/TrackerGeom/inc/Tracker.hh
@@ -162,6 +162,10 @@ namespace mu2e {
       return *(_allStraws_p.at(id.asUint16()));
     }
 
+    Straw &getStraw(StrawId const& id) {
+      return const_cast<Straw &>(this->getStraw(id));
+    }
+
     std::array<Straw,StrawId::_nustraws> const& getStraws() const{
       return _allStraws;
     }
@@ -183,12 +187,6 @@ namespace mu2e {
 
   protected:
 
-      Straw &getStraw(StrawId const& strawId)
-      {
-          // private accessor for non-const Straws
-          // via the const-accessor for getStraw so as to avoid code duplication
-          return const_cast<Straw &>(static_cast<const Tracker &>(*this).getStraw(strawId));
-      }
 
     std::string _name;
 


### PR DESCRIPTION
This should hopefully fix #77. All comments are welcome. An explanation of my changes:
- It seems like HepTransforms are being combined (+applied) in an unintended order. **adding in parentheses** in those expressions appears to correct the behaviour. My reasoning is:
    - A HepTransform is a GeneralUtilities object that describes a **rotation (about 0,0,0) followed by a translation** that may be applied to a CLHEP::Hep3Vector
    - C++ expressions are evaluated left-to-right. (further explanation below)
    - a straw position vector held by a panel shifted (using TrkAlignPanel rows) does not change by (dx,dy,dz) of the TrkAlignPanel row, but it does after I make the changes in this PR.
- Applying this logic to the alignment of straw positions, (and following the definition on https://mu2ewiki.fnal.gov/wiki/Alignment)
- (further explanation below)

I have run test jobs to see how the tracking responds to these changes. I applied the misalignments generated by JobConfig/reco/MT_MDC2018.C, which are plane misalignments proposed by Dave in Mu2e-doc-28722-v3. I will attach some quick plots of the de/dm chisq/ndof outputs and detsh branch information if anyone is interested.