### PR TITLE
Geometry updates

### DIFF
--- a/Mu2eG4/geom/DSShielding_v03.txt
+++ b/Mu2eG4/geom/DSShielding_v03.txt
@@ -1,0 +1,11 @@
+// VPSP and IFB shielding, downstream of the DS
+
+#include "Mu2eG4/geom/DSShielding_v02.txt"
+
+//update the titanium window in the IFB thickness
+double ifb.endwindow.halfLength = 0.0761; // mm
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/STM_v03.txt
+++ b/Mu2eG4/geom/STM_v03.txt
@@ -31,10 +31,6 @@ double vd.DSNeutronShieldExit.r     =  110.0;//Must be the same as the following
 //double ExtShieldDownstream.holeRadiusType11Box4Hole1 =  110.0;
 //double ExtShieldDownstream.detecHoleRadius           =  110.0;
 
-//DEPRECATED: Absorber in the MBS endplug hole. This causes too much brem photons for the STM (too high rate)
-//bool   mbs.CLV2.absorber.build          = true;
-//string mbs.CLV2.absorber.MaterialName   = "Polyethylene096";  
-//double mbs.CLV2.absorber.halfLength     = 15.0;//mm
 
 //Build STM within z = 34 inches (863.6 mm) of downstream hall wall
 double stm.z.allowed = 863.6;

--- a/Mu2eG4/geom/STM_v04.txt
+++ b/Mu2eG4/geom/STM_v04.txt
@@ -3,7 +3,7 @@
 #include "Mu2eG4/geom/STM_v03.txt"
 
 //turn off FOV collimator absorber
-bool   stm.FOVcollimator.absorber.build         =   true; //
+bool   stm.FOVcollimator.absorber.build         =   false; //
 double stm.FOVcollimator.absorber.halfLength    =   50.0; //
 
 //set magnet+shield material so it's effectively off

--- a/Mu2eG4/geom/STM_v04.txt
+++ b/Mu2eG4/geom/STM_v04.txt
@@ -1,0 +1,17 @@
+// (Muon) Stoping Target Monitor (STM)
+
+#include "Mu2eG4/geom/STM_v03.txt"
+
+//turn off FOV collimator absorber
+bool   stm.FOVcollimator.absorber.build         =   true; //
+double stm.FOVcollimator.absorber.halfLength    =   50.0; //
+
+//set magnet+shield material so it's effectively off
+string stm.magnet.material       = "G4_AIR";
+string stm.shield.materialLiner  = "G4_AIR";
+string stm.shield.material       = "G4_AIR";
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/Saddle_v03.txt
+++ b/Mu2eG4/geom/Saddle_v03.txt
@@ -4,6 +4,10 @@
 
 double Saddle.holeRadiusType4Hole1   = 1101.0;
 
+//increase hole cutout in MBS area support to remove very thin (<1 um) residual strip
+vector<double> Saddle.holeCenterType9Hole1 = {0,1550.001,0};
+double Saddle.holeRadiusType9Hole1   = 971.001;
+
 // This tells emacs to view this file in c++ mode.
 // Local Variables:
 // mode:c++

--- a/Mu2eG4/geom/geom_2019_PhaseI_hayman_v2.txt
+++ b/Mu2eG4/geom/geom_2019_PhaseI_hayman_v2.txt
@@ -120,7 +120,8 @@ vector<string> bfield.outerMaps = {
   "BFieldMaps/Mau9/ExtMonUCIInternal1AreaMap.header",
   "BFieldMaps/Mau9/ExtMonUCIInternal2AreaMap.header",
   "BFieldMaps/Mau9/ExtMonUCIAreaMap.header",
-  "BFieldMaps/Mau9/PSAreaMap.header"
+  "BFieldMaps/Mau13/PSAreaMap.header",
+  "BFieldMaps/Mau13/WorldMap.header"
 };
 
 // This scale factor is of limited use.

--- a/Mu2eG4/geom/geom_2019_PhaseI_hayman_v2.txt
+++ b/Mu2eG4/geom/geom_2019_PhaseI_hayman_v2.txt
@@ -1,5 +1,6 @@
 // Updated to be used in the 2019/2020 CRY simulation campaign, based off Mu2eG4/geom/geom_MARS_2019.txt
-// add hayman2 proton target
+// updates muon beam line internals + shielding, DS internals, 
+// and the production target + supports
 
 string detector.name  = "g4geom_v00";
 
@@ -40,7 +41,7 @@ double mu2e.detectorSystemZ0 = 10171.;   // mm  G4BL: (17730-7292=9801 mm)
 
 // Solenoids
 #include "Mu2eG4/geom/DetectorSolenoid_v05.txt"
-#include "Mu2eG4/geom/DSShielding_v02.txt"
+#include "Mu2eG4/geom/DSShielding_v03.txt"
 #include "Mu2eG4/geom/ProductionSolenoid_v02.txt"
 #include "Mu2eG4/geom/psEnclosure_v04.txt"
 #include "Mu2eG4/geom/PSShield_v06.txt"
@@ -54,18 +55,13 @@ double mu2e.detectorSystemZ0 = 10171.;   // mm  G4BL: (17730-7292=9801 mm)
 #include "Mu2eG4/geom/Pipe_v04.txt"
 #include "Mu2eG4/geom/ElectronicRack_v01.txt"
 
-//#include "Mu2eG4/geom/stoppingTarget_TDR.txt" // 17 foil tapered muon stopping target used for the TDR simulations
-//#include "Mu2eG4/geom/stoppingTarget_CD3C_34foils.txt" // 34 foil muon stopping target to be used for the CDC3 simulations
 // #include "Mu2eG4/geom/stoppingTargetHoles_DOE_review_2017.txt" // 37 foil muon stopping target with holes
 #include "Mu2eG4/geom/stoppingTargetHoles_v02.txt" // 37 foil muon stopping target with holes and thicker foils (0.1 mm -> 0.1056 mm)
 
 #include "Mu2eG4/geom/TSdA_v02.txt"
-#include "Mu2eG4/geom/muonBeamStop_v07.txt"
+#include "Mu2eG4/geom/muonBeamStop_v08.txt"
 
-//#include "Mu2eG4/geom/MSTM_v01.txt" // muon stopping target monitor (deprecated)
-//#include "Mu2eG4/geom/STM_v01.txt" // (muon) stopping target monitor
-//#include "Mu2eG4/geom/STM_v02.txt" // (muon) stopping target monitor
-#include "Mu2eG4/geom/STM_v03.txt" // (muon) stopping target monitor
+#include "Mu2eG4/geom/STM_v04.txt" // (muon) stopping target monitor
 
 // Proton Absorber
 #include "Mu2eG4/geom/protonAbsorber_cylindrical_v03.txt"
@@ -73,7 +69,6 @@ double mu2e.detectorSystemZ0 = 10171.;   // mm  G4BL: (17730-7292=9801 mm)
 
 // #include "Mu2eG4/geom/ProductionTarget_Hayman_v2_0.txt"
 #include "Mu2eG4/geom/ProductionTarget_Hayman_v2_1.txt"
-//#include "Mu2eG4/geom/protonBeamDump_v02.txt"
 #include "Mu2eG4/geom/protonBeamDump_v03.txt"
 #include "Mu2eG4/geom/extmon_fnal_v02.txt"
 

--- a/Mu2eG4/geom/geom_CRY_Summer2020.txt
+++ b/Mu2eG4/geom/geom_CRY_Summer2020.txt
@@ -1,0 +1,18 @@
+// Updated to be used in the 2019/2020 CRY simulation campaign, based off Mu2eG4/geom/geom_MARS_2019.txt
+// updates muon beam line internals + shielding, DS internals, 
+// and the production target + supports
+
+#include "Mu2eG4/geom/geom_2019_PhaseI_hayman_v2.txt"
+
+//
+//
+// End notes:
+//
+// 1) Sources of information:
+//
+//
+//
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/muonBeamStop_v08.txt
+++ b/Mu2eG4/geom/muonBeamStop_v08.txt
@@ -1,0 +1,11 @@
+// Muon Beam Dump/Stop
+
+//turn on absorber for STM
+bool   mbs.CLV2.absorber.build          = true;
+string mbs.CLV2.absorber.MaterialName   = "Polyethylene0935";
+double mbs.CLV2.absorber.halflength     =  10.0;
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/muonBeamStop_v08.txt
+++ b/Mu2eG4/geom/muonBeamStop_v08.txt
@@ -1,5 +1,7 @@
 // Muon Beam Dump/Stop
 
+#include "Mu2eG4/geom/muonBeamStop_v07.txt"
+
 //turn on absorber for STM
 bool   mbs.CLV2.absorber.build          = true;
 string mbs.CLV2.absorber.MaterialName   = "Polyethylene0935";

--- a/Mu2eG4/src/constructMBS.cc
+++ b/Mu2eG4/src/constructMBS.cc
@@ -695,44 +695,37 @@ namespace mu2e {
         CLV2OffsetInMu2eZ - zhl << ", " << CLV2OffsetInMu2eZ + zhl << endl;
     }
     
-
-    if ( MBSversion == 3 || MBSversion == 5) {
-
-      // CLV2 Absorber :  Variable thickness plug in MBS axial hole
-      if (_config.getBool("mbs.CLV2.absorber.build",false)){
+    // CLV2 Absorber :  Variable thickness plug in MBS axial hole
+    if (_config.getBool("mbs.CLV2.absorber.build",false)){
       
-        CLHEP::Hep3Vector CLV2AbsOffsetInMu2e = pCLV2ABSParams.originInMu2e();
-        // now local offset in mother volume
-        CLHEP::Hep3Vector CLV2AbsOffset = CLV2AbsOffsetInMu2e - MBSMOffsetInMu2e;
+      CLHEP::Hep3Vector CLV2AbsOffsetInMu2e = pCLV2ABSParams.originInMu2e();
+      // now local offset in mother volume
+      CLHEP::Hep3Vector CLV2AbsOffset = CLV2AbsOffsetInMu2e - MBSMOffsetInMu2e;
         
-        VolumeInfo CLV2AbsorberInfo  = nestTubs("CLV2Absorber",
-                                        pCLV2ABSParams.getTubsParams(),
-                                        findMaterialOrThrow(pCLV2ABSParams.materialName()),
-                                        0,
-                                        CLV2AbsOffset,
-                                        //detSolDownstreamVacInfo,
-                                        MBSMotherInfo,
-                                        0,
-                                        MBSisVisible,
-                                        orange,
-                                        MBSisSolid,
-                                        forceAuxEdgeVisible,
-                                        placePV,
-                                        doSurfaceCheck
-                                        );
+      VolumeInfo CLV2AbsorberInfo  = nestTubs("CLV2Absorber",
+					      pCLV2ABSParams.getTubsParams(),
+					      findMaterialOrThrow(pCLV2ABSParams.materialName()),
+					      0,
+					      CLV2AbsOffset,
+					      //detSolDownstreamVacInfo,
+					      MBSMotherInfo,
+					      0,
+					      MBSisVisible,
+					      orange,
+					      MBSisSolid,
+					      forceAuxEdgeVisible,
+					      placePV,
+					      doSurfaceCheck
+					      );
         
-        if ( verbosityLevel > 0) {
-          cout << __func__ << " CLV2AbsOffsetInMu2e                 : " << CLV2AbsOffsetInMu2e << endl;
-          cout << __func__ << " CLV2AbsOffsetInMBS                  : " << CLV2AbsOffset << endl;       
-          double zhl         = static_cast<G4Tubs*>(CLV2AbsorberInfo.solid)->GetZHalfLength();
-          double CLV2AbsOffsetInMu2eZ = CLV2AbsOffsetInMu2e[CLHEP::Hep3Vector::Z];
-          cout << __func__ << " CLV2Absorber         Z extent in Mu2e    : " <<
+      if ( verbosityLevel > 0) {
+	cout << __func__ << " CLV2AbsOffsetInMu2e                 : " << CLV2AbsOffsetInMu2e << endl;
+	cout << __func__ << " CLV2AbsOffsetInMBS                  : " << CLV2AbsOffset << endl;       
+	double zhl         = static_cast<G4Tubs*>(CLV2AbsorberInfo.solid)->GetZHalfLength();
+	double CLV2AbsOffsetInMu2eZ = CLV2AbsOffsetInMu2e[CLHEP::Hep3Vector::Z];
+	cout << __func__ << " CLV2Absorber         Z extent in Mu2e    : " <<
           CLV2AbsOffsetInMu2eZ - zhl << ", " << CLV2AbsOffsetInMu2eZ + zhl << endl;
-        }        
-        
-        
-        
-      }
+      }        
     }
 
     //Adding a shield at the front of the MBS to protect the calorimeter


### PR DESCRIPTION
Adding back in a poly absorber just upstream of the IFB window, and created a named file for the CRY 2020 campaign to use. 
Also took this opportunity to add in the WorldMap to the outer B-field maps, and update the PSAreaMap to Mau13 from Mau9.

Validated using Geant4 surface checking with the updated configuration, and the only code change (constructMBS.cc) doesn't affect any older geometries due to a flag defaulting to false (that isn't set to true in any files in Mu2eG4/geom/).