### PR TITLE
test new security feature

### DIFF
--- a/buildopts
+++ b/buildopts
@@ -9,6 +9,10 @@ if [[ $(basename $0) != buildopts ]]; then
 fi
 
 
+
+h
+
+
 #================================================================
 # known keywords
 kkw=(build g4vis g4mt g4vg trigger)


### PR DESCRIPTION
A recent change, see here: https://github.com/Mu2e/CI/commit/d3efcac7b5537cc226ce8facdc5da3c5a85b42c6

Prevents CI actions being run on pull requests opened by users that are not a member of the Mu2e organisation.

This adds an extra layer of checks, in addition to those implemented by the webhook.

I am testing this from my old GitHub account (which is not a member of the Mu2e org.)

I will trigger the bot manually from jenkins to test and then I will close the PR