### PR TITLE
Bug fix: fcl/standardServices.fcl referred to an undefined variable.

### DIFF
--- a/fcl/standardServices.fcl
+++ b/fcl/standardServices.fcl
@@ -2,6 +2,7 @@
 # This file defines some standard configurations for services
 #
 
+#include "fcl/minimalMessageService.fcl"
 #include "DbService/fcl/prolog.fcl"
 #include "ProditionsService/fcl/prolog.fcl"
 


### PR DESCRIPTION
Add an include that defines @local::default_message.