### PR TITLE
Created a folder with POMS configuration files

### DIFF
--- a/CampaignConfig/corsika.cfg
+++ b/CampaignConfig/corsika.cfg
@@ -1,0 +1,307 @@
+[global]
+group = mu2e
+experiment = mu2e
+wrapper = file:///${FIFE_UTILS_DIR}/libexec/fife_wrap
+account = srsoleti
+file_type = mc
+run_type = physics
+b_name = %(project_name)s
+basename = override_me
+treename = override_me
+sam_dataset = override_me
+fcl = override_me
+numevents = override_me
+numjobs = override_me
+startevent = 1
+description = corsika_dsstop
+outdir = override_me
+logdir = override_me
+streamname = only
+fcl_list = override_me
+stage_name = override_me
+project_name = corsika_dsstop
+tardir = /pnfs/mu2e/resilient/users/%(account)/gridexport/tmp.J0XFFWlueU/
+date = 20200420
+release = Offline
+
+[env_pass]
+IFDH_DEBUG = 1
+SAM_EXPERIMENT = %(experiment)s
+
+[submit]
+debug = True
+G = %(group)s
+#N = %(numjobs)s
+e = SAM_EXPERIMENT
+e_1 = IFDH_DEBUG
+e_2 = POMS4_CAMPAIGN_NAME
+e_3 = POMS4_CAMPAIGN_STAGE_NAME
+resource-provides = usage_model=DEDICATED,OPPORTUNISTIC
+generate-email-summary = True
+expected-lifetime = 23h
+OS = SL7
+memory = 2000MB
+email-to = %(account)s@fnal.gov
+tar_file_name = %(tardir)s/Code.tar.bz
+
+
+[job_setup]
+debug = True
+find_setups = False
+source_1 = /cvmfs/%(experiment)s.opensciencegrid.org/setup%(experiment)s-art.sh
+source_2 = ${_CONDOR_JOB_IWD}/Code/Offline/setup.sh
+setup_1 = mu2egrid
+setup_2 = dhtools
+setup_3 = ifdh_art v2_10_00 -q e19:prof
+setup_4 = mu2etools
+setup_5 = mu2efiletools
+setup_6 = corsika
+prescript_1 = LD_LIBRARY_PATH=${_CONDOR_JOB_IWD}/Code/Offline/vendor_perl/lib64/Digest/SHA:$LD_LIBRARY_PATH
+prescript_2 = PERL5LIB=${_CONDOR_JOB_IWD}/Code/Offline/vendor_perl/:$PERL5LIB
+ifdh_art = True
+
+[sam_consumer]
+limit = 1
+schema = xroot
+appvers = %(release)s
+appfamily = art
+appname = test
+
+[job_output]
+addoutput = *.art
+# rename = unique
+dest = %(outdir)s
+declare_metadata = True
+metadata_extractor = jsonMaker -x -f usr-sim
+add_location = True
+filter_metadata = checksum
+# filter_metadata = data_stream,file_format,art.first_event,art.last_event,art.process_name,art.file_format_version,art.file_format_era,checksum
+add_metadata = file_format=art
+hash = 2
+
+[job_output_2]
+addoutput = %(treename)s*.root
+# rename = unique
+dest = %(outdir)s
+hash = 2
+declare_metadata = False
+
+[job_output_1]
+addoutput = *.fcl
+;rename = unique
+dest = %(outdir)s
+declare_metadata = True
+metadata_extractor = json
+add_location = True
+filter_metadata = checksum
+# filter_metadata = data_stream,file_format,art.first_event,art.last_event,art.process_name,art.file_format_version,art.file_format_era,checksum
+add_metadata = file_format=fcl
+hash = 2
+
+[stage_gen_fcl]
+job_output_1.add_to_dataset = _poms_analysis
+job_output_1.filter_metadata = checksum,parents
+job_setup.prescript_3 = printf '#include "JobConfig/cosmic/cosmic_s1_dsstops_corsika.fcl"\n' > template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/fileNamesGenerator.sh 2000 %(account) > filenames.txt
+job_setup.prescript_5 = generate_fcl --description=corsika_dsstops --dsconf=%(date)s --inputs=filenames.txt --merge-factor=1 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_s1_fcl_%(date)s
+executable.name = true
+
+[stage_gen]
+# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
+# and followup with it to propagate it as input of next stage
+job_output.add_to_dataset = _poms_analysis
+job_output.dataset_exclude = *truncated*
+job_output_2.add_to_dataset = %(account)_gen_root_test
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_s1_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = %(dataset)s
+executable.name = \\\\\${_CONDOR_JOB_IWD}/Code/Offline/getFilename.sh
+job_setup.postscript = CORSIKA_EXE=`which corsika77100Linux_QGSJET_fluka`
+job_setup.postscript_2 = DATDIR=`dirname $CORSIKA_EXE`
+job_setup.postscript_3 = sed -e "s:_DATDIR_:$DATDIR/:" -e "s:_DIRECT_:`pwd`/:" -e "s:_SEED1_:`cat seed.txt`:" -e "s:_SEED2_:`cat seed.txt`:" -e "s:_NSHOW_:2000000:" ${_CONDOR_JOB_IWD}/Code/Offline/corsika_input_nolongi_TEMPLATE > corsika_conf.txt
+job_setup.postscript_4 = cat corsika_conf.txt
+job_setup.postscript_5 = corsika77100Linux_QGSJET_fluka < corsika_conf.txt > corsika_log.txt
+job_setup.postscript_6 = mv DAT* `cat filename.txt`
+job_setup.postscript_7 = mu2e -c torun.fcl --sam-data-tier=Output:sim
+job_setup.postscript_8 = rm torun.fcl
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_resampler_hi_fcl]
+job_output_1.add_to_dataset = _poms_analysis
+job_setup.prescript_3 = printf '#include "JobConfig/cosmic/dsstops_resampler_hi.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
+job_setup.prescript_5 = generate_fcl --description=corsika_resampler_hi --dsconf=%(date)s --aux=1:physics.filters.dsResample.fileNames:inputs.txt --run-number=1 --events-per-job=200000 -njobs=2000 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_hi_fcl_%(date)s
+executable.name = true
+
+[stage_resampler_hi]
+# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
+# and followup with it to propagate it as input of next stage
+job_output.add_to_dataset = _poms_analysis
+job_output.dataset_exclude = *truncated*
+job_output_2.add_to_dataset = %(account)_resampler_hi_root
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_hi_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = %(dataset)s
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_digi_hi_fcl]
+job_output_1.add_to_dataset = _poms_analysis
+job_setup.prescript_3 = printf '#include "JobConfig/primary/CORSIKA-offspill.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=corsika_digi_hi --dsconf=%(date)s --inputs=inputs.txt --merge=10 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_hi_fcl_%(date)s
+executable.name = true
+
+[stage_digi_hi]
+# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
+# and followup with it to propagate it as input of next stage
+job_output.add_to_dataset = _poms_analysis
+job_output.dataset_exclude = *truncated*
+job_output_2.add_to_dataset = %(account)_digi_hi_root
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_hi_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = %(dataset)s
+executable.arg_1 = --sam-data-tier=Output:dig
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_reco_hi_fcl]
+job_output_1.add_to_dataset = _poms_analysis
+job_setup.prescript_3 = printf '#include "JobConfig/reco/CORSIKA-cosmic-general-mix.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=corsika_reco_hi --dsconf=%(date)s --inputs=inputs.txt --merge=10 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_hi_fcl_%(date)s
+executable.name = true
+
+[stage_reco_hi]
+# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
+# and followup with it to propagate it as input of next stage
+job_output.add_to_dataset = _poms_analysis
+job_output.dataset_exclude = *truncated*
+job_output_2.add_to_dataset = %(account)_reco_hi_root
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_hi_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = %(dataset)s
+executable.arg_1 = --sam-data-tier=Output:mcs
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_resampler_lo_fcl]
+job_output_1.add_to_dataset = _poms_analysis
+job_setup.prescript_3 = printf '#include "JobConfig/cosmic/dsstops_resampler_lo.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
+job_setup.prescript_5 = generate_fcl --description=corsika_resampler_lo --dsconf=%(date)s --aux=1:physics.filters.dsResample.fileNames:inputs.txt --run-number=1 --events-per-job=200000 -njobs=2000 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_lo_fcl_%(date)s
+executable.name = true
+
+[stage_resampler_lo]
+# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
+# and followup with it to propagate it as input of next stage
+job_output.add_to_dataset = _poms_analysis
+job_output.dataset_exclude = *truncated*
+job_output_2.add_to_dataset = %(account)_resampler_lo_root
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_lo_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = %(dataset)s
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_digi_lo_fcl]
+job_output_1.add_to_dataset = _poms_analysis
+job_setup.prescript_3 = printf '#include "JobConfig/primary/CORSIKA-offspill.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=corsika_digi_lo --dsconf=%(date)s --inputs=inputs.txt --merge=10 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_lo_fcl_%(date)s
+executable.name = true
+
+[stage_digi_lo]
+# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
+# and followup with it to propagate it as input of next stage
+job_output.add_to_dataset = _poms_analysis
+job_output.dataset_exclude = *truncated*
+job_output_2.add_to_dataset = %(account)_digi_lo_root
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_lo_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = %(dataset)s
+executable.arg_1 = --sam-data-tier=Output:dig
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_reco_lo_fcl]
+job_output_1.add_to_dataset = _poms_analysis
+job_setup.prescript_3 = printf '#include "JobConfig/reco/CORSIKA-cosmic-general-mix.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=corsika_reco_lo --dsconf=%(date)s --inputs=inputs.txt --merge=10 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_lo_fcl_%(date)s
+executable.name = true
+
+[stage_reco_lo]
+# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
+# and followup with it to propagate it as input of next stage
+job_output.add_to_dataset = _poms_analysis
+job_output.dataset_exclude = *truncated*
+job_output_2.add_to_dataset = %(account)_reco_lo_root
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_lo_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = %(dataset)s
+executable.arg_1 = --sam-data-tier=Output:mcs
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[executable]
+name = mu2e

--- a/CampaignConfig/corsika.ini
+++ b/CampaignConfig/corsika.ini
@@ -1,0 +1,274 @@
+[campaign]
+experiment = mu2e
+poms_role = analysis
+name = corsika
+campaign_stage_list = gen_fcl, gen, resampler_hi_fcl, resampler_hi, resampler_lo_fcl, resampler_lo, digi_hi_fcl, digi_hi, digi_lo_fcl, digi_lo, reco_hi_fcl, reco_hi, reco_lo_fcl, reco_lo
+
+[campaign_defaults]
+vo_role = Analysis
+state = Active
+software_version = v1_0
+dataset_or_split_data = from_parent
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = "[]"
+test_param_overrides = "[]"
+login_setup = user_login
+job_type = mu2e_jobtype
+
+[campaign_stage gen_fcl]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "gen_fcl"]]
+test_param_overrides = [["--stage ", "gen_fcl"]]
+login_setup = user_login
+job_type = generate_fcl_jobtype
+
+[campaign_stage resampler_lo_fcl]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "resampler_lo_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "resampler_lo_fcl"]]
+login_setup = user_login
+job_type = generate_fcl_jobtype
+
+[campaign_stage resampler_hi_fcl]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "resampler_hi_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "resampler_hi_fcl"]]
+login_setup = user_login
+job_type = generate_fcl_jobtype
+
+[campaign_stage digi_lo_fcl]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "digi_lo_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "digi_lo_fcl"]]
+login_setup = user_login
+job_type = generate_fcl_jobtype
+
+[campaign_stage digi_hi_fcl]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "digi_hi_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "digi_hi_fcl"]]
+login_setup = user_login
+job_type = generate_fcl_jobtype
+
+[campaign_stage reco_lo_fcl]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "reco_lo_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "reco_lo_fcl"]]
+login_setup = user_login
+job_type = generate_fcl_jobtype
+
+[campaign_stage reco_hi_fcl]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "reco_hi_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "reco_hi_fcl"]]
+login_setup = user_login
+job_type = generate_fcl_jobtype
+
+[campaign_stage reco_lo]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "reco_lo"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "reco_lo"]]
+login_setup = user_login
+job_type = mu2e_jobtype
+
+[campaign_stage reco_hi]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "reco_hi"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "reco_hi"]]
+login_setup = user_login
+job_type = mu2e_jobtype
+
+[campaign_stage digi_lo]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "digi_lo"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "digi_lo"]]
+login_setup = user_login
+job_type = mu2e_jobtype
+
+
+[campaign_stage digi_hi]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "digi_hi"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "digi_hi"]]
+login_setup = user_login
+job_type = mu2e_jobtype
+
+[campaign_stage gen]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "gen"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "gen"]]
+login_setup = user_login
+job_type = corsika_jobtype
+
+[campaign_stage resampler_hi]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "resampler_hi"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "resampler_hi"]]
+login_setup = user_login
+job_type = mu2e_jobtype
+
+[campaign_stage resampler_lo]
+vo_role = Analysis
+state = Active
+software_version = Offline
+dataset_or_split_data = None
+cs_split_type = None
+completion_type = complete
+completion_pct = 95
+param_overrides = [["--stage ", "resampler_lo"], ["-Oglobal.dataset=", "%(dataset)s"]]
+test_param_overrides = [["--stage ", "resampler_lo"]]
+login_setup = user_login
+job_type = mu2e_jobtype
+
+[dependencies gen]
+campaign_stage_1 = gen_fcl
+file_pattern_1 = %.fcl
+
+[dependencies resampler_hi_fcl]
+campaign_stage_1 = gen
+file_pattern_1 = %.art
+
+[dependencies resampler_hi]
+campaign_stage_1 = resampler_hi_fcl
+file_pattern_1 = %.fcl
+
+[dependencies resampler_lo_fcl]
+campaign_stage_1 = gen
+file_pattern_1 = %.art
+
+[dependencies resampler_lo]
+campaign_stage_1 = resampler_lo_fcl
+file_pattern_1 = %.fcl
+
+[dependencies digi_hi_fcl]
+campaign_stage_1 = resampler_hi
+file_pattern_1 = %.art
+
+[dependencies digi_hi]
+campaign_stage_1 = digi_hi_fcl
+file_pattern_1 = %.fcl
+
+[dependencies digi_lo_fcl]
+campaign_stage_1 = resampler_lo
+file_pattern_1 = %.art
+
+[dependencies digi_lo]
+campaign_stage_1 = digi_lo_fcl
+file_pattern_1 = %.fcl
+
+[dependencies reco_hi_fcl]
+campaign_stage_1 = digi_hi
+file_pattern_1 = %.art
+
+[dependencies reco_hi]
+campaign_stage_1 = reco_hi_fcl
+file_pattern_1 = %.fcl
+
+
+[dependencies reco_lo_fcl]
+campaign_stage_1 = digi_lo
+file_pattern_1 = %.art
+
+[dependencies reco_lo]
+campaign_stage_1 = reco_lo_fcl
+file_pattern_1 = %.fcl
+
+[login_setup user_login]
+host = pomsgpvm01.fnal.gov
+account = poms_launcher
+setup = source /grid/fermiapp/products/common/etc/setups.sh;setup fife_utils v3_3
+
+[job_type mu2e_jobtype]
+launch_script = fife_launch
+parameters = [["-c ", "$UPLOADS/corsika.cfg"]]
+output_file_patterns = %.art
+
+[job_type generate_fcl_jobtype]
+launch_script = fife_launch
+parameters = [["-c ", "$UPLOADS/corsika.cfg"]]
+output_file_patterns = %.root
+
+[job_type corsika_jobtype]
+launch_script = fife_launch
+parameters = [["-c ", "$UPLOADS/corsika.cfg"]]
+output_file_patterns = %.art

--- a/CampaignConfig/mdc2020.cfg
+++ b/CampaignConfig/mdc2020.cfg
@@ -1,0 +1,589 @@
+[global]
+group = mu2e
+experiment = mu2e
+wrapper = file:///${FIFE_UTILS_DIR}/libexec/fife_wrap
+account = srsoleti
+file_type = mc
+run_type = physics
+b_name = %(project_name)s
+basename = override_me
+treename = override_me
+sam_dataset = override_me
+fcl = override_me
+numevents = override_me
+numjobs = override_me
+startevent = 1
+description = mdc2020
+outdir = override_me
+logdir = override_me
+streamname = only
+fcl_list = override_me
+stage_name = override_me
+project_name = mdc2020
+tardir = /pnfs/mu2e/resilient/users/%(account)/gridexport/tmp.jxfhDSoszN/
+date = 20200616
+release = Offline
+output_dataset = override_me
+artRoot_dataset = override_me
+histRoot_dataset = override_me
+
+[env_pass]
+IFDH_DEBUG = 1
+SAM_EXPERIMENT = %(experiment)s
+OUTPUT_DATASET = %(output_dataset)s
+ARTROOT_DATASET = %(artRoot_dataset)s
+HISTROOT_DATASET = %(histRoot_dataset)s
+
+[submit]
+debug = True
+G = %(group)s
+#N = %(numjobs)s
+e = SAM_EXPERIMENT
+e_1 = IFDH_DEBUG
+e_2 = POMS4_CAMPAIGN_NAME
+e_3 = POMS4_CAMPAIGN_STAGE_NAME
+resource-provides = usage_model=DEDICATED,OPPORTUNISTIC
+generate-email-summary = True
+expected-lifetime = 23h
+OS = SL7
+memory = 2000MB
+email-to = %(account)s@fnal.gov
+tar_file_name = %(tardir)s/Code.tar.bz
+
+[job_setup]
+debug = True
+find_setups = False
+source_1 = /cvmfs/%(experiment)s.opensciencegrid.org/setup%(experiment)s-art.sh
+source_2 = ${_CONDOR_JOB_IWD}/Code/Offline/setup.sh
+setup_1 = mu2egrid
+setup_2 = dhtools
+setup_3 = ifdh_art v2_10_05 -q e19:prof
+setup_4 = mu2etools
+setup_5 = mu2efiletools
+prescript_1 = LD_LIBRARY_PATH=${_CONDOR_JOB_IWD}/Code/Offline/vendor_perl/lib64/Digest/SHA:$LD_LIBRARY_PATH
+prescript_2 = PERL5LIB=${_CONDOR_JOB_IWD}/Code/Offline/vendor_perl/:$PERL5LIB
+ifdh_art = True
+
+[sam_consumer]
+limit = 1
+schema = xroot
+appvers = %(release)s
+appfamily = art
+appname = test
+
+[job_output]
+addoutput = *.fcl
+dest = %(outdir)s
+declare_metadata = True
+metadata_extractor = json
+add_location = True
+filter_metadata = checksum
+add_metadata = file_format=fcl
+hash = 2
+
+[job_output_1]
+addoutput = *.art
+dest = %(outdir)s
+declare_metadata = True
+metadata_extractor = jsonMaker -x -f usr-sim
+add_location = True
+filter_metadata = checksum
+add_metadata = file_format=art
+hash = 2
+
+[job_output_2]
+dest = %(outdir)s
+declare_metadata = True
+metadata_extractor = jsonMaker -x -f usr-sim
+add_location = True
+filter_metadata = checksum
+add_metadata = file_format=art
+hash = 2
+
+[job_output_3]
+dest = %(outdir)s
+declare_metadata = True
+metadata_extractor = jsonMaker -x -f usr-sim
+add_location = True
+filter_metadata = checksum
+add_metadata = file_format=art
+hash = 2
+
+[job_output_4]
+dest = %(outdir)s
+declare_metadata = True
+metadata_extractor = jsonMaker -x -f usr-sim
+add_location = True
+filter_metadata = checksum
+add_metadata = file_format=art
+hash = 2
+
+[job_output_4]
+dest = %(outdir)s
+declare_metadata = True
+metadata_extractor = jsonMaker -x -f usr-sim
+add_location = True
+filter_metadata = checksum
+add_metadata = file_format=art
+hash = 2
+
+[job_output_5]
+addoutput = *.tbz
+dest = %(outdir)s
+declare_metadata = True
+metadata_extractor = jsonMaker -x -f usr-etc
+add_location = True
+filter_metadata = checksum
+add_metadata = file_format=tbz
+hash = 2
+
+
+[stage_ps_fcl]
+job_output.add_to_dataset = sim.%(account).PS.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+global.output_dataset = sim.%(account).PS.%(date)s.fcl
+
+job_setup.prescript_3 = printf '#include "JobConfig/beam/PS.fcl"\n' > template.fcl
+executable.name = generate_fcl
+executable.arg_1 = --description=ps_fcl
+executable.arg_2 = --dsconf=%(date)s
+executable.arg_3 = --run-number=1
+executable.arg_4 = --events-per-job=100
+executable.arg_5 = --njobs=20
+executable.arg_6 = --embed
+executable.arg_7 = template.fcl
+job_setup.postscript_1 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.postscript_3 = mv 000/* .
+job_setup.postscript_4 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ps_fcl_%(date)s
+
+[stage_ps]
+job_output_1.addoutput = *PS-dsregion*.art
+job_output_2.addoutput = *PS-extmonbeam*.art
+job_output_3.addoutput = *PS-extmonregion*.art
+job_output_4.addoutput = *PS-mubeam*.art
+
+job_output_1.add_to_dataset = sim.%(account).PS-dsregion.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+job_output_2.add_to_dataset = sim.%(account).PS-extmonbeam.%(date)s.art
+job_output_2.filter_metadata = checksum,parents
+job_output_3.add_to_dataset = sim.%(account).PS-extmonregion.%(date)s.art
+job_output_3.filter_metadata = checksum,parents
+job_output_4.add_to_dataset = sim.%(account).PS-mubeam.%(date)s.art
+job_output_4.filter_metadata = checksum,parents
+job_output_5.add_to_dataset = bck.%(account).PS.%(date)s.tbz
+job_output_5.filter_metadata = checksum,parents
+
+global.artRoot_dataset = sim.%(account).PS-dsregion.%(date)s.art,sim.%(account).PS-extmonbeam.%(date)s.art,sim.%(account).PS-extmonregion.%(date)s.art,sim.%(account).PS-mubeam.%(date)s.art
+global.output_dataset = bck.%(account).PS.%(date)s.tbz
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ps_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).PS.%(date)s.fcl
+
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_ds_fcl]
+job_output.add_to_dataset = sim.%(account).DS.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+global.output_dataset = sim.%(account).DS.%(date)s.fcl
+
+job_setup.prescript_3 = printf '#include "JobConfig/beam/DS.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh sim.%(account).PS-mubeam.%(date)s.art > inputs.txt
+
+executable.name = generate_fcl
+executable.arg_1 = --description=ds_fcl
+executable.arg_2 = --dsconf=%(date)s
+executable.arg_3 = --inputs=inputs.txt
+executable.arg_4 = --merge-factor=1
+executable.arg_5 = --embed
+executable.arg_6 = template.fcl
+
+job_setup.postscript_1 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.postscript_3 = mv 000/* .
+job_setup.postscript_4 = rm template.fcl
+
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ds_fcl_%(date)s
+
+[stage_ds]
+job_output_1.addoutput = *DS-beam*.art
+job_output_2.addoutput = *DS-TGTstops*.art
+job_output_3.addoutput = *DS-OOTstops*.art
+job_output_4.addoutput = *DS-crv*.art
+
+job_output_1.add_to_dataset = sim.%(account).DS-beam.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+job_output_2.add_to_dataset = sim.%(account).DS-TGTstops.%(date)s.art
+job_output_2.filter_metadata = checksum,parents
+job_output_3.add_to_dataset = sim.%(account).DS-OOTstops.%(date)s.art
+job_output_3.filter_metadata = checksum,parents
+job_output_4.add_to_dataset = sim.%(account).DS-crv.%(date)s.art
+job_output_4.filter_metadata = checksum,parents
+job_output_5.add_to_dataset = bck.%(account).DS.%(date)s.tbz
+job_output_5.filter_metadata = checksum,parents
+
+global.artRoot_dataset = sim.%(account).DS-beam.%(date)s.art,sim.%(account).DS-TGTstops.%(date)s.art,sim.%(account).DS-OOTstops.%(date)s.art,sim.%(account).DS-crv.%(date)s.art
+
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ds_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).DS.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_ps_resampler_fcl]
+job_output.add_to_dataset = sim.%(account).PS-resampler-TrkCalCRV.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+global.output_dataset = sim.%(account).PS-resampler-TrkCalCRV.%(date)s.fcl
+
+job_setup.prescript_3 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh sim.%(account).PS-dsregion.%(date)s.art > inputs.txt
+
+executable.name = generate_fcl
+executable.arg_1 = --desc=ps_resampler_fcl
+executable.arg_2 = --dsconf=%(date)s
+executable.arg_3 = --auxinput=1:physics.filters.flashResample.fileNames:inputs.txt
+executable.arg_4 = --events-per-job=2000
+executable.arg_5 = --njobs=20
+executable.arg_6 = --run-number=1
+executable.arg_7 = --include
+executable.arg_8 = JobConfig/beam/PS-resampler.fcl
+
+job_setup.postscript_1 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.postscript_3 = mv 000/* .
+
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ds_fcl_%(date)s
+
+[stage_ps_resampler]
+job_output_1.addoutput = *PS-resampler-TrkCalCRV*.art
+job_output_1.add_to_dataset = sim.%(account).PS-resampler-TrkCalCRV.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+
+job_output_5.add_to_dataset = bck.%(account).PS-resampler-TrkCalCRV.%(date)s.tbz
+job_output_5.filter_metadata = checksum,parents
+
+global.artRoot_dataset = sim.%(account).PS-resampler-TrkCalCRV.%(date)s.art
+
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ps_resampler_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).PS-resampler-TrkCalCRV.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_ds_flash_fcl]
+job_output.add_to_dataset = sim.%(account).DS-flash.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+global.output_dataset = sim.%(account).DS-flash.%(date)s.fcl
+
+job_setup.prescript_3 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh sim.%(account).PS-mubeam.%(date)s.art > inputs.txt
+job_setup.prescript_4 = generate_fcl --desc=ds_flash_fcl --dsconf=%(date)s --auxinput=1:physics.filters.flashResample.fileNames:inputs.txt --include JobConfig/beam/DS-flash.fcl --events-per-job 2000 --njobs 20 --run-number 1
+job_setup.prescript_5 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_7 = mv 000/* .
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ds_flash_fcl_%(date)s
+executable.name = true
+
+[stage_ds_flash]
+job_output_1.addoutput = *DS-flash-TrkCal*.art
+job_output_1.add_to_dataset = sim.%(account).DS-flash-TrkCal.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+
+job_output_5.add_to_dataset = bck.%(account).DS-flash.%(date)s.tbz
+job_output_5.filter_metadata = checksum,parents
+
+job_output_2.addoutput = *DS-TGTstops*.art
+job_output_2.add_to_dataset = sim.%(account).DS-TGTstops.%(date)s.art
+job_output_2.filter_metadata = checksum,parents
+
+job_output_3.addoutput = *DS-OOTstops*.art
+job_output_3.add_to_dataset = sim.%(account).DS-OOTstops.%(date)s.art
+job_output_3.filter_metadata = checksum,parents
+
+job_output_4.addoutput = *DS-crv*.art
+job_output_4.add_to_dataset = sim.%(account).DS-crv.%(date)s.art
+job_output_4.filter_metadata = checksum,parents
+
+global.artRoot_dataset = sim.%(account).DS-flash-TrkCal.%(date)s.art,sim.%(account).DS-TGTstops.%(date)s.art,sim.%(account).DS-OOTstops.%(date)s.art,sim.%(account).DS-crv.%(date)s.art
+
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ds_flash_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).DS-flash.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_proton_fcl]
+job_output.add_to_dataset = sim.%(account).proton.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+
+job_setup.prescript_3 = printf '#include "JobConfig/beam/proton.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh sim.%(account).DS-TGTstops.%(date)s.art > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=proton_fcl --dsconf=%(date)s --inputs=inputs.txt --merge-factor=1 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_proton_fcl_%(date)s
+executable.name = true
+
+[stage_proton]
+job_output_1.addoutput = *proton-TrkCal*.art
+job_output_1.add_to_dataset = sim.%(account).proton-TrkCal.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+
+job_output_2.addoutput = *proton-CRV*.art
+job_output_2.add_to_dataset = sim.%(account).proton-CRV.%(date)s.art
+job_output_2.filter_metadata = checksum,parents
+
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_proton_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).proton.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_deuteron_fcl]
+job_output.add_to_dataset = sim.%(account).deuteron.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+
+job_setup.prescript_3 = printf '#include "JobConfig/beam/deuteron.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh sim.%(account).DS-TGTstops.%(date)s.art > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=deuteron_fcl --dsconf=%(date)s --inputs=inputs.txt --merge-factor=1 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_deuteron_fcl_%(date)s
+executable.name = true
+
+[stage_deuteron]
+job_output_1.addoutput = *deuteron-TrkCal*.art
+job_output_1.add_to_dataset = sim.%(account).deuteron-TrkCal.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+
+job_output_2.addoutput = *deuteron-CRV*.art
+job_output_2.add_to_dataset = sim.%(account).deuteron-CRV.%(date)s.art
+job_output_2.filter_metadata = checksum,parents
+
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_deuteron_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).deuteron.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_oot_fcl]
+job_output.add_to_dataset = sim.%(account).oot.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+
+job_setup.prescript_3 = printf '#include "JobConfig/beam/oot.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh sim.%(account).DS-OOTstops.%(date)s.art > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=oot_fcl --dsconf=%(date)s --inputs=inputs.txt --merge-factor=1 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_oot_fcl_%(date)s
+executable.name = true
+
+[stage_oot]
+job_output_1.addoutput = *oot-TrkCal*.art
+job_output_1.add_to_dataset = sim.%(account).oot-TrkCal.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+
+job_output_2.addoutput = *oot-CRV*.art
+job_output_2.add_to_dataset = sim.%(account).oot-CRV.%(date)s.art
+job_output_2.filter_metadata = checksum,parents
+
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_oot_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).oot.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_primary_fcl]
+job_output.add_to_dataset = sim.%(account).ceendpoint.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+
+job_setup.prescript_3 = printf '#include "JobConfig/mixing/CeEndpoint.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh sim.%(account).DS-TGTstops.%(date)s.art > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=ceendpoint_fcl --dsconf=%(date)s --inputs=inputs.txt --merge-factor=1 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ceendpoint_fcl_%(date)s
+executable.name = true
+
+[stage_primary]
+job_output_1.addoutput = *CeEndpoint*.art
+job_output_1.add_to_dataset = dig.%(account).CeEndpoint.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ceendpoint_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).ceendpoint.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:dig
+job_setup.multifile = False
+job_setup.setup_local = True
+
+
+[stage_primarymix_fcl]
+job_output.add_to_dataset = sim.%(account).ceendpointmix.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+
+job_setup.prescript_3 = printf '#include "JobConfig/mixing/CeEndpoint-mix.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh sim.%(account).DS-TGTstops.%(date)s.art > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=ceendpoint_fcl --dsconf=%(date)s --inputs=inputs.txt --merge-factor=1 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ceendpointmix_fcl_%(date)s
+executable.name = true
+
+[stage_primarymix]
+job_output_1.addoutput = *CeEndpoint-mix*.art
+job_output_1.add_to_dataset = dig.%(account).CeEndpoint-mix.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_ceendpointmix_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).ceendpointmix.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:dig
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_neutron_fcl]
+job_output.add_to_dataset = sim.%(account).neutron.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+
+job_setup.prescript_3 = printf '#include "JobConfig/beam/neutron.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh sim.%(account).DS-TGTstops.%(date)s.art > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=neutron_fcl --dsconf=%(date)s --inputs=inputs.txt --merge-factor=1 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_neutron_fcl_%(date)s
+executable.name = true
+
+[stage_neutron]
+job_output_1.addoutput = *neutron-TrkCal*.art
+job_output_1.add_to_dataset = sim.%(account).neutron-TrkCal.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+
+job_output_2.addoutput = *neutron-CRV*.art
+job_output_2.add_to_dataset = sim.%(account).neutron-CRV.%(date)s.art
+job_output_2.filter_metadata = checksum,parents
+
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_neutron_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).neutron.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_photon_fcl]
+job_output.add_to_dataset = sim.%(account).photon.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+
+job_setup.prescript_3 = printf '#include "JobConfig/beam/photon.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh sim.%(account).DS-TGTstops.%(date)s.art > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=photon_fcl --dsconf=%(date)s --inputs=inputs.txt --merge-factor=1 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_photon_fcl_%(date)s
+executable.name = true
+
+[stage_photon]
+job_output_1.addoutput = *photon-TrkCal*.art
+job_output_1.add_to_dataset = sim.%(account).photon-TrkCal.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+
+job_output_2.addoutput = *photon-CRV*.art
+job_output_2.add_to_dataset = sim.%(account).photon-CRV.%(date)s.art
+job_output_2.filter_metadata = checksum,parents
+
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_photon_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).photon.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[stage_dio_fcl]
+job_output.add_to_dataset = sim.%(account).dio.%(date)s.fcl
+job_output.filter_metadata = checksum,parents
+
+job_setup.prescript_3 = printf '#include "JobConfig/beam/dio.fcl"\n' >> template.fcl
+job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh sim.%(account).DS-TGTstops.%(date)s.art > inputs.txt
+job_setup.prescript_5 = generate_fcl --desc=dio_fcl --dsconf=%(date)s --inputs=inputs.txt --merge-factor=1 --embed template.fcl
+job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
+job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
+job_setup.prescript_8 = mv 000/* .
+job_setup.prescript_9 = rm template.fcl
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_dio_fcl_%(date)s
+executable.name = true
+
+[stage_dio]
+job_output_1.addoutput = *dio-TrkCal*.art
+job_output_1.add_to_dataset = sim.%(account).dio-TrkCal.%(date)s.art
+job_output_1.filter_metadata = checksum,parents
+
+job_output_2.addoutput = *dio-CRV*.art
+job_output_2.add_to_dataset = sim.%(account).dio-CRV.%(date)s.art
+job_output_2.filter_metadata = checksum,parents
+
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_dio_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = sim.%(account).dio.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
+[executable]
+name = \${_CONDOR_JOB_IWD}/Code/Offline/loggedMu2e.sh

--- a/CampaignConfig/mdc2020.ini
+++ b/CampaignConfig/mdc2020.ini
@@ -1,0 +1,318 @@
+[campaign]
+experiment=mu2e
+poms_role=analysis
+name=mdc2020
+state=Active
+campaign_keywords={}
+campaign_stage_list=primarymix,primarymix_fcl,primary,primary_fcl,oot,oot_fcl,dio,dio_fcl,photon,photon_fcl,neutron,neutron_fcl,deuteron,deuteron_fcl,proton,proton_fcl,ds_flash,ds_flash_fcl,ps_resampler,ps_resampler_fcl,ds,ds_fcl,ps,ps_fcl,approve
+
+[campaign_defaults]
+vo_role=Analysis
+software_version=Offline
+dataset_or_split_data=None
+cs_split_type=None
+completion_type=complete
+completion_pct=95
+param_overrides="[]"
+test_param_overrides="[]"
+merge_overrides=False
+login_setup=user_login
+job_type=mu2e_jobtype
+stage_type=regular
+output_ancestor_depth=1
+
+[campaign_stage primarymix]
+param_overrides=[["--stage ", "primarymix"]]
+test_param_overrides=[["--stage ", "primarymix"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage primarymix_fcl]
+param_overrides=[["--stage ", "primarymix_fcl"]]
+test_param_overrides=[["--stage ", "primarymix_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage primary]
+param_overrides=[["--stage ", "primary"]]
+test_param_overrides=[["--stage ", "primary"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage primary_fcl]
+param_overrides=[["--stage ", "primary_fcl"]]
+test_param_overrides=[["--stage ", "primary_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage oot]
+param_overrides=[["--stage ", "oot"]]
+test_param_overrides=[["--stage ", "oot"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage oot_fcl]
+param_overrides=[["--stage ", "oot_fcl"]]
+test_param_overrides=[["--stage ", "oot_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage dio]
+param_overrides=[["--stage ", "dio"]]
+test_param_overrides=[["--stage ", "dio"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage dio_fcl]
+param_overrides=[["--stage ", "dio_fcl"]]
+test_param_overrides=[["--stage ", "dio_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage photon]
+param_overrides=[["--stage ", "photon"]]
+test_param_overrides=[["--stage ", "photon"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage photon_fcl]
+param_overrides=[["--stage ", "photon_fcl"]]
+test_param_overrides=[["--stage ", "photon_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage neutron]
+param_overrides=[["--stage ", "neutron"]]
+test_param_overrides=[["--stage ", "neutron"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage neutron_fcl]
+param_overrides=[["--stage ", "neutron_fcl"]]
+test_param_overrides=[["--stage ", "neutron_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage deuteron]
+param_overrides=[["--stage ", "deuteron"]]
+test_param_overrides=[["--stage ", "deuteron"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage deuteron_fcl]
+param_overrides=[["--stage ", "deuteron_fcl"]]
+test_param_overrides=[["--stage ", "deuteron_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage proton]
+param_overrides=[["--stage ", "proton"]]
+test_param_overrides=[["--stage ", "proton"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage proton_fcl]
+param_overrides=[["--stage ", "proton_fcl"]]
+test_param_overrides=[["--stage ", "proton_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage ds_flash]
+param_overrides=[["--stage ", "ds_flash"]]
+test_param_overrides=[["--stage ", "ds_flash"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage ds_flash_fcl]
+param_overrides=[["--stage ", "ds_flash_fcl"]]
+test_param_overrides=[["--stage ", "ds_flash_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage ps_resampler]
+param_overrides=[["--stage ", "ps_resampler"]]
+test_param_overrides=[["--stage ", "ps_resampler"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage ps_resampler_fcl]
+param_overrides=[["--stage ", "ps_resampler_fcl"]]
+test_param_overrides=[["--stage ", "ps_resampler_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage ds]
+param_overrides=[["--stage ", "ds"]]
+test_param_overrides=[["--stage ", "ds"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage ds_fcl]
+param_overrides=[["--stage ", "ds_fcl"]]
+test_param_overrides=[["--stage ", "ds_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage ps]
+param_overrides=[["--stage ", "ps"]]
+test_param_overrides=[["--stage ", "ps"]]
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage ps_fcl]
+param_overrides=[["--stage ", "ps_fcl"]]
+test_param_overrides=[["--stage ", "ps_fcl"]]
+job_type=generate_fcl_jobtype
+merge_overrides=False
+stage_type=regular
+
+[campaign_stage approve]
+job_type=AwaitApproval
+merge_overrides=False
+stage_type=regular
+
+[login_setup user_login]
+host=pomsgpvm01.fnal.gov
+account=poms_launcher
+setup=source /grid/fermiapp/products/common/etc/setups.sh;setup fife_utils v3_3
+
+[job_type generate_fcl_jobtype]
+launch_script=fife_launch
+parameters=[["-c ", "$UPLOADS/mdc2020.cfg"]]
+output_file_patterns=%.fcl
+recoveries = []
+
+[job_type mu2e_jobtype]
+launch_script=fife_launch
+parameters=[["-c ", "$UPLOADS/mdc2020.cfg"]]
+output_file_patterns=%.art
+recoveries = []
+
+[job_type AwaitApproval]
+launch_script="setup poms_client v4_1_1; await_approval --experiment=%(experiment)s"
+parameters=[]
+output_file_patterns=%
+recoveries = []
+
+[dependencies primarymix]
+campaign_stage_1 = primarymix_fcl
+file_pattern_1 = %.fcl
+
+[dependencies primarymix_fcl]
+campaign_stage_1 = ds
+file_pattern_1 = %.art
+campaign_stage_2 = proton
+file_pattern_2 = %.art
+campaign_stage_3 = deuteron
+file_pattern_3 = %.art
+campaign_stage_4 = neutron
+file_pattern_4 = %.art
+campaign_stage_5 = photon
+file_pattern_5 = %.art
+campaign_stage_6 = dio
+file_pattern_6 = %.art
+campaign_stage_7 = ds_flash
+file_pattern_7 = %.art
+campaign_stage_8 = oot
+file_pattern_8 = %.art
+campaign_stage_9 = ps_resampler
+file_pattern_9 = %.art
+
+[dependencies primary]
+campaign_stage_1 = primary_fcl
+file_pattern_1 = %.fcl
+
+[dependencies primary_fcl]
+campaign_stage_1 = ds
+file_pattern_1 = %.art
+
+[dependencies oot]
+campaign_stage_1 = oot_fcl
+file_pattern_1 = %.fcl
+
+[dependencies oot_fcl]
+campaign_stage_1 = ds
+file_pattern_1 = %.art
+
+[dependencies dio]
+campaign_stage_1 = dio_fcl
+file_pattern_1 = %.fcl
+
+[dependencies dio_fcl]
+campaign_stage_1 = ds
+file_pattern_1 = %.art
+
+[dependencies photon]
+campaign_stage_1 = photon_fcl
+file_pattern_1 = %.fcl
+
+[dependencies photon_fcl]
+campaign_stage_1 = ds
+file_pattern_1 = %.art
+
+[dependencies neutron]
+campaign_stage_1 = neutron_fcl
+file_pattern_1 = %.fcl
+
+[dependencies neutron_fcl]
+campaign_stage_1 = ds
+file_pattern_1 = %.art
+
+[dependencies deuteron]
+campaign_stage_1 = deuteron_fcl
+file_pattern_1 = %.fcl
+
+[dependencies deuteron_fcl]
+campaign_stage_1 = ds
+file_pattern_1 = %.art
+
+[dependencies proton]
+campaign_stage_1 = proton_fcl
+file_pattern_1 = %.fcl
+
+[dependencies proton_fcl]
+campaign_stage_1 = ds
+file_pattern_1 = %.art
+
+[dependencies ds_flash]
+campaign_stage_1 = ds_flash_fcl
+file_pattern_1 = %.fcl
+
+[dependencies ds_flash_fcl]
+campaign_stage_1 = ps
+file_pattern_1 = %.art
+
+[dependencies ps_resampler]
+campaign_stage_1 = ps_resampler_fcl
+file_pattern_1 = %.fcl
+
+[dependencies ps_resampler_fcl]
+campaign_stage_1 = ps
+file_pattern_1 = %.art
+
+[dependencies ds]
+campaign_stage_1 = approve
+file_pattern_1 = %%
+
+[dependencies ds_fcl]
+campaign_stage_1 = ps
+file_pattern_1 = %.art
+
+[dependencies ps]
+campaign_stage_1 = ps_fcl
+file_pattern_1 = %.fcl
+
+[dependencies approve]
+campaign_stage_1 = ds_fcl
+file_pattern_1 = %%


### PR DESCRIPTION
In this PR I want to establish a new folder called `CampaignConfig` (on the style of `JobConfig`), which contains the configuration files for the POMS campaigns. In this way we can both keep track of the campaign configuration files used for official productions (e.g. MDC2020) and also allow users to create their own campaigns by adapting the existing configurations.