### PR TITLE
Added Crv waveforms to EventDisplay

### DIFF
--- a/CRVAnalysis/src/CRVAnalysis.cc
+++ b/CRVAnalysis/src/CRVAnalysis.cc
@@ -109,7 +109,7 @@ namespace mu2e
       MCSummary._nHitCounters=counters.size();
     }
 
-#if 0
+#if 1
     //locate points where the cosmic MC trajectories cross the xz plane of CRV-T
     if(mcTrajectoryCollection.isValid())
     {

--- a/EventDisplay/fcl/EventDisplay.fcl
+++ b/EventDisplay/fcl/EventDisplay.fcl
@@ -16,6 +16,7 @@ source :
 services :
 {
     GeometryService        : { inputFile : "Mu2eG4/geom/geom_common.txt" }
+    ConditionsService      : { conditionsfile : "Mu2eG4/test/conditions_01.txt" }
     GlobalConstantsService : { inputFile : "Mu2eG4/test/globalConstants_01.txt" }
 }
 

--- a/EventDisplay/fcl/EventDisplay.fcl
+++ b/EventDisplay/fcl/EventDisplay.fcl
@@ -15,9 +15,7 @@ source :
 
 services :
 {
-    GeometryService        : { inputFile : "Mu2eG4/geom/geom_common.txt" }
-    ConditionsService      : { conditionsfile : "Mu2eG4/test/conditions_01.txt" }
-    GlobalConstantsService : { inputFile : "Mu2eG4/test/globalConstants_01.txt" }
+  @table::Services.Core
 }
 
 physics :

--- a/EventDisplay/fcl/timeWindowDisplay.fcl
+++ b/EventDisplay/fcl/timeWindowDisplay.fcl
@@ -22,12 +22,8 @@ source : {
 }
 
 services : {
-  message      : @local::default_message
   TFileService : { fileName : "eventDisplay.root"  }
-
-  GeometryService        : { inputFile      : "Mu2eG4/geom/geom_common.txt"            }
-  ConditionsService      : { conditionsfile : "Mu2eG4/test/conditions_01.txt"      }
-  GlobalConstantsService : { inputFile      : "Mu2eG4/test/globalConstants_01.txt" }
+  @table::Services.Core
 }
 
 physics : {

--- a/EventDisplay/src/ContentSelector.cc
+++ b/EventDisplay/src/ContentSelector.cc
@@ -147,6 +147,9 @@ void ContentSelector::setAvailableCollections(const art::Event& event)
     _crvHitBox->GetListBox()->GetEntry(0)->SetBackgroundColor(0x00FF00);
   }
 
+//CRV Waveforms (not inside a menu)
+  event.getManyByType(_crvDigisVector);
+
 //Track Selection
   newEntries.clear();
   createNewEntries<mu2e::SimParticleCollection>(_simParticleVector, event, "SimParticle", newEntries, 1);
@@ -336,6 +339,10 @@ const CollectionType* ContentSelector::getSelectedCrvHitCollection() const
 }
 template const mu2e::CrvRecoPulseCollection* ContentSelector::getSelectedCrvHitCollection<mu2e::CrvRecoPulseCollection>() const;
 
+const std::vector<art::Handle<mu2e::CrvDigiCollection> > &ContentSelector::getSelectedCrvDigiCollection() const
+{
+  return _crvDigisVector;
+}
 
 template<typename CollectionType>
 std::vector<const CollectionType*> ContentSelector::getSelectedTrackCollection(std::vector<trackInfoStruct> &v) const

--- a/EventDisplay/src/ContentSelector.h
+++ b/EventDisplay/src/ContentSelector.h
@@ -14,6 +14,7 @@
 #include "RecoDataProducts/inc/CaloCrystalHitCollection.hh"
 #include "RecoDataProducts/inc/CaloHitCollection.hh"
 #include "RecoDataProducts/inc/CrvRecoPulseCollection.hh"
+#include "RecoDataProducts/inc/CrvDigiCollection.hh"
 #include "MCDataProducts/inc/PhysicalVolumeInfoMultiCollection.hh"
 #include "MCDataProducts/inc/MCTrajectoryCollection.hh"
 #include "MCDataProducts/inc/SimParticleCollection.hh"
@@ -50,6 +51,7 @@ class ContentSelector
   std::vector<art::Handle<mu2e::CaloCrystalHitCollection> > _caloCrystalHitVector;
   std::vector<art::Handle<mu2e::CaloHitCollection> > _caloHitVector;
   std::vector<art::Handle<mu2e::CrvRecoPulseCollection> > _crvRecoPulseVector;
+  std::vector<art::Handle<mu2e::CrvDigiCollection> > _crvDigisVector;
   std::vector<art::Handle<mu2e::SimParticleCollection> > _simParticleVector;
   std::vector<art::Handle<mu2e::MCTrajectoryCollection> > _mcTrajectoryVector;
   std::vector<art::Handle<mu2e::KalRepCollection> > _trkRecoTrkVector;
@@ -110,6 +112,7 @@ class ContentSelector
   template<typename CollectionType> const CollectionType* getSelectedHitCollection() const;
   template<typename CollectionType> const CollectionType* getSelectedCaloHitCollection() const;
   template<typename CollectionType> const CollectionType* getSelectedCrvHitCollection() const;
+  const std::vector<art::Handle<mu2e::CrvDigiCollection> >& getSelectedCrvDigiCollection() const;
   template<typename CollectionType> std::vector<const CollectionType*> getSelectedTrackCollection(std::vector<trackInfoStruct> &v) const;
   const mu2e::PhysicalVolumeInfoMultiCollection *getPhysicalVolumeInfoMultiCollection() const;
   const mu2e::MCTrajectoryCollection *getMCTrajectoryCollection(const trackInfoStruct &t) const;

--- a/EventDisplay/src/DataInterface.cc
+++ b/EventDisplay/src/DataInterface.cc
@@ -1098,8 +1098,9 @@ void DataInterface::fillEvent(boost::shared_ptr<ContentSelector> const &contentS
   double digitizationPeriod = crvPar->digitizationPeriod;
   double recoPulsePedestal  = crvPar->pedestal;
 
-  std::vector<art::Handle<mu2e::CrvDigiCollection> > crvDigisVector;
-  _event->getManyByType(crvDigisVector);
+//  std::vector<art::Handle<mu2e::CrvDigiCollection> > crvDigisVector;
+//  _event->getManyByType(crvDigisVector);
+  const std::vector<art::Handle<mu2e::CrvDigiCollection> > &crvDigisVector = contentSelector->getSelectedCrvDigiCollection();
   for(size_t i=0; i<crvDigisVector.size(); i++)
   {
     const art::Handle<mu2e::CrvDigiCollection> &crvDigis = crvDigisVector[i];

--- a/EventDisplay/src/DataInterface.cc
+++ b/EventDisplay/src/DataInterface.cc
@@ -10,6 +10,8 @@ using namespace std;
 #include "CLHEP/Vector/Rotation.h"
 #include "CalorimeterGeom/inc/DiskCalorimeter.hh"
 #include "CalorimeterGeom/inc/Calorimeter.hh"
+#include "ConditionsService/inc/CrvParams.hh"
+#include "ConditionsService/inc/ConditionsHandle.hh"
 #include "CosmicRayShieldGeom/inc/CosmicRayShield.hh"
 #include "DetectorSolenoidGeom/inc/DetectorSolenoid.hh"
 #include "EventDisplay/src/Cube.h"
@@ -31,6 +33,7 @@ using namespace std;
 #include "MCDataProducts/inc/StepPointMCCollection.hh"
 #include "Mu2eUtilities/inc/PhysicalVolumeMultiHelper.hh"
 #include "ConfigTools/inc/SimpleConfig.hh"
+#include "RecoDataProducts/inc/CrvDigiCollection.hh"
 #include "RecoDataProducts/inc/CaloCrystalHitCollection.hh"
 #include "RecoDataProducts/inc/CaloHitCollection.hh"
 #include "RecoDataProducts/inc/StrawHitCollection.hh"
@@ -1085,6 +1088,60 @@ void DataInterface::fillEvent(boost::shared_ptr<ContentSelector> const &contentS
     }
   }
 
+//CRV waveforms
+  for(std::map<int,boost::shared_ptr<Cube> >::iterator crvbar=_crvscintillatorbars.begin(); crvbar!=_crvscintillatorbars.end(); crvbar++)
+  {
+    crvbar->second->getComponentInfo()->getHistVector().clear();
+  }
+
+  mu2e::ConditionsHandle<mu2e::CrvParams> crvPar("ignored");
+  double digitizationPeriod = crvPar->digitizationPeriod;
+  double recoPulsePedestal  = crvPar->pedestal;
+
+  std::vector<art::Handle<mu2e::CrvDigiCollection> > crvDigisVector;
+  _event->getManyByType(crvDigisVector);
+  for(size_t i=0; i<crvDigisVector.size(); i++)
+  {
+    const art::Handle<mu2e::CrvDigiCollection> &crvDigis = crvDigisVector[i];
+    std::string moduleLabel = crvDigis.provenance()->moduleLabel();
+    for(size_t j=0; j<crvDigis->size(); j++)
+    {
+      mu2e::CrvDigi const& digi(crvDigis->at(j));
+      int index = digi.GetScintillatorBarIndex().asInt();
+      int sipm  = digi.GetSiPMNumber();
+      std::string multigraphName = Form("Waveform (%s) SiPM %i",moduleLabel.c_str(),sipm);
+      std::map<int,boost::shared_ptr<Cube> >::iterator crvbar=_crvscintillatorbars.find(index);
+      if(crvbar!=_crvscintillatorbars.end())
+      {
+        //each digi collection and each SiPM gets its own multigraph
+        bool newMultigraph=true;
+        int multigraphIndex=0;
+        std::vector<boost::shared_ptr<TObject> > &v=crvbar->second->getComponentInfo()->getHistVector();
+        for(size_t k=0; k<v.size(); k++)
+        {
+          //check whether multigraph exists already for this module label and SiPM
+          if(multigraphName.compare(v[k]->GetName())==0) {newMultigraph=false; multigraphIndex=k; break;}
+        }
+        if(newMultigraph)
+        {
+          boost::shared_ptr<TMultiGraph> waveform(new TMultiGraph(multigraphName.c_str(),multigraphName.c_str()));
+          waveform->GetXaxis()->SetTitle("t [ns]");
+          waveform->GetYaxis()->SetTitle("ADC");
+          v.push_back(boost::dynamic_pointer_cast<TObject>(waveform));
+          multigraphIndex=v.size()-1;
+        }
+
+        TGraph *graph = new TGraph(mu2e::CrvDigi::NSamples);
+        graph->SetMarkerStyle(20);
+        graph->SetMarkerSize(2);
+        for(size_t k=0; k<mu2e::CrvDigi::NSamples; k++)
+        { 
+          graph->SetPoint(k,(digi.GetStartTDC()+k)*digitizationPeriod,digi.GetADCs()[k]);
+        }
+        boost::dynamic_pointer_cast<TMultiGraph>(v[multigraphIndex])->Add(graph,"p");
+      }
+    }
+  }
 
 //CRV reco pulses
   const mu2e::CrvRecoPulseCollection *crvRecoPulses=contentSelector->getSelectedCrvHitCollection<mu2e::CrvRecoPulseCollection>();
@@ -1102,17 +1159,51 @@ void DataInterface::fillEvent(boost::shared_ptr<ContentSelector> const &contentS
       if(crvbar!=_crvscintillatorbars.end() && !std::isnan(time))
       {
         double previousStartTime=crvbar->second->getStartTime();
+        if(std::isnan(previousStartTime)) _crvhits.push_back(crvbar->second);  //first reco hit of this counter
+
+        if(std::isnan(previousStartTime) || time<previousStartTime) crvbar->second->setStartTime(time);
+
         if(std::isnan(previousStartTime))
         {
           findBoundaryT(_hitsTimeMinmax, time);  //is it Ok to exclude all following hits from the time window?
-          crvbar->second->setStartTime(time);
           crvbar->second->getComponentInfo()->setText(3,"Reco pulse SiPM0 PEs/time: ");
           crvbar->second->getComponentInfo()->setText(4,"Reco pulse SiPM1 PEs/time: ");
           crvbar->second->getComponentInfo()->setText(5,"Reco pulse SiPM2 PEs/time: ");
           crvbar->second->getComponentInfo()->setText(6,"Reco pulse SiPM3 PEs/time: ");
-          _crvhits.push_back(crvbar->second);
         }
         crvbar->second->getComponentInfo()->expandLine(sipm+3,Form("%i/%gns",PEs,time/CLHEP::ns));
+
+        //each digi collection and each SiPM gets its own multigraph
+        std::vector<boost::shared_ptr<TObject> > &v=crvbar->second->getComponentInfo()->getHistVector();
+        for(size_t k=0; k<v.size(); k++)
+        {
+          //check whether this multigraph is for the current SiPM
+          const char *multigraphName = v[k]->GetName();
+          int nameLength = strlen(multigraphName);
+          if(nameLength<1) continue;
+          if(atoi(multigraphName+nameLength-1)==sipm)
+          {
+            double fitParam0 = recoPulse.GetPulseHeight()*TMath::E();
+            double fitParam1 = recoPulse.GetPulseTime();
+            double fitParam2 = recoPulse.GetPulseBeta();
+
+            double tF1=fitParam1 - 2.5*fitParam2;
+            double tF2=fitParam1 + 2.5*fitParam2;
+            int nF=(tF2-tF1)/1.0 + 1;
+            TGraph *graph = new TGraph(nF);
+            for(int iF=0; iF<nF; iF++)
+            {
+              double t   = tF1 + iF*1.0;
+              double ADC = fitParam0*TMath::Exp(-(t-fitParam1)/fitParam2-TMath::Exp(-(t-fitParam1)/fitParam2));
+              if(isnan(ADC)) ADC=0;
+              ADC += recoPulsePedestal;
+              graph->SetPoint(iF,t,ADC);
+            }
+            graph->SetLineWidth(2);
+            graph->SetLineColor(2);
+            boost::dynamic_pointer_cast<TMultiGraph>(v[k])->Add(graph,"l");
+          }
+        }
       }
     }
   }

--- a/EventDisplay/src/DataInterface.cc
+++ b/EventDisplay/src/DataInterface.cc
@@ -1125,8 +1125,6 @@ void DataInterface::fillEvent(boost::shared_ptr<ContentSelector> const &contentS
         if(newMultigraph)
         {
           boost::shared_ptr<TMultiGraph> waveform(new TMultiGraph(multigraphName.c_str(),multigraphName.c_str()));
-          waveform->GetXaxis()->SetTitle("t [ns]");
-          waveform->GetYaxis()->SetTitle("ADC");
           v.push_back(boost::dynamic_pointer_cast<TObject>(waveform));
           multigraphIndex=v.size()-1;
         }
@@ -1171,7 +1169,7 @@ void DataInterface::fillEvent(boost::shared_ptr<ContentSelector> const &contentS
           crvbar->second->getComponentInfo()->setText(5,"Reco pulse SiPM2 PEs/time: ");
           crvbar->second->getComponentInfo()->setText(6,"Reco pulse SiPM3 PEs/time: ");
         }
-        crvbar->second->getComponentInfo()->expandLine(sipm+3,Form("%i/%gns",PEs,time/CLHEP::ns));
+        crvbar->second->getComponentInfo()->expandLine(sipm+3,Form("%iPEs/%.1fns",PEs,time/CLHEP::ns));
 
         //each digi collection and each SiPM gets its own multigraph
         std::vector<boost::shared_ptr<TObject> > &v=crvbar->second->getComponentInfo()->getHistVector();

--- a/EventDisplay/src/DataInterface.h
+++ b/EventDisplay/src/DataInterface.h
@@ -59,7 +59,6 @@ class DataInterface
   };
 
   private:
-  art::Event    *_event;
   TGeoManager   *_geometrymanager; //bare pointer needed since ROOT manages this object
   TGeoVolume    *_topvolume;       //bare pointer needed since ROOT manages this object
   EventDisplayFrame  *_mainframe;  //points to the EventDisplayFrame object
@@ -98,6 +97,8 @@ class DataInterface
 
   std::unique_ptr<mu2e::ParticleInfo> _particleInfo;
 
+  art::Event *_event;
+
   void createGeometryManager();
   void removeAllComponents();
   void removeNonGeometryComponents();
@@ -124,6 +125,7 @@ class DataInterface
   void startComponents();
   void updateComponents(double time, boost::shared_ptr<ContentSelector> contentSelector);
   void fillGeometry();
+  void setEvent(const art::Event *event) {_event=const_cast<art::Event*>(event);}
   void fillEvent(boost::shared_ptr<ContentSelector> const &contentSelector, const mu2e::SimParticleTimeOffset &timeOffsets);
   void makeSupportStructuresVisible(bool visible);
   void makeOtherStructuresVisible(bool visible);

--- a/EventDisplay/src/DataInterface.h
+++ b/EventDisplay/src/DataInterface.h
@@ -97,8 +97,6 @@ class DataInterface
 
   std::unique_ptr<mu2e::ParticleInfo> _particleInfo;
 
-  art::Event *_event;
-
   void createGeometryManager();
   void removeAllComponents();
   void removeNonGeometryComponents();
@@ -125,7 +123,6 @@ class DataInterface
   void startComponents();
   void updateComponents(double time, boost::shared_ptr<ContentSelector> contentSelector);
   void fillGeometry();
-  void setEvent(const art::Event *event) {_event=const_cast<art::Event*>(event);}
   void fillEvent(boost::shared_ptr<ContentSelector> const &contentSelector, const mu2e::SimParticleTimeOffset &timeOffsets);
   void makeSupportStructuresVisible(bool visible);
   void makeOtherStructuresVisible(bool visible);

--- a/EventDisplay/src/EventDisplayFrame.cc
+++ b/EventDisplay/src/EventDisplayFrame.cc
@@ -594,7 +594,6 @@ void EventDisplayFrame::fillGeometry()
 
 void EventDisplayFrame::setEvent(const art::Event& event, bool firstLoop)
 {
-  _dataInterface->setEvent(&event);
   _timeOffsets.updateMap(event);
 
   _eventNumber=event.id().event();

--- a/EventDisplay/src/EventDisplayFrame.cc
+++ b/EventDisplay/src/EventDisplayFrame.cc
@@ -594,6 +594,7 @@ void EventDisplayFrame::fillGeometry()
 
 void EventDisplayFrame::setEvent(const art::Event& event, bool firstLoop)
 {
+  _dataInterface->setEvent(&event);
   _timeOffsets.updateMap(event);
 
   _eventNumber=event.id().event();

--- a/EventDisplay/src/dict_classes/ComponentInfo.h
+++ b/EventDisplay/src/dict_classes/ComponentInfo.h
@@ -159,6 +159,8 @@ namespace mu2e_eventdisplay
         }
         else if(m)
         {
+          m->GetXaxis()->SetTitle("t [ns]");
+          m->GetYaxis()->SetTitle("ADC");
           m->GetXaxis()->SetLabelSize(0.05);
           m->GetXaxis()->SetTitleSize(0.05);
           m->GetXaxis()->SetTitleOffset(0.8);
@@ -166,11 +168,24 @@ namespace mu2e_eventdisplay
           m->GetYaxis()->SetTitleSize(0.05);
           m->GetYaxis()->SetTitleOffset(0.8);
           m->Draw("a");
-/*
-          std::string title = Form("%s %s",_name->c_str(),m->GetName());
-          TText *t = new TText(.05,.05,title.c_str());
-          t->Draw("same");
-*/
+
+          const string multigraphName = m->GetName();
+          if(multigraphName.compare(0,8,"Waveform")==0)
+          {
+            TText *t[3];
+            t[0] = new TText(.12,.95,_name->c_str());
+            t[1] = new TText(.12,.90,multigraphName.c_str());
+            int sipm=atoi(&multigraphName.back())+3;
+            const string s = _text[sipm]->GetTitle();
+            t[2] = new TText(.12,.85,Form("Reco pulse(s) %s",s.substr(17).c_str()));
+            for(int j=0; j<3; j++)
+            {
+              t[j]->SetNDC();
+              t[j]->SetTextSize(0.05);
+              t[j]->SetTextColor(1);
+              t[j]->Draw();
+            }
+          }
         }
         else _hist[i]->Draw();
       }

--- a/EventDisplay/src/dict_classes/ComponentInfo.h
+++ b/EventDisplay/src/dict_classes/ComponentInfo.h
@@ -17,6 +17,7 @@
 #include <TAxis.h>
 #include <TH1F.h>
 #include <TGraphErrors.h>
+#include <TMultiGraph.h>
 #include <iostream>
 #include <sstream>
 #include <vector>
@@ -133,7 +134,9 @@ namespace mu2e_eventdisplay
       if(i<_hist.size())
       {
         gStyle->SetOptTitle(0);
-        TGraph *g = dynamic_cast<TGraph*>(_hist[i].get());
+        TGraph      *g = dynamic_cast<TGraph*>(_hist[i].get());
+        TMultiGraph *m = dynamic_cast<TMultiGraph*>(_hist[i].get());
+        TH1         *h = dynamic_cast<TH1*>(_hist[i].get());
         if(g)
         {
           g->GetXaxis()->SetLabelSize(0.05);
@@ -144,21 +147,32 @@ namespace mu2e_eventdisplay
           g->GetYaxis()->SetTitleOffset(0.8);
           g->Draw("ap");
         }
-        else
-        {
-          TH1 *h = dynamic_cast<TH1*>(_hist[i].get());
-          if(h)
-          {                                    //TODO may need other settings
-            h->GetXaxis()->SetLabelSize(0.05);
-            h->GetXaxis()->SetTitleSize(0.05);
-            h->GetXaxis()->SetTitleOffset(0.8);
-            h->GetYaxis()->SetLabelSize(0.05);
-            h->GetYaxis()->SetTitleSize(0.05);
-            h->GetYaxis()->SetTitleOffset(0.8);
-            h->Draw("ap");
-          }
-          else _hist[i]->Draw();
+        else if(h)
+        {                                    //TODO may need other settings
+          h->GetXaxis()->SetLabelSize(0.05);
+          h->GetXaxis()->SetTitleSize(0.05);
+          h->GetXaxis()->SetTitleOffset(0.8);
+          h->GetYaxis()->SetLabelSize(0.05);
+          h->GetYaxis()->SetTitleSize(0.05);
+          h->GetYaxis()->SetTitleOffset(0.8);
+          h->Draw("ap");
         }
+        else if(m)
+        {
+          m->GetXaxis()->SetLabelSize(0.05);
+          m->GetXaxis()->SetTitleSize(0.05);
+          m->GetXaxis()->SetTitleOffset(0.8);
+          m->GetYaxis()->SetLabelSize(0.05);
+          m->GetYaxis()->SetTitleSize(0.05);
+          m->GetYaxis()->SetTitleOffset(0.8);
+          m->Draw("a");
+/*
+          std::string title = Form("%s %s",_name->c_str(),m->GetName());
+          TText *t = new TText(.05,.05,title.c_str());
+          t->Draw("same");
+*/
+        }
+        else _hist[i]->Draw();
       }
     }
 #endif


### PR DESCRIPTION
Added the option to display Crv Digis waveforms (overlayed with Crv RecoPulses, if available) in the EventDisplay.
Disabled a temporary workaround for the Crv part of the analysis tree, which was used for older cosmics files which didn't have MCTrajectories from stage 1.
![Event72884](https://user-images.githubusercontent.com/52871670/87384965-06887480-c56b-11ea-8dbf-8c7be67fc8df.JPG)

