### PR TITLE
Refactoring and clean up of the CORSIKA code

### DIFF
--- a/JobConfig/cosmic/cosmic_s1_dsstops_corsika.fcl
+++ b/JobConfig/cosmic/cosmic_s1_dsstops_corsika.fcl
@@ -12,15 +12,11 @@ targetParams: {
 
 source: {
     module_type: FromCorsikaBinary
-    fileNames: ["/pnfs/mu2e/persistent/users/srsoleti/corsika/DAT300001"]
+    fileNames: ["/pnfs/mu2e/persistent/users/srsoleti/corsika/sim.srsoleti.corsika.v1.30001.csk"]
     runNumber          : 1
     showerAreaExtension  : 10000
     @table::targetParams
-    resample: false
-    compact: true
     fluxConstant: 1.8e4
-    lowE: 1.3
-    highE: 1e6
 }
 
 

--- a/Sources/inc/CosmicCORSIKA.hh
+++ b/Sources/inc/CosmicCORSIKA.hh
@@ -234,10 +234,11 @@ namespace mu2e {
       static constexpr float _GeV2MeV = CLHEP::GeV / CLHEP::MeV;
       static constexpr float _cm2mm = CLHEP::cm / CLHEP::mm;
       static constexpr float _ns2s = CLHEP::ns / CLHEP::s;
-      static constexpr unsigned _fbsize_words = 5733 + 2;
+      static constexpr unsigned _fbsize_words = 5733 + 2; ///< CORSIKA fixed block size plus possible g77 padding per footnote 105
+                                                          ///< in the User Guide https://web.ikp.kit.edu/corsika/usersguide/usersguide.pdf
 
       CLHEP::Hep3Vector _cosmicReferencePointInMu2e;
-      float _fluxConstant = 1.8e4;
+      float _fluxConstant = 1.8e4; ///< Primary nucleon intensity for cosmic rays, as quoted in the PDG. Used for cosmic live-time calculation
       float _tOffset = 0; ///< Time offset of sample, defaults to zero (no offset) [s]
       bool _projectToTargetBox = false;
       float _showerAreaExtension = 0; ///< Extend distribution of corsika particles in x,z by this much (e.g. 1000 will extend 10 m in -x, +x, -z, and +z) [mm]

--- a/Sources/inc/CosmicCORSIKA.hh
+++ b/Sources/inc/CosmicCORSIKA.hh
@@ -54,8 +54,6 @@ struct Config
   fhicl::Atom<bool> projectToTargetBox{Name("projectToTargetBox"), Comment("Store only events that cross the target box"), false};
   fhicl::Atom<float> showerAreaExtension{Name("showerAreaExtension"), Comment("Extension of the generation box on the xz plane")};
   fhicl::Atom<float> tOffset{Name("tOffset"), Comment("Time offset"), 0};
-  fhicl::Atom<float> lowE{Name("lowE"), Comment("lowE"), 1.3};
-  fhicl::Atom<float> highE{Name("highE"), Comment("highE"), 1e6};
   fhicl::Atom<float> fluxConstant{Name("fluxConstant"), Comment("Primary cosmic nucleon flux constant")};
   fhicl::Atom<float> targetBoxXmin{Name("targetBoxXmin"), Comment("Target box x min")};
   fhicl::Atom<float> targetBoxXmax{Name("targetBoxXmax"), Comment("Target box x max")};
@@ -63,14 +61,15 @@ struct Config
   fhicl::Atom<float> targetBoxYmax{Name("targetBoxYmax"), Comment("Target box y max")};
   fhicl::Atom<float> targetBoxZmin{Name("targetBoxZmin"), Comment("Target box z min")};
   fhicl::Atom<float> targetBoxZmax{Name("targetBoxZmax"), Comment("Target box z max")};
-  fhicl::Atom<bool> resample{Name("resample"), Comment("Resampling flag")};
-  fhicl::Atom<bool> compact{Name("compact"), Comment("CORSIKA compact output flag")};
 };
+
 typedef fhicl::WrappedTable<Config> Parameters;
 
 class GenParticleCollection;
 
 namespace mu2e {
+
+  enum class Format { UNDEFINED, NORMAL, COMPACT };
 
   class CosmicCORSIKA {
 
@@ -78,6 +77,13 @@ namespace mu2e {
       CosmicCORSIKA(const Config& conf, SeedService::seed_t seed);
       // CosmicCORSIKA(art::Run &run, CLHEP::HepRandomEngine &engine);
       ~CosmicCORSIKA();
+
+      enum Format
+      {
+        UNDEFINED,
+        NORMAL,
+        COMPACT
+      };
 
       const std::map<unsigned int, int> corsikaToPdgId = {
           {1, 22},     // gamma
@@ -213,11 +219,10 @@ namespace mu2e {
       };
 
       virtual bool generate(GenParticleCollection &, unsigned int &);
-      void openFile(FILE *f);
+      void openFile(ifstream *f, unsigned &run, float &lowE, float &highE);
 
     private:
       bool genEvent(std::map<std::pair<int,int>, GenParticleCollection> &particles_map);
-      bool genEventCompact(std::map<std::pair<int,int>, GenParticleCollection> &particles_map);
       float wrapvarBoxNo(const float var, const float low, const float high, int &boxno);
 
       std::vector<CLHEP::Hep3Vector> _targetBoxIntersections;
@@ -229,6 +234,7 @@ namespace mu2e {
       static constexpr float _GeV2MeV = CLHEP::GeV / CLHEP::MeV;
       static constexpr float _cm2mm = CLHEP::cm / CLHEP::mm;
       static constexpr float _ns2s = CLHEP::ns / CLHEP::s;
+      static constexpr unsigned _fbsize_words = 5733 + 2;
 
       CLHEP::Hep3Vector _cosmicReferencePointInMu2e;
       float _fluxConstant = 1.8e4;
@@ -236,8 +242,6 @@ namespace mu2e {
       bool _projectToTargetBox = false;
       float _showerAreaExtension = 0; ///< Extend distribution of corsika particles in x,z by this much (e.g. 1000 will extend 10 m in -x, +x, -z, and +z) [mm]
 
-      std::string _refPointChoice;
-      bool _geomInfoObtained = false;
       float _targetBoxXmin = 0;
       float _targetBoxXmax = 0;
       float _targetBoxYmin = 0;
@@ -245,14 +249,20 @@ namespace mu2e {
       float _targetBoxZmin = 0;
       float _targetBoxZmax = 0;
 
-      FILE *in = nullptr;
-      int _loops = 0; // number of loops, necessary to skip the garbage data between blocks
-      float _garbage;
+      std::ifstream *input;
 
+      unsigned _current_event_number = -1;
+      unsigned _event_count = 0;
+      unsigned _run_number = -1;
       unsigned int _primaries = 0;
 
-      bool _resample = false;
-      bool _compact = true;
+      Format _infmt{Format::UNDEFINED};
+
+      union {
+        float fl[_fbsize_words];
+        unsigned in[_fbsize_words];
+        char ch[sizeof(fl[0])*_fbsize_words];
+      } _buf;
 
       CLHEP::HepJamesRandom _engine;
       CLHEP::RandFlat _randFlatX;

--- a/Sources/src/CosmicCORSIKA.cc
+++ b/Sources/src/CosmicCORSIKA.cc
@@ -125,6 +125,10 @@ namespace mu2e {
           throw std::runtime_error("Error: reclen too small");
         }
 
+        if(reclen > 4*_fbsize_words) {
+          throw std::runtime_error("Error: reclen too big");
+        }
+
         // Read the full record
         if(!input->read(_buf.ch, reclen)) {
           break;

--- a/Sources/src/CosmicCORSIKA.cc
+++ b/Sources/src/CosmicCORSIKA.cc
@@ -261,7 +261,6 @@ namespace mu2e {
       for (unsigned int i = 0; i < particles.size(); i++) {
         GenParticle particle = particles[i];
 
-
         _targetBoxIntersections.clear();
         VectorVolume particleTarget(particle.position(), particle.momentum().vect(),
                                     _targetBoxXmin, _targetBoxXmax,

--- a/Sources/src/CosmicCORSIKA.cc
+++ b/Sources/src/CosmicCORSIKA.cc
@@ -23,19 +23,74 @@ namespace mu2e {
         _targetBoxYmax(conf.targetBoxYmax()),  // mm
         _targetBoxZmin(conf.targetBoxZmin()), // mm
         _targetBoxZmax(conf.targetBoxZmax()),  // mm
-        _resample(conf.resample()),
-        _compact(conf.compact()),
         _engine(seed),
         _randFlatX(_engine, -(_targetBoxXmax-_targetBoxXmin+_showerAreaExtension)/2, +(_targetBoxXmax-_targetBoxXmin+_showerAreaExtension)/2),
         _randFlatZ(_engine, -(_targetBoxZmax-_targetBoxZmin+_showerAreaExtension)/2, +(_targetBoxZmax-_targetBoxZmin+_showerAreaExtension)/2)
   {
   }
 
-  void CosmicCORSIKA::openFile(FILE *f) {
-    in = f;
-    fread(&_garbage, 4, 1, in);
-  }
+  void CosmicCORSIKA::openFile(ifstream *f, unsigned &runNumber, float &lowE, float &highE)
+  {
+    input = f;
+    _current_event_number = -1;
+    _event_count = 0;
+    _run_number = -1;
+    _infmt = Format::UNDEFINED;
 
+    while( input->read(_buf.ch, 4)) {
+      unsigned reclen = _buf.in[0];
+      // CORSIKA records are in units of 4 bytes
+      if(reclen % 4) {
+        throw std::runtime_error("Error: record size not a multiple of 4");
+      }
+
+      // We will be looking at at least 8 bytes to determine the
+      // input file format, and all real CORSIKA records are longer
+      // than that.
+      if(reclen < 2*4) {
+        throw std::runtime_error("Error: reclen too small");
+      }
+
+      // Read the full record
+      if(!input->read(_buf.ch, reclen)) {
+        break;
+      }
+
+      // Determine the format and and store the decision for future blocks.
+      // We are starting file read, so should see the RUNH marker
+      // In COMPACT format each block is preceded by 4 bytes
+      // giving the size of the block in words.
+
+      if(!strncmp(_buf.ch+0, "RUNH", 4)) {
+        std::cout<<"Reading NORMAL format"<<std::endl;
+        _infmt = Format::NORMAL;
+      }
+      else if(!strncmp(_buf.ch+4, "RUNH", 4)) {
+        std::cout<<"Reading COMPACT format"<<std::endl;
+        _infmt = Format::COMPACT;
+      }
+      else {
+        throw std::runtime_error("Error: did not find the RUNH record to determine COMPACT flag");
+      }
+
+      unsigned iword = 0;
+      if(_infmt == Format::COMPACT) {
+        // Move to the beginning of the actual block
+        ++iword;
+      }
+
+      if(!strncmp(_buf.ch+4*iword, "RUNH", 4)) {
+        runNumber = lrint(_buf.fl[1+iword]);
+        lowE = float(_buf.fl[16+iword]);
+        highE = float(_buf.fl[17+iword]);
+      }
+
+      break;
+
+    }
+    input->clear();
+    input->seekg(0, ios::beg);
+  }
 
   CosmicCORSIKA::~CosmicCORSIKA(){
   }
@@ -48,301 +103,152 @@ namespace mu2e {
     return (var - (high - low) * floor(var / (high - low))) + low;
   }
 
-  bool CosmicCORSIKA::genEventCompact(std::map<std::pair<int,int>, GenParticleCollection> &particles_map) {
-    bool running = true;
-    int particleDataSubBlockCounter = 0;
-    const float xOffset = _randFlatX.fire();
-    const float zOffset = _randFlatZ.fire();
-    char word[5];
-
-    if (feof(in))
-      return false;
-
-    while (running)
-    {
-
-      fread(word, sizeof(char)*4, 1, in);
-			word[4] = '\0';
-
-			// Compact event blocks start with the EVHW word
-      if (strcmp(word, "EVHW") == 0) {
-        // The size of the event block is 12 4-byte words, EVHW + 11 floats
-				float eventBlock[11];
-				fread(eventBlock, sizeof(eventBlock), 1, in);
-        _primaries++;
-        if (particleDataSubBlockCounter > 0)
-        {
-          running = false;
-        }
-        particleDataSubBlockCounter = 0;
-      }
-      else
-			{
-        // We didn't find EVHW, so go back by 4 chars in the file
-        fseek(in, -sizeof(char)*4, SEEK_CUR);
-
-        // The first number in the block is the size of the block
-        int blockSize;
-        fread(&blockSize, sizeof(blockSize), 1, in);
-
-        // The blocks have multiple of 7 size
-        // see https://web.ikp.kit.edu/corsika/physics_description/corsika_phys.pdf
-        if (blockSize % 7 == 0 && blockSize > 0 && blockSize / 7 <= 39) {
-					unsigned int n_particles = blockSize / 7;
-
-          // Maximum size of the block is 7*39=273
-					float block[273];
-					fread(block, sizeof(float)*blockSize, 1, in);
-          fread(&_garbage, 4, 1, in);
-
-					char blockName[5];
-					memcpy(blockName, block, 4);
-					blockName[4] = '\0';
-
-					// End of run
-					if (strcmp(blockName, "RUNE") == 0)
-					{
-            // If resampling is on, we go back to the beginning of the file
-            if (_resample) {
-              std::cout << "Resampling file..." << std::endl;
-              fseek(in, 0, SEEK_SET);
-              fread(&_garbage, 4, 1, in);
-              continue;
-            } else {
-              _primaries = 0;
-              return false;
-            }
-					}
-          // Run header, we don't use it
-					else if (strcmp(blockName, "RUNH") == 0)
-					{
-						continue;
-					}
-          // Only the first event has a full size block
-					else if (strcmp(blockName, "EVTH") == 0)
-					{
-            _primaries++;
-          }
-          else
-					{
-            // We are inside a particle data block
-            particleDataSubBlockCounter++;
-            for (unsigned int i = 0; i < n_particles; i++)
-						{
-              unsigned int k = i * 7;
-              if (block[k] != 0)
-              {
-                const int id = (int)(block[k] / 1000);
-                const int pdgId = corsikaToPdgId.at(id);
-                const float P_x = block[k + 2] * _GeV2MeV;
-                const float P_y = -block[k + 3] * _GeV2MeV;
-                const float P_z = block[k + 1] * _GeV2MeV;
-
-                int boxnox = 0, boxnoz = 0;
-
-                const float x = wrapvarBoxNo(block[k + 5] * _cm2mm + xOffset, _targetBoxXmin - _showerAreaExtension, _targetBoxXmax + _showerAreaExtension, boxnox);
-                const float z = wrapvarBoxNo(-block[k + 4] * _cm2mm + zOffset, _targetBoxZmin - _showerAreaExtension, _targetBoxZmax + _showerAreaExtension, boxnoz);
-                std::pair xz(boxnox, boxnoz);
-                const float m = pdt->particle(pdgId).ref().mass(); // to MeV
-
-                const float energy = safeSqrt(P_x * P_x + P_y * P_y + P_z * P_z + m * m);
-
-                const Hep3Vector position(x, _targetBoxYmax, z);
-                const HepLorentzVector mom4(P_x, P_y, P_z, energy);
-
-                const float particleTime = block[k + 6] * _ns2s;
-
-                GenParticle part(static_cast<PDGCode::type>(pdgId),
-                                  GenId::cosmicCORSIKA, position, mom4,
-                                  particleTime);
-
-                if (particles_map.count(xz) == 0)
-                {
-                  GenParticleCollection parts;
-                  parts.push_back(part);
-                  particles_map.insert({xz, parts});
-                }
-                else
-                {
-                  particles_map[xz].push_back(part);
-                }
-              }
-						}
-					}
-				}
-
-			}
-
-		}
-
-    return true;
-  }
-
   bool CosmicCORSIKA::genEvent(std::map<std::pair<int,int>, GenParticleCollection> &particles_map) {
-    float block[273]; // all data blocks have this size
-    // static TDatabasePDG *pdgt = TDatabasePDG::Instance();
 
-    bool running = true; // end run condition
-    bool validParticleSubBlock = true;
-    int particleDataSubBlockCounter = 0;
+      const float xOffset = _randFlatX.fire();
+      const float zOffset = _randFlatZ.fire();
 
-    if (feof(in))
-      return false;
+      // FORTRAN sequential records are prefixed with their length
+      // in a 4-byte word
+      while( input->read(_buf.ch, 4)) {
 
-    // Particle offset, must be the same for every particle in one event
-    const float xOffset = _randFlatX.fire();
-    const float zOffset = _randFlatZ.fire();
-
-    while (running)
-    {
-      std::vector<GenParticle> showerParticles;
-      fread(block, sizeof(block), 1, in); // blocks have 273 informations
-      char blockName[5];
-      memcpy(blockName, block, 4);
-      blockName[4] = '\0';
-      _loops++;
-
-      if (_loops % 21 == 0)
-      { // 2 _garbage data floats between every 21 blocks
-
-        fread(&_garbage, 4, 1, in);
-        fread(&_garbage, 4, 1, in);
-      }
-
-      // std::cout << blockName << " " << sizeof(block) << " " << (int)block[0] << std::endl;
-
-      //__________RUN HEADER
-
-      if (strcmp(blockName, "RUNH") == 0)
-      {
-        continue;
-      }
-
-      //__________EVENT HEADER
-      else if (strcmp(blockName, "EVTH") == 0)
-      {
-        _primaries++;
-        validParticleSubBlock = true;
-      }
-      //__________EVENT END
-
-      else if (strcmp(blockName, "EVTE") == 0)
-      {
-        if (particleDataSubBlockCounter > 0)
-        {
-          running = false;
+        unsigned reclen = _buf.in[0];
+        // CORSIKA records are in units of 4 bytes
+        if(reclen % 4) {
+          throw std::runtime_error("Error: record size not a multiple of 4");
         }
-        particleDataSubBlockCounter = 0;
-      }
-      //__________END OF RUN
-      else if (strcmp(blockName, "RUNE") == 0)
-      {
-        _loops = 0;
-        if (_resample) {
-          std::cout << "Resampling file..." << std::endl;
-          fseek(in, 0, SEEK_SET);
-          fread(&_garbage, 4, 1, in);
-          continue;
-        } else {
-          std::cout << "End of run " << std::endl;
-          _primaries = 0;
-          return false;
+
+        // We will be looking at at least 8 bytes to determine the
+        // input file format, and all real CORSIKA records are longer
+        // than that.
+        if(reclen < 2*4) {
+          throw std::runtime_error("Error: reclen too small");
         }
-        // end run condition
-      }
-      else if (strcmp(blockName, "LONG")==0)
-      {
-        continue;
-      }
-      //__________PARTICLE DATA SUB-BLOCKS
 
-      else
-      {
+        // Read the full record
+        if(!input->read(_buf.ch, reclen)) {
+          break;
+        }
 
-        if (validParticleSubBlock == true)
-        {
-          for (int l = 1; l < 40; l++)
-          { // each sub-block has up to 39 particles. If a sub-block is not fulfilled, trailing zeros are added
+        unsigned n_part = 0;
+        //================================================================
+        // Go over blocks in the record
+        for(unsigned iword = 0; iword < reclen/4; ) {
 
-            int k = 7 * (l - 1);
-            float id = block[k];
-            //cout << "	" << k << " " << block[k] << " " << block[k+1] << " " << block[k+2] << " " << block[k+3] << " " << block[k+4] << " " << block[k+5] << " " << block[k+6] << endl;	// for verification purposes only
+          unsigned block_words = (_infmt == Format::COMPACT) ?
+            _buf.in[iword] : 273;
 
-            if ((int)(id / 1000) != 0)
-            {
-              if (id < 75000)
-              {
+          if(!block_words) {
+            throw std::runtime_error("Got block_words = 0\n");
+          }
 
-                if (block[k + 1] != 0)
-                {
-                  id = (int)(id / 1000);
-                  const int pdgId = corsikaToPdgId.at(id);
-                  const float P_x = block[k + 2] * _GeV2MeV;
-                  const float P_y = -block[k + 3] * _GeV2MeV;
-                  const float P_z = block[k + 1] * _GeV2MeV;
+          if(_infmt == Format::COMPACT) {
+            // Move to the beginning of the actual block
+            ++iword;
+          }
 
-                  int boxnox = 0, boxnoz = 0;
+          std::string event_marker =
+            (_infmt == Format::NORMAL || !_event_count) ? "EVTH" : "EVHW";
 
-                  const float x = wrapvarBoxNo(block[k + 5] * _cm2mm + xOffset, _targetBoxXmin - _showerAreaExtension, _targetBoxXmax + _showerAreaExtension, boxnox);
-                  const float z = wrapvarBoxNo(-block[k + 4] * _cm2mm + zOffset, _targetBoxZmin - _showerAreaExtension, _targetBoxZmax + _showerAreaExtension, boxnoz);
-                  std::pair xz(boxnox, boxnoz);
-                  const float m = pdt->particle(pdgId).ref().mass(); // to MeV
-
-                  const float energy = safeSqrt(P_x * P_x + P_y * P_y + P_z * P_z + m * m);
-
-                  const Hep3Vector position(x, _targetBoxYmax, z);
-                  const HepLorentzVector mom4(P_x, P_y, P_z, energy);
-
-                  const float particleTime = block[k + 6] * _ns2s;
-
-                  GenParticle part(static_cast<PDGCode::type>(pdgId),
-                                   GenId::cosmicCORSIKA, position, mom4,
-                                   particleTime);
-
-                  if (particles_map.count(xz) == 0) {
-                    GenParticleCollection parts;
-                    parts.push_back(part);
-                    particles_map.insert({xz, parts});
-                  } else {
-                    particles_map[xz].push_back(part);
-                  }
-
-                  particleDataSubBlockCounter++;
-                }
-              }
+          // Determine the type of the data block
+          if(!strncmp(_buf.ch+4*iword, "RUNH", 4)) {
+            _run_number = lrint(_buf.fl[1+iword]);
+          }
+          else if(!strncmp(_buf.ch+4*iword, "RUNE", 4)) {
+            unsigned end_run_number = lrint(_buf.fl[1+iword]);
+            unsigned end_event_count = lrint(_buf.fl[2+iword]);
+            if(end_run_number != _run_number) {
+              throw std::runtime_error("Error: run number mismatch in end of run record\n");
             }
-            else
-            {
-              validParticleSubBlock = false;
+            if(_event_count != end_event_count) {
+              std::cerr<<"RUNE: _event_count = "<<_event_count<<" end record = "<<end_event_count<<std::endl;
+              throw std::runtime_error("Error: event count mismatch in end of run record\n");
+            }
+            // Exit the read loop at the end of run
+            _primaries = 0;
+            return false;
+          }
+          else if(!strncmp(_buf.ch+4*iword, event_marker.data(), 4)) {
+            ++_event_count;
+            _current_event_number = lrint(_buf.fl[1+iword]);
+            ++_primaries;
+          }
+          else if(!strncmp(_buf.ch+4*iword, "EVTE", 4)) {
+            unsigned end_event_number = lrint(_buf.fl[1+iword]);
+            if(end_event_number != _current_event_number) {
+              throw std::runtime_error("Error: event number mismatch in end of event record\n");
             }
           }
+          else {
+            for (unsigned i_part = 0; i_part < block_words; i_part+=7) {
+              unsigned id = _buf.fl[iword + i_part] / 1000;
+              if (id == 0)
+                continue;
+              n_part++;
+              const int pdgId = corsikaToPdgId.at(id);
+              const float P_x = _buf.fl[iword + i_part + 2] * _GeV2MeV;
+              const float P_y = -_buf.fl[iword + i_part + 3] * _GeV2MeV;
+              const float P_z = _buf.fl[iword + i_part + 1] * _GeV2MeV;
+
+              int boxnox = 0, boxnoz = 0;
+
+              const float x = wrapvarBoxNo(_buf.fl[iword + i_part + 5] * _cm2mm + xOffset, _targetBoxXmin - _showerAreaExtension, _targetBoxXmax + _showerAreaExtension, boxnox);
+              const float z = wrapvarBoxNo(-_buf.fl[iword + i_part + 4] * _cm2mm + zOffset, _targetBoxZmin - _showerAreaExtension, _targetBoxZmax + _showerAreaExtension, boxnoz);
+              std::pair xz(boxnox, boxnoz);
+              const float m = pdt->particle(pdgId).ref().mass(); // to MeV
+
+              const float energy = safeSqrt(P_x * P_x + P_y * P_y + P_z * P_z + m * m);
+
+              const Hep3Vector position(x, _targetBoxYmax, z);
+              const HepLorentzVector mom4(P_x, P_y, P_z, energy);
+
+              const float particleTime = _buf.fl[iword + i_part + 6] * _ns2s;
+              GenParticle part(static_cast<PDGCode::type>(pdgId),
+                    GenId::cosmicCORSIKA, position, mom4,
+                    particleTime);
+
+              if (particles_map.count(xz) == 0) {
+                GenParticleCollection parts;
+                parts.push_back(part);
+                particles_map.insert({xz, parts});
+              } else {
+                particles_map[xz].push_back(part);
+              }
+            }
+
+          }
+
+          // Move to the next block
+          iword += block_words;
+
+        } // loop over blocks in a record
+
+        // Here we expect the FORTRAN end of record padding,
+        // read and verify its value.
+        if(!input->read(_buf.ch, 4)) {
+          break;
         }
-      }
-    }
+        if(_buf.in[0] != reclen) {
+          throw std::runtime_error("Error: unexpected FORTRAN record end padding");
+        }
 
-    return true;
+        if (n_part > 0) {
+          return true;
+        }
+
+      } // loop over records
+      return true;
   }
-
 
   bool CosmicCORSIKA::generate( GenParticleCollection& genParts, unsigned int &primaries)
   {
-
     // loop over particles in the truth object
     bool passed = false;
     while (!passed) {
-
       if (_particles_map.size() == 0)
       {
-        if (_compact) {
-          if (!genEventCompact(_particles_map))
-          {
-            return false;
-          }
-        } else {
-          if (!genEvent(_particles_map))
-          {
-            return false;
-          }
+        if (!genEvent(_particles_map)) {
+          return false;
         }
       }
 
@@ -373,7 +279,6 @@ namespace mu2e {
 
       for (unsigned int i = 0; i < crossingParticles.size(); i++) {
           GenParticle part = crossingParticles[i];
-          // std::cout << "Time offset " << timeOffset << std::endl;
           genParts.push_back(GenParticle(part.pdgId(), part.generatorId(), part.position(), part.momentum(), part.time()+_tOffset-timeOffset));
       }
       _particles_map.erase(_particles_map.begin()->first);

--- a/Sources/src/FromCorsikaBinary_source.cc
+++ b/Sources/src/FromCorsikaBinary_source.cc
@@ -8,7 +8,6 @@
 #include <cassert>
 #include <set>
 #include <string>
-#include <regex>
 
 #include "CLHEP/Vector/LorentzVector.h"
 #include "CLHEP/Vector/ThreeVector.h"
@@ -21,7 +20,6 @@
 #include "art/Framework/Principal/SubRunPrincipal.h"
 #include "art/Framework/Principal/EventPrincipal.h"
 #include "art/Framework/IO/Sources/put_product_in_principal.h"
-#include "art/Utilities/Globals.h" // FIXME-KJK: should not be necessary to use this
 #include "canvas/Persistency/Provenance/Timestamp.h"
 #include "canvas/Persistency/Provenance/RunID.h"
 #include "canvas/Persistency/Provenance/SubRunID.h"

--- a/Sources/src/FromCorsikaBinary_source.cc
+++ b/Sources/src/FromCorsikaBinary_source.cc
@@ -55,7 +55,7 @@ namespace mu2e {
       std::set<art::SubRunID> seenSRIDs_;
 
       std::string currentFileName_;
-      FILE *currentFile_ = nullptr;
+      std::ifstream *currentFile_ = nullptr;
       float garbage;
 
       unsigned currentSubRunNumber_; // from file
@@ -108,8 +108,6 @@ namespace mu2e {
       , runNumber_(conf().runNumber())
       , currentSubRunNumber_(-1U)
       , currentEventNumber_(0)
-      , _lowE(conf().lowE())
-      , _highE(conf().highE())
       , _fluxConstant(conf().fluxConstant())
       , _corsikaGen(conf(), art::ServiceHandle<SeedService>{}->getInputSourceSeed())
     {
@@ -128,46 +126,23 @@ namespace mu2e {
     void CorsikaBinaryDetail::readFile(const std::string& filename, art::FileBlock*& fb) {
 
       currentFileName_ = filename;
-      currentSubRunNumber_ = getSubRunNumber(filename);
       currentEventNumber_ = 0;
 
-      currentFile_ = fopen(filename.c_str(), "r");
-      _corsikaGen.openFile(currentFile_);
+      currentFile_ = new ifstream(currentFileName_);
+
+      unsigned subrun = 0;
+      float lowE, highE;
+      _corsikaGen.openFile(currentFile_, subrun, lowE, highE);
+      currentSubRunNumber_ = subrun;
+      _lowE = lowE;
+      _highE = highE;
       fb = new art::FileBlock(art::FileFormatVersion(1, "CorsikaBinaryInput"), currentFileName_);
-    }
-
-    //----------------------------------------------------------------
-    unsigned CorsikaBinaryDetail::getSubRunNumber(const std::string& filename) const {
-      std::regex re_corsika("^(.*/)?DAT([0-9]+)$");
-      std::regex re_mu2e("^(.*/)?sim\\.\\w+\\.[\\w-]+\\.[\\w-]+\\.([0-9]+)\\.csk$");
-
-      unsigned sr(-1);
-
-      std::smatch match;
-      if(std::regex_search(filename, match, re_corsika)) {
-        // [0]: the whole string
-        // [1]: dirname or emtpy
-        // [2]: the run number string
-        sr = std::stoi(match.str(2));
-      }
-      else if(std::regex_search(filename, match, re_mu2e)) {
-        // [0]: the whole string
-        // [1]: dirname or emtpy
-        // [2]: the run number string
-        sr = std::stoi(match.str(2));
-      }
-      else {
-        throw cet::exception("BADINPUT", " FromCorsikaBinary: ")
-          << " Can not parse filename to extract subrun number:  "<<filename<<"\n";
-      }
-
-      return sr;
     }
 
     //----------------------------------------------------------------
     void CorsikaBinaryDetail::closeCurrentFile() {
       currentFileName_ = "";
-      fclose(currentFile_);
+      currentFile_->close();
     }
 
     //----------------------------------------------------------------
@@ -180,6 +155,7 @@ namespace mu2e {
       std::unique_ptr<GenParticleCollection> particles(new GenParticleCollection());
       unsigned int primaries;
       bool still_data = _corsikaGen.generate(*particles, primaries);
+
       if (!still_data) {
         return false;
       }

--- a/Sources/src/FromCorsikaBinary_source.cc
+++ b/Sources/src/FromCorsikaBinary_source.cc
@@ -67,7 +67,6 @@ namespace mu2e {
                               art::RunPrincipal*&    outR,
                               art::SubRunPrincipal*& outSR,
                               art::EventPrincipal*&  outE);
-      unsigned getSubRunNumber(const std::string& filename) const;
 
       unsigned currentEventNumber_;
 


### PR DESCRIPTION
Following @gaponenko suggestions I implemented a new way to read the CORSIKA binary files. Now there is no need of specifying the format of the input binary file ("compact" or "full"): a common method is able to distinguish between the two and read the information accordingly. The run number is now obtained from the binary file content and not from the filename. Also, the "lowE" and "highE" parameters that were specified in the fcl can be read from the binary file, so they have been removed from the fcl configuration.