### PR TITLE
DB update

### DIFF
--- a/DbService/fcl/prolog.fcl
+++ b/DbService/fcl/prolog.fcl
@@ -1,9 +1,13 @@
 BEGIN_PROLOG
 
 DbEmpty : {
-   purpose :  "TRK_TEST"
-   version :  "v2_0"
+   # connect to the actual database
+   #purpose :  "TRK_TEST"
+   #version :  "v2_0"
    dbName : "mu2e_conditions_prd"
+   # take all database tables from local text file
+   purpose :  "EMPTY"
+   version :  ""
    #textFile : ["table.txt"]
    verbose : 0
 }

--- a/DbService/src/DbReader.cc
+++ b/DbService/src/DbReader.cc
@@ -205,6 +205,8 @@ int mu2e::DbReader::openHandle() {
   curl_easy_setopt(_curl_handle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
   // Enable redirection
   curl_easy_setopt(_curl_handle, CURLOPT_FOLLOWLOCATION, 1);
+  // do not require certificate verification
+  curl_easy_setopt(_curl_handle, CURLOPT_SSL_VERIFYPEER, 0);
 
   return 0;
 

--- a/DbTables/src/DbId.cc
+++ b/DbTables/src/DbId.cc
@@ -7,13 +7,13 @@ void mu2e::DbId::setDb(std::string const& name) {
   if(_name=="mu2e_conditions_prd") {
     _host = "ifdb05";
     _port = "5448";
-    _url =        "http://dbdata0vm.fnal.gov:9091/QE/mu2e/prod/app/SQ/query?";
-    _urlNoCache = "http://dbdata0vm.fnal.gov:9090/QE/mu2e/prod/app/SQ/query?";
+    _url =        "https://dbdata0vm.fnal.gov:8444/QE/mu2e/prod/app/SQ/query?";
+    _urlNoCache = "https://dbdata0vm.fnal.gov:9443/QE/mu2e/prod/app/SQ/query?";
   } else if(_name=="mu2e_conditions_dev") {
     _host = "ifdb04";
     _port = "5444";
-    _url =        "http://dbdata0vm.fnal.gov:9091/QE/mu2e/dev/app/SQ/query?";
-    _urlNoCache = "http://dbdata0vm.fnal.gov:9090/QE/mu2e/dev/app/SQ/query?";
+    _url =        "https://dbdata0vm.fnal.gov:8444/QE/mu2e/dev/app/SQ/query?";
+    _urlNoCache = "https://dbdata0vm.fnal.gov:9443/QE/mu2e/dev/app/SQ/query?";
   } else {
     throw cet::exception("UNKNOWN_DB_ID") 
       << "attempted to create DbId for unknown database "<<_name<<"\n";


### PR DESCRIPTION

1. Richie and Ryun reported some queries were not working.  This is fixed by updating to https and the latest port numbers.   
2. By accident, the default DbService behavior was set to read a test calibration from the real database, but this had no effect because no tables were requested.  When Ryun started using alignment tables, he discovered this mistake.  I set the default  purpose to "EMPTY" which means expect all database tables to come from a database text file.

