### PR TITLE
Remove bad std::move from CosmicReco

### DIFF
--- a/CosmicReco/src/CosmicTrackFinder_module.cc
+++ b/CosmicReco/src/CosmicTrackFinder_module.cc
@@ -323,7 +323,7 @@ namespace mu2e{
 							tmpHits.push_back(chit);
 						}
 				      }
-				      tmpResult._tseed._straw_chits = std::move(tmpHits);
+				      tmpResult._tseed._straw_chits = tmpHits;
 		      		}
 		      		track_seed_vec.push_back(tmpResult._tseed);
 		     


### PR DESCRIPTION
Correction to one of my suggestions on #157

The `std::move` stopped straw_chits filling properly during outlier hit filtering (my bad - this got put in #157 by my suggestion.)

Testing:
Before: track strawhits after drift fit were empty (0 tracks for 2000 events)
After: track strawhits are now filling properly (tracks are back)