### PR TITLE
Add source module to create ProtonBunchIntensity sequence

### DIFF
--- a/MCDataProducts/inc/ProcessCode.hh
+++ b/MCDataProducts/inc/ProcessCode.hh
@@ -43,39 +43,39 @@ namespace mu2e {
     // Add new elements just before lastEnum; do not insert new elements
     // prior to this - it will break backwards compatibility.
     enum enum_type {
-      unknown,                AlphaInelastic,          annihil,             AntiLambdaInelastic,
-      AntiNeutronInelastic,   AntiOmegaMinusInelastic, AntiProtonInelastic, AntiSigmaMinusInelastic,
-      AntiSigmaPlusInelastic, AntiXiMinusInelastic,    AntiXiZeroInelastic, CHIPSNuclearCaptureAtRest,
-      compt,                  conv,                    Decay,               DeuteronInelastic,
-      eBrem,                  eIoni,                   ElectroNuclear,      hBrems,
-      hElastic,               hIoni,                   hPairProd,           ionIoni,
-      KaonMinusInelastic,     KaonPlusInelastic,       KaonZeroLInelastic,  KaonZeroSInelastic,
-      LambdaInelastic,        msc,                     muBrems,             muIoni,
-      muMinusCaptureAtRest,   muMsc,                   muPairProd,          nCapture,
-      NeutronInelastic,       nFission,                nKiller,             OmegaMinusInelastic,
-      phot,                   PhotonInelastic,         PionMinusInelastic,  PionPlusInelastic,
-      PositronNuclear,        ProtonInelastic,         SigmaMinusInelastic, SigmaPlusInelastic,
-      StepLimiter,            Transportation,          TritonInelastic,     XiMinusInelastic,
-      XiZeroInelastic,        mu2eLowEKine,            mu2eKillerVolume,    mu2eMaxSteps,
-      mu2ePrimary,            muMinusConversionAtRest, hadElastic,          CoulombScat,
-      nuclearStopping,        mu2eMaxGlobalTime,       TNuclearCapture,     muMinusAtomicCapture,
-      MuAtomDecay,            Rayl,                    ionInelastic,        He3Inelastic,
-      alphaInelastic,         AntiHe3InelasticProcess, AntiAlphaInelasticProcess, AntiDeuteronInelastic,
-      dInelastic,             tInelastic,              RadioactiveDecay,    CHIPS_Inelastic,
-      NotSpecified,           hFritiofCaptureAtRest,   hBertiniCaptureAtRest, AntiTritonInelasticProcess,
-      anti_He3Inelastic,      anti_alphaInelastic,     anti_deuteronInelastic, anti_lambdaInelastic,
-      anti_neutronInelastic,  anti_omega_MinusInelastic, anti_protonInelastic, anti_sigma_PlusInelastic,
-      anti_sigma_MinusInelastic, anti_tritonInelastic, anti_xi_MinusInelastic, anti_xi0Inelastic,
-      kaon_PlusInelastic,     kaon_MinusInelastic,     kaon0LInelastic,     kaon0SInelastic,
-      lambdaInelastic,        neutronInelastic,        omega_MinusInelastic, pi_PlusInelastic,
-      pi_MinusInelastic,      protonInelastic,         sigma_PlusInelastic, sigma_MinusInelastic,
-      sigma0Inelastic,        xi_MinusInelastic,       xi0Inelastic,        positronNuclear,
-      electronNuclear,        photonNuclear,           antilambdaInelastic, DecayWithSpin,
-      ionElastic,             EMCascade,               DIO,                 NuclearCapture,
-      muonNuclear,            GammaToMuPair,           AnnihiToMuPair,      ee2hadr,
-      G4MinEkineCuts,         G4MaxTimeCuts,           OpAbsorption,        OpBoundary,
-      Scintillation,          inelastic,               G4ErrorEnergyLoss,   G4ErrorStepLengthLimit,
-      G4ErrorMagFieldLimit,   ePairProd,               FieldPropagator,     Mu2eRecorderProcess,
+      unknown,                AlphaInelastic,          annihil,             AntiLambdaInelastic, // 3
+      AntiNeutronInelastic,   AntiOmegaMinusInelastic, AntiProtonInelastic, AntiSigmaMinusInelastic, // 7
+      AntiSigmaPlusInelastic, AntiXiMinusInelastic,    AntiXiZeroInelastic, CHIPSNuclearCaptureAtRest, // 11
+      compt,                  conv,                    Decay,               DeuteronInelastic, // 15
+      eBrem,                  eIoni,                   ElectroNuclear,      hBrems, // 19
+      hElastic,               hIoni,                   hPairProd,           ionIoni,  // 23
+      KaonMinusInelastic,     KaonPlusInelastic,       KaonZeroLInelastic,  KaonZeroSInelastic, // 27
+      LambdaInelastic,        msc,                     muBrems,             muIoni,  // 31
+      muMinusCaptureAtRest,   muMsc,                   muPairProd,          nCapture,  // 35
+      NeutronInelastic,       nFission,                nKiller,             OmegaMinusInelastic, // 39
+      phot,                   PhotonInelastic,         PionMinusInelastic,  PionPlusInelastic, // 43
+      PositronNuclear,        ProtonInelastic,         SigmaMinusInelastic, SigmaPlusInelastic, // 47
+      StepLimiter,            Transportation,          TritonInelastic,     XiMinusInelastic, // 51
+      XiZeroInelastic,        mu2eLowEKine,            mu2eKillerVolume,    mu2eMaxSteps,  // 55
+      mu2ePrimary,            muMinusConversionAtRest, hadElastic,          CoulombScat, // 59
+      nuclearStopping,        mu2eMaxGlobalTime,       TNuclearCapture,     muMinusAtomicCapture, // 63
+      MuAtomDecay,            Rayl,                    ionInelastic,        He3Inelastic, // 67
+      alphaInelastic,         AntiHe3InelasticProcess, AntiAlphaInelasticProcess, AntiDeuteronInelastic, // 71
+      dInelastic,             tInelastic,              RadioactiveDecay,    CHIPS_Inelastic, // 75
+      NotSpecified,           hFritiofCaptureAtRest,   hBertiniCaptureAtRest, AntiTritonInelasticProcess, // 79
+      anti_He3Inelastic,      anti_alphaInelastic,     anti_deuteronInelastic, anti_lambdaInelastic, // 83
+      anti_neutronInelastic,  anti_omega_MinusInelastic, anti_protonInelastic, anti_sigma_PlusInelastic,  // 87
+      anti_sigma_MinusInelastic, anti_tritonInelastic, anti_xi_MinusInelastic, anti_xi0Inelastic,  // 91
+      kaon_PlusInelastic,     kaon_MinusInelastic,     kaon0LInelastic,     kaon0SInelastic, // 95
+      lambdaInelastic,        neutronInelastic,        omega_MinusInelastic, pi_PlusInelastic,  // 99
+      pi_MinusInelastic,      protonInelastic,         sigma_PlusInelastic, sigma_MinusInelastic, // 103
+      sigma0Inelastic,        xi_MinusInelastic,       xi0Inelastic,        positronNuclear, // 107
+      electronNuclear,        photonNuclear,           antilambdaInelastic, DecayWithSpin, // 111
+      ionElastic,             EMCascade,               DIO,                 NuclearCapture, // 115
+      muonNuclear,            GammaToMuPair,           AnnihiToMuPair,      ee2hadr, // 119
+      G4MinEkineCuts,         G4MaxTimeCuts,           OpAbsorption,        OpBoundary, // 123
+      Scintillation,          inelastic,               G4ErrorEnergyLoss,   G4ErrorStepLengthLimit, // 127
+      G4ErrorMagFieldLimit,   ePairProd,               FieldPropagator,     Mu2eRecorderProcess,  // 131
       mu2eProtonInelastic,    RadioactiveDecayBase,
       lastEnum,
       // An alias for backward compatibility

--- a/MCDataProducts/inc/ProtonBunchIntensitySummary.hh
+++ b/MCDataProducts/inc/ProtonBunchIntensitySummary.hh
@@ -1,0 +1,26 @@
+#ifndef MCDataProducts_ProtonBunchIntensitySummary_hh
+#define MCDataProducts_ProtonBunchIntensitySummary_hh
+#include <float.h>
+#include <math.h>
+//
+// This object summarizes the proton bunch intensity for a subrun. 
+//
+// Original author David Brown, LBNL
+namespace mu2e {
+  class ProtonBunchIntensitySummary {
+    public:
+      explicit ProtonBunchIntensitySummary() : _nev(0), _iave(0.0), _ivar(0.0) {}
+      explicit ProtonBunchIntensitySummary(unsigned nevents, float intensity, float ivar) : _nev(nevents), _iave(intensity), _ivar(ivar) {}
+      float averageIntensity() const { return _iave; }
+      float intensityVariance() const { return _ivar; }
+      float intensityRMS() const { return sqrt(_ivar); }
+      float spillDutyFactor() const { return 1.0/(1.0+_ivar/(_iave*_iave)); }
+    private:
+      unsigned _nev; // total number of events in this subrun 
+      float _iave; // average # of protons/microbunch
+      float _ivar; // variance of # of protons/microbunch
+  };
+}
+
+#endif
+

--- a/MCDataProducts/src/classes.h
+++ b/MCDataProducts/src/classes.h
@@ -39,6 +39,7 @@
 #include "MCDataProducts/inc/PhysicalVolumeInfoMultiCollection.hh"
 #include "MCDataProducts/inc/StepFilterMode.hh"
 #include "MCDataProducts/inc/ProtonBunchIntensity.hh"
+#include "MCDataProducts/inc/ProtonBunchIntensitySummary.hh"
 #include "MCDataProducts/inc/EventWeight.hh"
 
 // G4

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -105,6 +105,8 @@
 
  <class name="mu2e::ProtonBunchIntensity" />
  <class name="art::Wrapper<mu2e::ProtonBunchIntensity>"/>
+ <class name="mu2e::ProtonBunchIntensitySummary" />
+ <class name="art::Wrapper<mu2e::ProtonBunchIntensitySummary>"/>
 
  <class name="mu2e::StepFilterMode"/> 
 

--- a/Sources/src/PBISequence_source.cc
+++ b/Sources/src/PBISequence_source.cc
@@ -125,10 +125,13 @@ namespace mu2e {
       nprotAcc_ = {};
       float protons;
       unsigned nprotons;
-      while ( currentFile_->good()) {
+      while(true) {
 	*currentFile_ >> protons;
-	nprotons = (unsigned)rint(protons);
-	nprotAcc_(float(nprotons));
+	if ( currentFile_->good()) {
+	  nprotons = (unsigned)rint(protons);
+	  nprotAcc_(float(nprotons));
+	} else
+	break;
       }
       std::cout << "Read " << extract_result<tag::count>(nprotAcc_) << " events with " << extract_result<tag::mean>(nprotAcc_) << " <protons> " << extract_result<tag::variance>(nprotAcc_) << " variance from file " << currentFileName_ << std::endl;
       // rewind the file
@@ -154,10 +157,8 @@ namespace mu2e {
     {
       float protons;
       unsigned nprotons;
-      if (!currentFile_->good()) {
-        return false;
-      } 
       (*currentFile_) >>  protons;
+      if (!currentFile_->good()) return false;
       nprotons = (unsigned)rint(protons);
       managePrincipals(runNumber_, subRunNumber_, ++currentEventNumber_, outR, outSR, outE);
       std::unique_ptr<ProtonBunchIntensity> pbi(new ProtonBunchIntensity(nprotons));

--- a/Sources/src/PBISequence_source.cc
+++ b/Sources/src/PBISequence_source.cc
@@ -1,0 +1,209 @@
+// 
+// This source reads a text-formated sequence of #s of protons at the production target
+// and translate them into a set of events containing the corresponding PBI number.
+// Original author: David Bown (LBNL), 2020
+
+#include <iostream>
+#include <fstream>
+#include <boost/utility.hpp>
+#include <cassert>
+#include <set>
+#include <string>
+#include <cstdio>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/variance.hpp>
+
+#include "art/Framework/IO/Sources/Source.h"
+#include "art/Framework/Core/InputSourceMacros.h"
+#include "art/Framework/IO/Sources/SourceHelper.h"
+#include "art/Framework/Principal/RunPrincipal.h"
+#include "art/Framework/Principal/SubRunPrincipal.h"
+#include "art/Framework/Principal/EventPrincipal.h"
+#include "art/Framework/IO/Sources/put_product_in_principal.h"
+#include "canvas/Persistency/Provenance/Timestamp.h"
+#include "canvas/Persistency/Provenance/RunID.h"
+#include "canvas/Persistency/Provenance/SubRunID.h"
+#include "canvas/Persistency/Provenance/EventID.h"
+#include "canvas/Persistency/Provenance/BranchType.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "MCDataProducts/inc/ProtonBunchIntensity.hh"
+#include "MCDataProducts/inc/ProtonBunchIntensitySummary.hh"
+
+using namespace std;
+
+namespace mu2e {
+  using namespace boost::accumulators;
+
+  struct Config
+  {
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+    fhicl::Sequence<std::string> inputFiles{Name("fileNames"),Comment("List of text-formated PBI sequence files")};
+    fhicl::Atom<unsigned int> runNumber{Name("runNumber"), Comment("First run number"), 0};
+    fhicl::Atom<std::string> module_label{Name("module_label"), Comment("Art module label"), ""};
+    fhicl::Atom<std::string> module_type{Name("module_type"), Comment("Art module type"), ""};
+  };
+  typedef fhicl::WrappedTable<Config> Parameters;
+
+  //================================================================
+  class PBISequenceDetail : private boost::noncopyable {
+    std::string myModuleLabel_;
+    art::SourceHelper const& pm_;
+    unsigned runNumber_;
+    unsigned subRunNumber_;
+    unsigned currentEventNumber_;
+    art::SubRunID lastSubRunID_;
+    accumulator_set<float, stats< tag::mean, tag::variance>> nprotAcc_; // accumulator for proton statistics
+
+    std::string currentFileName_;
+    std::ifstream *currentFile_ = nullptr;
+
+    // A helper function used to manage the principals.
+    // This is boilerplate that does not change if you change the data products.
+    void managePrincipals ( int runNumber,
+	int subRunNumber,
+	int eventNumber,
+	art::RunPrincipal*&    outR,
+	art::SubRunPrincipal*& outSR,
+	art::EventPrincipal*&  outE);
+
+
+    public:
+    PBISequenceDetail(const Parameters &conf,
+	art::ProductRegistryHelper &,
+	const art::SourceHelper &);
+
+      void readFile(std::string const& filename, art::FileBlock*& fb);
+
+      bool readNext(art::RunPrincipal* const& inR,
+                    art::SubRunPrincipal* const& inSR,
+                    art::RunPrincipal*& outR,
+                    art::SubRunPrincipal*& outSR,
+                    art::EventPrincipal*& outE);
+
+      void closeCurrentFile();
+
+    };
+
+    //----------------------------------------------------------------
+    PBISequenceDetail::PBISequenceDetail(const Parameters& conf,
+                                             art::ProductRegistryHelper& rh,
+                                             const art::SourceHelper& pm)
+      : myModuleLabel_("PBISequence")
+      , pm_(pm)
+      , runNumber_(conf().runNumber())
+      , subRunNumber_(-1U)
+      , currentEventNumber_(0)
+    {
+      if(!art::RunID(runNumber_).isValid()) {
+        throw cet::exception("BADCONFIG", " PBISequence: ")
+          << " fhicl::ParameterSet specifies an invalid runNumber = "<<runNumber_<<"\n";
+      }
+// DNB
+// I don't understand why 'reconstitutes' is needed instead of 'produces', but it's
+// an emperical fact that this module fails in a cryptic way using 'produces'
+//
+      rh.reconstitutes<mu2e::ProtonBunchIntensity,art::InEvent>(myModuleLabel_);
+      rh.reconstitutes<mu2e::ProtonBunchIntensity,art::InSubRun>(myModuleLabel_);
+      rh.reconstitutes<mu2e::ProtonBunchIntensitySummary,art::InSubRun>(myModuleLabel_);
+    }
+
+    //----------------------------------------------------------------
+    void PBISequenceDetail::readFile(const std::string& filename, art::FileBlock*& fb) {
+      using namespace boost::accumulators;
+      currentFileName_ = filename;
+      currentFile_ = new ifstream(currentFileName_,std::ifstream::in);
+      // reset counters
+      subRunNumber_++;
+      currentEventNumber_ = 0;
+      // compute statistics on protons in this file
+      nprotAcc_ = {};
+      float protons;
+      unsigned nprotons;
+      while ( currentFile_->good()) {
+	*currentFile_ >> protons;
+	nprotons = (unsigned)rint(protons);
+	nprotAcc_(float(nprotons));
+      }
+      std::cout << "Read " << extract_result<tag::count>(nprotAcc_) << " events with " << extract_result<tag::mean>(nprotAcc_) << " <protons> " << extract_result<tag::variance>(nprotAcc_) << " variance from file " << currentFileName_ << std::endl;
+      // rewind the file
+      currentFile_->clear(ios::eofbit);
+      currentFile_->seekg (0, ios::beg); 
+      fb = new art::FileBlock(art::FileFormatVersion(1, "PBISequenceTextInput"), currentFileName_);
+    }
+
+    //----------------------------------------------------------------
+    void PBISequenceDetail::closeCurrentFile() {
+      currentFileName_ = "";
+      currentFile_->close();
+      delete currentFile_;
+      currentFile_ = nullptr;
+    }
+
+    //----------------------------------------------------------------
+    bool PBISequenceDetail::readNext(art::RunPrincipal* const& inR,
+                                       art::SubRunPrincipal* const& inSR,
+                                       art::RunPrincipal*& outR,
+                                       art::SubRunPrincipal*& outSR,
+                                       art::EventPrincipal*& outE)
+    {
+      float protons;
+      unsigned nprotons;
+      if (!currentFile_->good()) {
+        return false;
+      } 
+      (*currentFile_) >>  protons;
+      nprotons = (unsigned)rint(protons);
+      managePrincipals(runNumber_, subRunNumber_, ++currentEventNumber_, outR, outSR, outE);
+      std::unique_ptr<ProtonBunchIntensity> pbi(new ProtonBunchIntensity(nprotons));
+      art::put_product_in_principal(std::move(pbi), *outE, myModuleLabel_);
+      return true;
+
+    } // readNext()
+
+
+  // Each time that we encounter a new run, a new subRun or a new event, we need to make a new principal
+  // of the appropriate type.  This code does not need to change as the number and type of data products changes.
+  void PBISequenceDetail::managePrincipals ( int runNumber,
+                                          int subRunNumber,
+                                          int eventNumber,
+                                          art::RunPrincipal*&    outR,
+                                          art::SubRunPrincipal*& outSR,
+                                          art::EventPrincipal*&  outE){
+
+    art::Timestamp ts;
+
+    art::SubRunID newID(runNumber, subRunNumber);
+
+    if(newID != lastSubRunID_) {
+      // art takes ownership of the object pointed to by outSR and will delete it at the appropriate time.
+      outR = pm_.makeRunPrincipal(runNumber, ts);
+      outSR = pm_.makeSubRunPrincipal(runNumber,
+                                      subRunNumber,
+                                      ts);
+      // create the PBI subrun summary object
+      std::unique_ptr<ProtonBunchIntensitySummary> pbis(new ProtonBunchIntensitySummary(extract_result<tag::count>(nprotAcc_),extract_result<tag::mean>(nprotAcc_), extract_result<tag::variance>(nprotAcc_)));
+      std::cout << "SubRun " << subRunNumber << " PBI has SDF = " << pbis->spillDutyFactor() << std::endl;
+      art::put_product_in_principal(std::move(pbis), *outSR, myModuleLabel_);
+      // for backwards-compatibility
+      std::unique_ptr<ProtonBunchIntensity> pbi(new ProtonBunchIntensity((unsigned)rint(extract_result<tag::mean>(nprotAcc_))));
+      art::put_product_in_principal(std::move(pbi), *outSR, myModuleLabel_);
+
+    }
+    lastSubRunID_ = newID;
+
+    // art takes ownership of the object pointed to by outE and will delete it at the appropriate time.
+    outE = pm_.makeEventPrincipal(runNumber, subRunNumber, eventNumber, ts, false);
+
+  } // managePrincipals()
+    //----------------------------------------------------------------
+
+} // namespace mu2e
+
+typedef art::Source<mu2e::PBISequenceDetail> PBISequence;
+DEFINE_ART_INPUT_SOURCE(PBISequence);

--- a/Sources/test/PBISequence.fcl
+++ b/Sources/test/PBISequence.fcl
@@ -1,0 +1,28 @@
+#include "fcl/minimalMessageService.fcl"
+process_name: PBISequenceTest
+
+services: {
+  message : @local::default_message
+}
+
+source: {
+  module_type :  PBISequence 
+  fileNames: ["/pnfs/mu2e/persistent/users/brownd/SS_2020-05-23.dat"]
+  runNumber : 1
+}
+
+Output : {
+  module_type : RootOutput
+  outputCommands:   [ "drop *_*_*_*", "keep mu2e::ProtonBunchIntensity_*_*_*" ]
+  fileName : "SS_2020-05-23.art"
+}
+
+physics : {
+  producers : {}
+  filters : {}
+  analyzers : {}
+  TriggerPath : []
+  EndPath : [ Output ]
+}
+
+outputs : { Output : @local::Output}

--- a/Sources/test/PBISequence.fcl
+++ b/Sources/test/PBISequence.fcl
@@ -13,7 +13,9 @@ source: {
 
 Output : {
   module_type : RootOutput
-  outputCommands:   [ "drop *_*_*_*", "keep mu2e::ProtonBunchIntensity_*_*_*" ]
+  outputCommands:   [ "drop *_*_*_*",
+    "keep mu2e::ProtonBunchIntensity_*_*_*",
+    "keep mu2e::ProtonBunchIntensitySummary_*_*_*" ]
   fileName : "SS_2020-05-23.art"
 }
 


### PR DESCRIPTION
There is still one issue, that the new ProtonBunchIntensitySummary object is not being put into the SubRun as it should.  I don't know if the problem is related with that (new) class or with the art source code.  That functionality is not essential for this pull.