### PR TITLE
Fix: Have MVATools constructor follow the config file lookup policy

### DIFF
--- a/Mu2eUtilities/src/MVATools.cc
+++ b/Mu2eUtilities/src/MVATools.cc
@@ -76,7 +76,11 @@ namespace mu2e
     title_(), 
     label_(),
     activationTypeString_("none"),
-    mvaWgtsFile_(xmlfilename) { }
+    mvaWgtsFile_() { 
+
+    ConfigFileLookupPolicy configFile;
+    mvaWgtsFile_ = configFile(xmlfilename);
+  }
 
 
   MVATools::~MVATools() {


### PR DESCRIPTION
This commit corrects something that was missing in the initial TrkQual infrastructure update.