### PR TITLE
preparing for a future use of VecGeom

### DIFF
--- a/Mu2eG4/src/SConscript
+++ b/Mu2eG4/src/SConscript
@@ -19,6 +19,7 @@ helper=mu2e_helper(env)
 
 g4inc    = os.environ['G4INCLUDE'] + '/Geant4'
 g4libdir = os.environ['G4LIB']
+g4LibInc = [ '-L'+g4libdir, '-I'+g4inc ]
 g4_version = os.environ['GEANT4_VERSION']
 g4_version=g4_version.replace('_','')
 if g4_version[2] == '9':
@@ -53,6 +54,25 @@ elif  g4vis == 'none':
     G4GS_CPPFLAGS = []
 else:
     G4GS_CPPFLAGS = [ '-DG4VIS_USE_OPENGLX',    '-DG4VIS_USE_OPENGL' ]
+
+# Compiler switches if we want to build G4 with VecGeom
+
+g4vg = env['G4VG'];
+
+if g4vg == 'on':
+    G4GV_CPPFLAGS = [ '-DG4GEOM_USE_USOLIDS="all"' ]
+    vecGeomLib = os.environ['VECGEOM_LIB']
+    vecCoreLib = os.environ['VECCORE_LIB']
+    vecGeomInc = os.environ['VECGEOM_INC']
+    vecCoreInc = os.environ['VECCORE_INC']
+    vgcLibInc = [ '-L'+vecGeomLib
+                  , '-I'+vecGeomInc
+                  , '-L'+vecCoreLib
+                  , '-I'+vecCoreInc ]
+else:
+    G4GV_CPPFLAGS = []
+    vgcLibInc = []
+
 
 # print("mu2eopts      ",  mu2eopts)
 # print("G4GS_CPPFLAGS ",  G4GS_CPPFLAGS)
@@ -160,6 +180,10 @@ if g4vis != 'none':
     G4GLOBALIBS.append('libG4OpenGL')
     G4GLOBALIBS.append('libG4gl2ps')
 
+if g4vg != 'off':
+    G4GLOBALIBS.append('libvecgeom')
+    G4GLOBALIBS.append('libVc')
+
 if g4_version < '4095':
     G4LIBS = G4GRANULARLIBS
 else:
@@ -232,8 +256,8 @@ mainlib = helper.make_mainlib ( [
         'tbb',
         'pthread',
     ],
-                                [  G4CPPFLAGS, G4GS_CPPFLAGS ],
-                                [ '-L'+g4libdir, '-I'+g4inc ]
+                                [  G4CPPFLAGS, G4GS_CPPFLAGS, G4GV_CPPFLAGS ],
+                                [ g4LibInc, vgcLibInc ]
                                 )
 
 helper.make_plugins( [
@@ -271,8 +295,8 @@ helper.make_plugins( [
     'pthread',
     ],
                      [],
-                     [ G4CPPFLAGS, G4GS_CPPFLAGS ],
-                     [ '-L'+g4libdir, '-I'+g4inc ]
+                     [ G4CPPFLAGS, G4GS_CPPFLAGS, G4GV_CPPFLAGS ],
+                     [ g4LibInc, vgcLibInc ]
                      )
 
 # This tells emacs to view this file in python mode.

--- a/Mu2eG4/src/constructHall.cc
+++ b/Mu2eG4/src/constructHall.cc
@@ -31,6 +31,7 @@
 #include "G4GenericTrap.hh"
 #include "G4RotationMatrix.hh"
 #include "G4Orb.hh"
+#include "G4Box.hh"
 #include "G4SubtractionSolid.hh"
 #include "G4TwoVector.hh"
 #include "CLHEP/Vector/Rotation.h"

--- a/SConstruct
+++ b/SConstruct
@@ -101,6 +101,7 @@ env.Append( MU2EBASE = mu2eOpts["base"] )
 env.Append( BINDIR = mu2eOpts['bindir'] )
 env.Append( BUILD = mu2eOpts["build"] )
 env.Append( G4VIS = mu2eOpts["g4vis"] )
+env.Append( G4VG = mu2eOpts["g4vg"] )
 env.Append( G4MT = mu2eOpts["g4mt"] )
 
 # make the scons environment visible to all SConscript files (Import('env'))

--- a/buildopts
+++ b/buildopts
@@ -11,7 +11,7 @@ fi
 
 #================================================================
 # known keywords
-kkw=(build g4vis g4mt trigger)
+kkw=(build g4vis g4mt g4vg trigger)
 # a list of allowed values, the first one is the default
 opts_build() {
     echo prof debug
@@ -23,6 +23,10 @@ opts_g4vis() {
 # a list of allowed values, the first one is the default
 opts_g4mt() {
     echo on off
+}
+# a list of allowed values, the first one is the default
+opts_g4vg() {
+    echo off on
 }
 # a list of allowed values, the first one is the default
 opts_trigger(){

--- a/setup.sh
+++ b/setup.sh
@@ -110,6 +110,11 @@ if [[ $($MU2E_BASE_RELEASE/buildopts --g4vis) == qt ]]; then
     MU2E_G4_GRAPHICS_QUALIFIER=':+qt'
 fi
 
+MU2E_G4_VECGEOM_QUALIFIER=''
+if [[ $($MU2E_BASE_RELEASE/buildopts --g4vg) == on ]]; then
+    MU2E_G4_VECGEOM_QUALIFIER=':+vg'
+fi
+
 MU2E_G4_MT_QUALIFIER=''
 if [[ $($MU2E_BASE_RELEASE/buildopts --g4mt) == on ]]; then
     MU2E_G4_MT_QUALIFIER=':+mt'
@@ -123,7 +128,7 @@ setup -B art_root_io v1_03_01 -q${MU2E_UPS_QUALIFIERS}
 
 # Geant4 and its cross-section files.
 if [[ $($MU2E_BASE_RELEASE/buildopts --trigger) == "off" ]]; then
-  setup -B geant4 v4_10_6_p02a -q${MU2E_UPS_QUALIFIERS}${MU2E_G4_GRAPHICS_QUALIFIER}${MU2E_G4_MT_QUALIFIER}${MU2E_G4_EXTRA_QUALIFIER}
+  setup -B geant4 v4_10_6_p02a -q${MU2E_UPS_QUALIFIERS}${MU2E_G4_GRAPHICS_QUALIFIER}${MU2E_G4_VECGEOM_QUALIFIER}${MU2E_G4_MT_QUALIFIER}${MU2E_G4_EXTRA_QUALIFIER}
 else
   setup -B xerces_c v3_2_2   -q${MU2E_UPS_QUALIFIERS}
 fi


### PR DESCRIPTION
VecGeom will be enabled by ./buildopts --g4vg=on; requires special ups version of geant4 with vg qualifier, to be made routinely available in future
changes should have no impact in the default -g4vg=off case