### PR TITLE
Thread care

### DIFF
--- a/Mu2eG4/inc/Mu2eG4Config.hh
+++ b/Mu2eG4/inc/Mu2eG4Config.hh
@@ -200,9 +200,6 @@ namespace mu2e {
       fhicl::Atom<std::string> generatorModuleLabel {Name("generatorModuleLabel"), ""};
 
       fhicl::Atom<bool> G4InteralFiltering {Name("G4InteralFiltering"), false};
-//      fhicl::Atom<long> initialSeed {Name("initialSeed"),
-//         Comment("Only used by Mu2eG4MTRunManager when running in MT mode"),
-//          8 };
     };
   }
 }

--- a/Mu2eG4/inc/Mu2eG4MTRunManager.hh
+++ b/Mu2eG4/inc/Mu2eG4MTRunManager.hh
@@ -65,7 +65,6 @@ namespace mu2e {
     G4VUserPhysicsList* physicsList_;
 
     int rmvlevel_;
-    //long initialSeed_;
   };
 
 } // end namespace mu2e

--- a/Mu2eG4/src/Mu2eG4MTRunManager.cc
+++ b/Mu2eG4/src/Mu2eG4MTRunManager.cc
@@ -56,7 +56,6 @@ namespace mu2e {
     masterRunAction_(nullptr),
     physicsList_(nullptr),
     rmvlevel_(conf.debug().diagLevel())
-    //initialSeed_(art::ServiceHandle<SeedService>()->getSeed())
   {
     const_cast<CLHEP::HepRandomEngine*>(getMasterRandomEngine())->setSeed(art::ServiceHandle<SeedService>()->getSeed(),0);
   }

--- a/Mu2eG4/src/Mu2eG4MT_module.cc
+++ b/Mu2eG4/src/Mu2eG4MT_module.cc
@@ -25,6 +25,7 @@
 #include "Mu2eG4/inc/SimParticleHelper.hh"
 #include "Mu2eG4/inc/SimParticlePrimaryHelper.hh"
 #include "Mu2eG4/inc/Mu2eG4Config.hh"
+#include "Mu2eG4/inc/Mu2eG4MTRunManager.hh"
 
 // Data products that will be produced by this module.
 #include "MCDataProducts/inc/GenParticleCollection.hh"
@@ -46,6 +47,7 @@
 
 // Geant4 includes
 #include "G4Run.hh"
+#include "G4VUserPhysicsList.hh"
 
 // C++ includes.
 #include <cstdlib>
@@ -419,14 +421,14 @@ namespace mu2e {
   // Tell G4 that this run is over.
   void Mu2eG4MT::endRun(art::Run & run, art::ProcessingFrame const& procFrame) {
 
-    G4cout << "At endRun, we have " << myworkerRunManagerMap.size() << " members in the map\n";
-    // KJK - should move this to endJob
-
+    if (_mtDebugOutput){
+      G4cout << "At endRun, we have " << myworkerRunManagerMap.size() << " members in the map\n";
+    }
     WorkerRMMap::iterator it = myworkerRunManagerMap.begin();
     
     while (it != myworkerRunManagerMap.end()) {
       it->second.release();
-      it++;
+      ++it;
     }
         
     if (storePhysicsTablesDir_!="") {
@@ -435,7 +437,7 @@ namespace mu2e {
                << storePhysicsTablesDir_
                << G4endl;
       }
-      //NEED TO ADD THIS BACK IN  physicsList_->StorePhysicsTable(storePhysicsTablesDir_);
+      masterThread->masterRunManagerPtr()->getMasterPhysicsList()->StorePhysicsTable(storePhysicsTablesDir_);
     }
 
     G4cout << "at endRun: numExcludedEvents = " << numExcludedEvents << G4endl;

--- a/Mu2eG4/src/Mu2eG4WorkerRunManager.cc
+++ b/Mu2eG4/src/Mu2eG4WorkerRunManager.cc
@@ -86,9 +86,9 @@ namespace mu2e {
   {
     if (m_mtDebugOutput) {
       G4cout << "WorkerRM on thread " << workerID_ << " is being created\n!";
+      //to see random number seeds for each event and other verbosity, uncomment this
+      SetPrintProgress(1);
     }
-    //to see random number seeds for each event and other verbosity, uncomment this
-    SetPrintProgress(1);
   }
 
   // Destructor of base is called automatically.  No need to do anything.


### PR DESCRIPTION
I have made a change that ensures proper cleanup of the worker run managers at the end of the job, even in the case of additional threads being created. 