### PR TITLE
(IWYU + manual fixups) Mu2eUtilities includes cleanup 

### DIFF
--- a/Mu2eUtilities/inc/BinnedSpectrum.hh
+++ b/Mu2eUtilities/inc/BinnedSpectrum.hh
@@ -13,15 +13,22 @@
 //
 
 // C++ includes
-#include <assert.h>
-#include <iostream>
-#include <string>
-#include <utility>
-#include <vector>
+#include <assert.h>                    // for assert
+#include <stddef.h>                    // for size_t
+#include <iostream>                    // for operator<<, basic_ostream, bas...
+#include <utility>                     // for pair, move, make_pair, forward
+#include <vector>                      // for vector, vector<>::iterator
+#include <algorithm>                   // for max, reverse
+#include <array>                       // for array
+#include <memory>                      // for allocator_traits<>::value_type
+#include <type_traits>                 // for remove_reference<>::type
 
-#include "Mu2eUtilities/inc/Table.hh"
+#include "Mu2eUtilities/inc/Table.hh"  // for Table
+#include "cetlib_except/exception.h"   // for exception, operator<<
 
-namespace fhicl { class ParameterSet; }
+namespace fhicl {
+class ParameterSet;
+}  // namespace fhicl
 
 namespace mu2e {
 

--- a/Mu2eUtilities/inc/BinnedSpectrum.hh
+++ b/Mu2eUtilities/inc/BinnedSpectrum.hh
@@ -9,8 +9,8 @@
 // $Author: knoepfel $
 // $Date: 2014/04/25 17:26:42 $
 //
-// Original author Kyle Knoepfel 
-//                 
+// Original author Kyle Knoepfel
+//
 
 // C++ includes
 #include <assert.h>
@@ -19,10 +19,9 @@
 #include <utility>
 #include <vector>
 
-#include "cetlib_except/exception.h"
-
 #include "Mu2eUtilities/inc/Table.hh"
-#include "fhiclcpp/ParameterSet.h"
+
+namespace fhicl { class ParameterSet; }
 
 namespace mu2e {
 
@@ -80,14 +79,14 @@ namespace mu2e {
       if (_fixMax){
         for (double step = XMax-_binWidth/2.; step >= XMin + _binWidth/2.; step += _binWidth){
           abscissa.push_back( step );
-          pdf     .push_back( s.getWeight(step) ); 
+          pdf     .push_back( s.getWeight(step) );
         }
         std::reverse(abscissa.begin(),abscissa.end());
         std::reverse(pdf.begin(),pdf.end());
       }else{
-        for ( double step = XMin+_binWidth/2. ; step <= XMax-_binWidth/2.; step += _binWidth ) {	 
+        for ( double step = XMin+_binWidth/2. ; step <= XMax-_binWidth/2.; step += _binWidth ) {
           abscissa.push_back( step );
-          pdf     .push_back( s.getWeight(step) ); 
+          pdf     .push_back( s.getWeight(step) );
         }
       }
       if (_finalBin && abscissa[abscissa.size()-1] + _binWidth/2. < XMax){

--- a/Mu2eUtilities/inc/BinnedSpectrumWeightPhys.hh
+++ b/Mu2eUtilities/inc/BinnedSpectrumWeightPhys.hh
@@ -18,14 +18,8 @@
 #include "CLHEP/Units/PhysicalConstants.h"
 
 // Framework includes
-#include "art/Framework/Core/EDProducer.h"
-#include "art/Framework/Core/ModuleMacros.h"
-#include "art/Framework/Principal/Event.h"
-#include "art/Framework/Principal/Run.h"
-#include "art/Framework/Principal/Handle.h"
 #include "canvas/Utilities/InputTag.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
-#include "art_root_io/TFileService.h"
 #include "fhiclcpp/ParameterSet.h"
 
 // Mu2e includes
@@ -36,11 +30,15 @@
 #include "MCDataProducts/inc/EventWeight.hh"
 #include "Mu2eUtilities/inc/BinnedSpectrum.hh"
 
+namespace art {
+  class Event;
+}
+
 namespace mu2e {
 
   class BinnedSpectrumWeightPhys {
     enum SpectrumVar  { TOTAL_ENERGY, KINETIC_ENERGY, MOMENTUM };
-    
+
   private :
     fhicl::ParameterSet psphys_;
     art::InputTag input_;
@@ -78,20 +76,20 @@ namespace mu2e {
       if (spectrumVariable_ == TOTAL_ENERGY){
         for ( const auto& i: *genColl ) {
           if ((i.pdgId() == genPdg_ || genPdg_ == PDGCode::null) && i.generatorId() == genId_ ) {
-            sampleVal += i.momentum().e(); 
+            sampleVal += i.momentum().e();
           }
         }
       }else if (spectrumVariable_ == KINETIC_ENERGY){
         for ( const auto& i: *genColl ) {
           if ((i.pdgId() == genPdg_ || genPdg_ == PDGCode::null) && i.generatorId() == genId_ ) {
-            sampleVal += i.momentum().e() - i.momentum().restMass(); 
+            sampleVal += i.momentum().e() - i.momentum().restMass();
           }
         }
       }else{
         CLHEP::Hep3Vector mom(0,0,0);
         for ( const auto& i: *genColl ) {
           if ((i.pdgId() == genPdg_ || genPdg_ == PDGCode::null) && i.generatorId() == genId_ ) {
-            mom += i.momentum().vect(); 
+            mom += i.momentum().vect();
           }
         }
         sampleVal = mom.mag();

--- a/Mu2eUtilities/inc/CaloHitMCNavigator.hh
+++ b/Mu2eUtilities/inc/CaloHitMCNavigator.hh
@@ -10,10 +10,15 @@
 // Original author Rob Kutschke
 //
 
-#include "RecoDataProducts/inc/CaloHitCollection.hh"
-#include "MCDataProducts/inc/CaloHitMCTruthCollection.hh"
-#include "MCDataProducts/inc/PtrStepPointMCVectorCollection.hh"
-#include "MCDataProducts/inc/CaloHitSimPartMCCollection.hh"
+#include <ext/alloc_traits.h>                                // for __alloc_...
+#include <stddef.h>                                          // for size_t
+
+#include "RecoDataProducts/inc/CaloHitCollection.hh"         // for CaloHitC...
+#include "MCDataProducts/inc/CaloHitMCTruthCollection.hh"    // for CaloHitM...
+#include "MCDataProducts/inc/CaloHitSimPartMCCollection.hh"  // for CaloHitS...
+#include "MCDataProducts/inc/CaloHitMCTruth.hh"              // for CaloHitM...
+#include "MCDataProducts/inc/CaloHitSimPartMC.hh"            // for CaloHitS...
+#include "RecoDataProducts/inc/CaloHit.hh"                   // for CaloHit
 
 namespace mu2e {
 

--- a/Mu2eUtilities/inc/CoordinateString.hh
+++ b/Mu2eUtilities/inc/CoordinateString.hh
@@ -38,16 +38,10 @@
 // No free function currently exists for adding coordinates, but it
 // would be straightforward to do if needed.
 
-// C++ includes
-#include <algorithm>
-#include <array>
-#include <fstream>
-#include <iostream>
-#include <iterator>
-#include <utility>
-
-// Framework includes
-#include "cetlib_except/exception.h"
+#include <array>    // for array
+#include <fstream>  // for size_t
+#include <utility>  // for pair
+#include <string>   // for string
 
 namespace mu2e {
   

--- a/Mu2eUtilities/inc/EventWeightHelper.hh
+++ b/Mu2eUtilities/inc/EventWeightHelper.hh
@@ -10,14 +10,22 @@
 #ifndef Mu2eUtilities_inc_EventWeightHelper_hh
 #define Mu2eUtilities_inc_EventWeightHelper_hh
 
-#include <string>
+#include <string>                       // for string
+#include <algorithm>                    // for max
+#include <vector>                       // for vector
 
-#include "canvas/Utilities/InputTag.h"
-#include "art_root_io/TFileDirectory.h"
+#include "canvas/Utilities/InputTag.h"  // for InputTag
 
-namespace fhicl { class ParameterSet; }
-namespace art { class Event; }
+namespace fhicl {
+class ParameterSet;
+}  // namespace fhicl
+namespace art {
+class Event;
+}  // namespace art
 class TH1;
+namespace art {
+class TFileDirectory;
+}  // namespace art
 
 namespace mu2e {
 

--- a/Mu2eUtilities/inc/GeneratorSummaryHistograms.hh
+++ b/Mu2eUtilities/inc/GeneratorSummaryHistograms.hh
@@ -10,11 +10,13 @@
 // Contact person Rob Kutschke
 //
 
-#include "MCDataProducts/inc/GenParticleCollection.hh"
+#include <string>                             // for string
 
-#include "art_root_io/TFileDirectory.h"
+#include "MCDataProducts/inc/GenParticle.hh"  // for GenParticleCollection
 
-#include <string>
+namespace art {
+class TFileDirectory;
+}  // namespace art
 
 // Forward declarations
 

--- a/Mu2eUtilities/inc/HelixTool.hh
+++ b/Mu2eUtilities/inc/HelixTool.hh
@@ -1,16 +1,16 @@
 #ifndef Mu2eUtilities_HelixTool_hh
 #define Mu2eUtilities_HelixTool_hh
+#include "Math/GenVector/VectorUtil.h"  // for VectorUtil
+
+namespace mu2e {
+class Tracker;
+struct HelixSeed;
+}  // namespace mu2e
 //
 // Original author G. Pezzullo
 //
 
-#include "RecoDataProducts/inc/HelixSeed.hh"
-#include "RecoDataProducts/inc/ComboHit.hh"
-#include "RecoDataProducts/inc/StrawHitFlagCollection.hh"
-#include "DataProducts/inc/StrawId.hh"
-#include "TrackerGeom/inc/Tracker.hh"
 
-#include "Math/VectorUtil.h"
 using namespace ROOT::Math::VectorUtil;
 
 namespace mu2e {

--- a/Mu2eUtilities/inc/KalRepCollectionInfo.hh
+++ b/Mu2eUtilities/inc/KalRepCollectionInfo.hh
@@ -10,12 +10,21 @@
 // Contact person, Rob Kutschke
 //
 
-#include "Mu2eUtilities/inc/TrackPatRecType.hh"
-#include "Mu2eUtilities/inc/KalRepInstanceNameDecoder.hh"
-#include "RecoDataProducts/inc/KalRepCollection.hh"
-#include "RecoDataProducts/inc/KalRepPtrCollection.hh"
+#include <string>                                          // for string
 
-#include "art/Framework/Principal/Event.h"
+#include "Mu2eUtilities/inc/TrackPatRecType.hh"            // for TrackPatRe...
+#include "Mu2eUtilities/inc/KalRepInstanceNameDecoder.hh"  // for KalRepInst...
+#include "RecoDataProducts/inc/KalRepCollection.hh"        // for KalRepColl...
+#include "RecoDataProducts/inc/KalRepPtrCollection.hh"     // for KalRepPtr
+#include "Mu2eUtilities/inc/TrkSpecies.hh"                 // for TrkSpecies
+#include "RecoDataProducts/inc/TrkFitDirection.hh"         // for TrkFitDire...
+
+namespace art {
+class Event;
+class ProductID;
+template <typename T> class Handle;
+template <typename T> class ValidHandle;
+}  // namespace art
 
 namespace mu2e {
 

--- a/Mu2eUtilities/inc/MedianCalculator.hh
+++ b/Mu2eUtilities/inc/MedianCalculator.hh
@@ -7,10 +7,9 @@
 // from a set of elements that are stored internally in a vector
 //
 
-#include <vector>
-//#include <utility>
-#include <numeric>
-#include <functional>
+#include <stddef.h>    // for size_t
+#include <vector>      // for vector
+#include <functional>  // for binary_function
 
 namespace mu2e { 
   class MedianCalculator{

--- a/Mu2eUtilities/inc/ParametricFit.hh
+++ b/Mu2eUtilities/inc/ParametricFit.hh
@@ -1,11 +1,15 @@
 #ifndef _MU2E_UTILITIES_PARAMETRICFIT_HH
 #define _MU2E_UTILITIES_PARAMETRICFIT_HH
 
-#include "Math/VectorUtil.h"
-#include "TMatrix.h"
-#include "RecoDataProducts/inc/ComboHit.hh"
-#include "DataProducts/inc/XYZVec.hh"
-#include "RecoDataProducts/inc/CosmicTrack.hh"
+#include <vector>                               // for vector
+
+#include "DataProducts/inc/XYZVec.hh"           // for XYZVec
+#include "RecoDataProducts/inc/CosmicTrack.hh"  // for TrackAxes
+#include "DataProducts/inc/StrawEnd.hh"         // for mu2e
+
+namespace mu2e {
+struct ComboHit;
+}  // namespace mu2e
 
 using namespace mu2e;
 namespace ParametricFit{

--- a/Mu2eUtilities/inc/PhysicalVolumeMultiHelper.hh
+++ b/Mu2eUtilities/inc/PhysicalVolumeMultiHelper.hh
@@ -7,10 +7,10 @@
 #define Mu2eUtilities_PhysicalVolumeMultiHelper_hh
 
 #include "MCDataProducts/inc/PhysicalVolumeInfoMultiCollection.hh"
-#include "MCDataProducts/inc/SimParticleCollection.hh"
 #include "MCDataProducts/inc/SimParticle.hh"
 
 namespace mu2e {
+struct PhysicalVolumeInfo;
 
   class PhysicalVolumeMultiHelper {
   public:

--- a/Mu2eUtilities/inc/RandomLimitedExpo.hh
+++ b/Mu2eUtilities/inc/RandomLimitedExpo.hh
@@ -8,7 +8,6 @@
 //
 
 #include "CLHEP/Random/RandFlat.h"
-#include "CLHEP/Random/RandomEngine.h"
 #include "art/Framework/Services/Optional/RandomNumberGenerator.h"
 
 namespace mu2e {

--- a/Mu2eUtilities/inc/RandomUnitSphere.hh
+++ b/Mu2eUtilities/inc/RandomUnitSphere.hh
@@ -15,12 +15,13 @@
 //
 //
 
-#include <cmath>
+#include "CLHEP/Random/RandFlat.h"       // for RandFlat
+#include "CLHEP/Vector/ThreeVector.h"    // for Hep3Vector
+#include "CLHEP/Units/SystemOfUnits.h"   // for twopi
 
-#include "CLHEP/Random/RandFlat.h"
-#include "CLHEP/Random/RandomEngine.h"
-#include "CLHEP/Units/PhysicalConstants.h"
-#include "CLHEP/Vector/ThreeVector.h"
+namespace CLHEP {
+class HepRandomEngine;
+}  // namespace CLHEP
 
 namespace mu2e {
 

--- a/Mu2eUtilities/inc/SimParticleCollectionPrinter.hh
+++ b/Mu2eUtilities/inc/SimParticleCollectionPrinter.hh
@@ -3,13 +3,16 @@
 #ifndef Mu2eUtilities_inc_SimParticleCollectionPrinter_hh
 #define Mu2eUtilities_inc_SimParticleCollectionPrinter_hh
 
-#include <ostream>
-#include <string>
+#include <bits/exception.h>                   // for exception
+#include <ostream>                            // for ostream
+#include <string>                             // for string, allocator
 
-#include "fhiclcpp/types/Atom.h"
-#include "fhiclcpp/types/OptionalAtom.h"
-
-#include "MCDataProducts/inc/SimParticleCollection.hh"
+#include "fhiclcpp/types/Atom.h"              // for Atom
+#include "MCDataProducts/inc/SimParticle.hh"  // for SimParticle (ptr only)
+#include "fhiclcpp/ParameterSet.h"            // for ParameterSet
+#include "fhiclcpp/exception.h"               // for exception
+#include "fhiclcpp/types/Comment.h"           // for Comment
+#include "fhiclcpp/types/Name.h"              // for Name
 
 namespace mu2e {
   class SimParticleCollectionPrinter {

--- a/Mu2eUtilities/inc/SimParticleGetTau.hh
+++ b/Mu2eUtilities/inc/SimParticleGetTau.hh
@@ -10,16 +10,16 @@
 #define Mu2eUtilities_SimParticleGetTau_hh
 
 // C++ includes
-#include <vector>
-
-// Framework includes
-#include "canvas/Persistency/Common/Ptr.h"
+#include <vector>                                               // for vector
 
 // Mu2e includes
-#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"
-#include "GlobalConstantsService/inc/PhysicsParams.hh"
-#include "MCDataProducts/inc/SimParticle.hh"
-#include "MCDataProducts/inc/StepPointMCCollection.hh"
+#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"  // for Globa...
+#include "GlobalConstantsService/inc/PhysicsParams.hh"          // for Physi...
+#include "MCDataProducts/inc/StepPointMC.hh"                    // for StepP...
+
+namespace art {
+template <typename T> class Ptr;
+}  // namespace art
 
 namespace mu2e {
 

--- a/Mu2eUtilities/inc/SimParticleParentGetter.hh
+++ b/Mu2eUtilities/inc/SimParticleParentGetter.hh
@@ -35,17 +35,18 @@
 #ifndef Mu2eUtilities_SimParticleParentGetter_hh
 #define Mu2eUtilities_SimParticleParentGetter_hh
 
-#include <map>
+#include <map>                              // for map, map<>::value_compare
 
-#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Persistency/Common/Ptr.h"  // for Ptr, operator<
 
-#include "MCDataProducts/inc/GenParticle.hh"
-#include "MCDataProducts/inc/SimParticle.hh"
-#include "MCDataProducts/inc/StepPointMC.hh"
-
-namespace art { class Event; }
+namespace art {
+class Event;
+}  // namespace art
 
 namespace mu2e {
+class GenParticle;
+class StepPointMC;
+struct SimParticle;
 
   class SimParticleParentGetter {
     const art::Event *evt_;

--- a/Mu2eUtilities/inc/SimpleSpectrum.hh
+++ b/Mu2eUtilities/inc/SimpleSpectrum.hh
@@ -20,14 +20,13 @@
 //                by Czarnecki, et al (PRD 84, 013006)
 
 // C++ includes
-#include <map>
-#include <utility>
-#include <vector>
+#include <map>                                                  // for map
+#include <string>                                               // for string
 
 // Mu2e includes
-#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"
-#include "GlobalConstantsService/inc/PhysicsParams.hh"
-#include "GeneralUtilities/inc/EnumToStringSparse.hh"
+#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"  // for Globa...
+#include "GlobalConstantsService/inc/PhysicsParams.hh"          // for Physi...
+#include "GeneralUtilities/inc/EnumToStringSparse.hh"           // for EnumT...
 
 namespace mu2e {
 

--- a/Mu2eUtilities/inc/SortedStepPoints.hh
+++ b/Mu2eUtilities/inc/SortedStepPoints.hh
@@ -9,14 +9,12 @@
 // Original author Rob Kutschke
 //
 
-#include "CLHEP/Vector/ThreeVector.h"
-#include "MCDataProducts/inc/SimParticleCollection.hh"
-#include "MCDataProducts/inc/StepPointMCCollection.hh"
-#include <vector>
+#include <vector>                             // for vector
+
+#include "MCDataProducts/inc/SimParticle.hh"  // for SimParticleCollection
+#include "MCDataProducts/inc/StepPointMC.hh"  // for StepPointMC (ptr only)
 
 namespace mu2e {
-
-  class StepPointMC;
 
   class SortedStepPoints{
 

--- a/Mu2eUtilities/inc/TrackPatRecType.hh
+++ b/Mu2eUtilities/inc/TrackPatRecType.hh
@@ -7,7 +7,10 @@
 // Contact person, Rob Kutschke
 //
 
-#include "GeneralUtilities/inc/EnumToStringSparse.hh"
+#include <map>                                         // for map
+#include <string>                                      // for string
+
+#include "GeneralUtilities/inc/EnumToStringSparse.hh"  // for EnumToStringSp...
 
 namespace mu2e {
 

--- a/Mu2eUtilities/inc/TrkSpecies.hh
+++ b/Mu2eUtilities/inc/TrkSpecies.hh
@@ -17,7 +17,10 @@
 // Contact person, Rob Kutschke
 //
 
-#include "GeneralUtilities/inc/EnumToStringSparse.hh"
+#include <map>                                         // for map
+#include <string>                                      // for string
+
+#include "GeneralUtilities/inc/EnumToStringSparse.hh"  // for EnumToStringSp...
 
 namespace mu2e {
 

--- a/Mu2eUtilities/inc/checkSimParticleCollection.hh
+++ b/Mu2eUtilities/inc/checkSimParticleCollection.hh
@@ -1,6 +1,7 @@
 #ifndef Mu2eUtilities_checkSimParticleCollection_hh
 #define Mu2eUtilities_checkSimParticleCollection_hh
 
+#include "MCDataProducts/inc/SimParticle.hh"  // for SimParticleCollection
 //
 // Within a SimParticleColleciton, check that all mother/daughter pointers are self-consistent.
 //
@@ -10,8 +11,6 @@
 //
 // Contact person Rob Kutschke
 //
-
-#include "MCDataProducts/inc/SimParticleCollection.hh"
 
 namespace mu2e{
 

--- a/Mu2eUtilities/inc/decodeTrackPatRecType.hh
+++ b/Mu2eUtilities/inc/decodeTrackPatRecType.hh
@@ -9,13 +9,12 @@
 //  which looks for more information and is slower.
 //
 
-#include "Mu2eUtilities/inc/TrackPatRecType.hh"
+#include "Mu2eUtilities/inc/TrackPatRecType.hh"         // for TrackPatRecType
+#include "RecoDataProducts/inc/KalRepPtrCollection.hh"  // for KalRepPtr
 
-#include "RecoDataProducts/inc/KalRepPtrCollection.hh"
-
-#include "art/Framework/Principal/Event.h"
-
-#include "fhiclcpp/ParameterSet.h"
+namespace art {
+class Event;
+}  // namespace art
 
 namespace mu2e {
 

--- a/Mu2eUtilities/inc/particleEnteringG4Volume.hh
+++ b/Mu2eUtilities/inc/particleEnteringG4Volume.hh
@@ -8,12 +8,13 @@
 #ifndef Mu2eUtilities_inc_particleEnteringG4Volume_hh
 #define Mu2eUtilities_inc_particleEnteringG4Volume_hh
 
-#include "canvas/Persistency/Common/Ptr.h"
-#include "MCDataProducts/inc/SimParticle.hh"
-#include "MCDataProducts/inc/StepPointMC.hh"
-#include "MCDataProducts/inc/StrawGasStep.hh"
+#include "canvas/Persistency/Common/Ptr.h"  // for Ptr
 
 namespace mu2e{
+class StepPointMC;
+class StrawGasStep;
+struct SimParticle;
+
   art::Ptr<mu2e::SimParticle> particleEnteringG4Volume(const StepPointMC& step);
   art::Ptr<mu2e::SimParticle> particleEnteringG4Volume(const StrawGasStep& step);
 }

--- a/Mu2eUtilities/inc/rm48.hh
+++ b/Mu2eUtilities/inc/rm48.hh
@@ -1,6 +1,9 @@
 #ifndef Mu2eUtilities_rm48_hh
 #define Mu2eUtilities_rm48_hh
 
+namespace CLHEP {
+class RandFlat;
+}  // namespace CLHEP
 //
 //  Adapter to make CLHEP::RandFlat look like the cernlib rn48.
 //
@@ -21,8 +24,6 @@
 //  There is a potential problem.  If other codes also want
 //  to use rm48, this implementation will break the rule
 //  that each module gets its own random engine.
-
-#include "CLHEP/Random/RandFlat.h"
 
 // Called by the Daya Bay comsic code.
 extern "C" {

--- a/Mu2eUtilities/src/BinnedSpectrum.cc
+++ b/Mu2eUtilities/src/BinnedSpectrum.cc
@@ -1,17 +1,22 @@
+#include <exception>                                            // for excep...
+#include <string>                                               // for string
+
 #include "Mu2eUtilities/inc/BinnedSpectrum.hh"
-
-#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"
-#include "GlobalConstantsService/inc/ParticleDataTable.hh"
-#include "GlobalConstantsService/inc/PhysicsParams.hh"
-#include "ConfigTools/inc/ConfigFileLookupPolicy.hh"
-
-#include "Mu2eUtilities/inc/CzarneckiSpectrum.hh"
-#include "Mu2eUtilities/inc/SimpleSpectrum.hh"
-#include "Mu2eUtilities/inc/ConversionSpectrum.hh"
-#include "Mu2eUtilities/inc/EjectedProtonSpectrum.hh"
-#include "Mu2eUtilities/inc/MuonCaptureSpectrum.hh"
-#include "Mu2eUtilities/inc/PionCaptureSpectrum.hh"
-#include "DataProducts/inc/PDGCode.hh"
+#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"  // for Globa...
+#include "GlobalConstantsService/inc/ParticleDataTable.hh"      // for Parti...
+#include "GlobalConstantsService/inc/PhysicsParams.hh"          // for Physi...
+#include "ConfigTools/inc/ConfigFileLookupPolicy.hh"            // for Confi...
+#include "Mu2eUtilities/inc/CzarneckiSpectrum.hh"               // for Czarn...
+#include "Mu2eUtilities/inc/SimpleSpectrum.hh"                  // for Simpl...
+#include "Mu2eUtilities/inc/ConversionSpectrum.hh"              // for Conve...
+#include "Mu2eUtilities/inc/EjectedProtonSpectrum.hh"           // for Eject...
+#include "Mu2eUtilities/inc/MuonCaptureSpectrum.hh"             // for MuonC...
+#include "Mu2eUtilities/inc/PionCaptureSpectrum.hh"             // for PionC...
+#include "DataProducts/inc/PDGCode.hh"                          // for PDGCode
+#include "HepPDT/Measurement.hh"                                // for Measu...
+#include "HepPDT/ParticleData.hh"                               // for Parti...
+#include "fhiclcpp/ParameterSet.h"                              // for Param...
+#include "fhiclcpp/exception.h"                                 // for excep...
 
 namespace mu2e {
 
@@ -48,7 +53,7 @@ namespace mu2e {
       // should be total energy
       double elow = psphys.get<double>("elow",0);
       double ehi  = psphys.get<double>("ehi" );
-                                        // for radiatively corrected spectrum, elow and ehi are derivatives 
+                                        // for radiatively corrected spectrum, elow and ehi are derivatives
       double bin   = psphys.get<double>("spectrumResolution");
       // int    ratio = *ehi/bin;
       // *ehi         = (ratio+1.)*bin;
@@ -87,7 +92,7 @@ namespace mu2e {
       double elow = psphys.get<double>("elow",0);
       double ehi = psphys.get<double>("ehi",0);
       this->initialize(loadTable<2>( ConfigFileLookupPolicy()( psphys.get<std::string>("spectrumFileName"))),psphys.get<bool>("BinCenter", false),elow,ehi);
-    
+
       if(_xmin < 0.0) throw cet::exception("BADCONFIG")
         << "BinnedSpectrum: negative energy endpoint "<< _xmin  <<"\n";
     }

--- a/Mu2eUtilities/src/CoordinateString.cc
+++ b/Mu2eUtilities/src/CoordinateString.cc
@@ -1,8 +1,13 @@
 //
 // Original author: Kyle Knoepfel
 
+#include <cstdlib>                            // for atof, atoi
+#include <iostream>                           // for cout
+#include <memory>                             // for allocator, allocator_tr...
+#include <vector>                             // for vector
+
 #include "Mu2eUtilities/inc/CoordinateString.hh"
-#include "GeneralUtilities/inc/splitLine.hh"
+#include "GeneralUtilities/inc/splitLine.hh"  // for splitLine
 
 namespace mu2e {
 

--- a/Mu2eUtilities/src/CzarneckiSpectrum.cc
+++ b/Mu2eUtilities/src/CzarneckiSpectrum.cc
@@ -9,19 +9,18 @@
 // $Date: 2014/05/01 18:12:26 $
 //
 
+#include <array>                                                // for array
+#include <string>                                               // for alloc...
+#include <utility>                                              // for pair
+
 // Mu2e includes
-#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"
-#include "GlobalConstantsService/inc/PhysicsParams.hh"
-#include "ConfigTools/inc/ConfigFileLookupPolicy.hh"
-#include "Mu2eUtilities/inc/CzarneckiSpectrum.hh"
-
+#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"  // for Globa...
+#include "GlobalConstantsService/inc/PhysicsParams.hh"          // for Physi...
+#include "ConfigTools/inc/ConfigFileLookupPolicy.hh"            // for Confi...
+#include "Mu2eUtilities/inc/CzarneckiSpectrum.hh"               // for Czarn...
 // Framework includes
-#include "cetlib/pow.h"
-
-// C++ includes
-#include <fstream>
-#include <iostream>
-#include <vector>
+#include "cetlib/pow.h"                                         // for square
+#include "Mu2eUtilities/inc/Table.hh"                           // for Table
 
 namespace mu2e {
 

--- a/Mu2eUtilities/src/EventWeightHelper.cc
+++ b/Mu2eUtilities/src/EventWeightHelper.cc
@@ -1,14 +1,18 @@
 // Andrei Gaponenko, 2016
 
+#include <exception>                   // for exception
+#include <memory>                             // for unique_ptr
+#include <typeinfo>                           // for type_info
+
 #include "Mu2eUtilities/inc/EventWeightHelper.hh"
-
-#include "fhiclcpp/ParameterSet.h"
-#include "art/Framework/Principal/Event.h"
-#include "art_root_io/TFileDirectory.h"
-
-#include "MCDataProducts/inc/EventWeight.hh"
-
-#include "TH1.h"
+#include "fhiclcpp/ParameterSet.h"            // for ParameterSet
+#include "art/Framework/Principal/Event.h"    // for Event
+#include "art_root_io/TFileDirectory.h"       // for TFileDirectory
+#include "MCDataProducts/inc/EventWeight.hh"  // for EventWeight
+#include "TH1.h"                              // for TH1D, TH1
+#include "art/Framework/Principal/Handle.h"   // for ValidHandle
+#include "fhiclcpp/coding.h"                  // for ps_sequence_t, sequence_t
+#include "fhiclcpp/exception.h"               // for exception
 
 namespace mu2e {
 

--- a/Mu2eUtilities/src/GeneratorSummaryHistograms.cc
+++ b/Mu2eUtilities/src/GeneratorSummaryHistograms.cc
@@ -8,24 +8,26 @@
 // Contact person Rob Kutschke
 //
 
+#include <cmath>                                            // for M_PI
+#include <vector>                                           // for vector
+
 // Mu2e includes
 #include "Mu2eUtilities/inc/GeneratorSummaryHistograms.hh"
-#include "GeometryService/inc/DetectorSystem.hh"
-#include "GeometryService/inc/GeomHandle.hh"
-#include "StoppingTargetGeom/inc/zBinningForFoils.hh"
-#include "StoppingTargetGeom/inc/StoppingTarget.hh"
-
+#include "GeometryService/inc/DetectorSystem.hh"            // for DetectorS...
+#include "GeometryService/inc/GeomHandle.hh"                // for GeomHandle
+#include "StoppingTargetGeom/inc/zBinningForFoils.hh"       // for zBinningF...
+#include "StoppingTargetGeom/inc/StoppingTarget.hh"         // for StoppingT...
 // Framework includes
-#include "art_root_io/TFileService.h"
-#include "art/Framework/Services/Registry/ServiceHandle.h"
-
-// Root includes
-#include "TH1F.h"
-#include "TH2F.h"
-
-// C++ includes
-#include <iostream>
-#include <cmath>
+#include "art_root_io/TFileService.h"                       // for TFileService
+#include "art/Framework/Services/Registry/ServiceHandle.h"  // for ServiceHa...
+#include "CLHEP/Vector/LorentzVector.h"                     // for HepLorent...
+#include "CLHEP/Vector/ThreeVector.h"                       // for Hep3Vector
+#include "GeneralUtilities/inc/Binning.hh"                  // for Binning
+#include "MCDataProducts/inc/GenId.hh"                      // for GenId
+#include "TH1.h"                                            // for TH1F
+#include "TH2.h"                                            // for TH2F
+#include "art_root_io/TFileDirectory.h"                     // for TFileDire...
+#include "canvas/Utilities/Exception.h"                     // for Exception
 
 namespace mu2e {
 

--- a/Mu2eUtilities/src/HelixTool.cc
+++ b/Mu2eUtilities/src/HelixTool.cc
@@ -1,4 +1,20 @@
+#include <math.h>                                // for sqrtf, fabs, M_PI
+#include <stddef.h>                              // for size_t
+#include <array>                                 // for array
+#include <vector>                                // for vector
+
 #include "Mu2eUtilities/inc/HelixTool.hh"
+#include "CLHEP/Vector/ThreeVector.h"            // for Hep3Vector
+#include "DataProducts/inc/XYZVec.hh"            // for XYZVec
+#include "GeomPrimitives/inc/TubsParams.hh"      // for TubsParams
+#include "RecoDataProducts/inc/ComboHit.hh"      // for ComboHit, ComboHitCo...
+#include "RecoDataProducts/inc/HelixSeed.hh"     // for HelixSeed
+#include "RecoDataProducts/inc/RobustHelix.hh"   // for RobustHelix
+#include "RecoDataProducts/inc/StrawHitFlag.hh"  // for StrawHitFlag
+#include "TrackerGeom/inc/Panel.hh"              // for Panel
+#include "TrackerGeom/inc/Plane.hh"              // for Plane
+#include "TrackerGeom/inc/Straw.hh"              // for Straw
+#include "TrackerGeom/inc/Tracker.hh"            // for Tracker
 
 
 namespace mu2e {
@@ -57,7 +73,7 @@ namespace mu2e {
       int   nPanels = pln->nPanels();
       if (nPanels == 0 )         continue;
       std::array<int,2>   idPanels = {0, (nPanels-1)};
-	
+
       for (size_t ipn=0; ipn<idPanels.size(); ++ipn){
 	const Panel* panel = &pln->getPanel(ipn);
 	float    z = (panel->getStraw(0).getMidPoint().z()+panel->getStraw(1).getMidPoint().z())/2.;
@@ -67,12 +83,12 @@ namespace mu2e {
 	XYZVec  pos;
 	pos.SetZ(z);
 	robustHel->position(pos);
-	
+
 	//now check that we are in the active area of tracker
 	float   hitR = sqrtf(pos.x()*pos.x() + pos.y()*pos.y());
 	if (hitR < _trackerRIn )  continue;
 	if (hitR > _trackerROut)  continue;
-	  
+
 	++expected_faces;
       }//end loop over the two panels
     }//end loop over the planes

--- a/Mu2eUtilities/src/HistTrackSum.cc
+++ b/Mu2eUtilities/src/HistTrackSum.cc
@@ -1,10 +1,11 @@
+#include <memory>                                // for allocator_traits<>::...
+#include <vector>                                // for vector
+
 #include "Mu2eUtilities/inc/HistTrackSum.hh"
-
-#include "art_root_io/TFileDirectory.h"
-
-#include "TH1.h"
-
-#include "RecoDataProducts/inc/TrackSummary.hh"
+#include "art_root_io/TFileDirectory.h"          // for TFileDirectory
+#include "TH1.h"                                 // for TH1D, TH1
+#include "RecoDataProducts/inc/TrackSummary.hh"  // for TrackSummary, TrackS...
+#include "CLHEP/Vector/ThreeVector.h"            // for Hep3Vector
 
 namespace mu2e {
 

--- a/Mu2eUtilities/src/KalRepCollectionInfo.cc
+++ b/Mu2eUtilities/src/KalRepCollectionInfo.cc
@@ -4,7 +4,17 @@
 // Contact person, Rob Kutschke
 //
 
+#include <exception>                           // for exception
+#include <memory>                                     // for allocator, uniq...
+#include <typeinfo>                                   // for type_info
+
 #include "Mu2eUtilities/inc/KalRepCollectionInfo.hh"
+#include "art/Framework/Principal/Event.h"            // for Event
+#include "art/Framework/Principal/Handle.h"           // for Handle, ValidHa...
+#include "art/Framework/Principal/Provenance.h"       // for Provenance
+#include "canvas/Persistency/Provenance/ProductID.h"  // for ProductID
+#include "fhiclcpp/ParameterSet.h"                    // for ParameterSet
+#include "fhiclcpp/exception.h"                       // for exception
 
 namespace {
 

--- a/Mu2eUtilities/src/KalRepInstanceNameDecoder.cc
+++ b/Mu2eUtilities/src/KalRepInstanceNameDecoder.cc
@@ -6,8 +6,8 @@
 //
 
 #include "Mu2eUtilities/inc/KalRepInstanceNameDecoder.hh"
-
-#include "cetlib_except/exception.h"
+#include "cetlib_except/exception.h"                   // for exception, ope...
+#include "GeneralUtilities/inc/EnumToStringSparse.hh"  // for EnumToStringSp...
 
 mu2e::KalRepInstanceNameDecoder::KalRepInstanceNameDecoder( std::string const& instanceName ):
   instanceName_(instanceName),

--- a/Mu2eUtilities/src/LsqSums2.cc
+++ b/Mu2eUtilities/src/LsqSums2.cc
@@ -1,9 +1,7 @@
 //-----------------------------------------------------------------------------
 // LsqSums2
 //-----------------------------------------------------------------------------
-#include <cstdio>
-#include <cmath>
-#include "Mu2eUtilities/inc/LsqSums2.hh"
+#include "Mu2eUtilities/inc/LsqSums2.hh"  // for LsqSums2
 
 
 LsqSums2::LsqSums2() {

--- a/Mu2eUtilities/src/LsqSums4.cc
+++ b/Mu2eUtilities/src/LsqSums4.cc
@@ -1,9 +1,9 @@
 //-----------------------------------------------------------------------------
 // LsqSums4
 //-----------------------------------------------------------------------------
-#include <cstdio>
-#include <cmath>
-#include "Mu2eUtilities/inc/LsqSums4.hh"
+#include <cmath>                          // for sqrt
+
+#include "Mu2eUtilities/inc/LsqSums4.hh"  // for LsqSums4
 
 
 LsqSums4::LsqSums4() {

--- a/Mu2eUtilities/src/MVATools.cc
+++ b/Mu2eUtilities/src/MVATools.cc
@@ -1,61 +1,77 @@
-#include "ConfigTools/inc/ConfigFileLookupPolicy.hh"
-#include "Mu2eUtilities/inc/MVATools.hh"
+#include <xercesc/util/PlatformUtils.hpp>             // for XMLPlatformUtils
+#include <xercesc/parsers/XercesDOMParser.hpp>        // for XercesDOMParser
+#include <exception>                           // for exception
+#include <ext/alloc_traits.h>                         // for __alloc_traits<...
+#include <math.h>                                     // for expf, tanh
+#include <stdlib.h>                                   // for atoi, NULL, strtof
+#include <iostream>                                   // for operator<<, endl
+#include <string>                                     // for string, operator<<
+#include <vector>                                     // for vector, vector<...
+#include <limits>                                     // for numeric_limits
+#include <algorithm>                                  // for max, max_element
+#include <utility>                                    // for move
 
+#include "ConfigTools/inc/ConfigFileLookupPolicy.hh"  // for ConfigFileLooku...
+#include "Mu2eUtilities/inc/MVATools.hh"              // for MVATools, MVATo...
 // From the art tool-chain
-#include "fhiclcpp/ParameterSet.h"
-
-#include <xercesc/util/PlatformUtils.hpp>
-#include <xercesc/parsers/XercesDOMParser.hpp>
-#include <xercesc/dom/DOM.hpp>
-#include <xercesc/sax/HandlerBase.hpp>
-#include <iostream>
-#include <iomanip>
-#include <string>
-#include <vector>
-#include <sstream>
-#include <limits>
+#include "fhiclcpp/ParameterSet.h"                    // for ParameterSet
+#include "DataProducts/inc/MVAMask.hh"                // for MVAMask
+#include "cetlib_except/exception.h"                  // for exception, oper...
+#include "fhiclcpp/exception.h"                       // for exception
+#include "fhiclcpp/types/Atom.h"                      // for Atom
+#include "xercesc/dom/DOMDocument.hpp"                // for DOMDocument
+#include "xercesc/dom/DOMElement.hpp"                 // for DOMElement
+#include "xercesc/dom/DOMNamedNodeMap.hpp"            // for DOMNamedNodeMap
+#include "xercesc/dom/DOMNode.hpp"                    // for DOMNode
+#include "xercesc/dom/DOMNodeList.hpp"                // for DOMNodeList
+#include "xercesc/dom/DOMXPathResult.hpp"             // for DOMXPathResult
+#include "xercesc/parsers/AbstractDOMParser.hpp"      // for AbstractDOMPars...
+#include "xercesc/util/XMLException.hpp"              // for XMLException
+#include "xercesc/util/XMLString.hpp"                 // for XMLString
+#include "xercesc/util/XercesDefs.hpp"                // for xercesc
+#include "xercesc/util/Xerces_autoconf_config.hpp"    // for XMLCh, XMLSize_t
 
 using namespace xercesc;
 
-namespace mu2e 
+namespace mu2e
 {
 
-  MVATools::MVATools(const Config& config) : 
+  MVATools::MVATools(const Config& config) :
     x_(),
     y_(),
     fv_(),
-    wgts_(), 
-    maxNeurons_(0), 
+    wgts_(),
+    maxNeurons_(0),
     activeType_(aType::null),
     oldMVA_(false),
     isNorm_(false),
-    voffset_(), 
-    vscale_(), 
-    title_(), 
+    voffset_(),
+    vscale_(),
+    title_(),
     label_(),
     activationTypeString_("none"),
-    mvaWgtsFile_() 
+    mvaWgtsFile_()
   {
      ConfigFileLookupPolicy configFile;
      std::string weights = config.weights();
      mvaWgtsFile_ = configFile(weights);
   }
 
-  MVATools::MVATools(fhicl::ParameterSet const& pset) : 
+  MVATools::MVATools(fhicl::ParameterSet const& pset) :
     x_(),
     y_(),
     fv_(),
-    wgts_(), 
-    maxNeurons_(0), 
+    wgts_(),
+    maxNeurons_(0),
     activeType_(aType::null),
     oldMVA_(false),
     isNorm_(false),
-    voffset_(), 
-    vscale_(), 
-    title_(), 
+    voffset_(),
+    vscale_(),
+    title_(),
     label_(),
     activationTypeString_("none"),
-    mvaWgtsFile_() 
+    mvaWgtsFile_()
   {
      ConfigFileLookupPolicy configFile;
      std::string weights = pset.get<std::string>("MVAWeights");
@@ -73,7 +89,7 @@ namespace mu2e
       try
       {
          XMLPlatformUtils::Initialize();
-      } 
+      }
       catch (XMLException& e)
       {
          char* message = XMLString::transcode( e.getMessage() ) ;
@@ -100,7 +116,7 @@ namespace mu2e
   }
 
   void MVATools::getGen(xercesc::DOMDocument* xmlDoc)
-  {       
+  {
       XMLCh* ATT_GENERAL = XMLString::transcode("GeneralInfo");
       XMLCh* ATT_INFO = XMLString::transcode("Info");
       XMLCh* TAG_NAME = XMLString::transcode("name");
@@ -110,7 +126,7 @@ namespace mu2e
       DOMXPathResult* xpathRes = xmlDoc->evaluate(xpathStr,xmlDoc->getDocumentElement(),NULL,
                                                   DOMXPathResult::ORDERED_NODE_SNAPSHOT_TYPE, NULL);
       XMLString::release(&xpathStr) ;
-      DOMElement* optElem = dynamic_cast<DOMElement* >(xpathRes->getNodeValue());    
+      DOMElement* optElem = dynamic_cast<DOMElement* >(xpathRes->getNodeValue());
       xpathRes->release();
 
 
@@ -125,8 +141,8 @@ namespace mu2e
           {
 	     DOMNode* attr = attrs->item(ia);
 	     char* attValue = XMLString::transcode(attr->getNodeValue());
-	     if (XMLString::equals(TAG_NAME,attr->getNodeName()) )     label = std::string(attValue);          
-	     if (XMLString::equals(TAG_VALUE,attr->getNodeName()) )    value = std::string(attValue);          
+	     if (XMLString::equals(TAG_NAME,attr->getNodeName()) )     label = std::string(attValue);
+	     if (XMLString::equals(TAG_VALUE,attr->getNodeName()) )    value = std::string(attValue);
              XMLString::release(&attValue);
           }
 	  if (label.find("TMVA Release") != std::string::npos)
@@ -134,8 +150,8 @@ namespace mu2e
  	     std::string code = value.substr(value.find("[")+1,value.find("]")-value.find("[")-1);
 	     int iversion = atoi(code.c_str());
              if (iversion < 262657) oldMVA_ = true;
-	  }      
-      }   
+	  }
+      }
 
       XMLString::release(&ATT_GENERAL);
       XMLString::release(&ATT_INFO);
@@ -144,7 +160,7 @@ namespace mu2e
   }
 
   void MVATools::getOpts(xercesc::DOMDocument* xmlDoc)
-  {       
+  {
       XMLCh* ATT_OPTION = XMLString::transcode("Option");
       XMLCh* TAG_NAME = XMLString::transcode("name");
       XMLCh* TAG_MODIFIED = XMLString::transcode("modified");
@@ -153,7 +169,7 @@ namespace mu2e
       DOMXPathResult* xpathRes = xmlDoc->evaluate(xpathStr,xmlDoc->getDocumentElement(),NULL,
                                                   DOMXPathResult::ORDERED_NODE_SNAPSHOT_TYPE, NULL);
       XMLString::release(&xpathStr) ;
-      DOMElement* optElem = dynamic_cast<DOMElement* >(xpathRes->getNodeValue());    
+      DOMElement* optElem = dynamic_cast<DOMElement* >(xpathRes->getNodeValue());
       xpathRes->release();
 
       DOMNodeList* children = optElem->getElementsByTagName(ATT_OPTION);
@@ -168,26 +184,26 @@ namespace mu2e
           {
 	     DOMNode* attr = attrs->item(ia);
 	     char* attValue = XMLString::transcode(attr->getNodeValue());
-	     if (XMLString::equals(TAG_NAME,attr->getNodeName()) ) label = std::string(attValue);          
-	     if (XMLString::equals(TAG_MODIFIED,attr->getNodeName()) ) modified = std::string(attValue);          
+	     if (XMLString::equals(TAG_NAME,attr->getNodeName()) ) label = std::string(attValue);
+	     if (XMLString::equals(TAG_MODIFIED,attr->getNodeName()) ) modified = std::string(attValue);
              XMLString::release(&attValue);
           }
           if (label.find("NeuronType") != std::string::npos)
 	  {
 	     std::string val(value);
-	     if (val.find("tanh") != std::string::npos)    activeType_ = aType::tanh;  
-	     if (val.find("sigmoid") != std::string::npos) activeType_ = aType::sigmoid;  
+	     if (val.find("tanh") != std::string::npos)    activeType_ = aType::tanh;
+	     if (val.find("sigmoid") != std::string::npos) activeType_ = aType::sigmoid;
 	     if (val.find("ReLU") != std::string::npos)    activeType_ = aType::relu;
-             activationTypeString_ = val;  	   
-	  }      
+             activationTypeString_ = val;
+	  }
           if (label.find("VarTransform") != std::string::npos)
 	  {
 	     std::string val(value);
 	     if (modified.find("Yes") != std::string::npos) isNorm_ = true;
-	     if (isNorm_ && val.find("N") == std::string::npos) 
+	     if (isNorm_ && val.find("N") == std::string::npos)
                throw cet::exception("RECO")<<"mu2e::MVATools: unknown normalization mode" << std::endl;
-	  }      
-      }   
+	  }
+      }
 
       if (activeType_ == aType::null) throw cet::exception("RECO")<<"mu2e::MVATools: unknown activation function" << std::endl;
 
@@ -213,7 +229,7 @@ namespace mu2e
 
       DOMNodeList* children = varElem->getElementsByTagName(TAG_VARIABLE);
       for( XMLSize_t ix = 0 ; ix < children->getLength() ; ++ix )
-      {       
+      {
          float vmin(std::numeric_limits<float>::max());
          float vmax(0.0);
          std::string label,title;
@@ -282,29 +298,29 @@ namespace mu2e
           char* nSynapses  = XMLString::transcode(neuronElement->getAttribute(ATT_NSYNAPSES));
           unsigned iSynapses  = atoi(nSynapses);
 
-          if (iLayer != iCurrentLayer) 
+          if (iLayer != iCurrentLayer)
 	  {
               if (iCurrentLayer > -1) links_.push_back(nNeurons);
 	      iCurrentLayer=iLayer;
               nNeurons=0;
-	  } 
+	  }
 
-	  if (nNeuron->getFirstChild()==NULL) continue; //output neuron has no children        
+	  if (nNeuron->getFirstChild()==NULL) continue; //output neuron has no children
 
-	  char* cw = XMLString::transcode(nNeuron->getFirstChild()->getNodeValue());        
+	  char* cw = XMLString::transcode(nNeuron->getFirstChild()->getNodeValue());
 	  std::string sw(cw),temp;
           std::stringstream ss(sw);
           std::vector<float> w;
-	  while(ss >> temp) w.push_back(strtof(temp.c_str(),NULL));        
+	  while(ss >> temp) w.push_back(strtof(temp.c_str(),NULL));
 	  if (w.size() != iSynapses) throw cet::exception("RECO")<<"mu2e::MVATools: internal error" << std::endl;
 	  wtemp.push_back(std::move(w));
 
 	  XMLString::release(&cw);
-	  ++nNeurons;      
+	  ++nNeurons;
       }
 
       // the weights are given in a back-propagation style, continuous weights are from a neuron of the previous layer to all neurons of the next layer
-      // for evaluation, forward-propagation style is better, contiguous weights from all neurons of the previous layer to a single neuron of the next layer 
+      // for evaluation, forward-propagation style is better, contiguous weights from all neurons of the previous layer to a single neuron of the next layer
       // we also need the number of synapses / layer, which is given by the number of neurons in the next layer -1 to remove bias neuron
       //
       std::vector<unsigned> layerToNeurons(1,0),synapsessPerLayer;
@@ -313,11 +329,11 @@ namespace mu2e
       synapsessPerLayer.push_back(1);
 
       for (unsigned iLayer=1;iLayer < layerToNeurons.size(); ++iLayer)
-      {    
+      {
 	  for (unsigned iOut=0;iOut<synapsessPerLayer[iLayer-1];++iOut)
-	  {        
+	  {
 	     std::vector<float> temp;
-	     for (unsigned iIn=layerToNeurons[iLayer-1];iIn<layerToNeurons[iLayer];++iIn) wgts_.push_back(wtemp[iIn][iOut]);                   
+	     for (unsigned iIn=layerToNeurons[iLayer-1];iIn<layerToNeurons[iLayer];++iIn) wgts_.push_back(wtemp[iIn][iOut]);
 	  }
       }
 
@@ -326,19 +342,19 @@ namespace mu2e
       y_ = std::vector<float>(maxNeurons_,0.0f);
 
       XMLString::release(&ATT_INDEX);
-      XMLString::release(&ATT_NSYNAPSES);    
+      XMLString::release(&ATT_NSYNAPSES);
   }
 
 
 
 
-  float MVATools::evalMVA(const std::vector<double >& v, const MVAMask& mask) const 
+  float MVATools::evalMVA(const std::vector<double >& v, const MVAMask& mask) const
   {
-     for (size_t i=0;i<v.size();++i)  fv_[i] = static_cast<float>(v[i]);   
+     for (size_t i=0;i<v.size();++i)  fv_[i] = static_cast<float>(v[i]);
      return evalMVA(fv_,mask);
   }
 
-  float MVATools::evalMVA(const std::vector<float>& v, const MVAMask& mask) const 
+  float MVATools::evalMVA(const std::vector<float>& v, const MVAMask& mask) const
   {
 
       // Normalize the input data and add the bias node, skip masked values
@@ -360,7 +376,7 @@ namespace mu2e
       //perform feed forward calculation up to the last hidden layer
       unsigned idxWeight(0);
       for (unsigned k=0;k<links_.size()-1;++k)
-      {          
+      {
           //the number of synpases is given by the number of neurons in the next layer -1 (do not count bias neuron!)
           for (unsigned j=0;j<links_[k+1]-1;++j)
           {
@@ -368,10 +384,10 @@ namespace mu2e
 	     for (unsigned i=0;i<links_[k];++i) y_[j] += wgts_[i+idxWeight]*x_[i];
              y_[j] = activation(y_[j]);
              idxWeight += links_[k];
-          }      
-          x_.swap(y_); 
+          }
+          x_.swap(y_);
           x_[links_[k+1]-1] = 1.0f; //add bias neuron
-      }   
+      }
 
       //calculate output neuron value
       float yf(0.0);
@@ -403,7 +419,7 @@ namespace mu2e
   }
 
 
-  void MVATools::showMVA() const 
+  void MVATools::showMVA() const
   {
       std::cout << "MVA weights from file:" <<     mvaWgtsFile_ << std::endl;;
       std::cout << "MVA NLayers: " << links_.size()-1 << std::endl;;
@@ -429,16 +445,16 @@ namespace mu2e
 
       int idx(0);
       for (unsigned k=0;k<links_.size()-1;++k)
-      {          
+      {
         std::cout<<"Layer "<<k<<std::endl;
-        for (unsigned j=0;j<links_[k+1]-1;++j)  
+        for (unsigned j=0;j<links_[k+1]-1;++j)
         {
 	  std::cout<<"Synapses 1.."<<links_[k]<<" of current layer to synapse "<<j<<" of next layer"<<std::endl;
 	  for (unsigned i=idx;i<idx+links_[k];++i)std::cout<<wgts_[i]<<" ";
 	  std::cout<<std::endl;
           idx += links_[k];
-        }      
-      }   
+        }
+      }
 
       std::cout<<"Layer "<<links_.size()-1<<std::endl;
       std::cout<<"Synapses 1.."<<links_.back()<<" of current layer to synapse 0 of next layer"<<std::endl;

--- a/Mu2eUtilities/src/McUtilsToolBase.cc
+++ b/Mu2eUtilities/src/McUtilsToolBase.cc
@@ -2,12 +2,18 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "art/Framework/Principal/Event.h"
-#include "fhiclcpp/ParameterSet.h"
+#include <stddef.h>                              // for NULL
 
-#include "Mu2eUtilities/inc/McUtilsToolBase.hh"
+#include "Mu2eUtilities/inc/McUtilsToolBase.hh"  // for McUtilsToolBase
+
+namespace art {
+class Event;
+}  // namespace art
 
 namespace mu2e {
+class SimParticle;
+class TrkStrawHit;
+
 //-----------------------------------------------------------------------------
 // ID of the SimParticle corresponding to the straw hit 'Index' in the 
 // StrawHitCollection

--- a/Mu2eUtilities/src/MedianCalculator.cc
+++ b/Mu2eUtilities/src/MedianCalculator.cc
@@ -1,6 +1,9 @@
+#include <iostream>                   // for endl
+#include <algorithm>                  // for sort
+#include <memory>                     // for allocator_traits<>::value_type
+
 #include "Mu2eUtilities/inc/MedianCalculator.hh"
-#include <iostream>
-#include "cetlib_except/exception.h"
+#include "cetlib_except/exception.h"  // for exception, operator<<
 
 namespace mu2e {
 

--- a/Mu2eUtilities/src/ModuleHistToolBase.cc
+++ b/Mu2eUtilities/src/ModuleHistToolBase.cc
@@ -8,6 +8,10 @@
 
 #include "Mu2eUtilities/inc/ModuleHistToolBase.hh"
 
+namespace art {
+class TFileService;
+}  // namespace art
+
 namespace mu2e {
 
   // ModuleHist::ModuleHist() {

--- a/Mu2eUtilities/src/MuonCaptureSpectrum.cc
+++ b/Mu2eUtilities/src/MuonCaptureSpectrum.cc
@@ -2,21 +2,25 @@
 // radiative muon capture; largely cloned from radiative pion capture.  see doc-db 4378
 //
 // Mu2e includes
-#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"
-#include "GlobalConstantsService/inc/PhysicsParams.hh"
-#include "GlobalConstantsService/inc/ParticleDataTable.hh"
-#include "Mu2eUtilities/inc/MuonCaptureSpectrum.hh"
-#include "Mu2eUtilities/inc/RandomUnitSphere.hh"
-
-// Framework includes
-#include "art/Framework/Services/Optional/RandomNumberGenerator.h"
-#include "cetlib/pow.h"
-
-// CLHEP includes
-#include "CLHEP/Random/RandFlat.h"
-
+#include <math.h>                                               // for sqrt
+#include <stdlib.h>                                             // for abs
 // C++ includes
-#include <iostream>
+#include <iostream>                                             // for std
+#include <memory>                                               // for alloc...
+
+#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"  // for Globa...
+#include "GlobalConstantsService/inc/PhysicsParams.hh"          // for Physi...
+#include "GlobalConstantsService/inc/ParticleDataTable.hh"      // for Parti...
+#include "Mu2eUtilities/inc/MuonCaptureSpectrum.hh"             // for MuonC...
+#include "Mu2eUtilities/inc/RandomUnitSphere.hh"                // for Rando...
+#include "cetlib/pow.h"                                         // for diff_...
+// CLHEP includes
+#include "CLHEP/Random/RandFlat.h"                              // for RandFlat
+#include "CLHEP/Vector/LorentzVector.h"                         // for HepLo...
+#include "CLHEP/Vector/ThreeVector.h"                           // for Hep3V...
+#include "DataProducts/inc/PDGCode.hh"                          // for PDGCode
+#include "HepPDT/Measurement.hh"                                // for Measu...
+#include "HepPDT/ParticleData.hh"                               // for Parti...
 
 using namespace std;
 
@@ -25,8 +29,8 @@ using cet::square;
 
 namespace mu2e {
 
-  MuonCaptureSpectrum::MuonCaptureSpectrum(CLHEP::RandFlat* rnFlat, RandomUnitSphere* rnUnitSphere):  
-    _spectrum    (RMC             ), 
+  MuonCaptureSpectrum::MuonCaptureSpectrum(CLHEP::RandFlat* rnFlat, RandomUnitSphere* rnUnitSphere):
+    _spectrum    (RMC             ),
     _spectrum2D  (KrollWadaJoseph ),
     _kMaxUserSet (false           ),
     _kMaxUser    (0.              ),
@@ -42,11 +46,11 @@ namespace mu2e {
   }
 
   MuonCaptureSpectrum::MuonCaptureSpectrum(bool kMaxUserSet, double kMaxUser, double kMaxMax,
-					   CLHEP::RandFlat* rnFlat, RandomUnitSphere* rnUnitSphere): 
-    _spectrum    (RMC             ), 
+					   CLHEP::RandFlat* rnFlat, RandomUnitSphere* rnUnitSphere):
+    _spectrum    (RMC             ),
     _spectrum2D  (KrollWadaJoseph ),
-    _kMaxUserSet (kMaxUserSet     ), 
-    _kMaxUser    (kMaxUser        ), 
+    _kMaxUserSet (kMaxUserSet     ),
+    _kMaxUser    (kMaxUser        ),
     _kMaxMax     (kMaxMax         ),
     _rnFlat      (rnFlat          ),
     _rnUnitSphere(rnUnitSphere    )
@@ -68,7 +72,7 @@ namespace mu2e {
 
     weight = getRMCSpectrum(E, _kMaxUserSet,_kMaxUser,_kMaxMax);
 
-    //   std::cout << "spectrum is " << _spectrum << std::endl; 
+    //   std::cout << "spectrum is " << _spectrum << std::endl;
 
     //    if (_spectrum == Flat) {std::cout << "Flat Spectrum" << std::endl;}
     //if (_spectrum==RMC) {std::cout << "RMC Spectrum" << std::endl;}
@@ -79,7 +83,7 @@ namespace mu2e {
 
 
   double MuonCaptureSpectrum::get2DWeight(double x, double y, double E ) const {
-    
+
     double weight(0.);
     if      ( _spectrum2D == Flat2D          ) weight = getFlat( E, x, y );
     else if ( _spectrum2D == KrollWadaJoseph ) weight = getKrollWadaJosephSpectrum( E, x, y );
@@ -97,7 +101,7 @@ namespace mu2e {
 
   //=======================================================
   // Analytic fit to the photon energy spectrum for Al
-  //  - 
+  //  -
   //  - see doc-db 4378; use higher kmax
   //=======================================================
 
@@ -105,26 +109,26 @@ namespace mu2e {
     double kMax;
     if (kMaxUserSet){
       kMax = kMaxUser;
-    } 
+    }
     else {
       kMax = kMaxMax;
-    } 
+    }
 
     if ( e > kMax ) return 0.;
 
     double xFit = e/kMax;
 
-   
+
     //    double value = (1 - 2*xFit +2*xFit*xFit)*xFit*(1-xFit)*(1-xFit);
- 
+
     //    std::cout << " kMax, xfit, value = " << kMax << " " << xFit << " " << value << std::endl;
-    
+
     return (1 - 2*xFit +2*xFit*xFit)*xFit*(1-xFit)*(1-xFit);
   }
 
 
   //=======================================================
-  // Analytic expression for electron/positron energies via 
+  // Analytic expression for electron/positron energies via
   //  - Kroll and Wada, Phys. Rev. 98, 1355 (1955)
   //  - Joseph, Il Nuovo Cimento 16, 997 (1960)
   //=======================================================
@@ -136,14 +140,14 @@ namespace mu2e {
   }
 
 //------------------------------------------------------------------------------
-// E - energy (k0) of the emitted virtual photon, x - mass of the e+e- pair 
+// E - energy (k0) of the emitted virtual photon, x - mass of the e+e- pair
 //-----------------------------------------------------------------------------
   double MuonCaptureSpectrum::getKrollWadaJosephSpectrum(double E, double x, double y) const {
 
     // mass of the recoiling system, neglecting the muon binding energy and nuclear recoil
 
     double M = _MN + _mmu - E;
-    
+
     // Set pdf to zero if x is out of bounds
     if (  x > E || x < 2*_me ) return 0.;
 
@@ -154,23 +158,23 @@ namespace mu2e {
     // Set parameters
     static const double rV  = 0.57;
     static const double muS = 0.064;
-    
+
     double xe = x/E;
     double rT = 1+rV*rV/3 - 2*muS*xe*xe;
 
     double xl = (1./(1-0.466*xe*xe)+1.88*(rV*rV/6 + muS*(1-xe*xe)))/(1+muS);
     double rL = 0.142*xl*xl;
-    
+
     double kRatio2 = ( pow(2*E*M + E*E,2) - 2*x*x*(2*M*M + 2*E*M + E*E ) + pow( x, 4 ) )/pow(2*E*M + E*E,2) ;
     double kRatio  = sqrt( kRatio2 );
 
     double prefactor = ( pow( E+M,2 ) + M*M - x*x )/( pow( E+M,2 ) + M*M );
-    
+
     double trans     = rT*( ( 1+y*y )/x + 4*_me*_me/pow(x,3) );
     double longit    = rL*(1-y*y)*8*pow(E+M,2)*x/pow( 2*E*M + E*E + x*x, 2 );
-    
+
     double prob      = kRatio*prefactor*( trans + longit );
-    
+
     return prob;
 
   }
@@ -199,24 +203,24 @@ namespace mu2e {
 					// generate invariant mass and energy splitting
     fire(ePhoton,x,y);
 
-    double eElectron = 0.5*( ePhoton - y*std::sqrt( cet::diff_of_squares( ePhoton, x ) ) ); 
-    double ePositron = 0.5*( ePhoton + y*std::sqrt( cet::diff_of_squares( ePhoton, x ) ) ); 
-        
+    double eElectron = 0.5*( ePhoton - y*std::sqrt( cet::diff_of_squares( ePhoton, x ) ) );
+    double ePositron = 0.5*( ePhoton + y*std::sqrt( cet::diff_of_squares( ePhoton, x ) ) );
+
     // Get electron/positron momentum magnitudes
 
     double pElectron = std::sqrt( cet::diff_of_squares( eElectron, _me ) );
     double pPositron = std::sqrt( cet::diff_of_squares( ePositron, _me ) );
-        
+
     // Produce electron momentum
     CLHEP::Hep3Vector p3electron = _rnUnitSphere->fire( pElectron );
 
     // Get positron momentum
     CLHEP::Hep3Vector p3positron( p3electron );
     p3positron.setMag( pPositron );
-        
+
     // - theta (opening angle wrt electron) is constrained by virtual mass formula
     // - phi is allowed to vary between 0 and 2pi
-        
+
     double cosTheta = 1/(2*pElectron*pPositron)*( cet::square(ePhoton) - cet::sum_of_squares( x, pElectron, pPositron) );
 
     double phi = 2*M_PI*_rnFlat->fire();
@@ -225,10 +229,10 @@ namespace mu2e {
     CLHEP::Hep3Vector n1 = (std::abs(p3electron.x()) < std::abs(p3electron.y())) ?
       ((std::abs(p3electron.x()) < std::abs(p3electron.z())) ? CLHEP::Hep3Vector(1,0,0) : CLHEP::Hep3Vector(0,0,1)) :
       ((std::abs(p3electron.x()) < std::abs(p3electron.y())) ? CLHEP::Hep3Vector(1,0,0) : CLHEP::Hep3Vector(0,1,0));
-        
+
     // - construct a vector perpendicular to the electron momentum
     CLHEP::Hep3Vector perp = p3electron.cross(n1);
-        
+
     p3positron.rotate(perp      , std::acos(cosTheta) );
     p3positron.rotate(p3electron, phi                 );
 

--- a/Mu2eUtilities/src/ParametricFit.cc
+++ b/Mu2eUtilities/src/ParametricFit.cc
@@ -1,11 +1,16 @@
 //Author: S Middleton
 //Purpose: Stores all the functions associated with building and interpretting parametric line equations for the purpose of cosmic track based alignment. This includes calculting track axes, hit errors and re-orientating those errors, track residuals are also calcuated here.
 
-#include "Mu2eUtilities/inc/ParametricFit.hh"
-#include "RecoDataProducts/inc/CosmicTrack.hh"
+#include <math.h>                                 // for sqrt, cos, sin, pow
+#include <stdlib.h>                               // for abs
+#include <algorithm>                              // for max
+#include <iostream>                               // for operator<<, endl
 
-//ROOT
-#include "TMath.h"
+#include "Mu2eUtilities/inc/ParametricFit.hh"
+#include "RecoDataProducts/inc/CosmicTrack.hh"    // for TrackAxes
+#include "Math/GenVector/Cartesian3D.h"           // for Cartesian3D
+#include "Math/GenVector/DisplacementVector3D.h"  // for operator*, Displace...
+#include "RecoDataProducts/inc/ComboHit.hh"       // for ComboHit
 
 using namespace std;
 using namespace mu2e;

--- a/Mu2eUtilities/src/PhysicalVolumeMultiHelper.cc
+++ b/Mu2eUtilities/src/PhysicalVolumeMultiHelper.cc
@@ -1,10 +1,14 @@
 // Andrei Gaponenko, 2013
 
-#include "Mu2eUtilities/inc/PhysicalVolumeMultiHelper.hh"
+#include <memory>                     // for allocator, allocator_traits<>::...
 
-#include "cetlib_except/exception.h"
+#include "Mu2eUtilities/inc/PhysicalVolumeMultiHelper.hh"
+#include "cetlib_except/exception.h"  // for exception, operator<<
+#include "cetlib/map_vector.h"        // for map_vector, map_vector_key, ope...
 
 namespace mu2e {
+struct PhysicalVolumeInfo;
+
   PhysicalVolumeMultiHelper::PhysicalVolumeMultiHelper(const PhysicalVolumeInfoMultiCollection& coll)
     : pi_(&coll)
   {}

--- a/Mu2eUtilities/src/PionCaptureSpectrum.cc
+++ b/Mu2eUtilities/src/PionCaptureSpectrum.cc
@@ -5,23 +5,26 @@
 // $Date: 2014/02/05 21:32:26 $
 //
 
-// Mu2e includes
-#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"
-#include "GlobalConstantsService/inc/PhysicsParams.hh"
-#include "GlobalConstantsService/inc/ParticleDataTable.hh"
-#include "Mu2eUtilities/inc/PionCaptureSpectrum.hh"
-#include "Mu2eUtilities/inc/RandomUnitSphere.hh"
-
-// Framework includes
-#include "art/Framework/Services/Optional/RandomNumberGenerator.h"
-#include "cetlib/pow.h"
-
-// CLHEP includes
-#include "CLHEP/Random/RandFlat.h"
-#include "CLHEP/Vector/LorentzVector.h"
-
+#include <math.h>                                               // for sqrt
+#include <stdlib.h>                                             // for abs
 // C++ includes
-#include <iostream>
+#include <iostream>                                             // for std
+#include <memory>                                               // for alloc...
+
+// Mu2e includes
+#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"  // for Globa...
+#include "GlobalConstantsService/inc/PhysicsParams.hh"          // for Physi...
+#include "GlobalConstantsService/inc/ParticleDataTable.hh"      // for Parti...
+#include "Mu2eUtilities/inc/PionCaptureSpectrum.hh"             // for PionC...
+#include "Mu2eUtilities/inc/RandomUnitSphere.hh"                // for Rando...
+#include "cetlib/pow.h"                                         // for diff_...
+// CLHEP includes
+#include "CLHEP/Random/RandFlat.h"                              // for RandFlat
+#include "CLHEP/Vector/LorentzVector.h"                         // for HepLo...
+#include "CLHEP/Vector/ThreeVector.h"                           // for Hep3V...
+#include "DataProducts/inc/PDGCode.hh"                          // for PDGCode
+#include "HepPDT/Measurement.hh"                                // for Measu...
+#include "HepPDT/ParticleData.hh"                               // for Parti...
 
 using namespace std;
 
@@ -30,8 +33,8 @@ using cet::square;
 
 namespace mu2e {
 
-  PionCaptureSpectrum::PionCaptureSpectrum(CLHEP::RandFlat* rnFlat, RandomUnitSphere* rnUnitSphere):  
-    _spectrum    (Bistirlich      ), 
+  PionCaptureSpectrum::PionCaptureSpectrum(CLHEP::RandFlat* rnFlat, RandomUnitSphere* rnUnitSphere):
+    _spectrum    (Bistirlich      ),
     _spectrum2D  (KrollWadaJoseph ),
     _kMaxUserSet (false           ),
     _kMaxUser    (0.              ),
@@ -47,11 +50,11 @@ namespace mu2e {
   }
 
   PionCaptureSpectrum::PionCaptureSpectrum(bool kMaxUserSet, double kMaxUser, double kMaxMax,
-					   CLHEP::RandFlat* rnFlat, RandomUnitSphere* rnUnitSphere): 
-    _spectrum    (Bistirlich      ), 
+					   CLHEP::RandFlat* rnFlat, RandomUnitSphere* rnUnitSphere):
+    _spectrum    (Bistirlich      ),
     _spectrum2D  (KrollWadaJoseph ),
-    _kMaxUserSet (kMaxUserSet     ), 
-    _kMaxUser    (kMaxUser        ), 
+    _kMaxUserSet (kMaxUserSet     ),
+    _kMaxUser    (kMaxUser        ),
     _kMaxMax     (kMaxMax         ),
     _rnFlat      (rnFlat          ),
     _rnUnitSphere(rnUnitSphere    )
@@ -94,10 +97,10 @@ namespace mu2e {
 // Analytic fit to the photon energy spectrum for Mg
 //  - J.A.Bistirlich, et al, Phys. Rev. C 5, 1867 (1972)
 //  - commented out: fit results given in I. Sarra, mu2e-docdb-665-v2
-//    Ivano fitted the distribution in fig 7b in the paper, whereas the one 
+//    Ivano fitted the distribution in fig 7b in the paper, whereas the one
 //    to fit is the one in fig 7a. The paper is not very clear on that,
 //    see mu2e-19366 for details
-//    new fit is the same parameterization of the spectrum in fig 7a, 
+//    new fit is the same parameterization of the spectrum in fig 7a,
 //    normalization the fit function: integral(f) = 1
 //=======================================================
   double PionCaptureSpectrum::getBistirlichSpectrum(double e) const {
@@ -136,7 +139,7 @@ namespace mu2e {
 
 
 //------------------------------------------------------------------------------
-// E - energy (k0) of the emitted virtual photon, x - mass of the e+e- pair 
+// E - energy (k0) of the emitted virtual photon, x - mass of the e+e- pair
 //-----------------------------------------------------------------------------
   double PionCaptureSpectrum::getKrollWadaJosephSpectrum(double E, double x, double y) const {
 

--- a/Mu2eUtilities/src/PointLinePCA_XYZ.cc
+++ b/Mu2eUtilities/src/PointLinePCA_XYZ.cc
@@ -1,4 +1,9 @@
+#include <iosfwd>                                 // for std
+
 #include "Mu2eUtilities/inc/PointLinePCA_XYZ.hh"
+#include "Math/GenVector/Cartesian3D.h"           // for Cartesian3D
+#include "Math/GenVector/DisplacementVector3D.h"  // for operator-, Displace...
+
 using namespace std;
 namespace mu2e{
 	PointLinePCA_XYZ::PointLinePCA_XYZ( XYZVec const& point,

--- a/Mu2eUtilities/src/PoissonHistogramBinning.cc
+++ b/Mu2eUtilities/src/PoissonHistogramBinning.cc
@@ -29,10 +29,9 @@
 //     mean +/- width*sqrt(mean), rounded to integers with, at most, 100
 //     bins.
 //
-#include "Mu2eUtilities/inc/PoissonHistogramBinning.hh"
+#include <cmath>  // for floor, sqrt, ceil
 
-#include <iostream>
-#include <cmath>
+#include "Mu2eUtilities/inc/PoissonHistogramBinning.hh"
 
 using namespace std;
 

--- a/Mu2eUtilities/src/ProtonPulseRandPDF.cc
+++ b/Mu2eUtilities/src/ProtonPulseRandPDF.cc
@@ -6,13 +6,27 @@
 //
 // Original author: Kyle Knoepfel
 
+#include <exception>
+#include <stdlib.h>                                                 // for abs
+// C++ includes
+#include <algorithm>
+#include <array>
+#include <string>
+#include <utility>                                                  // for pair
+#include <vector>
+
 // Mu2e includes
 #include "ConditionsService/inc/ConditionsHandle.hh"
 #include "ConfigTools/inc/ConfigFileLookupPolicy.hh"
 #include "Mu2eUtilities/inc/ProtonPulseRandPDF.hh"
-
-// C++ includes
-#include <algorithm>
+#include "CLHEP/Random/RandGeneral.h"
+#include "ConditionsService/inc/AcceleratorParams.hh"
+#include "Mu2eUtilities/inc/Table.hh"
+#include "art/Framework/Services/Optional/RandomNumberGenerator.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "fhiclcpp/exception.h"
+#include "fhiclcpp/types/Atom.h"                                    // for Atom
+#include "fhiclcpp/types/OptionalAtom.h"
 
 // The following defines the proton pulse shape parameters (pdf width,
 // pdf step and differential distribution).  Please note that it is

--- a/Mu2eUtilities/src/RandomLimitedExpo.cc
+++ b/Mu2eUtilities/src/RandomLimitedExpo.cc
@@ -4,14 +4,13 @@
 // Original author Gianni Onorato
 //
 
+//C++ includes
+#include <cmath>                      // for exp, log
+
 // Framework includes
 #include "Mu2eUtilities/inc/RandomLimitedExpo.hh"
-
-//C++ includes
-#include <cmath>
-
 //CLHEP includes
-#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandFlat.h"    // for RandFlat
 
 namespace mu2e{
 

--- a/Mu2eUtilities/src/RandomUnitSphere.cc
+++ b/Mu2eUtilities/src/RandomUnitSphere.cc
@@ -10,10 +10,11 @@
 //
 
 #include "Mu2eUtilities/inc/RandomUnitSphere.hh"
-#include "Mu2eUtilities/inc/ThreeVectorUtil.hh"
+#include "Mu2eUtilities/inc/ThreeVectorUtil.hh"  // for polar3Vector
 
-#include "art/Framework/Services/Registry/ServiceHandle.h"
-#include "art/Framework/Services/Optional/RandomNumberGenerator.h"
+namespace CLHEP {
+class HepRandomEngine;
+}  // namespace CLHEP
 
 using CLHEP::Hep3Vector;
 using CLHEP::RandFlat;

--- a/Mu2eUtilities/src/ShankerWatanabeSpectrum.cc
+++ b/Mu2eUtilities/src/ShankerWatanabeSpectrum.cc
@@ -8,23 +8,24 @@
 // $Date: 2014/05/01 18:12:26 $
 //
 
+#include <stddef.h>                                             // for size_t
+#include <iostream>                                             // for opera...
+#include <array>                                                // for array
+#include <utility>                                              // for pair
+#include <vector>                                               // for alloc...
+
 // Mu2e includes
-#include "GlobalConstantsService/inc/ParticleDataTable.hh"
-#include "GlobalConstantsService/inc/PhysicsParams.hh"
-#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"
-#include "ConfigTools/inc/ConfigFileLookupPolicy.hh"
-#include "DataProducts/inc/PDGCode.hh"
-#include "Mu2eUtilities/inc/ShankerWatanabeSpectrum.hh"
-
-// CLHEP includes
-#include "CLHEP/Units/PhysicalConstants.h"
-
+#include "GlobalConstantsService/inc/ParticleDataTable.hh"      // for Parti...
+#include "GlobalConstantsService/inc/PhysicsParams.hh"          // for Physi...
+#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"  // for Globa...
+#include "ConfigTools/inc/ConfigFileLookupPolicy.hh"            // for Confi...
+#include "DataProducts/inc/PDGCode.hh"                          // for PDGCode
+#include "Mu2eUtilities/inc/ShankerWatanabeSpectrum.hh"         // for Shank...
 // Framework includes
-#include "cetlib/pow.h"
-
-// C++ includes
-#include <fstream>
-#include <iostream>
+#include "cetlib/pow.h"                                         // for square
+#include "HepPDT/Measurement.hh"                                // for Measu...
+#include "HepPDT/ParticleData.hh"                               // for Parti...
+#include "Mu2eUtilities/inc/Table.hh"                           // for Table
 
 using namespace std;
 
@@ -33,7 +34,7 @@ namespace mu2e {
   ShankerWatanabeSpectrum::ShankerWatanabeSpectrum() :
     _table ( loadTable<2,false>( ConfigFileLookupPolicy()("ConditionsService/data/watanabe.tbl" ) ) )
   {
-    _wanaEndPoint    = _table(0,0); 
+    _wanaEndPoint    = _table(0,0);
     _wanaEndPointVal = _table(0,1);
     _norm     = _wanaEndPointVal / evaluateShanker( _wanaEndPoint );
   }
@@ -66,14 +67,14 @@ namespace mu2e {
 
     const double deltaPrimeMax = mumass - bindEnergy;
     const double muEndPoint    = deltaPrimeMax - cet::square(deltaPrimeMax)/(2*phy->getAtomicMass());
-    
+
     if (E > muEndPoint) return 0;
-    
+
     const double delta1 = mumass - bindEnergy - E - cet::square(E)/(2*phy->getAtomicMass());
 
     double shD(0.), shE(0.), shF(0.);
     unsigned zpower (1);
-    
+
     for ( size_t i(0); i < phy->getShankerNcoeffs() ; i++ ) {
       shD    += phy->getShankerDcoefficients().at(i)*zpower;
       shE    += phy->getShankerEcoefficients().at(i)*zpower;
@@ -106,17 +107,17 @@ namespace mu2e {
   }
 
 
-  double ShankerWatanabeSpectrum::interpolate(const double E, 
+  double ShankerWatanabeSpectrum::interpolate(const double E,
                                               const TableRow<2>& row_after,
                                               const TableRow<2>& row,
                                               const TableRow<2>& row_before ) const {
-    
+
     const double e1(  row_after.first );  const double p1(  row_after.second.at(0) );
     const double e2(        row.first );  const double p2(        row.second.at(0) );
     const double e3( row_before.first );  const double p3( row_before.second.at(0) );
-    
+
     const double discr = e1*e1*e2 + e1*e3*e3 + e2*e2*e3 - e3*e3*e2 - e1*e1*e3 - e1*e2*e2;
-    
+
     const double A = (p1*e2 + p3*e1 + p2*e3 - p3*e2 - p1*e3 - p2*e1) / discr;
 
     const double B = (e1*e1*p2 + e3*e3*p1 + e2*e2*p3 - e3*e3*p2 - e1*e1*p3 - e2*e2*p1) / discr;

--- a/Mu2eUtilities/src/SimParticleCollectionPrinter.cc
+++ b/Mu2eUtilities/src/SimParticleCollectionPrinter.cc
@@ -1,6 +1,12 @@
 // Andrei Gaponenko, 2013
 
+#include <utility>                            // for pair
+
 #include "Mu2eUtilities/inc/SimParticleCollectionPrinter.hh"
+#include "CLHEP/Vector/LorentzVector.h"       // for operator<<
+#include "CLHEP/Vector/ThreeVector.h"         // for operator<<
+#include "MCDataProducts/inc/ProcessCode.hh"  // for operator<<
+#include "cetlib/map_vector.h"                // for operator<<
 
 namespace mu2e {
   //================================================================

--- a/Mu2eUtilities/src/SimParticleGetTau.cc
+++ b/Mu2eUtilities/src/SimParticleGetTau.cc
@@ -1,15 +1,12 @@
+#include <algorithm>                          // for binary_search, for_each
+
 #include "Mu2eUtilities/inc/SimParticleGetTau.hh"
-
 // Framework includes
-#include "canvas/Persistency/Common/Ptr.h"
-
-// CLHEP includes
-#include "CLHEP/Vector/LorentzVector.h"
-
+#include "canvas/Persistency/Common/Ptr.h"    // for Ptr
 // cetlib includes
-#include "cetlib_except/exception.h"
-
-#include <iostream>
+#include "cetlib_except/exception.h"          // for operator<<, exception
+#include "MCDataProducts/inc/ProcessCode.hh"  // for ProcessCode, ProcessCod...
+#include "MCDataProducts/inc/SimParticle.hh"  // for SimParticle
 
 namespace mu2e {
   

--- a/Mu2eUtilities/src/SimParticleParentGetter.cc
+++ b/Mu2eUtilities/src/SimParticleParentGetter.cc
@@ -1,16 +1,22 @@
+#include <memory>                                       // for unique_ptr
+#include <string>                                       // for string
+#include <typeinfo>                                     // for type_info
+#include <utility>                                      // for pair, make_pair
+#include <vector>                                       // for vector, vecto...
+
 #include "Mu2eUtilities/inc/SimParticleParentGetter.hh"
+#include "art/Framework/Principal/Event.h"              // for Event
+#include "MCDataProducts/inc/SimParticle.hh"            // for SimParticle
+#include "MCDataProducts/inc/StepPointMC.hh"            // for StepPointMC
+#include "MCDataProducts/inc/GenParticleSPMHistory.hh"  // for GenParticleSP...
+#include "MCDataProducts/inc/GenSimParticleLink.hh"     // for GenSimParticl...
+#include "cetlib_except/exception.h"                    // for operator<<
+#include "art/Framework/Principal/Handle.h"             // for Handle
+#include "canvas/Persistency/Common/Assns.h"            // for Assns, Assns<...
 
-#include "art/Framework/Principal/Event.h"
-#include "art/Framework/Principal/Provenance.h"
-#include "canvas/Persistency/Common/FindOne.h"
-#include "canvas/Utilities/InputTag.h"
-
-#include "MCDataProducts/inc/SimParticle.hh"
-#include "MCDataProducts/inc/StepPointMC.hh"
-#include "MCDataProducts/inc/GenParticleSPMHistory.hh"
-#include "MCDataProducts/inc/GenSimParticleLink.hh"
-
-#include "cetlib_except/exception.h"
+namespace mu2e {
+class GenParticle;
+}  // namespace mu2e
 
 //#define AGDEBUG(stuff) std::cerr<<"AG: "<<__FILE__<<", line "<<__LINE__<<": "<<stuff<<std::endl;
 #define AGDEBUG(stuff)

--- a/Mu2eUtilities/src/SimParticleTimeOffsets.cc
+++ b/Mu2eUtilities/src/SimParticleTimeOffsets.cc
@@ -1,12 +1,26 @@
-#include "Mu2eUtilities/inc/SimParticleTimeOffset.hh"
+#include <exception>                            // for exception
+#include <algorithm>                                   // for max
+#include <map>                                         // for _Rb_tree_iterator
+#include <memory>                                      // for allocator, uni...
+#include <string>                                      // for string
+#include <typeinfo>                                    // for type_info
+#include <utility>                                     // for pair
+#include <vector>                                      // for vector
 
-#include "cetlib_except/exception.h"
-
-#include "fhiclcpp/ParameterSet.h"
-#include "art/Framework/Principal/Event.h"
-
-#include "MCDataProducts/inc/StepPointMC.hh"
-#include "MCDataProducts/inc/StrawGasStep.hh"
+#include "Mu2eUtilities/inc/SimParticleTimeOffset.hh"  // for SimParticleTim...
+#include "cetlib_except/exception.h"                   // for exception, ope...
+#include "fhiclcpp/ParameterSet.h"                     // for ParameterSet
+#include "art/Framework/Principal/Event.h"             // for Event
+#include "MCDataProducts/inc/StepPointMC.hh"           // for StepPointMC
+#include "MCDataProducts/inc/StrawGasStep.hh"          // for StrawGasStep
+#include "MCDataProducts/inc/SimParticle.hh"           // for SimParticle
+#include "MCDataProducts/inc/SimParticleTimeMap.hh"    // for SimParticleTim...
+#include "art/Framework/Principal/Handle.h"            // for ValidHandle
+#include "canvas/Persistency/Common/Ptr.h"             // for Ptr, operator<<
+#include "canvas/Utilities/InputTag.h"                 // for InputTag
+#include "fhiclcpp/coding.h"                           // for ps_sequence_t
+#include "fhiclcpp/exception.h"                        // for exception
+#include "fhiclcpp/types/Sequence.h"                   // for Sequence
 
 
 namespace mu2e {

--- a/Mu2eUtilities/src/SimpleSpectrum.cc
+++ b/Mu2eUtilities/src/SimpleSpectrum.cc
@@ -5,11 +5,14 @@
 // $Date: 2014/02/25 17:14:10 $
 //
 
+#include <cstddef>                    // for size_t, std
+#include <vector>                     // for vector, allocator
+
 // Mu2e includes
 #include "Mu2eUtilities/inc/SimpleSpectrum.hh"
-
 // Framework includes
-#include "cetlib/pow.h"
+#include "cetlib/pow.h"               // for square
+#include "cetlib_except/exception.h"  // for exception, operator<<
 
 using namespace std;
 

--- a/Mu2eUtilities/src/SortedStepPoints.cc
+++ b/Mu2eUtilities/src/SortedStepPoints.cc
@@ -7,9 +7,11 @@
 // Original author Rob Kutschke
 //
 
-#include "Mu2eUtilities/inc/SortedStepPoints.hh"
+#include <math.h>                        // for abs
+#include <iostream>                      // for std
 
-#include <iostream>
+#include "Mu2eUtilities/inc/SortedStepPoints.hh"
+#include "CLHEP/Vector/ThreeVector.h"    // for Hep3Vector
 //#include "MCDataProducts/inc/StepPointMCCollection.hh"
 
 using namespace std;

--- a/Mu2eUtilities/src/Table.cc
+++ b/Mu2eUtilities/src/Table.cc
@@ -9,8 +9,10 @@
 //
 // Original author: Kyle Knoepfel
 
+#include <numeric>    // for accumulate
+#include <algorithm>  // for max, for_each
+
 #include "Mu2eUtilities/inc/Table.hh"
-#include <numeric>
 
 namespace mu2e {
 

--- a/Mu2eUtilities/src/TrackCuts.cc
+++ b/Mu2eUtilities/src/TrackCuts.cc
@@ -1,10 +1,14 @@
+#include <exception>                      // for exception
+#include <memory>                                // for allocator_traits<>::...
+#include <vector>                                // for vector
+
 #include "Mu2eUtilities/inc/TrackCuts.hh"
-
-#include "fhiclcpp/ParameterSet.h"
-
-#include "TH1.h"
-
-#include "RecoDataProducts/inc/TrackSummary.hh"
+#include "fhiclcpp/ParameterSet.h"               // for ParameterSet
+#include "TH1.h"                                 // for TH1, TH1D
+#include "RecoDataProducts/inc/TrackSummary.hh"  // for TrackSummary, TrackS...
+#include "CLHEP/Vector/ThreeVector.h"            // for Hep3Vector
+#include "cetlib_except/exception.h"             // for exception, operator<<
+#include "fhiclcpp/exception.h"                  // for exception
 
 namespace mu2e {
 
@@ -83,7 +87,7 @@ namespace mu2e {
       lastfailed = 5;
     }
 
-    const bool timeCutPassed = 
+    const bool timeCutPassed =
       (cutt0min_ < cutt0max_) ?  // check for time wrapping
       ((cutt0min_ < trk.t0()) && (trk.t0() < cutt0max_)) : // no wrapping
       ((trk.t0() < cutt0max_) || (cutt0min_ < trk.t0()));  // time wrapped, discontinuous acceptance region

--- a/Mu2eUtilities/src/TrackPatRecType.cc
+++ b/Mu2eUtilities/src/TrackPatRecType.cc
@@ -27,6 +27,9 @@
 // Contact person, Rob Kutschke
 //
 
+#include <type_traits>  // for __decay_and_strip<>::__type
+#include <utility>      // for make_pair, pair
+
 #include "Mu2eUtilities/inc/TrackPatRecType.hh"
 
 namespace mu2e {

--- a/Mu2eUtilities/src/TrackTool.cc
+++ b/Mu2eUtilities/src/TrackTool.cc
@@ -8,12 +8,12 @@
 // Original author Rob Kutschke
 //
 
-#include <cmath>
-#include <iostream>
+#include <cmath>                            // for cos, sin, atan2, sqrt, M_PI
+#include <iostream>                         // for std
 
-#include "Mu2eUtilities/inc/TrackTool.hh"
-
-#include "CLHEP/Units/PhysicalConstants.h"
+#include "Mu2eUtilities/inc/TrackTool.hh"   // for TrackTool
+#include "CLHEP/Units/PhysicalConstants.h"  // for c_light
+#include "CLHEP/Vector/ThreeVector.h"       // for Hep3Vector
 
 using namespace std;
 //using CLHEP::Hep3Vector;

--- a/Mu2eUtilities/src/TriggerResultsNavigator.cc
+++ b/Mu2eUtilities/src/TriggerResultsNavigator.cc
@@ -1,19 +1,31 @@
-#include "fhiclcpp/ParameterSet.h"
-#include "fhiclcpp/ParameterSetRegistry.h"
-#include "Mu2eUtilities/inc/TriggerResultsNavigator.hh"
-#include <iostream>
-#include <iomanip>
+#include <exception>                              // for exception
+#include <stddef.h>                                      // for size_t
+#include <iostream>                                      // for operator<<
+#include <iomanip>                                       // for operator<<
+#include <algorithm>                                     // for max
+#include <map>                                           // for map, operator==
+#include <string>                                        // for string, allo...
+#include <utility>                                       // for pair
+#include <vector>                                        // for vector
+
+#include "fhiclcpp/ParameterSet.h"                       // for ParameterSet
+#include "fhiclcpp/ParameterSetRegistry.h"               // for ParameterSet...
+#include "Mu2eUtilities/inc/TriggerResultsNavigator.hh"  // for TriggerResul...
+#include "canvas/Persistency/Common/HLTenums.h"          // for HLTState
+#include "canvas/Persistency/Common/TriggerResults.h"    // for TriggerResults
+#include "fhiclcpp/coding.h"                             // for ps_sequence_t
+#include "fhiclcpp/exception.h"                          // for exception
 
 namespace mu2e {
 
-  TriggerResultsNavigator::TriggerResultsNavigator(const art::TriggerResults* trigResults): 
+  TriggerResultsNavigator::TriggerResultsNavigator(const art::TriggerResults* trigResults):
     _trigResults(trigResults){
     auto const  id   = trigResults->parameterSetID();
     auto const& pset = fhicl::ParameterSetRegistry::get(id);
     //set the vector<string> with the names of the tirgger_paths
     _trigPathsNames  = pset.get<std::vector<std::string>>("trigger_paths");
-      
-    //loop over trigResults to fill the map <string, unsigned int) 
+
+    //loop over trigResults to fill the map <string, unsigned int)
     for (unsigned int i=0; i< _trigPathsNames.size(); ++i){
       _trigMap.insert(std::pair<std::string, unsigned int>(_trigPathsNames[i], i));
     }
@@ -43,15 +55,15 @@ namespace mu2e {
     size_t index = findTrigPath(name);
     return _trigResults->accept(index);
   }
-  
+
   bool
   TriggerResultsNavigator::wasrun(std::string const& name) const
   {
     size_t index = findTrigPath(name);
     return _trigResults->wasrun(index);
   }
-  
-  std::vector<std::string>   
+
+  std::vector<std::string>
   TriggerResultsNavigator::triggerModules(std::string const& name) const{
     std::vector<std::string>     modules;
 
@@ -66,17 +78,17 @@ namespace mu2e {
     return modules;
   }
 
-  unsigned                   
+  unsigned
   TriggerResultsNavigator::indexLastModule(std::string const& name) const{
     size_t index = findTrigPath(name);
     return _trigResults->index(index);
    }
 
-  std::string                
+  std::string
   TriggerResultsNavigator::nameLastModule (std::string const& name) const{
     unsigned                    indexLast  = indexLastModule(name);
     std::vector<std::string>    modulesVec = triggerModules(name);
-    
+
     if ( modulesVec.size() == 0) {
       std::string nn = "PATH "+name+" NOT FOUND";
       std::cout << "[TriggerResultsNavigator::nameLastModule] " << nn << std::endl;
@@ -85,14 +97,14 @@ namespace mu2e {
       return modulesVec[indexLast];
     }
   }
-  
-  art::hlt::HLTState 
+
+  art::hlt::HLTState
   TriggerResultsNavigator::state(std::string const& name) const{
     size_t index = findTrigPath(name);
     return _trigResults->state(index);
   }
 
-  void 
+  void
   TriggerResultsNavigator::print() const {
     std::cout << "TriggerResultsNaviogator Map" << std::endl;
     std::cout << "//------------------------------------------//" << std::endl;
@@ -107,7 +119,7 @@ namespace mu2e {
       std::cout <<"//"<<std::setw(24) << name << std::setw(2) << index << (good == true ? 1:0) << "//"<< std::endl;
       // %24s  %2li       %i    //\n", name.c_str(), index, good == true ? 1:0);
     }
-      
+
   }
 
 }

--- a/Mu2eUtilities/src/TrkSpecies.cc
+++ b/Mu2eUtilities/src/TrkSpecies.cc
@@ -8,6 +8,9 @@
 // Contact person, Rob Kutschke
 //
 
+#include <type_traits>  // for __decay_and_strip<>::__type
+#include <utility>      // for make_pair, pair
+
 #include "Mu2eUtilities/inc/TrkSpecies.hh"
 
 namespace mu2e {

--- a/Mu2eUtilities/src/TwoLinePCA.cc
+++ b/Mu2eUtilities/src/TwoLinePCA.cc
@@ -10,8 +10,10 @@
 // Original author Rob Kutschke
 //
 
-#include <iostream>
-#include "Mu2eUtilities/inc/TwoLinePCA.hh"
+#include <iostream>                         // for std
+
+#include "Mu2eUtilities/inc/TwoLinePCA.hh"  // for TwoLinePCA
+#include "CLHEP/Vector/ThreeVector.h"       // for Hep3Vector
 
 using namespace std;
 

--- a/Mu2eUtilities/src/TwoLinePCA_XYZ.cc
+++ b/Mu2eUtilities/src/TwoLinePCA_XYZ.cc
@@ -10,8 +10,12 @@
 // Original author Rob Kutschke
 //
 
-#include <iostream>
-#include "Mu2eUtilities/inc/TwoLinePCA_XYZ.hh"
+#include <iostream>                               // for std
+
+#include "Mu2eUtilities/inc/TwoLinePCA_XYZ.hh"    // for TwoLinePCA_XYZ
+#include "DataProducts/inc/XYZVec.hh"             // for XYZVec
+#include "Math/GenVector/Cartesian3D.h"           // for Cartesian3D
+#include "Math/GenVector/DisplacementVector3D.h"  // for DisplacementVector3D
 
 using namespace std;
 

--- a/Mu2eUtilities/src/VectorVolume.cc
+++ b/Mu2eUtilities/src/VectorVolume.cc
@@ -5,8 +5,12 @@
 // _original author Stefano Roberto Soleti
 //
 
-#include <iostream>
-#include "Mu2eUtilities/inc/VectorVolume.hh"
+#include <iostream>                           // for std
+#include <vector>                             // for vector
+
+#include "Mu2eUtilities/inc/VectorVolume.hh"  // for VectorVolume
+#include "CLHEP/Vector/ThreeVector.h"         // for Hep3Vector
+#include "GeneralUtilities/inc/safeSqrt.hh"   // for safeSqrt
 
 using namespace std;
 

--- a/Mu2eUtilities/src/checkSimParticleCollection.cc
+++ b/Mu2eUtilities/src/checkSimParticleCollection.cc
@@ -7,15 +7,16 @@
 //
 // Contact person Rob Kutschke
 
+#include <vector>                                         // for vector, all...
+#include <cstddef>                                        // for size_t, std
+#include <utility>                                        // for pair
+
 // Mu2e includes
 #include "Mu2eUtilities/inc/checkSimParticleCollection.hh"
-#include "MCDataProducts/inc/SimParticleCollection.hh"
-
 // art includes
-#include "messagefacility/MessageLogger/MessageLogger.h"
-#include "cetlib_except/exception.h"
-
-#include <vector>
+#include "messagefacility/MessageLogger/MessageLogger.h"  // for MaybeLogger_
+#include "cetlib_except/exception.h"                      // for exception
+#include "cetlib/map_vector.h"                            // for operator<<
 
 using namespace std;
 

--- a/Mu2eUtilities/src/decodeTrackPatRecType.cc
+++ b/Mu2eUtilities/src/decodeTrackPatRecType.cc
@@ -3,9 +3,18 @@
 //  reconstruct a given track.
 //
 
+#include <exception>                          // for exception
+#include <memory>                                    // for allocator, uniqu...
+#include <string>                                    // for string
+#include <typeinfo>                                  // for type_info
+
 #include "Mu2eUtilities/inc/decodeTrackPatRecType.hh"
-#include "RecoDataProducts/inc/KalRepCollection.hh"
-#include "art/Framework/Principal/Handle.h"
+#include "RecoDataProducts/inc/KalRepCollection.hh"  // for KalRepCollection
+#include "art/Framework/Principal/Handle.h"          // for Handle
+#include "art/Framework/Principal/Event.h"           // for Event
+#include "art/Framework/Principal/Provenance.h"      // for Provenance
+#include "fhiclcpp/ParameterSet.h"                   // for ParameterSet
+#include "fhiclcpp/exception.h"                      // for exception
 
 namespace mu2e {
 

--- a/Mu2eUtilities/src/particleEnteringG4Volume.cc
+++ b/Mu2eUtilities/src/particleEnteringG4Volume.cc
@@ -1,4 +1,7 @@
 #include "Mu2eUtilities/inc/particleEnteringG4Volume.hh"
+#include "MCDataProducts/inc/SimParticle.hh"   // for SimParticle
+#include "MCDataProducts/inc/StepPointMC.hh"   // for StepPointMC
+#include "MCDataProducts/inc/StrawGasStep.hh"  // for StrawGasStep
 
 art::Ptr<mu2e::SimParticle> mu2e::particleEnteringG4Volume(const StepPointMC& step) {
     art::Ptr<SimParticle> p = step.simParticle();

--- a/Mu2eUtilities/src/polar3Vector.cc
+++ b/Mu2eUtilities/src/polar3Vector.cc
@@ -9,11 +9,12 @@
 // Original author Rob Kutschke
 //
 
-#include <cmath>
+#include <cmath>                                 // for cos, sin
 
-#include "Mu2eUtilities/inc/ThreeVectorUtil.hh"
-#include "GeneralUtilities/inc/safeSqrt.hh"
-#include "GeneralUtilities/inc/sqrtOrThrow.hh"
+#include "Mu2eUtilities/inc/ThreeVectorUtil.hh"  // for polar3Vector
+#include "GeneralUtilities/inc/safeSqrt.hh"      // for safeSqrt
+#include "GeneralUtilities/inc/sqrtOrThrow.hh"   // for sqrtOrThrow
+#include "CLHEP/Vector/ThreeVector.h"            // for Hep3Vector
 
 using CLHEP::Hep3Vector;
 

--- a/Mu2eUtilities/src/rm48.cc
+++ b/Mu2eUtilities/src/rm48.cc
@@ -10,7 +10,7 @@
 //  See rm48.hh for details.
 
 #include "Mu2eUtilities/inc/rm48.hh"
-#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandFlat.h"    // for RandFlat
 
 // Scope is local to this file so namespace is irrelevant.
 static CLHEP::RandFlat* distribution(0);


### PR DESCRIPTION
I installed Clang and IWYU in a clean (local) environment, and it ran it like this:
```
iwyu_tool -p . Mu2eUtilities/src/*.cc -j 6 | fix_includes --comments --noreorder
```
After this, I fixed up some common mistakes that it made, which yielded these changes.

It changed a lot of files. In quite a few places it removed superfluous includes, replaced some includes with forward-declarations, and added in includes for symbols being included indirectly.

I also did the same procedure for Analyses, but I will open another PR for that.

I ran a Clean build + Validation test with 2000 events on master and the PR+master merge version, which yielded this: 
https://github.com/ryuwd/Offline/pull/24#issuecomment-592864283

If you are logged in on Fermilab VPN, or accessing the links on that comment on-site you can view the validation plots directly.

I recommend viewing the diffs with whitespace changes ignored

closes #98 