### PR TITLE
Fix: Required classes_def.xml entries to enable CosmicTrackSeed products to be stored

### DIFF
--- a/RecoDataProducts/src/classes_def.xml
+++ b/RecoDataProducts/src/classes_def.xml
@@ -8,6 +8,13 @@
 
  <class name="std::vector<std::pair<unsigned int, unsigned int> >"/>
 <!--  ********* cosmics  ********* -->
+ <class name="TrackParams"/>
+ <class name="TrackCov"/>
+ <class name="TrackAxes"/>
+ <class name="TrackEquation"/>
+ <class name="TrackSeedDiag"/>
+ 
+ <class name="mu2e::CosmicTrack"/>
  <class name="mu2e::CosmicTrackSeed"/>
  <class name="mu2e::CosmicTrackSeedCollection"/>
  <class name="art::Ptr<mu2e::CosmicTrackSeed>"/>


### PR DESCRIPTION
The `CosmicTrackSeed` data product contains a number of structs such as `CosmicTrack`, `TrackParams`, `TrackCov`, `TrackAxes`, `TrackEquation`, `TrackSeedDiag`, which did not have entries in `classes_def.xml`. (These entries appear to fix the problem for now.)

HN thread: https://mu2e-hnews.fnal.gov/HyperNews/Mu2e/get/HELPBug/300/1/1/1/1/1/1/1.html