### PR TITLE
Fix infinite loop caused by non-const getStraw

### DIFF
--- a/TrackerGeom/inc/Tracker.hh
+++ b/TrackerGeom/inc/Tracker.hh
@@ -163,7 +163,7 @@ namespace mu2e {
     }
 
     Straw &getStraw(StrawId const& id) {
-      return const_cast<Straw &>(this->getStraw(id));
+      return const_cast<Straw &>(*(_allStraws_p.at(id.asUint16())));
     }
 
     std::array<Straw,StrawId::_nustraws> const& getStraws() const{

--- a/TrackerGeom/inc/Tracker.hh
+++ b/TrackerGeom/inc/Tracker.hh
@@ -159,11 +159,11 @@ namespace mu2e {
     }
 
     const Straw& getStraw( const StrawId id) const{
-      return *(_allStraws_p.at(id.asUint16()));
+      return getStrawById(id);
     }
 
     Straw &getStraw(StrawId const& id) {
-      return const_cast<Straw &>(*(_allStraws_p.at(id.asUint16())));
+      return const_cast<Straw &>(getStrawById(id));
     }
 
     std::array<Straw,StrawId::_nustraws> const& getStraws() const{
@@ -286,6 +286,9 @@ namespace mu2e {
     Tracker(Tracker&& other) noexcept; // move constructor
     Tracker& operator=(Tracker&& other) noexcept; // move assignment
 
+    Straw const& getStrawById(StrawId const&id) const {
+        return *(_allStraws_p.at(id.asUint16()));
+    }
   };
 
 } //namespace mu2e


### PR DESCRIPTION
@kutschke @rlcee 

Bugfix as per discussion: const and non-const getStraw getter now both call upon private getter `Tracker::getStrawById(Straw const&id) const`

non-const getter works correctly (misalignment job runs and completes)

Validation now runs without getting stuck in infinite loop: (the job runs without a segfault / inf-recursion stack overflow)

```
(gdb) file mu2e 
Reading symbols from mu2e...done.
(gdb) run -n 10 -c Validation/fcl/ceSimReco.fcl
Starting program: /cvmfs/mu2e.opensciencegrid.org/artexternals/art/v3_04_00/slf7.x86_64.e19.prof/bin/mu2e -n 10 -c Validation/fcl/ceSimReco.fcl
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
%MSG-e duplicateDestination: 

============================================================================ 

    Duplicate name for a MessageLogger Statistics destination: "cout"
    Only original configuration instructions are used. 

============================================================================ 

%MSG
Conditions file: /mu2e/app/users/roneil/RefactorTest/Offline/Mu2eG4/test/conditions_01.txt
Conditions lines: 69  hash: 4488990509537453743
GlobalConstants file: /mu2e/app/users/roneil/RefactorTest/Offline/Mu2eG4/test/globalConstants_01.txt
GlobalConstants lines: 108  hash: 2363920393760819664
 --------------- HepPDT Version 3.04.01 --------------- 
found 534 particles
 --------------- HepPDT Version 3.04.01 --------------- 
found 275 particles
found 3116 particles
[Detaching after fork from child process 31967]
[Detaching after fork from child process 31969]
[Detaching after fork from child process 31971]
[Detaching after fork from child process 31973]
[Detaching after fork from child process 31975]
[Detaching after fork from child process 31977]
[Detaching after fork from child process 31985]
[Detaching after fork from child process 32024]
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_4550_0 ... Done.
CRV sector 0 (R1) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_4550_0
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_1045_1 ... Done.
CRV sector 1 (R2) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_1045_1
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_3040_0 ... Done.
CRV sector 2 (R3) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_3040_0
CRV sector 3 (R4) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_4550_0
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_3200_0 ... Done.
CRV sector 4 (R5) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_3200_0
CRV sector 5 (L1) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_4550_0
CRV sector 6 (L2) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_3200_0
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_6000_1 ... Done.
CRV sector 7 (T1) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_6000_1
CRV sector 8 (T2) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_6000_1
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_6000_0 ... Done.
CRV sector 9 (T3) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_6000_0
CRV sector 10 (T4) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_6000_0
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_5000_1 ... Done.
CRV sector 11 (E1) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_5000_1
CRV sector 12 (E2) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_5000_1
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_6900_1 ... Done.
CRV sector 13 (U) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_6900_1
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_5700_0 ... Done.
CRV sector 14 (D1) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_5700_0
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_2370_1 ... Done.
CRV sector 15 (D2) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_2370_1
CRV sector 16 (D3) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_2370_1
CRV sector 17 (D4) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_5700_0
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_900_1 ... Done.
CRV sector 18 (C1) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_900_1
CRV sector 19 (C2) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_900_1
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_2100_1 ... Done.
CRV sector 20 (C3) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_2100_1
Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_1550_1 ... Done.
CRV sector 21 (C4) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_1550_1

**************************************************************
 Geant4 version Name: geant4-10-05-patch-01 [MT]   (17-April-2019)
                       Copyright : Geant4 Collaboration
                      References : NIM A 506 (2003), 250-303
                                 : IEEE-TNS 53 (2006), 270-278
                                 : NIM A 835 (2016), 186-225
                             WWW : http://geant4.org/
**************************************************************

RootTreeSampler: reading 9212530 entries.  Tree stoppedMuonDumper/stops, file /cvmfs/mu2e.opensciencegrid.org/DataFiles/mergedMuonStops/nts.mu2e.DS-TGTstops.MDC2018a.001002_00000000.root
Geometry file: /mu2e/app/users/roneil/RefactorTest/Offline/Mu2eG4/geom/geom_common_current.txt
Geometry lines: 16781  hash: 10930018386697000684
physicsListDecider invoked with ShieldingM
<<< Geant4 Physics List simulation engine: ShieldingM
<<< Reference Physics List ShieldingM is built

You are setting a new verbose level for Particle HP package.
the new value will be used in whole of the Particle HP package, i.e., models and cross sections for Capture, Elastic, Fission and Inelastic interaction.

 Shielding : threshold between BERT and FTFP is over the interval : 9.5 to 9.9 GeV

/cvmfs/mu2e.opensciencegrid.org/artexternals/g4neutron/v4_5/NULL/G4NDL4.5
@@@ G4ParticleHPInelastic instantiated for particle neutron data directory variable is G4NEUTRONHPDATA pointing to /cvmfs/mu2e.opensciencegrid.org/artexternals/g4neutron/v4_5/NULL/G4NDL4.5/Inelastic
@@@ G4ParticleHPInelasticData instantiated for particle neutron data directory variable is G4NEUTRONHPDATA pointing to /cvmfs/mu2e.opensciencegrid.org/artexternals/g4neutron/v4_5/NULL/G4NDL4.5
=======================================================================
======       Radioactive Decay Physics Parameters              ========
=======================================================================
Max life time                                     1.4427e+06 ps
Internal e- conversion flag                       1
Stored internal conversion coefficients           1
Enable correlated gamma emission                  0
Max 2J for sampling of angular correlations       10
Atomic de-excitation enabled                      1
Auger electron emission enabled                   1
Auger cascade enabled                             1
Check EM cuts disabled for atomic de-excitation   1
Use Bearden atomic level energies                 0
=======================================================================
@@@ G4ParticleHPInelastic instantiated for particle neutron data directory variable is G4NEUTRONHPDATA pointing to /cvmfs/mu2e.opensciencegrid.org/artexternals/g4neutron/v4_5/NULL/G4NDL4.5/Inelastic
registerSensitiveDetectors looking for sd with name: tracker
registerSensitiveDetectors looking for sd with name: virtualdetector
registerSensitiveDetectors looking for sd with name: CRV
registerSensitiveDetectors looking for sd with name: calorimeter
registerSensitiveDetectors looking for sd with name: calorimeterRO
registerSensitiveDetectors looking for sd with name: protonabsorber
Begin processing the 1st record. run: 1 subRun: 0 event: 1 at 06-Feb-2020 17:29:01 CST
06-Feb-2020 17:29:02 CST  Opened output file with pattern "mcs.owner.val-ceSimReco.dsconf.seq.art"
Begin processing the 2nd record. run: 1 subRun: 0 event: 2 at 06-Feb-2020 17:29:07 CST
Begin processing the 3rd record. run: 1 subRun: 0 event: 3 at 06-Feb-2020 17:29:07 CST
Begin processing the 5th record. run: 1 subRun: 0 event: 5 at 06-Feb-2020 17:29:08 CST
Begin processing the 9th record. run: 1 subRun: 0 event: 9 at 06-Feb-2020 17:29:09 CST
%MSG-i Summary:  GenEventCounter:genCounter@EndSubRun 06-Feb-2020 17:29:09 CST  run: 1 subRun: 0
Creating GenEventCount record: 10 events for run: 1 subRun: 0

%MSG
%MSG-i INFO:  GenEventCountReader:genCountLogger@EndSubRun  06-Feb-2020 17:29:09 CST run: 1 subRun: 0
GenEventCount: 10 events in run: 1 subRun: 0

%MSG
  Event processing inside ProcessOneEvent time summary
  User=0.3s Real=0.504482338s Sys=0s
at endRun: numExcludedEvents = 0
06-Feb-2020 17:29:10 CST  Closed output file "mcs.owner.val-ceSimReco.dsconf.seq.art"
SUMMARY CrvCoincidence    0 / 5 events satisfied coincidence requirements
SUMMARY CrvCoincidence    Total dead time: 0 / 6250 = 0%   using time window 500 ns ... 1750 ns
%MSG-i Summary:  FilterStatusG4:g4status@EndJob 06-Feb-2020 17:29:10 CST  ModuleEndJob
FilterStatusG4_module summary:
    10 events with status 0

%MSG
%MSG-i Summary:  GenEventCountReader:genCountLogger@EndJob  06-Feb-2020 17:29:10 CST ModuleEndJob
GenEventCount total: 10 events in 1 SubRuns

%MSG

===============================================================================================================================================================
TimeTracker printout (sec)                                                       Min           Avg           Max         Median          RMS         nEvts   
===============================================================================================================================================================
Full event                                                                   0.00964217     0.231946      0.600181      0.177856      0.212001        10     
---------------------------------------------------------------------------------------------------------------------------------------------------------------
source:EmptyEvent(read)                                                      9.4304e-05    0.000157261   0.000288881   0.000167187   5.74485e-05      10     
TriggerPath:generate:StoppedParticleReactionGun                              2.0861e-05    5.14989e-05   0.000277765   2.6261e-05    7.55813e-05      10     
TriggerPath:genCounter:GenEventCounter                                        9.62e-07     1.5318e-06     2.131e-06    1.4505e-06    4.21168e-07      10     
TriggerPath:g4run:Mu2eG4                                                     0.00808518     0.0507356     0.126535      0.0266464     0.0445107       10     
TriggerPath:g4status:FilterStatusG4                                          1.1285e-05    3.34892e-05   0.000186175   1.5763e-05    5.10946e-05      10     
TriggerPath:protonTimeMap:GenerateProtonTimes                                2.7058e-05    6.47564e-05   0.000285642   4.09195e-05   7.40625e-05      10     
TriggerPath:muonTimeMap:GenerateMuonLife                                     1.9914e-05    3.48123e-05   0.000134164   2.40665e-05   3.31861e-05      10     
TriggerPath:cosmicTimeMap:GenerateCosmicTimes                                2.9629e-05    5.77457e-05   0.00025631    3.48565e-05   6.64527e-05      10     
TriggerPath:EWMProducer:EventWindowMarkerProducer                            1.1125e-05    1.74016e-05   6.0935e-05    1.30105e-05   1.45379e-05      10     
TriggerPath:makeSGS:MakeStrawGasSteps                                        3.5155e-05    0.000323168   0.000780608   0.000319483   0.000229595      10     
TriggerPath:makeSD:StrawDigisFromStrawGasSteps                               6.3236e-05    0.00826538     0.0205473    0.00919077     0.0073051       10     
TriggerPath:DigiFilter:StrawDigiMCFilter                                     1.9233e-05    5.05286e-05   0.000150442   2.91365e-05   4.60727e-05      10     
[art]:TriggerResults:TriggerResultInserter                                    1.086e-05    1.76009e-05    4.399e-05      1.6e-05     9.3057e-06       10     
end_path:genCountLogger:GenEventCountReader                                   1.594e-06    3.7589e-06    1.0081e-05    3.3515e-06    2.39155e-06      10     
end_path:digiCompressionCheck:CompressDigiMCsCheck                           4.1022e-05    0.00014226    0.000339013   0.000136733   9.66075e-05      10     
end_path:Output:RootOutput                                                    1.854e-06    3.3685e-06     5.165e-06     3.301e-06    1.13966e-06      10     
end_path:Output:RootOutput(write)                                            0.000337562   0.00200737    0.00562217    0.00218109    0.00155018       10     
TriggerPath:CaloShowerStepFromStepPt:CaloShowerStepFromStepPt                 0.0234779     0.0274332     0.0308702     0.0275465    0.00253813        5     
TriggerPath:CaloShowerStepROFromShowerStep:CaloShowerStepROFromShowerStep    0.000105048   0.00022817    0.000617927   0.00013823    0.000195357       5     
TriggerPath:CaloDigiFromShower:CaloDigiFromShower                             0.0133231     0.0141571     0.0161989     0.0136536    0.00105356        5     
TriggerPath:CrvPhotons:CrvPhotonGenerator                                    7.0145e-05    0.000115794   0.00028644    7.1897e-05    8.53955e-05       5     
TriggerPath:CrvSiPMCharges:CrvSiPMChargeGenerator                            0.00791623    0.00835411    0.00938022    0.00808743    0.000528907       5     
TriggerPath:CrvWaveforms:CrvWaveformsGenerator                               0.00466162    0.00491695    0.00523488    0.00484309    0.000198959       5     
TriggerPath:CrvDigi:CrvDigitizer                                             2.5721e-05    4.39544e-05   0.000110109   2.8779e-05    3.31098e-05       5     
TriggerPath:compressDigiMCs:CompressDigiMCs                                  0.000681331   0.00116604    0.00283887    0.000798743   0.000838432       5     
TriggerPath:protonBunchIntensity:ProtonBunchIntensityFlat                    1.5243e-05    1.9203e-05    2.6323e-05    1.6435e-05    4.18453e-06       5     
TriggerPath:CaloRecoDigiFromDigi:CaloRecoDigiFromDigi                        0.000212398   0.000573094    0.0014582    0.000388142   0.00045177        5     
TriggerPath:CaloCrystalHitFromHit:CaloCrystalHitFromHit                      4.1978e-05    0.000109615   0.000367738   4.5711e-05    0.000129075       5     
TriggerPath:CaloProtoClusterFromCrystalHit:CaloProtoClusterFromCrystalHit    5.6907e-05    0.000122176   0.000373684    6.02e-05     0.00012577        5     
TriggerPath:CaloClusterFromProtoCluster:CaloClusterFromProtoCluster          3.7914e-05    0.00013641    0.000399835   4.0059e-05    0.000140321       5     
TriggerPath:makeSH:StrawHitReco                                              6.2562e-05    0.000957532    0.0044957    7.0413e-05    0.00176911        5     
TriggerPath:makePH:CombineStrawHits                                          2.6164e-05    0.000105295   0.000406716   3.0694e-05    0.00015073        5     
TriggerPath:FlagBkgHits:FlagBkgHits                                          6.3026e-05    0.000204193   0.000734382   7.1852e-05    0.000265183       5     
TriggerPath:TimeClusterFinderDe:TimeClusterFinder                            6.4011e-05    0.000207594   0.000685167    8.565e-05    0.000239802       5     
TriggerPath:HelixFinderDe:RobustHelixFinder                                  0.000106278   0.000330234   0.00107387    0.000124693   0.00037474        5     
TriggerPath:CalTimePeakFinder:CalTimePeakFinder                              3.0655e-05    5.38288e-05   0.000144132   3.1116e-05    4.51556e-05       5     
TriggerPath:CalHelixFinderDe:CalHelixFinder                                  0.000204783   0.00477843     0.0228017    0.000292727   0.00901184        5     
TriggerPath:MHDeM:MergeHelices                                               0.000162426   0.000239376   0.000481267   0.000180117   0.00012182        5     
TriggerPath:MHDeP:MergeHelices                                                3.821e-05    4.05946e-05    4.613e-05    4.0076e-05    2.89918e-06       5     
TriggerPath:KSFDeM:KalSeedFit                                                0.00110626    0.00374041     0.0125377    0.00153109    0.00442233        5     
TriggerPath:KSFDeP:KalSeedFit                                                2.7925e-05    0.000321568   0.00148368    3.1335e-05    0.00058106        5     
TriggerPath:KFFDeM:KalFinalFit                                                0.121081      0.266309      0.487997      0.285839      0.133197         5     
TriggerPath:KFFDeP:KalFinalFit                                                9.304e-05    0.000294403   0.00103366    0.00010668    0.000369846       5     
TriggerPath:CrvRecoPulses:CrvRecoPulsesFinder                                 2.469e-05    4.99156e-05   0.000138639   3.0028e-05    4.44309e-05       5     
TriggerPath:CrvCoincidence:CrvCoincidenceCheck                               2.9184e-05    5.53234e-05   0.000146213   3.3376e-05    4.55223e-05       5     
TriggerPath:CrvCoincidenceClusterFinder:CrvCoincidenceClusterFinder          2.4449e-05    5.52068e-05   0.000155946    2.833e-05    5.06825e-05       5     
TriggerPath:CaloMCFix:FixCaloShowerStepPtrs                                  0.00030609    0.000478186   0.000715001   0.000446161   0.000138648       5     
TriggerPath:FindMCPrimary:FindMCPrimary                                      5.8116e-05    9.52532e-05   0.000210262   6.6465e-05    5.79208e-05       5     
TriggerPath:CrvCoincidenceClusterMatchMC:CrvCoincidenceClusterMatchMC        4.9398e-05    7.54268e-05   0.000157766   5.5783e-05    4.12996e-05       5     
TriggerPath:SelectRecoMC:SelectRecoMC                                        0.000609364   0.00104964    0.00259618    0.000689074   0.000773839       5     
TriggerPath:compressRecoMCs:CompressDigiMCs                                  0.00069583    0.000859394   0.00110589    0.00083329    0.00014942        5     
TriggerPath:RecoFilter:RecoMomFilter                                         1.4853e-05    2.76412e-05   7.5399e-05    1.5843e-05     2.389e-05        5     
===============================================================================================================================================================

......... (truncated) ...........

Art has completed and will exit with status 0.
[Inferior 1 (process 31726) exited normally]
(gdb) 


```
