### PR TITLE
art v3 06 02 port

### DIFF
--- a/Analyses/src/ReadCaloDigi_module.cc
+++ b/Analyses/src/ReadCaloDigi_module.cc
@@ -777,7 +777,7 @@ namespace mu2e {
 
 
       CaloCrystalHit const& hit    = caloCrystalHits->at(ic);
-      CLHEP::Hep3Vector crystalPos = crystalPos = _calorimeter->geomUtil().mu2eToDiskFF(diskId,_calorimeter->crystal(crystalId).position());
+      CLHEP::Hep3Vector crystalPos = _calorimeter->geomUtil().mu2eToDiskFF(diskId,_calorimeter->crystal(crystalId).position());
 
       _cryEtot             += hit.energyDep();
       _cryTime[_nHits]      = hit.time();

--- a/CalPatRec/src/SConscript
+++ b/CalPatRec/src/SConscript
@@ -12,7 +12,7 @@ Import('mu2e_helper')
 
 babarlibs     = env['BABARLIBS']
 rootlibs      = env['ROOTLIBS']
-extrarootlibs = ['Spectrum', 'TMVA' , 'Minuit' , 'XMLIO' ]
+extrarootlibs = ['TMVA' , 'Minuit' , 'XMLIO' ]
 
 helper=mu2e_helper(env);
 # helper=calpatrec_helper();

--- a/CosmicReco/src/SConscript
+++ b/CosmicReco/src/SConscript
@@ -12,7 +12,7 @@ helper=mu2e_helper(env)
 
 rootlibs  = env['ROOTLIBS']
 babarlibs = env['BABARLIBS']
-extrarootlibs = ['Spectrum', 'TMVA' , 'Minuit' , 'XMLIO', 'Minuit2', 'Geom', 'Geom', 'GeomPainter', 'Ged']
+extrarootlibs = [ 'TMVA' , 'Minuit' , 'XMLIO', 'Minuit2', 'Geom', 'Geom', 'GeomPainter', 'Ged']
 mainlib = helper.make_mainlib ( [
     'mu2e_BTrkData',
     'mu2e_Mu2eBTrk',

--- a/Filters/src/FilterG4Out_module.cc
+++ b/Filters/src/FilterG4Out_module.cc
@@ -28,6 +28,7 @@
 // Andrei Gaponenko, 2013
 
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 #include <algorithm>
@@ -92,14 +93,17 @@ namespace mu2e {
 
     //----------------
     class ProductIDSelector : public art::SelectorBase {
-      const art::Event *evt_;
       art::ProductID pid_;
       virtual bool doMatch(const art::BranchDescription& p) const override {
         return p.productID() == pid_;
       }
     public:
-      ProductIDSelector(const art::Event& evt, const art::ProductID& pid) : evt_(&evt), pid_(pid) {}
-      virtual ProductIDSelector* clone() const { return new ProductIDSelector(*this); }
+      ProductIDSelector( const art::ProductID& pid) : pid_(pid) {}
+      std::string doPrint(std::string const& indent) const override {
+        std::ostringstream os;
+        os << pid_;
+        return indent + "art::ProductID: " + os.str();
+      }
     };
 
     //----------------
@@ -445,7 +449,7 @@ namespace mu2e {
 
       // Is there anything to copy into this output?
       if(iss != toBeKept.end()) {
-        ProductIDSelector csel(event, iss->first);
+        ProductIDSelector csel(iss->first);
         art::Handle<SimParticleCollection> inputParticles;
         event.get(csel, inputParticles);
 

--- a/Sandbox/src/Source00_source.cc
+++ b/Sandbox/src/Source00_source.cc
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <boost/utility.hpp>
 
+#include "fhiclcpp/types/Name.h"
 #include "art/Framework/IO/Sources/Source.h"
 #include "art/Framework/Core/InputSourceMacros.h"
 #include "art/Framework/IO/Sources/SourceHelper.h"

--- a/Sources/src/FromCorsikaBinary_source.cc
+++ b/Sources/src/FromCorsikaBinary_source.cc
@@ -13,6 +13,7 @@
 #include "CLHEP/Vector/ThreeVector.h"
 #include "CLHEP/Units/SystemOfUnits.h"
 
+#include "fhiclcpp/types/Name.h"
 #include "art/Framework/IO/Sources/Source.h"
 #include "art/Framework/Core/InputSourceMacros.h"
 #include "art/Framework/IO/Sources/SourceHelper.h"

--- a/Sources/src/FromExtMonFNALMARSFile_source.cc
+++ b/Sources/src/FromExtMonFNALMARSFile_source.cc
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <set>
 
+#include "fhiclcpp/types/Name.h"
 #include "art/Framework/IO/Sources/Source.h"
 #include "art/Framework/Core/InputSourceMacros.h"
 #include "art/Framework/IO/Sources/SourceHelper.h"

--- a/Sources/src/PBISequence_source.cc
+++ b/Sources/src/PBISequence_source.cc
@@ -41,6 +41,7 @@
 #include <boost/accumulators/statistics/mean.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
 
+#include "fhiclcpp/types/Name.h"
 #include "art/Framework/IO/Sources/Source.h"
 #include "art/Framework/Core/InputSourceMacros.h"
 #include "art/Framework/IO/Sources/SourceHelper.h"
@@ -177,7 +178,7 @@ namespace mu2e {
       }
       // rewind the file
       currentFile_->clear(ios::eofbit);
-      currentFile_->seekg (0, ios::beg); 
+      currentFile_->seekg (0, ios::beg);
       fb = new art::FileBlock(art::FileFormatVersion(1, "PBISequenceTextInput"), currentFileName_);
     }
 

--- a/TrackerMC/src/StrawDigisFromStrawGasSteps_module.cc
+++ b/TrackerMC/src/StrawDigisFromStrawGasSteps_module.cc
@@ -297,7 +297,7 @@ namespace mu2e {
       _toff(config().SPTO())
       {
         if (config().spmodule() != ""){
-          _selector = _selector && art::ModuleLabelSelector(config().spmodule());
+          _selector = art::Selector(_selector && art::ModuleLabelSelector(config().spmodule()));
         }
 	// Tell the framework what we consume.
 	consumesMany<StrawGasStepCollection>();

--- a/TrkPatRec/src/SConscript
+++ b/TrkPatRec/src/SConscript
@@ -9,7 +9,7 @@ import os
 Import('env')
 Import('mu2e_helper')
 
-extrarootlibs = ['Spectrum', 'TMVA', 'Minuit', 'XMLIO']
+extrarootlibs = [ 'TMVA', 'Minuit', 'XMLIO']
 
 babarlibs = env['BABARLIBS']
 rootlibs = env['ROOTLIBS']

--- a/scripts/build/python/sconstruct_helper.py
+++ b/scripts/build/python/sconstruct_helper.py
@@ -130,7 +130,7 @@ def mergeFlags(mu2eOpts):
     build = mu2eOpts['build']
     flags = ['-std=c++17','-Wall','-Wno-unused-local-typedefs','-g',
              '-Werror','-Wl,--no-undefined','-gdwarf-2', '-Wl,--as-needed',
-             '-Werror=return-type','-Winit-self','-Woverloaded-virtual']
+             '-Werror=return-type','-Winit-self','-Woverloaded-virtual', '-DBOOST_BIND_GLOBAL_PLACEHOLDERS' ]
     if build == 'prof':
         flags = flags + [ '-O3', '-fno-omit-frame-pointer', '-DNDEBUG' ]
     elif build == 'debug':

--- a/scripts/build/python/sconstruct_helper.py
+++ b/scripts/build/python/sconstruct_helper.py
@@ -53,7 +53,7 @@ def mu2eEnvironment():
 # the list of root libraries
 # This comes from: root-config --cflags --glibs
 def rootLibs():
-    return [ 'GenVector', 'Core', 'RIO', 'Net', 'Hist', 'Spectrum', 'MLP', 'Graf', 'Graf3d', 'Gpad', 'Tree',
+    return [ 'GenVector', 'Core', 'RIO', 'Net', 'Hist', 'MLP', 'Graf', 'Graf3d', 'Gpad', 'Tree',
              'Rint', 'Postscript', 'Matrix', 'Physics', 'MathCore', 'Thread', 'Gui', 'm', 'dl' ]
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -103,7 +103,7 @@ build=$($MU2E_BASE_RELEASE/buildopts --build)
 # and is therefore different from the value shown in
 # SETUP_<productname> environment vars, or by the "ups active" command.
 export MU2E_UPS_QUALIFIERS=+e19:+${build}
-export MU2E_ART_SQUALIFIER=s99
+export MU2E_ART_SQUALIFIER=s100
 
 MU2E_G4_GRAPHICS_QUALIFIER=''
 if [[ $($MU2E_BASE_RELEASE/buildopts --g4vis) == qt ]]; then
@@ -123,8 +123,8 @@ fi
 export MU2E_G4_EXTRA_QUALIFIER=''
 
 # Setup the framework and its dependent products
-setup -B art v3_06_01 -q${MU2E_UPS_QUALIFIERS}
-setup -B art_root_io v1_04_01 -q${MU2E_UPS_QUALIFIERS}
+setup -B art v3_06_02 -q${MU2E_UPS_QUALIFIERS}
+setup -B art_root_io v1_04_02 -q${MU2E_UPS_QUALIFIERS}
 
 # Geant4 and its cross-section files.
 if [[ $($MU2E_BASE_RELEASE/buildopts --trigger) == "off" ]]; then
@@ -134,10 +134,10 @@ else
 fi
 
 # Get access to raw data formats.
-setup -B mu2e_artdaq_core v1_04_03 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
+setup -B mu2e_artdaq_core v1_04_04 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
 
 # Other libraries we need.
-setup -B pcie_linux_kernel_module v2_03_03 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}
+setup -B pcie_linux_kernel_module v2_03_04 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}
 
 setup -B heppdt   v03_04_02 -q${MU2E_UPS_QUALIFIERS}
 setup -B BTrk   v1_02_25  -q${MU2E_UPS_QUALIFIERS}:p383b

--- a/setup.sh
+++ b/setup.sh
@@ -103,7 +103,7 @@ build=$($MU2E_BASE_RELEASE/buildopts --build)
 # and is therefore different from the value shown in
 # SETUP_<productname> environment vars, or by the "ups active" command.
 export MU2E_UPS_QUALIFIERS=+e19:+${build}
-export MU2E_ART_SQUALIFIER=s97
+export MU2E_ART_SQUALIFIER=s98
 
 MU2E_G4_GRAPHICS_QUALIFIER=''
 if [[ $($MU2E_BASE_RELEASE/buildopts --g4vis) == qt ]]; then
@@ -123,33 +123,33 @@ fi
 export MU2E_G4_EXTRA_QUALIFIER=''
 
 # Setup the framework and its dependent products
-setup -B art v3_05_01 -q${MU2E_UPS_QUALIFIERS}
-setup -B art_root_io v1_03_01 -q${MU2E_UPS_QUALIFIERS}
+setup -B art v3_06_00 -q${MU2E_UPS_QUALIFIERS}
+setup -B art_root_io v1_04_00 -q${MU2E_UPS_QUALIFIERS}
 
 # Geant4 and its cross-section files.
 if [[ $($MU2E_BASE_RELEASE/buildopts --trigger) == "off" ]]; then
-  setup -B geant4 v4_10_6_p02a -q${MU2E_UPS_QUALIFIERS}${MU2E_G4_GRAPHICS_QUALIFIER}${MU2E_G4_VECGEOM_QUALIFIER}${MU2E_G4_MT_QUALIFIER}${MU2E_G4_EXTRA_QUALIFIER}
+  setup -B geant4 v4_10_6_p02b -q${MU2E_UPS_QUALIFIERS}${MU2E_G4_GRAPHICS_QUALIFIER}${MU2E_G4_VECGEOM_QUALIFIER}${MU2E_G4_MT_QUALIFIER}${MU2E_G4_EXTRA_QUALIFIER}
 else
-  setup -B xerces_c v3_2_2   -q${MU2E_UPS_QUALIFIERS}
+  setup -B xerces_c v3_2_3   -q${MU2E_UPS_QUALIFIERS}
 fi
 
 # Get access to raw data formats.
-setup -B mu2e_artdaq_core v1_04_01 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
+setup -B mu2e_artdaq_core v1_04_02 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
 
 # Other libraries we need.
-setup -B pcie_linux_kernel_module v2_03_01 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}
+setup -B pcie_linux_kernel_module v2_03_02 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}
 
-setup -B heppdt   v3_04_01j -q${MU2E_UPS_QUALIFIERS}
-setup -B BTrk   v1_02_22  -q${MU2E_UPS_QUALIFIERS}
-setup -B cry   v1_7m  -q${MU2E_UPS_QUALIFIERS}
-setup -B gsl v2_5  -q${build}
-setup curl v7_64_1
+setup -B heppdt   v03_04_02 -q${MU2E_UPS_QUALIFIERS}
+setup -B BTrk   v1_02_25  -q${MU2E_UPS_QUALIFIERS}:p383b
+setup -B cry   v1_7n  -q${MU2E_UPS_QUALIFIERS}
+setup -B gsl v2_6a
+setup curl v7_67_0
 
 # The build system.
-setup -B scons v3_1_1  -q +p372
+setup -B scons v3_1_2  -q +p383b
 
 # The debugger
-setup -B gdb v8_2_1
+setup -B gdb v9_2
 
 # satellite releases run this setup, then add itself to the following
 

--- a/setup.sh
+++ b/setup.sh
@@ -103,7 +103,7 @@ build=$($MU2E_BASE_RELEASE/buildopts --build)
 # and is therefore different from the value shown in
 # SETUP_<productname> environment vars, or by the "ups active" command.
 export MU2E_UPS_QUALIFIERS=+e19:+${build}
-export MU2E_ART_SQUALIFIER=s98
+export MU2E_ART_SQUALIFIER=s99
 
 MU2E_G4_GRAPHICS_QUALIFIER=''
 if [[ $($MU2E_BASE_RELEASE/buildopts --g4vis) == qt ]]; then
@@ -123,8 +123,8 @@ fi
 export MU2E_G4_EXTRA_QUALIFIER=''
 
 # Setup the framework and its dependent products
-setup -B art v3_06_00 -q${MU2E_UPS_QUALIFIERS}
-setup -B art_root_io v1_04_00 -q${MU2E_UPS_QUALIFIERS}
+setup -B art v3_06_01 -q${MU2E_UPS_QUALIFIERS}
+setup -B art_root_io v1_04_01 -q${MU2E_UPS_QUALIFIERS}
 
 # Geant4 and its cross-section files.
 if [[ $($MU2E_BASE_RELEASE/buildopts --trigger) == "off" ]]; then
@@ -134,10 +134,10 @@ else
 fi
 
 # Get access to raw data formats.
-setup -B mu2e_artdaq_core v1_04_02 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
+setup -B mu2e_artdaq_core v1_04_03 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
 
 # Other libraries we need.
-setup -B pcie_linux_kernel_module v2_03_02 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}
+setup -B pcie_linux_kernel_module v2_03_03 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}
 
 setup -B heppdt   v03_04_02 -q${MU2E_UPS_QUALIFIERS}
 setup -B BTrk   v1_02_25  -q${MU2E_UPS_QUALIFIERS}:p383b


### PR DESCRIPTION
Updated from art v3_05_01 to v3_06_02.  Several art bugs were discovered during the port and it required two bug fix art releases to converge.

The changes required by the port were:

1. Update usage of art::Selector to conform to the new interface; removed an unused data member in our custom selector.
2. New #include needed in source modules
3. Root no longer has -lSpectrum; remove from all link lists.
4. BOOST has declared many of the features that we use to be deprecated.  This generates compiler warnings which are turned into errors with our use of -Werror.  I added the build option '-DBOOST_BIND_GLOBAL_PLACEHOLDERS' which tells BOOST to allow the deprecated code without issuing  warning.  We have homework to upgrade our use of BOOST and remove this option.

I ran all of the tests in the nightly validation.  All of the do-they-run tests passed and 3 of the 4 sets of validation histograms compared exactly.  Validation/fcl/reco.fcl had some differences shown at:

        https://home.fnal.gov/~kutschke/Mu2e/compare/reco/result.html

This was traced to the new version of ROOT that came along with the new art.  The module CaloFilters/src/FilterEcalMVATrigger_module.cc loads some saved state for TMVA objects and uses the TMVA objects. The net effect is that one event failed the filter with the new art but passed the filter with the old art.  I removed this module from the two paths on which it is used and reran the tests.   The histograms all matched exactly.

Homework:

1. Update our use of boost to avoid deprecated features
2. Check if CaloFilters/src/FilterEcalMVATrigger_module.cc is working correctly; the tests above had poor coverage.
