### PR TITLE
Clang-tidy and Clang-format config amendments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,10 +1,9 @@
 ---
 BasedOnStyle: LLVM
 AlignAfterOpenBracket: Align
-BreakBeforeBraces: Stroustrup
 ColumnLimit: '100'
 DerivePointerAlignment: 'false'
-IndentWidth: '4'
+IndentWidth: '2'
 Language: Cpp
 PointerAlignment: Left
 ReflowComments: 'true'
@@ -14,5 +13,5 @@ SpacesInSquareBrackets: 'false'
 Standard: Auto
 TabWidth: '4'
 UseTab: Never
-
+BreakConstructorInitializers: AfterColon
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-braces-around-statements,readability-misleading-indentation,readability-non-const-parameter'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
@@ -7,7 +7,7 @@ FormatStyle:     none
 User:            roneil
 CheckOptions:    
   - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
+    value:           '0'
   - key:             google-readability-function-size.StatementThreshold
     value:           '800'
   - key:             google-readability-namespace-comments.ShortNamespaceLines


### PR DESCRIPTION
These changes are proposed in response to email conversations earlier in the year with Rob. 

The extra clang-tidy checks are added to spot and discourage if-statements without braces. There is an additional check to spot and discourage misleading indentation behaviour, and finally a check to encourage the use of const function arguments (where it is 'safer' to do so.) 

Added checks: 
- readability-braces-around-statements
- readability-misleading-indentation 
- readability-non-const-parameter

They can be looked up on the clang website: https://clang.llvm.org/extra/clang-tidy/checks/list.html

The clang-format config changes ensure a consistent brace style, and use of the most common indent width, which appears(!) to be 2 - of course this change will have no immediate effect since clang-format is not in regular use. The final addition ensures that in constructor initialiser lists we have one variable initialised per line.
