### PR TITLE
Scons optimisation suggestions

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -70,7 +70,9 @@ env = Environment( CPPPATH = sch.cppPath(mu2eOpts),   # $ART_INC ...
 )
 
 # Make the Compilation DB generator available in the environment
-env.Tool('compilation_db')
+env.Tool('compilation_db', COMPILATIONDB_COMSTR="@")
+
+# Only re-compute an MD5 hash for a build target if the timestamp changed.
 env.Decider('MD5-timestamp')
 
 # Define and register the rule for building dictionaries.

--- a/SConstruct
+++ b/SConstruct
@@ -14,6 +14,10 @@ from mu2e_helper import mu2e_helper
 # this will contain global config info about the build
 mu2eOpts = {}
 
+# Intelligent caching of implicit dependencies
+SetOption('implicit_cache', 1)
+
+
 # add a mu2e debug print option like "--mu2ePrint=5"
 AddOption('--mu2ePrint', dest='mu2ePrint',
           type='int',nargs=1,default=1,

--- a/SConstruct
+++ b/SConstruct
@@ -70,7 +70,7 @@ env = Environment( CPPPATH = sch.cppPath(mu2eOpts),   # $ART_INC ...
 )
 
 # Make the Compilation DB generator available in the environment
-env.Tool('compilation_db', COMPILATIONDB_COMSTR="@")
+env.Tool('compilation_db', COMPILATIONDB_COMSTR=None)
 
 # Only re-compute an MD5 hash for a build target if the timestamp changed.
 env.Decider('MD5-timestamp')

--- a/SConstruct
+++ b/SConstruct
@@ -4,8 +4,8 @@
 import os, re, string, sys
 
 import SCons 
-
 SCons.Defaults.DefaultEnvironment(tools = []) 
+
 # Functions that do small tasks and build lists
 import sconstruct_helper as sch
 # handles how the input files are collected and the output files are named
@@ -13,10 +13,6 @@ from mu2e_helper import mu2e_helper
 
 # this will contain global config info about the build
 mu2eOpts = {}
-
-# Intelligent caching of implicit dependencies
-SetOption('implicit_cache', 1)
-
 
 # add a mu2e debug print option like "--mu2ePrint=5"
 AddOption('--mu2ePrint', dest='mu2ePrint',

--- a/SConstruct
+++ b/SConstruct
@@ -3,6 +3,9 @@
 #
 import os, re, string, sys
 
+import SCons 
+
+SCons.Defaults.DefaultEnvironment(tools = []) 
 # Functions that do small tasks and build lists
 import sconstruct_helper as sch
 # handles how the input files are collected and the output files are named
@@ -68,6 +71,7 @@ env = Environment( CPPPATH = sch.cppPath(mu2eOpts),   # $ART_INC ...
 
 # Make the Compilation DB generator available in the environment
 env.Tool('compilation_db')
+env.Decider('MD5-timestamp')
 
 # Define and register the rule for building dictionaries.
 # sources are classes.h, classes_def.xml,

--- a/scripts/build/python/sconstruct_helper.py
+++ b/scripts/build/python/sconstruct_helper.py
@@ -158,9 +158,9 @@ def BaBarLibs():
 def sconscriptList(mu2eOpts):
     ss=[]
     ss_append = ss.append
-    for root,dirs,files in os.walk('.'):
-        for file in files:
-            if file == 'SConscript': ss_append(os.path.join(root[2:],file))
+    for root, _, files in os.walk('.'):
+        if 'SConscript' in files:
+            ss_append(os.path.join(root[2:], 'SConscript'))
 
     # If we are making a build for the trigger, do not build everything.
     if mu2eOpts["trigger"] == 'on':
@@ -175,9 +175,8 @@ def sconscriptList(mu2eOpts):
 
 # Make sure the build directories are created
 def makeSubDirs(mu2eOpts):
-    for dir in ['libdir','bindir','tmpdir', 'gendir'] :
-        cmd = "mkdir -p "+mu2eOpts[dir]
-        subprocess.call(cmd, shell=True)
+    for mdir in [mu2eOpts[d] for d in ['libdir','bindir','tmpdir', 'gendir']]:
+        os.makedirs(mdir, exist_ok=True)
 
 #
 # a method for creating build-on-demand targets

--- a/scripts/build/python/sconstruct_helper.py
+++ b/scripts/build/python/sconstruct_helper.py
@@ -157,9 +157,10 @@ def BaBarLibs():
 # Walk the directory tree to locate all SConscript files.
 def sconscriptList(mu2eOpts):
     ss=[]
+    ss_append = ss.append
     for root,dirs,files in os.walk('.'):
         for file in files:
-            if file == 'SConscript': ss.append('%s/%s'%(root[2:],file))
+            if file == 'SConscript': ss_append(os.path.join(root[2:],file))
 
     # If we are making a build for the trigger, do not build everything.
     if mu2eOpts["trigger"] == 'on':

--- a/site_scons/site_tools/compilation_db.py
+++ b/site_scons/site_tools/compilation_db.py
@@ -182,7 +182,7 @@ def generate(env, **kwargs):
     )
 
     env["BUILDERS"]["__COMPILATIONDB_Database"] = SCons.Builder.Builder(
-        action=SCons.Action.Action(WriteCompilationDb, "$COMPILATIONDB_COMSTR"),
+        action=SCons.Action.Action(WriteCompilationDb,None),#"$COMPILATIONDB_COMSTR"),
         target_scanner=SCons.Scanner.Scanner(
             function=ScanCompilationDb, node_class=None
         ),


### PR DESCRIPTION
Some suggestions to reduce scons overhead. Most/all of these come from the [Scons wiki page](https://github.com/SCons/scons/wiki/GoFastButton).

#### benchmark (mu2egpvm05)
<details><summary>Read more</summary>
<p>

To test these, I ran `time scons` on a fully built, up-to-date build of Offline. There is no actual re-building to do, so all the time is spent scanning dependencies. 

Before recording these times, I ran `scons` a few times to make sure the overhead from reading from network disks, cvmfs, etc didn't slow things down.

##### head of master
```
time scons
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
Building compilation database gen/compile_commands.json
scons: done building targets.

real	1m7.813s
user	1m1.551s
sys	0m1.999s
```
##### this branch after `git merge master` (i.e. no change to Offline code)
(The merge commit is not pushed)
```
time scons
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
Building compilation database gen/compile_commands.json
scons: done building targets.

real	0m29.145s
user	0m26.707s
sys	0m0.967s
```

</p>
</details>


It's worth noting that changing the number of jobs **`-j N` only affects how many build commands are run in parallel**, the dependency scans+checks are not parallelised. (i.e. the time taken for `scons -j 8` should be roughly the same as for `scons`, given no build targets changed)

#### 1.  `env.Decider('MD5-timestamp')`

SCons uses MD5 file hashes to determine whether a file changed, which can be expensive over many files. `MD5-timestamp` only computes and compares a hash if the time-modified timestamp mismatches the cached timestamp.

#### 2. `SCons.Defaults.DefaultEnvironment(tools = []) `

Don't load any tools into the default environment. This is OK because the build is configured in a custom `Environment` object. The default environment is not used.

#### 3. `SetOption('implicit_cache', 1)`

This isn't the same as `--implicit-deps-unchanged`, and it's not as fast, but it is more accurate. 

There are some caveats worth noting which are best explained at the below link (see bullet point list)
https://scons.org/doc/0.97/HTML/scons-user/x933.html

I suspect the most likely case that would cause issues would be if the ups products changed version after someone merged into an old development branch, for example, and tried to re-build rather than cleanbuild. A simple fix is to run scons with the `--implicit-deps-unchanged` flag.