### PR TITLE
Use Proditions Tracker in CosmicReco

### DIFF
--- a/CosmicReco/src/CosmicAnalyzer_module.cc
+++ b/CosmicReco/src/CosmicAnalyzer_module.cc
@@ -49,9 +49,9 @@
 #include "TLatex.h"
 #include "TGraph.h"
 #include "TProfile.h"
-using namespace std; 
+using namespace std;
 
-namespace mu2e 
+namespace mu2e
 {
   class CosmicAnalyzer : public art::EDAnalyzer {
     public:
@@ -74,8 +74,8 @@ namespace mu2e
       virtual void beginRun(const art::Run& r) override;
       virtual void analyze(const art::Event& e) override;
       virtual void endJob() override;
-    private: 
-      
+    private:
+
       Config _conf;
 
       int  _diag;
@@ -92,7 +92,7 @@ namespace mu2e
       const StrawDigiMCCollection* _mcdigis;
       CosmicTrackMCInfo trueinfo;
 
-    
+
       	//TTree Info:
       TTree* _cosmic_analysis;
 
@@ -118,13 +118,13 @@ namespace mu2e
       TH2F* _seedA0_v_seedB1;
       TH2F* _seedB1_v_seedA1;
       TH2F* _seedA0_v_seedB0;
-    
+
     //True MC paramets in global coords:
       TH1F* _truea1XYZ;
       TH1F* _trueb1XYZ;
       TH1F* _truea0XYZ;
       TH1F* _trueb0XYZ;
-      
+
       //Angles Info:
       TH1F* _mc_phi_angle;
       TH1F* _reco_phi_angle;
@@ -196,7 +196,7 @@ namespace mu2e
       TH1F* _A1MinuitMCDiff;
       TH1F* _B0MinuitMCDiff;
       TH1F* _B1MinuitMCDiff;
-      
+
 
       	//Drift diags:
       TH1F* _FullFitEndDOCAs;
@@ -219,7 +219,7 @@ namespace mu2e
       TH2F* _seedDeltaB1_v_minuitB1;
 
       // add event id
-      Int_t _evt; 
+      Int_t _evt;
 
       //Numbers:
       Int_t _nsh, _nch; // # associated straw hits / event
@@ -230,10 +230,10 @@ namespace mu2e
       Int_t _n_planes; // # stations
       int n_analyze =0;
       Float_t _hit_time, _hit_drift_time, _cluster_time, _dt;
-      const Tracker* tracker;
+
       //Flags:
       Bool_t _StraightTrackInit, _StraightTrackConverged, _StraightTrackOK, _hitsOK;
-      Int_t _strawid; 
+      Int_t _strawid;
       vector<ComboHitInfoMC> _chinfomc;
       CosmicTrackMCInfo FitMC(const StrawDigiMCCollection*& _mcdigis);
       CosmicTrackMCInfo FillDriftMC(ComboHit const& chit, double reco_ambig, CosmicTrackMCInfo info, const Tracker* tracker);
@@ -250,7 +250,7 @@ namespace mu2e
 	_mcdigistag (conf().mcdigistag()),
 	_toff (conf().toff())
     {
-      
+
 	if(_mcdiag){
 	      for (auto const& tag : conf().toff().inputs()) {
 		consumes<SimParticleTimeMap>(tag);
@@ -262,10 +262,10 @@ namespace mu2e
 
 
     void CosmicAnalyzer::beginJob() {
-      
+
       // create diagnostics if requested...
       if(_diag > 0){
-	if(_mcdiag) { 
+	if(_mcdiag) {
 		outputfile.open("CosmicAnalysis.csv");
 	}
 	art::ServiceHandle<art::TFileService> tfs;
@@ -280,7 +280,7 @@ namespace mu2e
         _cosmic_analysis->Branch("PanelsCrossedInEvent", &_n_panels, "PanelsCrossedInEvent/I");
         _cosmic_analysis->Branch("PlanesCrossedInEvent", &_n_planes, "PlanesCrossedInEvent/I");
         _cosmic_analysis->Branch("StatonsCrossedInEvent", &_n_stations, "StationsCrossedInEvent/I");
-        _cosmic_analysis->Branch("TimeClustersInEvent", &_ntc, "TimeClusterInEvent/I"); 
+        _cosmic_analysis->Branch("TimeClustersInEvent", &_ntc, "TimeClusterInEvent/I");
         _cosmic_analysis->Branch("hit_time", &_hit_time, "hit_time/F");
         _cosmic_analysis->Branch("hit_drit_time", &_hit_drift_time, "hit_drift_time/F");
         _cosmic_analysis->Branch("cluster_time", &_cluster_time, "cluster_time/F");
@@ -289,28 +289,28 @@ namespace mu2e
         _cosmic_analysis->Branch("StraightTrackInit",&_StraightTrackInit,"StraightTrackInit/B");
         _cosmic_analysis->Branch("StraightTrackOK",&_StraightTrackOK,"StraightTrackOK/B");
         _cosmic_analysis->Branch("StraightTrackConverged",&_StraightTrackConverged,"StraightTrackConverged/B");
-        
-	
+
+
 	//--------------------------------Truth----------------------------------------//
 	if(_mcdiag ){
-		
+
 		_truea0XYZ = tfs->make<TH1F>("True Track Parameter A0 XYZ","True Track Parameter A0 XYZ " ,50,-10000, 10000);
 		_truea0XYZ->GetXaxis()->SetTitle("Track Parameter A0 XYZ");
 		_truea0XYZ->SetStats();
-		
+
 		_trueb0XYZ = tfs->make<TH1F>("True Track Parameter B0 XYZ","True Track Parameter B0 XYZ " ,50,-5000, 5000);
 		_trueb0XYZ->GetXaxis()->SetTitle("Track Parameter B0 XYZ");
 		_trueb0XYZ->SetStats();
-		
+
 		_truea1XYZ = tfs->make<TH1F>("True Track Parameter A1 XYZ ","True Track Parameter A1 XYZ" ,50,-5,5);
 		_truea1XYZ->GetXaxis()->SetTitle("Track Parameter A1 XYZ");
 		_truea1XYZ->SetStats();
-		
+
 		_trueb1XYZ = tfs->make<TH1F>("True Track Parameter B1 XYZ ","True Track Parameter B1 XYZ " ,50,-5,5);
 		_trueb1XYZ->GetXaxis()->SetTitle("Track Parameter B1");
 		_trueb1XYZ->SetStats();
 
-		
+
 		_mc_phi_angle = tfs->make<TH1F>("#phi_{true, fit}","#phi_{true, fit}" ,100,-3.141529,3.141529);
 		_mc_phi_angle->GetXaxis()->SetTitle("#phi_{true, fit} [rad]");
 
@@ -332,31 +332,31 @@ namespace mu2e
 		_A0pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull A_{0} v #theta_{true,fit}  ","Seed Parameter Pull A_{0} v #theta_{true,fit} ",100,0,3.141529,-200,200);
 		_A0pull_v_theta_true->GetXaxis()->SetTitle("#theta_{true}");
 		_A0pull_v_theta_true->GetYaxis()->SetTitle("Parameter Pull A_{0}");
-		
+
 		_B0pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull B_{0} v #theta_{true,fit}  ","Seed Parameter Pull B_{0} v #theta_{true,fit} ",100,0,3.141529,-200,200);
 		_B0pull_v_theta_true->GetXaxis()->SetTitle("#theta_{true}");
 		_B0pull_v_theta_true->GetYaxis()->SetTitle("Parameter Pull B_{0}");
-		
+
 		_A1pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull A_{1} v #theta_{true,fit}  ","Seed Parameter Pull A_{1} v #theta_{true,fit} ",100,0,3.141529,-10,10);
 		_A1pull_v_theta_true->GetXaxis()->SetTitle("#theta_{true}");
 		_A1pull_v_theta_true->GetYaxis()->SetTitle("Parameter Pull A_{1}");
-		
+
 		_B1pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull B_{1} v #theta_{true,fit}  ","Seed Parameter Pull B_{1} v #theta_{true,fit} ",100,0,3.141529,-10,10);
 		_B1pull_v_theta_true->GetXaxis()->SetTitle("#theta_{true}");
 		_B1pull_v_theta_true->GetYaxis()->SetTitle("Parameter Pull B_{1}");
-		
+
 		_A0SeedMCDiff = tfs->make<TH1F>("A^{seed}_{0}- A^{MC}_{0} ","A^{seed}_{0}- A^{MC}_{0}" ,100,-100, 100);
 		_A0SeedMCDiff->GetXaxis()->SetTitle("#Delta #A_{0}");
 		_A0SeedMCDiff->SetStats();
-		
+
 		_A1SeedMCDiff = tfs->make<TH1F>("A^{seed}_{1} - A^{MC}_{1}","A^{seed}_{1} - A^{MC}_{1}" ,100,-0.5 , 0.5);
 		_A1SeedMCDiff->GetXaxis()->SetTitle("#Delta A_{1}");
 		_A1SeedMCDiff->SetStats();
-		
+
 		_B0SeedMCDiff = tfs->make<TH1F>("B^{seed}_{0} - B^{seed}_{0}" ,"B^{seed}_{0} - B^{MC}_{0}",100,-100, 100);
 		_B0SeedMCDiff->GetXaxis()->SetTitle("#Delta B^{seed}_{0}");
 		_B0SeedMCDiff->SetStats();
-		
+
 		_B1SeedMCDiff = tfs->make<TH1F>("B^{seed}_{1} - B^{seed}_{1}", "B^{seed}_{1} - B^{seed}_{1}" ,100,-0.5, 0.5);
 		_B1SeedMCDiff->GetXaxis()->SetTitle("#Delta B^{seed}_{1}");
 		_B1SeedMCDiff->SetStats();
@@ -364,15 +364,15 @@ namespace mu2e
 		_A0MinuitMCDiff = tfs->make<TH1F>(" A0_{Minuit} - A0_{MC} "," A0_{Minuit} - A0_{Minuit}" ,100,-100,100);
 		_A0MinuitMCDiff->GetXaxis()->SetTitle("#Delta A0 [mm]");
 		_A0MinuitMCDiff->SetStats();
-		
+
 		_A1MinuitMCDiff = tfs->make<TH1F>(" A1_{Minuit} - A1_{MC} "," A1_{Minuit} - A1_{MC}" ,100,-0.5,0.5);
 		_A1MinuitMCDiff->GetXaxis()->SetTitle("#Delta A1 ");
 		_A1MinuitMCDiff->SetStats();
-		
+
 		_B0MinuitMCDiff = tfs->make<TH1F>(" B0_{Minuit} - B0_{MC} "," B0_{Minuit} - B0_{MC}" ,100,-100,100);
 		_B0MinuitMCDiff->GetXaxis()->SetTitle("#Delta B0 [mm]");
 		_B0MinuitMCDiff->SetStats();
-		
+
 		_B1MinuitMCDiff = tfs->make<TH1F>(" B1_{Minuit} - B1_{MC}  "," B1_{Minuit} - B1_{MC}" ,100,-0.5,0.5);
 		_B1MinuitMCDiff->GetXaxis()->SetTitle("#Delta B1 ");
 		_B1MinuitMCDiff->SetStats();
@@ -396,22 +396,22 @@ namespace mu2e
 	_reco_phi_angle = tfs->make<TH1F>("#phi Angle of Reconstructred Track","#phi_{reco} Angle of Tracl " ,20,0,3.141529);
 	_reco_phi_angle->GetXaxis()->SetTitle("#phi_{reco} [rad]");
 	_reco_phi_angle->SetStats();
-	
+
 
         //------------------------------------------Seed---------------------------- --------------//
 
 	_seed_a0 = tfs->make<TH1F>("Seed Track Parameter A0 ","Seed Track Parameter A0 " ,50,-2000, 2000);
 	_seed_a0->GetXaxis()->SetTitle("Seed Track Parameter A0");
 	_seed_a0->SetStats();
-	
+
 	_seed_b0 = tfs->make<TH1F>("Seed  Track Parameter B0 ","Seed Track Parameter B0  " ,50,-2000, 2000);
 	_seed_b0->GetXaxis()->SetTitle("Seed Track Parameter B0");
 	_seed_b0->SetStats();
-	
+
 	_seed_a1 = tfs->make<TH1F>("Seed Track Parameter A1  ","Seed vTrack Parameter A1 " ,50,-1,1);
 	_seed_a1->GetXaxis()->SetTitle("Seed Track Parameter A1");
 	_seed_a1->SetStats();
-	
+
 	_seed_b1 = tfs->make<TH1F>("Seed Track Parameter B1  ","Seed Track Parameter B1  " ,50,-1,1);
 	_seed_b1->GetXaxis()->SetTitle("Seed Track Parameter B1");
 	_seed_b1->SetStats();
@@ -419,15 +419,15 @@ namespace mu2e
 	_seed_a0XYZ = tfs->make<TH1F>("Seed Track Parameter A0 XYZ","Seed Track Parameter A0 XYZ " ,50,-10000, 10000);
 	_seed_a0XYZ->GetXaxis()->SetTitle("Seed Track Parameter A0 XYZ");
 	_seed_a0XYZ->SetStats();
-	
+
 	_seed_b0XYZ = tfs->make<TH1F>("Seedf Track Parameter B0 XYZ","Seed Track Parameter B0 XYZ " ,50,-5000, 5000);
 	_seed_b0XYZ->GetXaxis()->SetTitle("Seed Track Parameter B0 XYZ");
 	_seed_b0XYZ->SetStats();
-	
+
 	_seed_a1XYZ = tfs->make<TH1F>("Seedf Track Parameter A1 XYZ ","Seed Track Parameter A1 XYZ" ,50,-5,5);
 	_seed_a1XYZ->GetXaxis()->SetTitle("Seed Track Parameter A1 XYZ");
 	_seed_a1XYZ->SetStats();
-	
+
 	_seed_b1XYZ = tfs->make<TH1F>("Seed Track Parameter B1 XYZ ","Seed Track Parameter B1 XYZ " ,50,-5,5);
 	_seed_b1XYZ->GetXaxis()->SetTitle("Seed Track Parameter B1");
 	_seed_b1XYZ->SetStats();
@@ -435,7 +435,7 @@ namespace mu2e
 	_niters  = tfs->make<TH1F>("Seed Number of Iterations Until Seed Fit Converged  ","Number of Iterations Until Seed Fit Converged " ,100,0, 100);
 	_niters->GetXaxis()->SetTitle("Seed Number of Iterations Until Seed Fit Converged");
 	_niters->SetStats();
-	
+
 	_seedA0_v_seedA1 = tfs->make<TH2F>("Seed A_{0} v A_{1}", "Seed A_{0} v A_{1}", 50, -0.2, 0.2, 50, -1500, 1500);
 	_seedA0_v_seedA1->GetXaxis()->SetTitle("A_{1}");
 	_seedA0_v_seedA1->GetYaxis()->SetTitle("A_{0}");
@@ -443,19 +443,19 @@ namespace mu2e
 	_seedB0_v_seedB1 = tfs->make<TH2F>("Seed B_{0} v B_{1}", "Seed B_{0} v B_{1}", 50, -0.2, 0.2, 50, -1500, 1500);
 	_seedB0_v_seedB1->GetXaxis()->SetTitle("B_{1}");
 	_seedB0_v_seedB1->GetYaxis()->SetTitle("B_{0}");
-	
+
 	_seedA0_v_seedB1 = tfs->make<TH2F>("Seed A_{0} v B_{1}", "Seed A_{0} v B_{1}", 50, -0.2, 0.2, 50, -1500, 1500);
 	_seedA0_v_seedB1->GetXaxis()->SetTitle("B_{1}");
 	_seedA0_v_seedB1->GetYaxis()->SetTitle("A_{0");
-	
+
 	_seedA0_v_seedB0 = tfs->make<TH2F>("Seed B_{0} v A_{0}", "Seed B_{0} v A_{0}", 50, -1500,1500, 50, -2000, 2000);
 	_seedA0_v_seedB0->GetXaxis()->SetTitle("B_{0}");
 	_seedA0_v_seedB0->GetYaxis()->SetTitle("A_{0} ");
-	
+
 	_seedB1_v_seedA1 = tfs->make<TH2F>("Seed B_{1} v A_{1}", "Seed B_{1} v A_{1}", 100, -0.2,0.2, 100, -0.2,0.2);
 	_seedB1_v_seedA1->GetXaxis()->SetTitle("B_{1}");
 	_seedB1_v_seedA1->GetYaxis()->SetTitle("A_{1} ");
-	
+
 	_Seed_Cov_A0 = tfs->make<TH1F>("#sigma_{A_{0}}", "#sigma_{A_{0}}" ,100,0, 100);
 	_Seed_Cov_A0->GetXaxis()->SetTitle("#sigma_{A_{0}}");
 
@@ -464,10 +464,10 @@ namespace mu2e
 
 	_Seed_Cov_A1 = tfs->make<TH1F>("Seed #sigma_{A_{1}}", "Seed #sigma_{A_{1}}" ,100,0, 0.5);
 	_Seed_Cov_A1->GetXaxis()->SetTitle("#sigma_{A_{1}}");
-	
+
 	_Seed_Cov_B0 = tfs->make<TH1F>("Seed #sigma_{B_{0}}", "Seed #sigma_{B_{0}}" ,100,0, 100);
 	_Seed_Cov_B0->GetXaxis()->SetTitle("#sigma_{B_{0}}");
-		
+
 	_Seed_Cov_B1 = tfs->make<TH1F>("Seed #sigma_{B_{1}}", "Seed #sigma_{B_{1}}" ,100,0, 0.5);
 	_Seed_Cov_B1->GetXaxis()->SetTitle("#sigma_{B_{1}}");
 
@@ -476,35 +476,35 @@ namespace mu2e
 
 	_chisq_ndf_plot_init = tfs->make<TH1F>("Seed Init ChiSq/NDF","Seed Init ChiSq/NDF" ,100,0, 10);
 	_chisq_ndf_plot_init->GetXaxis()->SetTitle("Init. #Chi^{2}/N");
-	
+
 	_chisq_ndf_plot_final = tfs->make<TH1F>("Seed Final ChiSq/NDF","Seed Final ChiSq/NDF" ,100,0,10);
 	_chisq_ndf_plot_final->GetXaxis()->SetTitle("Final #Chi^{2}/N");
-	
+
 	_chisq_ndf_plot_finalX = tfs->make<TH1F>("Seed Final ChiSq/NDF X''","Seed Final ChiSq/NDF X''" ,100,0,10);
 	_chisq_ndf_plot_finalX->GetXaxis()->SetTitle("Final X '' #Chi^{2}/N");
-	
+
         _chisq_ndf_plot_finalY = tfs->make<TH1F>("Seed Final ChiSq/NDF Y''","Seed Final ChiSq/NDF Y''" ,100,0,10);
 	_chisq_ndf_plot_finalY->GetXaxis()->SetTitle("Final Y '' #Chi^{2}/N");
-	
+
 	_chisq_ndf_plot_initX = tfs->make<TH1F>("Seed Init Chi2/NDF  X''","Seed Init Chi2/NDF X''" ,100,0,10);
 	_chisq_ndf_plot_initX->GetXaxis()->SetTitle("Initial X '' #Chi^{2}/N");
-	
+
         _chisq_ndf_plot_initY = tfs->make<TH1F>("Seed Init Chi2/NDF Y''","initial chisq_ndf_plot Y''" ,100,0,10);
 	_chisq_ndf_plot_initY->GetXaxis()->SetTitle("Initial Y '' #Chi^{2}/N");
-	
+
 	_change_chisq_ndf_plot_X = tfs->make<TH1F>("Seed Total Change in Chisq/ ndf X''","Total Change in Chisq/ ndf X''" ,50,-10,20);
 	_change_chisq_ndf_plot_X->GetXaxis()->SetTitle("Initial X '' #Chi^{2}/N");
-	
+
 	_change_chisq_ndf_plot_Y = tfs->make<TH1F>("Seed Total Change in Chisq/ ndf Y''","Seed Total Change in Chisq/ ndf Y''" ,50,-10,20);
 	_change_chisq_ndf_plot_Y->GetXaxis()->SetTitle("Initial Y '' #Chi^{2}/N");
-	
+
 	_change_chisq_ndf_plot_Total = tfs->make<TH1F>("Seed Total Change in #Chi^{2}/ ndf","Seed Total Change in #Chi^{2}/ ndf" ,50,-5,20);
 	_change_chisq_ndf_plot_Total->GetXaxis()->SetTitle("Total Change in #Chi^{2}/ndf");
-	
+
         _total_residualsX_init = tfs->make<TH1F>("Seedf Initial Residuals X'' ","Initial Residuals X'' " ,50,-1000,1000);
 	_total_residualsX_init->GetXaxis()->SetTitle("Initial Residual X'' [mm]");
 	_total_residualsX_init->SetStats();
-	
+
 	_total_residualsY_init = tfs->make<TH1F>("Seed Initial Residuals Y''","Seed Initial Residuals Y'' " ,50,-1000,1000);
 	_total_residualsY_init->GetXaxis()->SetTitle("Initial Residual Y'' [mm]");
 	_total_residualsY_init->SetStats();
@@ -512,60 +512,60 @@ namespace mu2e
 	_total_pullsX_init = tfs->make<TH1F>("Seed Initial PullSeed  X","Initial Pull X''" ,200,-50, 50);
 	_total_pullsX_init->GetXaxis()->SetTitle("Pull X");
 	_total_pullsX_init->SetStats();
-	
+
 	_total_pullsY_init = tfs->make<TH1F>("Seed Initial Pull Y''","Seed Initial Pull Y''" ,200,-50, 50);
 	_total_pullsY_init->GetXaxis()->SetTitle("Initial Pull Y");
 	_total_pullsY_init->SetStats();
-       
+
 	_total_residualsX_final = tfs->make<TH1F>("Seed Final Residuals X''  ","Seed Final Residuals X''#chi^{2}/dof all  " ,100,-200,200);
 	_total_residualsX_final->GetXaxis()->SetTitle("Residual X'' [mm]");
 	_total_residualsX_final->SetStats();
-	
+
 	_total_residualsY_final = tfs->make<TH1F>("Seed Final Residuals Y'' ","Seed Final Residuals Y'' #chi^{2}/dof all " ,100,-200,200);
 	_total_residualsY_final->GetXaxis()->SetTitle("Final Residual Y'' [mm]");
 	_total_residualsY_final->SetStats();
-	
+
 	_total_pullsX_final = tfs->make<TH1F>("Seed Final Pull X'' #chi^{2}/dof alSeed l ","Seed Final Pull X''#chi^{2}/dof all " ,50,-2, 2);
 	_total_pullsX_final->GetXaxis()->SetTitle("Final Pull X''");
-	
-	
+
+
 	_total_pullsY_final = tfs->make<TH1F>("Seed Final Pull Y''#chi^{2}/dof all ","Seed Final Pull Y''#chi^{2}/dof all " ,50,-2, 2);
 	_total_pullsY_final->GetXaxis()->SetTitle("Final Pull Y''");
-	
+
 	_FinalErrX = tfs->make<TH1F>("Seed Final Errors in X''","Seed Final Errors in X'' " ,50,0, 100);
 	_FinalErrX->GetXaxis()->SetTitle("#sigma_{X''} [mm]");
 	_FinalErrX->SetStats();
-	
+
 	_FinalErrY = tfs->make<TH1F>("Seed Final Errors in Y''","Seed Final Errors in Y'' " ,50,0, 100);
 	_FinalErrY->GetXaxis()->SetTitle("#sigma_{Y''} [mm]");
 	_FinalErrY->SetStats();
-	
+
 	_InitErrX = tfs->make<TH1F>("Seed Initial Errors in X''","Seed Initial Errors in X'' " ,50,0, 100);
 	_InitErrX->GetXaxis()->SetTitle("#sigma_{X''} [mm]");
 	_InitErrX->SetStats();
-	
+
 	_InitErrY = tfs->make<TH1F>("Seed Initial Errors in Y''","Seed Initial Errors in Y'' " ,50,0, 100);
 	_InitErrY->GetXaxis()->SetTitle("#sigma_{Y''} [mm]");
 	_InitErrY->SetStats();
-	
+
 	_FinalErrTot = tfs->make<TH1F>("Seed Final Errors Total","Seed Final Errors Total " ,50,0, 100);
 	_FinalErrTot->GetXaxis()->SetTitle("#sigma_{Y''} [mm]");
 	_FinalErrTot->SetStats();
-	
+
 	_InitErrTot = tfs->make<TH1F>("Seed Initial Errors Total","Seed Initial Errors Total " ,50,0, 100);
 	_InitErrTot->GetXaxis()->SetTitle("#sigma_{X''} [mm]");
 	_InitErrTot->SetStats();
 
 	//------------------------Straw Fit-------------------------------//
-	
+
 	_total_residualsX_Minuit = tfs->make<TH1F>("Minuit Residuals X''  ","Minuit Final Residuals X'' " ,100,-200,200);
 	_total_residualsX_Minuit->GetXaxis()->SetTitle("Minuit Res. X'' [mm]");
 	_total_residualsX_Minuit->SetStats();
-	
+
 	_total_residualsY_Minuit = tfs->make<TH1F>("Minuit Residuals Y'' ","Minuit Residuals Y''  " ,100,-200,200);
 	_total_residualsY_Minuit->GetXaxis()->SetTitle("Minuit Res. Y'' [mm]");
 	_total_residualsY_Minuit->SetStats();
-	
+
 	_FullFitEndDOCAs = tfs->make<TH1F>("Final DOCAs ","Final DOCAs" ,50,0,10);
 	_FullFitEndDOCAs->GetXaxis()->SetTitle("Final DOCAs [mm]");
 	_FullFitEndDOCAs->SetStats();
@@ -573,7 +573,7 @@ namespace mu2e
 	_GaussianEndDOCAs = tfs->make<TH1F>("Gaussian DOCAs ","Gaussian DOCAs" ,50,0,10);
 	_GaussianEndDOCAs->GetXaxis()->SetTitle("Gaussian DOCAs [mm]");
 	_GaussianEndDOCAs->SetStats();
-	
+
 	_StartDOCAs = tfs->make<TH1F>("Initial DOCAs ","InitialDOCAs" ,50, 0,10);
 	_StartDOCAs->GetXaxis()->SetTitle("Initial DOCAs [mm]");
 	_StartDOCAs->SetStats();
@@ -593,75 +593,75 @@ namespace mu2e
 	_A0MinuitFitDiff = tfs->make<TH1F>(" A0 Minuit Diff "," A0 Minuit Diff" ,100,-100,100);
 	_A0MinuitFitDiff->GetXaxis()->SetTitle("#Delta A0 [mm]");
 	_A0MinuitFitDiff->SetStats();
-	
+
 	_A1MinuitFitDiff = tfs->make<TH1F>(" A1 Minuit Diff "," A1 Minuit Diff" ,100,-3,3);
 	_A1MinuitFitDiff->GetXaxis()->SetTitle("#Delta A1 ");
 	_A1MinuitFitDiff->SetStats();
-	
+
 	_B0MinuitFitDiff = tfs->make<TH1F>(" B0 Minuit Diff "," B0 Minuit Diff" ,100,-100,100);
 	_B0MinuitFitDiff->GetXaxis()->SetTitle("#Delta B0 [mm] ");
 	_B0MinuitFitDiff->SetStats();
-	
+
 	_B1MinuitFitDiff = tfs->make<TH1F>(" B1 Minuit Diff "," B1 Minuit Diff" ,100,-3,3);
 	_B1MinuitFitDiff->GetXaxis()->SetTitle("#Delta B1 ");
 	_B1MinuitFitDiff->SetStats();
-	
+
 	_minuit_pullsX_final = tfs->make<TH1F>("Miuit Pull X'' ","Minuit Pull X'' " ,50,-2, 2);
 	_minuit_pullsX_final->GetXaxis()->SetTitle("Minuit Pull X''");
-	
+
 	_minuit_pullsY_final = tfs->make<TH1F>("Minuit Pull Y'' ","Minuit Pull Y'' " ,50,-2, 2);
 	_minuit_pullsY_final->GetXaxis()->SetTitle("Minuit Pull Y''");
-	
+
 	_NLL = tfs->make<TH1F>(" Log(L) "," Log(L)" ,200,0,1000);
 	_NLL->GetXaxis()->SetTitle("Log(L) ");
 	_NLL->SetStats();
-	
+
 	_A0Minuit = tfs->make<TH1F>(" A0_{Minuit} "," A0_{Minuit} " ,50,-10000,10000);
 	_A0Minuit->GetXaxis()->SetTitle(" [mm]");
 	_A0Minuit->SetStats();
-	
+
 	_A1Minuit = tfs->make<TH1F>(" A1_{Minuit}  "," A1_{Minuit}" ,50,-5,5);
 	_A1Minuit->GetXaxis()->SetTitle("A1 ");
 	_A1Minuit->SetStats();
-	
+
 	_B0Minuit = tfs->make<TH1F>(" B0_{Minuit}"," B0_{Minuit} " ,50,-5000,5000);
 	_B0Minuit->GetXaxis()->SetTitle(" [mm]");
 	_B0Minuit->SetStats();
-	
+
 	_B1Minuit = tfs->make<TH1F>(" B1_{Minuit}  "," B1_{Minuit} " ,50,-5,5);
 	_B1Minuit->GetXaxis()->SetTitle(" B1 ");
 	_B1Minuit->SetStats();
-	
-	
+
+
 	}
-      } 
+      }
 
     void CosmicAnalyzer::beginRun(const art::Run& run){
-	mu2e::GeomHandle<mu2e::Tracker> th;
-       tracker = th.get();
 
-}
+	}
+
       void CosmicAnalyzer::analyze(const art::Event& event) {
-       
+       	Tracker const* tracker = _alignedTracker_h.getPtr(event.id()).get();
+
         _evt = event.id().event();  // add event id
         if(!findData(event)) // find data
-      		throw cet::exception("RECO")<<"No Time Clusters in event"<< endl; 
-       
+      		throw cet::exception("RECO")<<"No Time Clusters in event"<< endl;
+
         //find time clusters:
     	_ntc = _tccol->size();
         _nch = _chcol->size();
-        
+
         for(size_t itc=0; itc<_tccol->size();++itc){
 		TimeCluster tc = (*_tccol)[itc];
         	_cluster_time =  tc._t0._t0;
-                
+
 	}
-	
-	
+
+
         //loop over tracks
         for(size_t ist = 0;ist < _coscol->size(); ++ist){
         	n_analyze+=1;
-        	
+
         	CosmicTrackSeed sts =(*_coscol)[ist];
 		CosmicTrack st = sts._track;
 		TrkFitFlag const& status = sts._status;
@@ -669,9 +669,9 @@ namespace mu2e
 		if(st.converged == false or st.minuit_converged  == false) { continue;}
 		std::vector<int> panels, planes, stations;
 
-		_reco_phi_angle->Fill(st.get_fit_phi()); 
-		_niters->Fill(st.get_iter()); 
-		
+		_reco_phi_angle->Fill(st.get_fit_phi());
+		_niters->Fill(st.get_iter());
+
                 _seed_a1->Fill(st.FitParams.A1);
                 _seed_b1->Fill(st.FitParams.B1);
                 _seed_a0->Fill(st.FitParams.A0);
@@ -688,30 +688,30 @@ namespace mu2e
                 _Seed_Cov_B1->Fill(st.FitParams.Covarience.sigB1);
                 _Seed_Cov_B0B1->Fill(st.FitParams.Covarience.sigB1B0);
 		_Seed_Cov_A0A1->Fill(st.FitParams.Covarience.sigA1A0);
-	
+
                 _seedA0_v_seedA1->Fill(st.FitParams.A1,st.FitParams.A0);
                 _seedB0_v_seedB1->Fill(st.FitParams.B1,st.FitParams.B0);
                 _seedA0_v_seedB1->Fill(st.FitParams.B1,st.FitParams.A0);
 	        _seedA0_v_seedB0->Fill(st.FitParams.A0,st.FitParams.B0);
 	        _seedB1_v_seedA1->Fill(st.FitParams.B1,st.FitParams.A1);
-	 	
+
 		_A0MinuitFitDiff->Fill(st.MinuitFitParams.A0-st.FitEquationXYZ.Pos.X());
 		_A1MinuitFitDiff->Fill(st.MinuitFitParams.A1-st.FitEquationXYZ.Dir.X());
 		_B0MinuitFitDiff->Fill(st.MinuitFitParams.B0- st.FitEquationXYZ.Pos.Y());
 		_B1MinuitFitDiff->Fill(st.MinuitFitParams.B1-st.FitEquationXYZ.Dir.Y());
-		
+
 	        _A0Minuit->Fill(st.MinuitFitParams.A0);
 	        _A1Minuit->Fill(st.MinuitFitParams.A1);
 	        _B0Minuit->Fill(st.MinuitFitParams.B0);
 	        _B1Minuit->Fill(st.MinuitFitParams.B1);
 
 	       if(_mcdiag){
-			
+
 			trueinfo = FitMC(_mcdigis);
-			
+
 			_mc_phi_angle->Fill(trueinfo.TruePhi);
-	                _mc_theta_angle->Fill(trueinfo.TrueTheta);                  
-	                
+	                _mc_theta_angle->Fill(trueinfo.TrueTheta);
+
 			_truea1XYZ->Fill(trueinfo.TrueFitEquation.Dir.X());
 		        _trueb1XYZ->Fill(trueinfo.TrueFitEquation.Dir.Y());
 		        _truea0XYZ->Fill(trueinfo.TrueFitEquation.Pos.X());
@@ -723,7 +723,7 @@ namespace mu2e
 				_A1MinuitMCDiff->Fill((trueinfo.TrueFitEquation.Dir.X() - st.MinuitFitParams.A1));///(st.MinuitFitParams.Covarience.sigA1));
 		 	}if(st.MinuitFitParams.Covarience.sigB0 !=0){
 				_B0MinuitMCDiff->Fill((trueinfo.TrueFitEquation.Pos.Y()- st.MinuitFitParams.B0));///(st.MinuitFitParams.Covarience.sigB0));
-				
+
 			}if(st.MinuitFitParams.Covarience.sigB1 !=0){
 				_B1MinuitMCDiff->Fill((trueinfo.TrueFitEquation.Dir.Y() - st.MinuitFitParams.B1));//(st.MinuitFitParams.Covarience.sigB1));
 		       }
@@ -732,31 +732,31 @@ namespace mu2e
 		      	_A1SeedMCDiff->Fill(trueinfo.TrueFitEquation.Dir.X() -st.FitEquationXYZ.Dir.X());
 	       	     	_B0SeedMCDiff->Fill(trueinfo.TrueFitEquation.Pos.Y() - st.FitEquationXYZ.Pos.Y());
 		     	_B1SeedMCDiff->Fill(trueinfo.TrueFitEquation.Dir.Y()  - st.FitEquationXYZ.Dir.Y());
-		      
+
 			_seedDeltaA0_v_minuitA0->Fill(trueinfo.TrueFitEquation.Pos.X()- st.FitEquationXYZ.Pos.X(), st.MinuitFitParams.A0);
 			_seedDeltaB0_v_minuitB0->Fill(trueinfo.TrueFitEquation.Pos.Y()- st.FitEquationXYZ.Pos.Y(), st.MinuitFitParams.B0);
 		        _seedDeltaA1_v_minuitA1->Fill(trueinfo.TrueFitEquation.Dir.X()- st.FitEquationXYZ.Dir.X(), st.MinuitFitParams.A1);
 			_seedDeltaB1_v_minuitB1->Fill(trueinfo.TrueFitEquation.Dir.Y()- st.FitEquationXYZ.Dir.Y(), st.MinuitFitParams.B1);
-	  		
-			
+
+
 	    }
-		
+
 		_chisq_ndf_plot_init->Fill(st.Diag.InitialChiTot);
                 _chisq_ndf_plot_final->Fill(st.Diag.FinalChiTot);
-                
+
                 _chisq_ndf_plot_finalX->Fill(st.Diag.FinalChiX);
                 _chisq_ndf_plot_finalY->Fill(st.Diag.FinalChiY);
-               
+
                 _chisq_ndf_plot_initX->Fill(st.Diag.InitialChiX);
                 _chisq_ndf_plot_initY->Fill(st.Diag.InitialChiY);
-               
+
                 _change_chisq_ndf_plot_X->Fill(st.Diag.InitialChiX-st.Diag.FinalChiX);
                 _change_chisq_ndf_plot_Y->Fill(st.Diag.InitialChiY-st.Diag.FinalChiY);
                 _change_chisq_ndf_plot_Total->Fill(st.Diag.InitialChiTot-st.Diag.FinalChiTot);
-		
+
 		for(size_t i=0; i<sts._straw_chits.size();i++){
 			    ComboHit const& chit = sts._straw_chits[i];
-			    
+
 			    double StartDOCA = DriftFitUtils::GetTestDOCA(chit, st.FitParams.A0,st.FitParams.A1, st.FitParams.B0, st.FitParams.B1,tracker);
 			    _StartDOCAs->Fill(StartDOCA);
 			    //double StartTOCA = DriftFitUtils::TimeResidual(StartDOCA, srep, sts._t0.t0(), chit);
@@ -778,12 +778,12 @@ namespace mu2e
 					outputfile<<DriftFitUtils::GetTestDOCA(chit, trueinfo.TrueFitEquation.Pos.X(), trueinfo.TrueFitEquation.Dir.X(), trueinfo.TrueFitEquation.Pos.Y(),trueinfo.TrueFitEquation.Dir.Y(), tracker)<<","<<DOCA<<","<<RecoAmbig/DriftFitUtils::GetAmbig(chit, trueinfo.TrueFitEquation.Pos.X(), trueinfo.TrueFitEquation.Dir.X(), trueinfo.TrueFitEquation.Pos.Y(),trueinfo.TrueFitEquation.Dir.Y(),  tracker)<<","<<trueinfo.TrueTheta<<","<<st.MinuitFitParams.A0<<","<<st.MinuitFitParams.A1
 <<","<<st.MinuitFitParams.B0<<","<<st.MinuitFitParams.B1<<","<<trueinfo.TrueFitEquation.Pos.X()<<","<<trueinfo.TrueFitEquation.Dir.X()
 <<","<<trueinfo.TrueFitEquation.Pos.Y()<<","<<trueinfo.TrueFitEquation.Dir.Y()<<endl;
-			}      
+			}
 			}
 	        }
 
-     
-	        for(auto const& tseed : *_coscol) {   
+
+	        for(auto const& tseed : *_coscol) {
                 	TrkFitFlag const& status = tseed._status;
                 	_hitsOK = status.hasAllProperties(TrkFitFlag::hitsOK);
                 	_StraightTrackOK = status.hasAllProperties(TrkFitFlag::helixOK);
@@ -793,10 +793,10 @@ namespace mu2e
 
 		for(size_t ich = 0;ich < _chcol->size(); ++ich){
                         ComboHit const& chit =(*_chcol)[ich];
-			
+
                 //-----------Fill diag details:----------//
                         _nhits = chit.nStrawHits();
-                        _nsh = chit.nStrawHits(); 
+                        _nsh = chit.nStrawHits();
                         panels.push_back(chit.strawId().panel());
 		        planes.push_back(chit.strawId().plane());
 			stations.push_back(chit.strawId().station());
@@ -809,77 +809,77 @@ namespace mu2e
                 _n_panels = std::set<float>( panels.begin(), panels.end() ).size();
 		_n_planes = std::set<float>( planes.begin(), planes.end() ).size();
 		_n_stations = std::set<float>( stations.begin(), stations.end() ).size();
-	 
+
       }//end analyze
       _cosmic_analysis->Fill();
       if(_mcdiag){
 	      cout<<"true + "<< _AMBIG->GetBinContent(2,2)/_AMBIG->Integral()<<endl;
-	      cout<<"true - "<< _AMBIG->GetBinContent(1,1)/_AMBIG->Integral()<<endl;	
+	      cout<<"true - "<< _AMBIG->GetBinContent(1,1)/_AMBIG->Integral()<<endl;
 	      cout<<"false + "<< _AMBIG->GetBinContent(2,1)/_AMBIG->Integral()<<endl;
 	      cout<<"false - "<< _AMBIG->GetBinContent(1,2)/_AMBIG->Integral()<<endl;
-	      
+
       }
-	
+
      }
 
 void CosmicAnalyzer::endJob() {
 	if(_diag and _mcdiag) outputfile.close();
 }
 
-CosmicTrackMCInfo CosmicAnalyzer::FitMC(const StrawDigiMCCollection*& _mcdigis){	
-	::BuildLinearFitMatrixSums S; 
+CosmicTrackMCInfo CosmicAnalyzer::FitMC(const StrawDigiMCCollection*& _mcdigis){
+	::BuildLinearFitMatrixSums S;
         CosmicTrackMCInfo TrackTrueInfo;
-    	
-        StrawDigiMC hitP1; 
+
+        StrawDigiMC hitP1;
 	StrawDigiMC first = (*_mcdigis)[0];
 
         //Get StepPointMC:
 	auto const& spmcp0= first.strawGasStep(StrawEnd::cal);
         XYZVec pos0(spmcp0->position().x(), spmcp0->position().y(), spmcp0->position().z());
         XYZVec dir0(spmcp0->momentum().x(), spmcp0->momentum().y(), spmcp0->momentum().z());
-	
+
         for(size_t ich = 0;ich < _mcdigis->size(); ++ich){
             hitP1 = (*_mcdigis)[ich];
-	    
+
             //Get StepPointMC:
 	    auto const& spmcp = hitP1.strawGasStep(StrawEnd::cal);
             XYZVec posN(spmcp->position().x(), spmcp->position().y(), spmcp->position().z());
-            
+
             //Use Step Point MC direction as the True Axes:
             XYZVec ZPrime = spmcp->momentum().unit();
-            
+
             //Store True Track details:
             TrackAxes TrueAxes = ParametricFit::GetTrackAxes(ZPrime);
             TrackTrueInfo.TrueTrackCoordSystem = (TrueAxes);
-	    
+
             //Apply routine to the True Tracks (for validation):
             XYZVec point(posN.x(), posN.y(), posN.z());
             XYZVec X(1,0,0);
             XYZVec Y(0,1,0);
             XYZVec Z(0,0,1);
             S.addPoint( point, X,Y,Z, 1,1);
-            
-        }   
-    
+
+        }
+
      TrackParams RawTrueParams(S.GetAlphaX()[0][0], S.GetAlphaX()[1][0], S.GetAlphaY()[0][0], S.GetAlphaY()[1][0]);
-     
+
      XYZVec TruePos(S.GetAlphaX()[0][0], S.GetAlphaY()[0][0], 0);
-     
+
      XYZVec TrueDir(S.GetAlphaX()[1][0], S.GetAlphaY()[1][0], 1);
      TrueDir = TrueDir.Unit();
      TrueDir = TrueDir/TrueDir.Z();
-     
+
      pos0.SetX(pos0.X()-(dir0.X()*pos0.Z()/dir0.Z()));
      pos0.SetY(pos0.Y()-(dir0.Y()*pos0.Z()/dir0.Z()));
      pos0.SetZ(pos0.Z()-(dir0.Z()*pos0.Z()/dir0.Z()));
      dir0 = dir0/dir0.Z();
-  
+
      TrackEquation TrueTrack(pos0, dir0);
-     
+
      TrackTrueInfo.TrueFitEquation = (TrueTrack);
      TrackTrueInfo.TruePhi =(atan(TrueDir.y()/TrueDir.x()));
      TrackTrueInfo.TrueTheta = (acos(TrueDir.x()/sqrt(TrueDir.Mag2())));
-     
+
      return TrackTrueInfo;
      }
 
@@ -898,9 +898,9 @@ CosmicTrackMCInfo CosmicAnalyzer::FillDriftMC(ComboHit const& chit, double RecoA
 }
 
 bool CosmicAnalyzer::findData(const art::Event& evt){
-	_chcol = 0; 
+	_chcol = 0;
         _tccol = 0;
-        _coscol = 0; 
+        _coscol = 0;
 	auto chH = evt.getValidHandle<ComboHitCollection>(_chtag);
 	_chcol = chH.product();
 	auto tcH = evt.getValidHandle<TimeClusterCollection>(_tctag);
@@ -908,7 +908,7 @@ bool CosmicAnalyzer::findData(const art::Event& evt){
 	auto stH = evt.getValidHandle<CosmicTrackSeedCollection>(_costag);
 	_coscol =stH.product();
         if(_mcdiag){
-	    
+
 	   _mcdigis=0;
            auto mcdH = evt.getValidHandle<StrawDigiMCCollection>(_mcdigistag);
            _mcdigis = mcdH.product();

--- a/CosmicReco/src/CosmicAnalyzer_module.cc
+++ b/CosmicReco/src/CosmicAnalyzer_module.cc
@@ -32,6 +32,9 @@
 #include "GeneralUtilities/inc/ParameterSetHelpers.hh"
 #include "GeometryService/inc/GeomHandle.hh"
 #include "GeometryService/inc/DetectorSystem.hh"
+
+#include "ProditionsService/inc/ProditionsHandle.hh"
+
 // Framework includes.
 #include "art/Framework/Core/EDAnalyzer.h"
 #include "art/Framework/Principal/Event.h"
@@ -230,7 +233,7 @@ namespace mu2e
       Int_t _n_planes; // # stations
       int n_analyze =0;
       Float_t _hit_time, _hit_drift_time, _cluster_time, _dt;
-
+	  ProditionsHandle<Tracker> _alignedTracker_h;
       //Flags:
       Bool_t _StraightTrackInit, _StraightTrackConverged, _StraightTrackOK, _hitsOK;
       Int_t _strawid;

--- a/CosmicReco/src/CosmicTrackDetails_module.cc
+++ b/CosmicReco/src/CosmicTrackDetails_module.cc
@@ -32,6 +32,9 @@
 #include "GeneralUtilities/inc/ParameterSetHelpers.hh"
 #include "GeometryService/inc/GeomHandle.hh"
 #include "GeometryService/inc/DetectorSystem.hh"
+
+#include "ProditionsService/inc/ProditionsHandle.hh"
+
 // Framework includes.
 #include "art/Framework/Core/EDAnalyzer.h"
 #include "art/Framework/Principal/Event.h"
@@ -56,9 +59,9 @@
 #include "TrackerGeom/inc/Tracker.hh"
 #include "TrackerGeom/inc/Straw.hh"
 
-using namespace std; 
+using namespace std;
 
-namespace mu2e 
+namespace mu2e
 {
   class CosmicTrackDetails : public art::EDAnalyzer {
     public:
@@ -81,8 +84,8 @@ namespace mu2e
       virtual void beginRun(const art::Run& r) override;
       virtual void analyze(const art::Event& e) override;
       virtual void endJob() override;
-    private: 
-      
+    private:
+
       Config _conf;
 
       int  _diag;
@@ -107,7 +110,7 @@ namespace mu2e
       Float_t _TrueB1;
       Float_t _TrueA0;
       Float_t _TrueB0;
-      
+
       //Angles Info:
       Float_t _mc_phi_angle;
       Float_t _reco_phi_angle;
@@ -145,9 +148,9 @@ namespace mu2e
       float _hit_time[8129];
       float _hit_drift_time[8129];
       // add event id
-      Int_t _evt; 
+      Int_t _evt;
 
-      
+
       //Numbers:
       Int_t _nsh, _nch; // # associated straw hits / event
       Int_t _ntc; // # clusters/event
@@ -159,10 +162,10 @@ namespace mu2e
       int _nused;
       Float_t _cluster_time;
 
-     
+      ProditionsHandle<Tracker> _alignedTracker_h;
       //Flags:
       Bool_t _StraightTrackInit, _StraightTrackConverged, _StraightTrackOK, _hitsOK;
-      Int_t _strawid; 
+      Int_t _strawid;
       vector<ComboHitInfoMC> _chinfomc;
       CosmicTrackMCInfo FitMC(const StrawDigiMCCollection*& _mcdigis);
       CosmicTrackMCInfo FillDriftMC(ComboHit const& chi, double reco_ambig, CosmicTrackMCInfo info, double t0, const Tracker* tracker);
@@ -179,7 +182,7 @@ namespace mu2e
 	_mcdigistag (conf().mcdigistag()),
 	_toff (conf().toff())
     {
-      
+
 	if(_mcdiag){
 	      for (auto const& tag : conf().toff().inputs()) {
 		consumes<SimParticleTimeMap>(tag);
@@ -190,10 +193,10 @@ namespace mu2e
     CosmicTrackDetails::~CosmicTrackDetails(){}
 
     void CosmicTrackDetails::beginJob() {
-      
+
       // create diagnostics if requested...
       if(_diag > 0){
-	
+
 	art::ServiceHandle<art::TFileService> tfs;
 	//Tree for detailed diagnostics
 	_cosmic_tree=tfs->make<TTree>("cosmic_tree"," Diagnostics for Cosmic Track Fitting");
@@ -209,14 +212,14 @@ namespace mu2e
         _cosmic_tree->Branch("PanelsCrossedInEvent", &_n_panels, "PanelsCrossedInEvent/I");
         _cosmic_tree->Branch("PlanesCrossedInEvent", &_n_planes, "PlanesCrossedInEvent/I");
         _cosmic_tree->Branch("StatonsCrossedInEvent", &_n_stations, "StationsCrossedInEvent/I");
-        _cosmic_tree->Branch("TimeClustersInEvent", &_ntc, "TimeClusterInEvent/I"); 
+        _cosmic_tree->Branch("TimeClustersInEvent", &_ntc, "TimeClusterInEvent/I");
         _cosmic_tree->Branch("hit_time", &_hit_time, "hit_time[nused]/F");
         _cosmic_tree->Branch("hit_drit_time", &_hit_drift_time, "hit_drift_time[nused]/F");
         _cosmic_tree->Branch("hitsOK",&_hitsOK,"hitsOK/B");
         _cosmic_tree->Branch("StraightTrackInit",&_StraightTrackInit,"StraightTrackInit/B");
         _cosmic_tree->Branch("StraightTrackOK",&_StraightTrackOK,"StraightTrackOK/B");
         _cosmic_tree->Branch("StraightTrackConverged",&_StraightTrackConverged,"StraightTrackConverged/B");
-        
+
 	_cosmic_tree->Branch("MinuitA0",&_MinuitA0,"MinuitA0/F");
         _cosmic_tree->Branch("MinuitA1",&_MinuitA1,"MinuitA1/F");
 	_cosmic_tree->Branch("MinuitB0",&_MinuitA0,"MinuitB0/F");
@@ -227,7 +230,7 @@ namespace mu2e
 	_cosmic_tree->Branch("ErrorB0",&_ErrorA0,"ErrorB0/F");
         _cosmic_tree->Branch("ErrorB1",&_ErrorA1,"ErrorB1/F");
 
-	
+
 	_cosmic_tree->Branch("FitCovA0",&_FitCovA0,"FitCovA0/F");
         _cosmic_tree->Branch("FitCovA1",&_FitCovA1,"FitCovA1/F");
 	_cosmic_tree->Branch("FitCovB0",&_FitCovA0,"FitCovB0/F");
@@ -238,7 +241,7 @@ namespace mu2e
        	_cosmic_tree->Branch("RecoPhi",&_reco_phi_angle, "RecoPhi/F");
 	_cosmic_tree->Branch("RecoTheta",&_reco_theta_angle, "RecoTheta/F");
 
-       
+
         _cosmic_tree->Branch("FitDOCAs",&_FitDOCAs,"FitDOCAs[nused]/F");
 	_cosmic_tree->Branch("RecoAmbig",&_RecoAmbig,"RecoAmbig[nused]/F");
 	_cosmic_tree->Branch("FitTOCAs",&_FitTOCAs,"FitTOCAs[nused]/F");
@@ -256,50 +259,50 @@ namespace mu2e
 	_cosmic_tree->Branch("TrueDOCAs",&_TrueDOCAs,"TrueDOCAs[nused]/F");
 	_cosmic_tree->Branch("TrueTimeResiduals",&_TrueTimeResiduals,"TrueTimeResiduals[nused]/F");
 	_cosmic_tree->Branch("TrueAmbig",&_TrueAmbig,"TrueAmbig[nused]/F");
-	
+
 	}
-	
-	
+
+
 	}
       }
 
 	void CosmicTrackDetails::beginRun(const art::Run& run){
-		mu2e::GeomHandle<mu2e::Tracker> th;
-      		tracker = th.get();
 	}
 
-      void CosmicTrackDetails::analyze(const art::Event& event) {
-       
+      void CosmicTrackDetails::analyze(const art::Event& event)
+      {
+        tracker = _alignedTracker_h.getPtr(event.id()).get();
+
         _evt = event.id().event();  // add event id
         if(!findData(event)) // find data
-      		throw cet::exception("RECO")<<"No Time Clusters in event"<< endl; 
-       
+      		throw cet::exception("RECO")<<"No Time Clusters in event"<< endl;
+
         //find time clusters:
     	_ntc = _tccol->size();
         _nch = _chcol->size();
-        
+
         for(size_t itc=0; itc<_tccol->size();++itc){
 		TimeCluster tc = (*_tccol)[itc];
         	_cluster_time =  tc._t0._t0;
-                
+
 	}
-	
-	
+
+
         //loop over tracks
         for(size_t ist = 0;ist < _coscol->size(); ++ist){
         	n_analyze+=1;
-        	
+
         	CosmicTrackSeed sts =(*_coscol)[ist];
 		CosmicTrack st = sts._track;
                 double t0 = sts._t0.t0();
 		TrkFitFlag const& status = sts._status;
         	if (!status.hasAllProperties(TrkFitFlag::helixOK) ){continue;}
 		if(st.converged == false or st.minuit_converged  == false) { continue;}
-		
+
 		std::vector<int> panels, planes, stations;
 
-		_reco_phi_angle=(st.get_fit_phi()); 
-		_reco_theta_angle=(st.get_fit_theta()); 
+		_reco_phi_angle=(st.get_fit_phi());
+		_reco_theta_angle=(st.get_fit_theta());
 	        _MinuitA0=(st.MinuitFitParams.A0);
 	        _MinuitA1=(st.MinuitFitParams.A1);
 	        _MinuitB1=(st.MinuitFitParams.B1);
@@ -318,12 +321,12 @@ namespace mu2e
 		_FitCovB0B1 = st.MinuitFitParams.Covarience.sigB0B1;
 
 	       if(_mcdiag){
-			
+
 			trueinfo = FitMC(_mcdigis);
-			
+
 			_mc_phi_angle=(trueinfo.TruePhi);
-	                _mc_theta_angle=(trueinfo.TrueTheta);                  
-	                
+	                _mc_theta_angle=(trueinfo.TrueTheta);
+
 			_TrueA1=(trueinfo.TrueFitEquation.Dir.X());
 		        _TrueB1=(trueinfo.TrueFitEquation.Dir.Y());
 		        _TrueA0=(trueinfo.TrueFitEquation.Pos.X());
@@ -332,10 +335,10 @@ namespace mu2e
 		for(size_t i=0; i<sts._straw_chits.size();i++){
 			    ComboHit const& chit = sts._straw_chits[i];
 			    _nused = i;
-			
+
                 //-----------Fill diag details:----------//
                              //_nhits[_nused] = chit.nStrawHits();
-                       	    
+
                              panels.push_back(chit.strawId().panel());
 		             planes.push_back(chit.strawId().plane());
 			     stations.push_back(chit.strawId().station());
@@ -348,20 +351,20 @@ namespace mu2e
 			    double fitdoca = DriftFitUtils::GetTestDOCA(chit, st.MinuitFitParams.A0,st.MinuitFitParams.A1, st.MinuitFitParams.B0, st.MinuitFitParams.B1,  tracker);
 			    _FitDOCAs[_nused] = fitdoca;
 			    _RecoAmbig[_nused] = DriftFitUtils::GetAmbig(chit, st.MinuitFitParams.A0,st.MinuitFitParams.A1, st.MinuitFitParams.B0, st.MinuitFitParams.B1, tracker);
-			 
+
 			  // _FitTOCAs[_nused] = DriftFitUtils::TimeResidual(fitdoca, strawResponse, t0, chit); --->TODO---> think how to access this here without the Diag frameworj
-    
+
 			   if(_mcdiag){
 				trueinfo = FitMC(_mcdigis);
 				trueinfo = FillDriftMC(chit, _RecoAmbig[_nused], trueinfo, t0, tracker);
-				
+
 		    		_TrueDOCAs[_nused] =DriftFitUtils::GetTestDOCA(chit, trueinfo.TrueFitEquation.Pos.X(), trueinfo.TrueFitEquation.Dir.X(), trueinfo.TrueFitEquation.Pos.Y(),trueinfo.TrueFitEquation.Dir.Y(),  tracker);
 				_TrueTimeResiduals[_nused] = _TrueDOCAs[_nused]/0.0625;//TODO
     				_TrueAmbig[_nused] = DriftFitUtils::GetAmbig(chit, trueinfo.TrueFitEquation.Pos.X(), trueinfo.TrueFitEquation.Dir.X(), trueinfo.TrueFitEquation.Pos.Y(),trueinfo.TrueFitEquation.Dir.Y(), tracker);
-			
+
 		           }
 		}
-		
+
                _hitsOK = status.hasAllProperties(TrkFitFlag::hitsOK);
 		if(status.hasAllProperties(TrkFitFlag::Straight)){
 		      _StraightTrackOK = status.hasAllProperties(TrkFitFlag::helixOK);
@@ -369,7 +372,7 @@ namespace mu2e
 		      _StraightTrackInit = status.hasAllProperties(TrkFitFlag::circleInit);
         	}
 
-		
+
                 //----------------Get panels/planes/stations per track:------------------//
                 _n_panels = std::set<float>( panels.begin(), panels.end() ).size();
 		_n_planes = std::set<float>( planes.begin(), planes.end() ).size();
@@ -378,67 +381,67 @@ namespace mu2e
 	 		_cosmic_tree->Fill();
 	       }
       }
-      
+
       }
 
 
 void CosmicTrackDetails::endJob() {}
 
-CosmicTrackMCInfo CosmicTrackDetails::FitMC(const StrawDigiMCCollection*& _mcdigis){	
-	
-	::BuildLinearFitMatrixSums S; 
+CosmicTrackMCInfo CosmicTrackDetails::FitMC(const StrawDigiMCCollection*& _mcdigis){
+
+	::BuildLinearFitMatrixSums S;
         CosmicTrackMCInfo TrackTrueInfo;
-    	
-        StrawDigiMC hitP1; 
+
+        StrawDigiMC hitP1;
 	StrawDigiMC first = (*_mcdigis)[0];
 
         //Get StepPointMC:
 	auto const& spmcp0= first.earlyStrawGasStep();
         XYZVec pos0(spmcp0->position().x(), spmcp0->position().y(), spmcp0->position().z());
         XYZVec dir0(spmcp0->momentum().x(), spmcp0->momentum().y(), spmcp0->momentum().z());
-	
+
         for(size_t ich = 0;ich < _mcdigis->size(); ++ich){
             hitP1 = (*_mcdigis)[ich];
-	    
+
             //Get StepPointMC:
 	    auto const& spmcp= hitP1.earlyStrawGasStep();
             XYZVec posN(spmcp->position().x(), spmcp->position().y(), spmcp->position().z());
-            
+
             //Use Step Point MC direction as the True Axes:
             XYZVec ZPrime = (spmcp->momentum().Unit());
-            
+
             //Store True Track details:
             TrackAxes TrueAxes = ParametricFit::GetTrackAxes(ZPrime);
             TrackTrueInfo.TrueTrackCoordSystem = (TrueAxes);
-	    
+
             //Apply routine to the True Tracks (for validation):
             XYZVec point(posN.x(), posN.y(), posN.z());
             XYZVec X(1,0,0);
             XYZVec Y(0,1,0);
             XYZVec Z(0,0,1);
             S.addPoint( point, X,Y,Z, 1,1);
-            
-        }   
-    
+
+        }
+
      TrackParams RawTrueParams(S.GetAlphaX()[0][0], S.GetAlphaX()[1][0], S.GetAlphaY()[0][0], S.GetAlphaY()[1][0]);
-     
+
      XYZVec TruePos(S.GetAlphaX()[0][0], S.GetAlphaY()[0][0], 0);
-     
+
      XYZVec TrueDir(S.GetAlphaX()[1][0], S.GetAlphaY()[1][0], 1);
      TrueDir = TrueDir.Unit();
      TrueDir = TrueDir/TrueDir.Z();
-     
+
      pos0.SetX(pos0.X()-(dir0.X()*pos0.Z()/dir0.Z()));
      pos0.SetY(pos0.Y()-(dir0.Y()*pos0.Z()/dir0.Z()));
      pos0.SetZ(pos0.Z()-(dir0.Z()*pos0.Z()/dir0.Z()));
      dir0 = dir0/dir0.Z();
-  
+
      TrackEquation TrueTrack(pos0, dir0);
-     
+
      TrackTrueInfo.TrueFitEquation = (TrueTrack);
      TrackTrueInfo.TruePhi =(atan(TrueDir.y()/TrueDir.x()));
      TrackTrueInfo.TrueTheta = (acos(TrueDir.x()/sqrt(TrueDir.Mag2())));
-     
+
      return TrackTrueInfo;
      }
 
@@ -450,14 +453,14 @@ CosmicTrackMCInfo CosmicTrackDetails::FillDriftMC(ComboHit const& chit, double R
      info.Ambig.push_back(trueambig);
      info.TrueDOCA.push_back(true_doca);
      //info.TrueTimeResiduals.push_back(true_time_residual);
-    
+
      return info;
 }
 
 bool CosmicTrackDetails::findData(const art::Event& evt){
-	_chcol = 0; 
+	_chcol = 0;
         _tccol = 0;
-        _coscol = 0; 
+        _coscol = 0;
 	auto chH = evt.getValidHandle<ComboHitCollection>(_chtag);
 	_chcol = chH.product();
 	auto tcH = evt.getValidHandle<TimeClusterCollection>(_tctag);
@@ -465,7 +468,7 @@ bool CosmicTrackDetails::findData(const art::Event& evt){
 	auto stH = evt.getValidHandle<CosmicTrackSeedCollection>(_costag);
 	_coscol =stH.product();
         if(_mcdiag){
-	    
+
 	   _mcdigis=0;
            auto mcdH = evt.getValidHandle<StrawDigiMCCollection>(_mcdigistag);
            _mcdigis = mcdH.product();

--- a/CosmicReco/src/SConscript
+++ b/CosmicReco/src/SConscript
@@ -69,6 +69,7 @@ helper.make_plugins( [
    'mu2e_DataProducts',
    'mu2e_GeneralUtilities',
    'mu2e_TrkReco',
+   'mu2e_GeomPrimitives',
    babarlibs,
    'art_Framework_Core',
    'art_Framework_Principal',


### PR DESCRIPTION
Motivated by the same reasons in #123, need for Millepede-II tests.

I left the tracker variable as a const ptr in CosmicTrackDetails,CosmicAnalyzer ::analyze as using a reference would have required many utility functions to be refactored, or all calls to those functions changed to pass `&tracker`

PR Validation:
- no modules outside CosmicReco are affected
- CosmicReco job runs successfully
- Proditions Tracker by default is nominal
```
TValCompare Status Summary:
  301 Compared
    6 marked to skip
    0 had unknown status
    0 could not be compared
   41 had at least one histogram empty
    0 failed loose comparison
    0 passed loose comparison, failed tight
    0 passed tight comparison, not perfect match
  254 had perfect match
  254 passed loose or better
  254 passed tight or better
```
P.S. my editor removed a lot of trailing whitespace again - sorry (viewing with whitespace changes off much clearer)