### PR TITLE
fix: Temp memory fix for StrawResponseMaker

### DIFF
--- a/TrackerConditions/src/StrawResponseMaker.cc
+++ b/TrackerConditions/src/StrawResponseMaker.cc
@@ -58,8 +58,8 @@ namespace mu2e {
     double sigma = _config.parameterizedDriftSigma();
     double tau = _config.parameterizedDriftTau();
     int parameterizedDriftBins = _config.parameterizedDriftBins();
+    
     TH1D h("","",10000,-20,80);
-
     for (int i=0;i<parameterizedDriftBins;i++){
       double doca = i*2.5/parameterizedDriftBins;
       double hypotenuse = sqrt(pow(doca,2) + pow(tau*_config.linearDriftVelocity(),2));
@@ -70,9 +70,11 @@ namespace mu2e {
         h.SetBinContent(it+1,exp(sigma*sigma/(2*tau_eff*tau_eff)-tresid/tau_eff)*(1-TMath::Erf((sigma*sigma-tau_eff*tresid)/(sqrt(2)*sigma*tau_eff))));
       }
       h.Scale(1.0/h.Integral());
+
       _parDriftDocas.push_back(doca);
       _parDriftOffsets.push_back(h.GetMean());
       _parDriftRes.push_back(h.GetRMS());
+      h.Reset();
     }
     
     auto ptr = std::make_shared<StrawResponse>(

--- a/TrackerConditions/src/StrawResponseMaker.cc
+++ b/TrackerConditions/src/StrawResponseMaker.cc
@@ -58,6 +58,10 @@ namespace mu2e {
     double sigma = _config.parameterizedDriftSigma();
     double tau = _config.parameterizedDriftTau();
     int parameterizedDriftBins = _config.parameterizedDriftBins();
+
+    _parDriftDocas.reserve(parameterizedDriftBins);
+    _parDriftOffsets.reserve(parameterizedDriftBins);
+    _parDriftRes.reserve(parameterizedDriftBins);
     
     TH1D h("","",10000,-20,80);
     for (int i=0;i<parameterizedDriftBins;i++){

--- a/TrackerConditions/src/StrawResponseMaker.cc
+++ b/TrackerConditions/src/StrawResponseMaker.cc
@@ -3,7 +3,7 @@
 // data products
 #include <cmath>
 #include <algorithm>
-#include <TH1F.h>
+#include <TH1D.h>
 #include <TMath.h>
 #include "DataProducts/inc/StrawId.hh"
 #include "TrackerConditions/inc/StrawDrift.hh"
@@ -63,7 +63,7 @@ namespace mu2e {
       double hypotenuse = sqrt(pow(doca,2) + pow(tau*_config.linearDriftVelocity(),2));
       double tau_eff = hypotenuse/_config.linearDriftVelocity() - doca/_config.linearDriftVelocity();
 
-      TH1F *h = new TH1F("","",10000,-20,80);
+      TH1D h = new TH1D("","",10000,-20,80);
       for (int it=0;it<h->GetNbinsX();it++){
         double tresid = h->GetBinCenter(it+1);
         h->SetBinContent(it+1,exp(sigma*sigma/(2*tau_eff*tau_eff)-tresid/tau_eff)*(1-TMath::Erf((sigma*sigma-tau_eff*tresid)/(sqrt(2)*sigma*tau_eff))));

--- a/TrackerConditions/src/StrawResponseMaker.cc
+++ b/TrackerConditions/src/StrawResponseMaker.cc
@@ -58,20 +58,21 @@ namespace mu2e {
     double sigma = _config.parameterizedDriftSigma();
     double tau = _config.parameterizedDriftTau();
     int parameterizedDriftBins = _config.parameterizedDriftBins();
+    TH1D h("","",10000,-20,80);
+
     for (int i=0;i<parameterizedDriftBins;i++){
       double doca = i*2.5/parameterizedDriftBins;
       double hypotenuse = sqrt(pow(doca,2) + pow(tau*_config.linearDriftVelocity(),2));
       double tau_eff = hypotenuse/_config.linearDriftVelocity() - doca/_config.linearDriftVelocity();
 
-      TH1D h = new TH1D("","",10000,-20,80);
-      for (int it=0;it<h->GetNbinsX();it++){
-        double tresid = h->GetBinCenter(it+1);
-        h->SetBinContent(it+1,exp(sigma*sigma/(2*tau_eff*tau_eff)-tresid/tau_eff)*(1-TMath::Erf((sigma*sigma-tau_eff*tresid)/(sqrt(2)*sigma*tau_eff))));
+      for (int it=0;it<h.GetNbinsX();it++){
+        double tresid = h.GetBinCenter(it+1);
+        h.SetBinContent(it+1,exp(sigma*sigma/(2*tau_eff*tau_eff)-tresid/tau_eff)*(1-TMath::Erf((sigma*sigma-tau_eff*tresid)/(sqrt(2)*sigma*tau_eff))));
       }
-      h->Scale(1.0/h->Integral());
+      h.Scale(1.0/h.Integral());
       _parDriftDocas.push_back(doca);
-      _parDriftOffsets.push_back(h->GetMean());
-      _parDriftRes.push_back(h->GetRMS());
+      _parDriftOffsets.push_back(h.GetMean());
+      _parDriftRes.push_back(h.GetRMS());
     }
     
     auto ptr = std::make_shared<StrawResponse>(


### PR DESCRIPTION
Changed `TH1F` to `TH1D`.
Creates a `TH1D` in the stack rather than on the heap to fix memory problems.
Only one histogram object is created. It is reset at the end of each loop and re-used.
I rustled this up fairly quickly so I will rely on FNALbuild to check this doesn't cause any compile issues or deviations in validation with the old version of this (current HEAD).

I triggered the job manually in Jenkins.