### PR TITLE
update products to art v3_05_00

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -103,7 +103,7 @@ build=$($MU2E_BASE_RELEASE/buildopts --build)
 # and is therefore different from the value shown in
 # SETUP_<productname> environment vars, or by the "ups active" command.
 export MU2E_UPS_QUALIFIERS=+e19:+${build}
-export MU2E_ART_SQUALIFIER=s94
+export MU2E_ART_SQUALIFIER=s96
 
 MU2E_G4_GRAPHICS_QUALIFIER=''
 if [[ $($MU2E_BASE_RELEASE/buildopts --g4vis) == qt ]]; then
@@ -118,8 +118,8 @@ fi
 export MU2E_G4_EXTRA_QUALIFIER=''
 
 # Setup the framework and its dependent products
-setup -B art v3_04_00 -q${MU2E_UPS_QUALIFIERS}
-setup -B art_root_io v1_02_00 -q${MU2E_UPS_QUALIFIERS}
+setup -B art v3_05_00 -q${MU2E_UPS_QUALIFIERS}
+setup -B art_root_io v1_03_00 -q${MU2E_UPS_QUALIFIERS}
 
 # Geant4 and its cross-section files.
 if [[ $($MU2E_BASE_RELEASE/buildopts --trigger) == "off" ]]; then
@@ -129,13 +129,13 @@ else
 fi
 
 # Get access to raw data formats.
-setup -B mu2e_artdaq_core v1_03_07 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:online
+setup -B mu2e_artdaq_core v1_03_07 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
 
 # Other libraries we need.
 setup -B pcie_linux_kernel_module v2_02_13 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}
 
 setup -B heppdt   v3_04_01j -q${MU2E_UPS_QUALIFIERS}
-setup -B BTrk   v1_02_21  -q${MU2E_UPS_QUALIFIERS}
+setup -B BTrk   v1_02_22  -q${MU2E_UPS_QUALIFIERS}
 setup -B cry   v1_7m  -q${MU2E_UPS_QUALIFIERS}
 setup -B gsl v2_5  -q${build}
 setup curl v7_64_1


### PR DESCRIPTION
Update products for art v3_05_00.  Changed mu2e_artdaq_core qualifier from online back to offline.  ceSimReco check shows no physics change.