### PR TITLE
Move compile_commands to the gen folder

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -12,21 +12,21 @@ from mu2e_helper import mu2e_helper
 mu2eOpts = {}
 
 # add a mu2e debug print option like "--mu2ePrint=5"
-AddOption('--mu2ePrint', dest='mu2ePrint', 
+AddOption('--mu2ePrint', dest='mu2ePrint',
           type='int',nargs=1,default=1,
           help='mu2e print level (0-10) default=1')
 mu2ePrint = GetOption("mu2ePrint")
 mu2eOpts["mu2ePrint"] = mu2ePrint
 
 # add an option to print only short lines for each target
-AddOption('--mu2eCompactPrint', dest='mu2eCompactPrint', 
+AddOption('--mu2eCompactPrint', dest='mu2eCompactPrint',
           action="store_true",default=False,
           help='print only a short text line for each target')
 mu2eCompactPrint = GetOption("mu2eCompactPrint")
 
 mu2eOpts["mu2eCompactPrint"] = mu2eCompactPrint
 
-# Check that some important environment variables have been set; 
+# Check that some important environment variables have been set;
 # result is a dictionary of the options
 moreOpts = sch.mu2eEnvironment()
 mu2eOpts.update(moreOpts)
@@ -70,7 +70,7 @@ env = Environment( CPPPATH = sch.cppPath(mu2eOpts),   # $ART_INC ...
 env.Tool('compilation_db')
 
 # Define and register the rule for building dictionaries.
-# sources are classes.h, classes_def.xml, 
+# sources are classes.h, classes_def.xml,
 # targets are dict.cpp, .rootmap and .pcm
 # LIBTEXT is the library for the dict - not a target, only text for names
 genreflex = Builder(action=Action("export HOME="+os.environ["HOME"]+"; "+"genreflex ${SOURCES[0]} -s ${SOURCES[1]} $_CPPINCFLAGS -l $LIBTEXT -o ${TARGETS[0]} --fail_on_warnings --rootmap-lib=$LIBTEXT  --rootmap=${TARGETS[1]} $DEBUG_FLAG",genreflexcomstr))
@@ -109,12 +109,12 @@ ss = sch.sconscriptList(mu2eOpts)
 # make sure lib, bin and tmp are there
 sch.makeSubDirs(mu2eOpts)
 
-# Allow a compile_commands.json to be generated if requested (scons -Q compiledb).
-compileCommands = env.CompilationDatabase('compile_commands.json')
+# Generate a compile_commands.json
+compileCommands = env.CompilationDatabase('gen/compile_commands.json')
 compileDb = env.Alias("compiledb", compileCommands)
 
 # operate on the SConscript files
-# regular python commands like os.path() are executed immediately as they are encontered, 
+# regular python commands like os.path() are executed immediately as they are encontered,
 # scons builder commands like env.SharedLibrary are examined for dependences and scheduled
 # to be executed in parallel, as possible
 env.SConscript(ss)

--- a/scripts/build/python/sconstruct_helper.py
+++ b/scripts/build/python/sconstruct_helper.py
@@ -33,6 +33,7 @@ def mu2eEnvironment():
     mu2eOpts['libdir'] = base+'/lib'
     mu2eOpts['bindir'] = base+'/bin'
     mu2eOpts['tmpdir'] = base+'/tmp'
+    mu2eOpts['gendir'] = base+'/gen'
 
     envopts = os.environ['MU2E_SETUP_BUILDOPTS'].strip()
     fsopts  = subprocess.check_output(primaryBase+"/buildopts",shell=True).strip().decode() # decode to convert byte string to text
@@ -173,7 +174,7 @@ def sconscriptList(mu2eOpts):
 
 # Make sure the build directories are created
 def makeSubDirs(mu2eOpts):
-    for dir in ['libdir','bindir','tmpdir'] :
+    for dir in ['libdir','bindir','tmpdir', 'gendir'] :
         cmd = "mkdir -p "+mu2eOpts[dir]
         subprocess.call(cmd, shell=True)
 


### PR DESCRIPTION
Moved `compile_commands.json` to `gen/` and made sure `gen/` is created before executing build targets. Tested on mu2ebuild01 with fresh clone of Offline

**N.B.**
- `compile_commands.json` is created for any build
- `scons -Q compiledb` generates a `compile_commands.json` without executing other build targets
- `compile_commands.json` is removed correctly after `scons -c`