### PR TITLE
Remove old FCL param from prolog

### DIFF
--- a/TrackerAlignment/fcl/prolog.fcl
+++ b/TrackerAlignment/fcl/prolog.fcl
@@ -7,7 +7,6 @@ BEGIN_PROLOG
     CosmicTrackSeedCollection : "CosmicTrackFinderTimeFit"
 
     MinTraversedPlanes : 3
-    MaxPValue : 1
     MinTraversedPanelsPerPlane : 0
 
     MaxTimeRes : 10.0


### PR DESCRIPTION
In master, running my module with this prolog `#include`d will cause validated FCL errors on job startup. I forgot to remove this line when I was removing some obsolete FCL parameters from my module.