### PR TITLE
Aligned Plane and Panel origins in Aligned Tracker

### DIFF
--- a/GeometryService/src/TrackerMaker.cc
+++ b/GeometryService/src/TrackerMaker.cc
@@ -16,6 +16,7 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "GeometryService/inc/G4GeometryOptions.hh"
 #include "GeometryService/inc/GeomHandle.hh"
+#include "Mu2eUtilities/inc/HepTransform.hh"
 
 #include <cmath>
 #include <iomanip>
@@ -771,12 +772,13 @@ namespace mu2e {
     panel._EBKeyPhiExtraRotation = _EBKeyPhiExtraRotation;
 
     // set the panel origin for alignment
+    HepTransform plane_to_tracker(0.0,0.0,plane.origin().z(),0.0,0.0,0.0);
     CLHEP::Hep3Vector dv = panel.straw0MidPoint()
-      - plane_to_tracker.displacement();
+        - plane_to_tracker.displacement();
     double rz = dv.phi();
 
-    CLHEP::HepTransform panel_to_tracker(dv.x(),dv.y(),plane.origin().z()+dv.z(),0.0,0.0,rz);
-    panel._origin = (panel_to_tracker) * CLHEP::Hep3Vector(0,0,0);
+    HepTransform panel_to_plane(dv.x(), dv.y(), dv.z(),0.0,0.0,rz);
+    panel._origin = (plane_to_tracker * panel_to_plane) * CLHEP::Hep3Vector(0,0,0);
 
   }  // end makePanel
 

--- a/GeometryService/src/TrackerMaker.cc
+++ b/GeometryService/src/TrackerMaker.cc
@@ -410,7 +410,7 @@ namespace mu2e {
   void plntest( const Plane& plane){
     cout << "Plane: "
          << plane.id() << " "
-         << plane.origin() 
+         << plane.origin()
          << endl;
   }
 
@@ -604,7 +604,7 @@ namespace mu2e {
     // create a Panel in the Tracker global list of all panels
     panels.at(pnlId.uniquePanel()) = Panel(pnlId);
     Panel& panel = panels.at(pnlId.uniquePanel());
-    // put a pointer to this Panel on its Plane 
+    // put a pointer to this Panel on its Plane
     plane._panels.at(pnlId.getPanel()) = &panel;
 
     _strawPanelConstrCount = -1;
@@ -769,6 +769,14 @@ namespace mu2e {
     panel._EBKeyMaterial         = _EBKeyMaterial;
     panel._EBKeyShieldMaterial   = _EBKeyShieldMaterial;
     panel._EBKeyPhiExtraRotation = _EBKeyPhiExtraRotation;
+
+    // set the panel origin for alignment
+    Hep3Vector dv = panel.straw0MidPoint()
+      - plane_to_tracker.displacement();
+    double rz = dv.phi();
+
+    HepTransform panel_to_tracker(dv.x(),dv.y(),plane.origin().z()+dv.z(),0.0,0.0,rz);
+    panel._origin = (panel_to_tracker) * Hep3Vector(0,0,0);
 
   }  // end makePanel
 
@@ -1206,7 +1214,7 @@ namespace mu2e {
           << "TrackerMaker::makeSupportStructure expected an even number of planes. Saw " << StrawId::_nplanes << " planes.\n";
       }
 
-      // From upstream end of most upstream station to the 
+      // From upstream end of most upstream station to the
       // downstream end of the most downstream station.
       // Including all materials.
       double overallLength = (StrawId::_nstations-1)*_planeSpacing + 2.*_planeHalfSeparation + 2.* _innerRingHalfLength;

--- a/GeometryService/src/TrackerMaker.cc
+++ b/GeometryService/src/TrackerMaker.cc
@@ -16,7 +16,7 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "GeometryService/inc/G4GeometryOptions.hh"
 #include "GeometryService/inc/GeomHandle.hh"
-#include "Mu2eUtilities/inc/HepTransform.hh"
+#include "GeneralUtilities/inc/HepTransform.hh"
 
 #include <cmath>
 #include <iomanip>

--- a/GeometryService/src/TrackerMaker.cc
+++ b/GeometryService/src/TrackerMaker.cc
@@ -771,12 +771,12 @@ namespace mu2e {
     panel._EBKeyPhiExtraRotation = _EBKeyPhiExtraRotation;
 
     // set the panel origin for alignment
-    Hep3Vector dv = panel.straw0MidPoint()
+    CLHEP::Hep3Vector dv = panel.straw0MidPoint()
       - plane_to_tracker.displacement();
     double rz = dv.phi();
 
-    HepTransform panel_to_tracker(dv.x(),dv.y(),plane.origin().z()+dv.z(),0.0,0.0,rz);
-    panel._origin = (panel_to_tracker) * Hep3Vector(0,0,0);
+    CLHEP::HepTransform panel_to_tracker(dv.x(),dv.y(),plane.origin().z()+dv.z(),0.0,0.0,rz);
+    panel._origin = (panel_to_tracker) * CLHEP::Hep3Vector(0,0,0);
 
   }  // end makePanel
 

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -113,7 +113,7 @@ namespace mu2e {
 
   // now set the aligned Panel midpoint and direction
   panel._straw0Direction = panel.getStraw(0).getDirection();
-  panel._straw0MidPoint = aligned_straw0MidPoint;
+  panel._straw0MidPoint = aligned_straw0MidPoint / StrawId::_nlayers;
 
       } // panel loop
 

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -82,9 +82,11 @@ namespace mu2e {
 	// make an intermediate multiplication
 	HepTransform panel_temp = plane_temp * (panel_to_plane * align_panel);
 
+  Hep3Vector aligned_straw0MidPoint;
+
 	for(size_t istr=0; istr< StrawId::_nstraws; istr++) {
           Straw &straw = tracker.getStraw(panel.getStraw(istr).id());
-	  
+
           // how to place the straw in the panel
 	  double dx = straw.getMidPoint().perp()
 	    - panel.straw0MidPoint().perp();
@@ -106,7 +108,13 @@ namespace mu2e {
 	  straw._c = aligned_straw;
 	  straw._w = aligned_straw_dir;
 
+    aligned_straw0MidPoint += straw.getMidPoint();
 	} // straw loop
+
+  // now set the aligned Panel midpoint and direction
+  panel._straw0Direction = panel.getStraw(0).getDirection();
+  panel._straw0MidPoint = aligned_straw0MidPoint;
+
       } // panel loop
     } // plane loop
 

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -111,9 +111,9 @@ namespace mu2e {
     aligned_straw0MidPoint += straw.getMidPoint();
 	} // straw loop
 
-  // now set the aligned Panel midpoint and direction
-  panel._straw0Direction = panel.getStraw(0).getDirection();
-  panel._straw0MidPoint = aligned_straw0MidPoint / StrawId::_nlayers;
+        // now set the aligned Panel midpoint and direction
+        panel._straw0Direction = panel.getStraw(0).getDirection();
+        panel._straw0MidPoint = aligned_straw0MidPoint / StrawId::_nlayers;
 
       } // panel loop
 

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -116,6 +116,8 @@ namespace mu2e {
   panel._straw0MidPoint = aligned_straw0MidPoint;
 
       } // panel loop
+
+      plane._origin += plane_temp * Hep3Vector(0,0,0);
     } // plane loop
 
     return ptr;

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -85,7 +85,7 @@ namespace mu2e {
   Hep3Vector aligned_straw0MidPoint;
 
 	for(size_t istr=0; istr< StrawId::_nstraws; istr++) {
-          Straw &straw = tracker.getStraw(panel.getStraw(istr).id());
+    Straw &straw = tracker.getStraw(panel.getStraw(istr).id());
 
           // how to place the straw in the panel
 	  double dx = straw.getMidPoint().perp()

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -82,7 +82,6 @@ namespace mu2e {
         // make an intermediate multiplication
         HepTransform panel_temp = plane_temp * (panel_to_plane * align_panel);
 
-        Hep3Vector aligned_straw0MidPoint;
 
         for(size_t istr=0; istr< StrawId::_nstraws; istr++) {
           Straw &straw = tracker.getStraw(panel.getStraw(istr).id());
@@ -106,13 +105,18 @@ namespace mu2e {
 
           straw._c = aligned_straw;
           straw._w = aligned_straw_dir;
-
-          aligned_straw0MidPoint += straw.getMidPoint();
         } // straw loop
+
+        Hep3Vector aligned_straw0MidPoint;
+        for ( uint16_t ilay=0; ilay < StrawId::_nlayers; ++ilay ) {
+          const Straw& strw = tracker.getStraw(StrawId(panel.id().asUint16() + ilay));
+          aligned_straw0MidPoint += strw.getMidPoint();
+        }
+        aligned_straw0MidPoint /= StrawId::_nlayers;
 
         // now set the aligned Panel midpoint and direction
         panel._straw0Direction = panel.getStraw(0).getDirection();
-        panel._straw0MidPoint = aligned_straw0MidPoint / StrawId::_nlayers;
+        panel._straw0MidPoint = aligned_straw0MidPoint;
 
       } // panel loop
 

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -119,7 +119,7 @@ namespace mu2e {
 
       // set the aligned plane origin
       // because we're a friend of Tracker, we can access the non-const Plane object
-      tracker._planes.at(plane.id().asUint16())._origin = plane_temp * Hep3Vector(0,0,0);
+      tracker._planes.at(plane.id().getPlane())._origin = plane_temp * Hep3Vector(0,0,0);
     } // plane loop
 
     return ptr;

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -117,7 +117,10 @@ namespace mu2e {
 
       } // panel loop
 
-      plane._origin += plane_temp * Hep3Vector(0,0,0);
+
+      // set the aligned plane origin
+      // because we're a friend of Tracker, we can access the non-const Plane object
+      tracker._planes.at(plane.id().asUint16())._origin = plane_temp * Hep3Vector(0,0,0);
     } // plane loop
 
     return ptr;

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -118,7 +118,7 @@ namespace mu2e {
         panel._straw0Direction = panel.getStraw(0).getDirection();
         panel._straw0MidPoint = aligned_straw0MidPoint;
 
-        panel._origin = (plane_temp * panel_to_plane) * Hep3Vector(0,0,0);
+        panel._origin = ((plane_temp * panel_to_plane) * Hep3Vector(0,0,0));
 
       } // panel loop
 

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -114,9 +114,11 @@ namespace mu2e {
         }
         aligned_straw0MidPoint /= StrawId::_nlayers;
 
-        // now set the aligned Panel midpoint and direction
+        // now set the aligned straw0 midpoint and direction, and set new aligned panel origin
         panel._straw0Direction = panel.getStraw(0).getDirection();
         panel._straw0MidPoint = aligned_straw0MidPoint;
+
+        panel._origin = (plane_temp * panel_to_plane) * Hep3Vector(0,0,0);
 
       } // panel loop
 

--- a/TrackerGeom/inc/Panel.hh
+++ b/TrackerGeom/inc/Panel.hh
@@ -34,6 +34,7 @@ namespace mu2e {
   class Panel{
 
     friend class TrackerMaker;
+    friend class AlignedTrackerMaker;
     friend class Tracker; // needed for deep copy
 
   public:

--- a/TrackerGeom/inc/Panel.hh
+++ b/TrackerGeom/inc/Panel.hh
@@ -150,7 +150,7 @@ namespace mu2e {
     mutable CLHEP::Hep3Vector _straw0Direction;
 
     // panel origin
-    CLHEP::Hep3Vector _origin;
+    mutable CLHEP::Hep3Vector _origin;
 
     // electronic boards; they are placed wrt to the panel, but in a
     // different mother volume one per panel

--- a/TrackerGeom/inc/Panel.hh
+++ b/TrackerGeom/inc/Panel.hh
@@ -89,6 +89,8 @@ namespace mu2e {
     CLHEP::Hep3Vector straw0MidPoint()  const { return _straw0MidPoint;  }
     CLHEP::Hep3Vector straw0Direction() const { return _straw0Direction; }
 
+    CLHEP::Hep3Vector const& origin() const { return _origin; }
+
     // Formatted string embedding the id of the panel.
     std::string name( std::string const& base ) const;
 
@@ -146,6 +148,9 @@ namespace mu2e {
     //         declarations can go away.
     mutable CLHEP::Hep3Vector _straw0MidPoint;
     mutable CLHEP::Hep3Vector _straw0Direction;
+
+    // panel origin
+    CLHEP::Hep3Vector _origin;
 
     // electronic boards; they are placed wrt to the panel, but in a
     // different mother volume one per panel

--- a/TrackerGeom/inc/Plane.hh
+++ b/TrackerGeom/inc/Plane.hh
@@ -24,6 +24,8 @@ namespace mu2e {
 
   class Plane{
 
+    friend class AlignedTrackerMaker;
+
     friend class TrackerMaker;
     friend class Tracker; // needed for deep copy
 


### PR DESCRIPTION
[**Whitespace-free diff here**](https://github.com/Mu2e/Offline/pull/162/files?diff=unified&w=1)

For completeness, set the aligned panel and plane origins in AlignedTrackerMaker. `straw0Midpoint` is calculated as in `fillPointers`.

The aligned panel origin in the detector coord system is calculated by using `plane_temp` to do a transformation of a (0,0,0)-vector in the aligned plane system to the detector coordinate system.

Ideally we have the origin vectors / midpoints so the alignment derivative functions can calculate aligned straw midpoints and directions without manipulating and combining transformations (by knowing the origin of the plane/panel we can transform easily to the plane/panel system, do the rotation, and transform back). 

And, generally speaking because users of the aligned `Tracker` object in future may need access to these correct quantities, which are best calculated in AlignedTrackerMaker.

I spotted hard tabs in AlignedTrackerMaker.cc, which I have removed. (I assume nobody else has made changes to this file in their own branches and that these changes won't cause any conflicts or disruption)

Ran without problems on a misaligned TrkAnaDigisReco job over CeEndpoint-mix.