### PR TITLE
Intercepting also filenames with Mu2e convention

### DIFF
--- a/JobConfig/cosmic/cosmic_s1_dsstops_corsika.fcl
+++ b/JobConfig/cosmic/cosmic_s1_dsstops_corsika.fcl
@@ -1,0 +1,38 @@
+#include "JobConfig/cosmic/cosmic_s1_dsstops.fcl"
+
+targetParams: {
+    projectToTargetBox : true
+    targetBoxXmin: -10000
+    targetBoxXmax: 3000
+    targetBoxYmin: -5000
+    targetBoxYmax: 5000
+    targetBoxZmin: -5000
+    targetBoxZmax: 21000
+}
+
+source: {
+    module_type: FromCorsikaBinary
+    fileNames: ["/pnfs/mu2e/persistent/users/srsoleti/corsika/DAT300001"]
+    runNumber          : 1
+    showerAreaExtension  : 10000
+    @table::targetParams
+    resample: false
+    compact: true
+    fluxConstant: 1.8e4
+    lowE: 1.3
+    highE: 1e6
+}
+
+
+physics.producers.generate.module_type  : CORSIKAEventGenerator
+physics.producers.generate.corsikaModuleLabel: "FromCorsikaBinary"
+physics.producers.generate.refPointChoice: "UNDEFINED"
+physics.producers.generate.projectToTargetBox : true
+physics.producers.generate.targetBoxYmax : 5000
+physics.producers.generate.intDist: -1
+
+physics.producers.generate.inputFile    : @erase
+physics.producers.generate.stashSize    : @erase
+
+services.GeometryService.inputFile : "JobConfig/cosmic/geom_cosmic.txt"
+services.GeometryService.simulatedDetector : { tool_type: "Mu2e" }

--- a/Sources/inc/CosmicCORSIKA.hh
+++ b/Sources/inc/CosmicCORSIKA.hh
@@ -48,9 +48,6 @@ struct Config
   using Name = fhicl::Name;
   using Comment = fhicl::Comment;
   fhicl::Sequence<std::string> showerInputFiles{Name("fileNames"),Comment("List of CORSIKA binary output paths")};
-  fhicl::Atom<int> firstEventNumber{Name("firstEventNumber"), Comment("First event number"), 0};
-  fhicl::Atom<int> firstSubRunNumber{Name("firstSubRunNumber"), Comment("First subrun number"), 0};
-  fhicl::Atom<int> maxEvents{Name("maxEvents"), Comment("Max number of events"), 0};
   fhicl::Atom<unsigned int> runNumber{Name("runNumber"), Comment("First run number"), 0};
   fhicl::Atom<std::string> module_label{Name("module_label"), Comment("Art module label"), ""};
   fhicl::Atom<std::string> module_type{Name("module_type"), Comment("Art module type"), ""};

--- a/Sources/src/FromCorsikaBinary_source.cc
+++ b/Sources/src/FromCorsikaBinary_source.cc
@@ -137,13 +137,32 @@ namespace mu2e {
 
     //----------------------------------------------------------------
     unsigned CorsikaBinaryDetail::getSubRunNumber(const std::string& filename) const {
-      const std::string::size_type islash = filename.find("DAT") ;
-      const std::string basename = (islash == std::string::npos) ? filename : filename.substr(islash + 3);
+      const std::string::size_type corsikaConvention = filename.find("DAT");
+      const std::string::size_type mu2eConvention = filename.find(".csk");
+
       unsigned sr(-1);
-      std::istringstream is(basename);
-      if(!(is>>sr)) {
-        throw cet::exception("BADINPUTS")<<"Expect an unsigned integer at the beginning of input file name, got "<<basename<<"\n";
+
+      if (corsikaConvention != std::string::npos) {
+          const std::string basename = filename.substr(corsikaConvention + 3);
+          std::istringstream is(basename);
+          if (!(is >> sr)) {
+              throw cet::exception("BADINPUTS")
+                  << "Expect an unsigned integer at the beginning of input file name, got "
+                  << basename << "\n";
+          }
+      } else if (mu2eConvention != std::string::npos) {
+          unsigned last = filename.find_last_of(".");
+          std::string filenameNoExt = filename.substr(0, last);
+          last = filenameNoExt.find_last_of(".");
+          std::string subrun = filenameNoExt.substr(last+1);
+          std::istringstream is(subrun);
+          if (!(is >> sr)) {
+              throw cet::exception("BADINPUTS")
+                  << "Expect an unsigned integer as fifth field in the filename, got "
+                  << filename << "\n";
+          }
       }
+
       return sr;
     }
 

--- a/Sources/src/FromCorsikaBinary_source.cc
+++ b/Sources/src/FromCorsikaBinary_source.cc
@@ -137,8 +137,8 @@ namespace mu2e {
 
     //----------------------------------------------------------------
     unsigned CorsikaBinaryDetail::getSubRunNumber(const std::string& filename) const {
-      const std::string::size_type corsikaConvention = filename.find("DAT");
-      const std::string::size_type mu2eConvention = filename.find(".csk");
+      const std::string::size_type corsikaConvention = filename.find_last_of("DAT");
+      const std::string::size_type mu2eConvention = filename.find_last_of(".csk");
 
       unsigned sr(-1);
 


### PR DESCRIPTION
Now the code is able to parse the fifth field of a filename in the Mu2e convention and use it as a subrun number.