### PR TITLE
Remove unneeded art::Wrapper

### DIFF
--- a/DataProducts/src/classes.h
+++ b/DataProducts/src/classes.h
@@ -46,5 +46,3 @@
 #include "CLHEP/Matrix/Vector.h"
 #include "CLHEP/Matrix/Matrix.h"
 #include "CLHEP/Matrix/SymMatrix.h"
-
-template class art::Wrapper<mu2e::IndexMap>;


### PR DESCRIPTION
As requested, I've removed the art::Wrapper for the mu2e::IndexMap. I'd put this in when I first developed IndexMap and it isn't required. The IndexMap gets used in the compression so I've run the following:

- 1000 primary-only CeEndpoint
    - gen, sim and digi stages: JobConfig/primary/CeEndpoint.fcl
    - reco stage: JobConfig/reco/CeEndpoint.fcl
    - trkana stage: TrkDiag/fcl/TrkAnaReco.fcl
- 100 CeEndpoint-mix
    - gen, sim and digi stages: locally generated fcl files because it needs background frame file lists
    - reco stage: JobConfig/reco/CeEndpoint-mix.fcl
    - trkana stage: TrkDiag/fcl/TrkAnaReco.fcl

Every stage ran normally, and the output of TrkAna looks OK. 