### PR TITLE
Mixing Straw Gas Steps

### DIFF
--- a/JobConfig/beam/deuteron.fcl
+++ b/JobConfig/beam/deuteron.fcl
@@ -16,6 +16,7 @@ outputs: { @table::mu2e.outputs.g4s4Defs }
 
 physics.producers.generate.physics: {
     pdgId : 1000010020 # deuteron
+    genId : StoppedParticleReactionGun
     spectrumShape: ejectedProtons # same spectrum for protons and deuterons, as in the MECO note
     spectrumVariable: kineticEnergy
     nbins: 1000

--- a/JobConfig/beam/dio.fcl
+++ b/JobConfig/beam/dio.fcl
@@ -16,6 +16,7 @@ outputs: { @table::mu2e.outputs.g4s4Defs }
 
 physics.producers.generate.physics: {
     pdgId : 11
+    genId : StoppedParticleReactionGun
     spectrumShape: Czarnecki
     spectrumVariable: totalEnergy
     elow: 1.  // MeV

--- a/JobConfig/beam/neutron.fcl
+++ b/JobConfig/beam/neutron.fcl
@@ -16,6 +16,7 @@ outputs: { @table::mu2e.outputs.g4s4Defs }
 
 physics.producers.generate.physics: {
     pdgId : 2112
+    genId : StoppedParticleReactionGun
     spectrumShape: tabulated
     spectrumFileName: "ConditionsService/data/neutronSpectrum.txt"
     spectrumVariable: kineticEnergy

--- a/JobConfig/beam/oot.fcl
+++ b/JobConfig/beam/oot.fcl
@@ -18,7 +18,9 @@ physics.producers.generate: {
     module_type: StoppedParticleG4Gun
     verbosityLevel : 1
     pdgId: 13 // mu-
-    muonStops : @local::mu2e.ootMuonStops
+    muonStops : { @table::mu2e.ootMuonStops
+   	       	  inputFiles : @local::mergedMuon_ootStops_mdc2018
+    }
 }
 
 services.TFileService.fileName: "nts.owner.oot.version.sequencer.root"

--- a/JobConfig/beam/photon.fcl
+++ b/JobConfig/beam/photon.fcl
@@ -16,6 +16,7 @@ outputs: { @table::mu2e.outputs.g4s4Defs }
 
 physics.producers.generate.physics: {
     pdgId : 22
+    genId : StoppedParticleReactionGun
     spectrumShape: flat
     spectrumVariable: totalEnergy
     elow: 0.0 // MeV

--- a/JobConfig/beam/prolog.fcl
+++ b/JobConfig/beam/prolog.fcl
@@ -218,7 +218,9 @@ mu2e.physics.g4s4Muons.producers.generate: {
    module_type: StoppedParticleReactionGun
    verbosityLevel : 1
    physics: @nil
-   muonStops : @local::mu2e.tgtMuonStops
+   muonStops : { @table::mu2e.tgtMuonStops
+   	       	 inputFiles : @local::mergedMuon_tgtStops_mdc2018
+   }
 }
 
 mu2e.physics.g4s4Muons.producers.genCounter: {

--- a/JobConfig/beam/prolog.fcl
+++ b/JobConfig/beam/prolog.fcl
@@ -3,19 +3,14 @@
 #include "CaloMC/fcl/prolog.fcl"
 #include "Mu2eG4/fcl/prolog.fcl"
 #include "EventGenerator/fcl/prolog.fcl"
+#include "TrackerMC/fcl/prolog.fcl"
 
 BEGIN_PROLOG
 
-mu2e.services.simServices: {
-   message: @local::default_message
-   TFileService: { fileName: @nil }
-   RandomNumberGenerator: {defaultEngineKind: "MixMaxRng" }
-   GeometryService: { inputFile: "JobConfig/common/geom_baseline.txt" }
-   ConditionsService: { conditionsfile: "Mu2eG4/test/conditions_01.txt" }
-   GlobalConstantsService: { inputFile: "Mu2eG4/test/globalConstants_01.txt" }
-   G4Helper: {}
-   SeedService: @local::automaticSeeds
-}
+mu2e.services.simServices: { @table::Services.Sim }
+
+// Change the geometry file
+mu2e.services.simServices.GeometryService.inputFile : "JobConfig/common/geom_baseline.txt"
 
 // Default seeding of random engines - the seed will be overwritten in grid jobs
 mu2e.services.simServices.SeedService.baseSeed:  8
@@ -77,7 +72,9 @@ mu2e.outputs.g4s4Defs: {
          "keep *_detectorFilter_*_*",
          "keep *_CaloShowerCrystalSteps_*_*",
          "keep *_CaloShowerROSteps_*_*",
-         "keep *_compressPVDetector_*_*"
+         "keep *_compressPVDetector_*_*",
+	 "drop mu2e::StepPointMCs_detectorFilter_tracker_*",
+	 "keep mu2e::StrawGasSteps_makeSGS_*_*"
       ]
       fileName: @nil
    }
@@ -127,6 +124,10 @@ mu2e.physics.g4s4CommonBase: {
 	 module_type: CaloShowerUpdater
 	 showerInput: "CaloShowerStepFromStepPt:calorimeterRO"
 	 newSimParticles: "detectorFilter"
+      }
+
+      makeSGS : { @table::TrackerMC.producers.makeSGS
+      	      	  SkipTheseStepPoints : "g4run" # this will run after detectorFilter so want to ignore steps from g4run
       }
 
       compressPVDetector: {
@@ -199,7 +200,7 @@ mu2e.physics.g4s4CommonBase: {
 }
 
 crvPathCommon: [ g4run, g4consistent, crvFilter, compressPVCRV ]
-detPathCommon: [ g4run, g4consistent, CaloShowerStepFromStepPt, detectorFilter, CaloShowerCrystalSteps, CaloShowerROSteps, compressPVDetector ]
+detPathCommon: [ g4run, g4consistent, CaloShowerStepFromStepPt, detectorFilter, CaloShowerCrystalSteps, CaloShowerROSteps, compressPVDetector, makeSGS ]
 g4StatusPathCommon:  [ g4run, "!g4status", compressPVFull ]
 
 #----------------------------------------------------------------

--- a/JobConfig/beam/prolog.fcl
+++ b/JobConfig/beam/prolog.fcl
@@ -200,7 +200,7 @@ mu2e.physics.g4s4CommonBase: {
 }
 
 crvPathCommon: [ g4run, g4consistent, crvFilter, compressPVCRV ]
-detPathCommon: [ g4run, g4consistent, CaloShowerStepFromStepPt, detectorFilter, CaloShowerCrystalSteps, CaloShowerROSteps, compressPVDetector, makeSGS ]
+detPathCommon: [ g4run, g4consistent, CaloShowerStepFromStepPt, detectorFilter, CaloShowerCrystalSteps, CaloShowerROSteps, compressPVDetector, @sequence::TrackerMC.StepSim ]
 g4StatusPathCommon:  [ g4run, "!g4status", compressPVFull ]
 
 #----------------------------------------------------------------

--- a/JobConfig/beam/proton.fcl
+++ b/JobConfig/beam/proton.fcl
@@ -16,6 +16,7 @@ outputs: { @table::mu2e.outputs.g4s4Defs }
 
 physics.producers.generate.physics: {
     pdgId : 2212
+    genId : StoppedParticleReactionGun
     spectrumShape: ejectedProtons
     spectrumVariable: kineticEnergy
     nbins: 1000

--- a/JobConfig/mixing/prolog.fcl
+++ b/JobConfig/mixing/prolog.fcl
@@ -32,7 +32,6 @@ mixerTemplateTrkCal.mu2e.products: {
    simParticleMixer: { mixingMap: [ [ "detectorFilter", "" ] ] }
    stepPointMCMixer: { mixingMap:
       [
-	 [ "detectorFilter:tracker", ":" ],
 	 [ "detectorFilter:virtualdetector", ":" ],
 	 [ "detectorFilter:protonabsorber", ":" ]
       ]
@@ -41,6 +40,11 @@ mixerTemplateTrkCal.mu2e.products: {
       [
 	 [ "CaloShowerCrystalSteps", "calorimeter" ],
 	 [ "CaloShowerROSteps", "calorimeterRO" ]
+      ]
+   }
+   strawGasStepMixer : { mixingMap: 
+      [
+        [ "makeSGS", "" ]
       ]
    }
 }

--- a/JobConfig/primary/prolog.fcl
+++ b/JobConfig/primary/prolog.fcl
@@ -65,7 +65,7 @@ Primary: {
 # must define this outside the brackets due to internal dependence
 Primary.TriggerPath : [ @sequence::Primary.GenAndG4,
   @sequence::CommonMC.DigiSim,
-  @sequence::TrackerMC.DigiSim,
+  @sequence::TrackerMC.StepAndDigiSim,
   DigiFilter,
   @sequence::CaloDigiMC.DigiSim,
   @sequence::CrvDAQPackage.CrvResponseSequence,

--- a/Mu2eG4/fcl/g4test_03.fcl
+++ b/Mu2eG4/fcl/g4test_03.fcl
@@ -68,7 +68,7 @@ physics : {
 
   }
 
-  p1 : [generate, g4run, @sequence::CommonMC.DigiSim, @sequence::TrackerMC.DigiSim, @sequence::CaloDigiMC.DigiSim,
+  p1 : [generate, g4run, @sequence::CommonMC.DigiSim, @sequence::TrackerMC.StepAndDigiSim, @sequence::CaloDigiMC.DigiSim,
          @sequence::CaloReco.Reco,randomsaver ]
   e1 : [readGens, checkhits, outfile]
 

--- a/Mu2eG4/fcl/transportOnly.fcl
+++ b/Mu2eG4/fcl/transportOnly.fcl
@@ -68,7 +68,7 @@ physics : {
 
   }
 
-  p1 : [generate , g4run, @sequence::CommonMC.DigiSim, @sequence::TrackerMC.DigiSim, @sequence::CaloDigiMC.DigiSim, @sequence::CaloReco.Reco,randomsaver ]
+  p1 : [generate , g4run, @sequence::CommonMC.DigiSim, @sequence::TrackerMC.StepAndDigiSim, @sequence::CaloDigiMC.DigiSim, @sequence::CaloReco.Reco,randomsaver ]
 #  e1 : [readGens, checkhits, readvd, outfile, dump]
   e1 : [readGens, checkhits, readvd, outfile]
 

--- a/TrackerMC/fcl/prolog.fcl
+++ b/TrackerMC/fcl/prolog.fcl
@@ -8,7 +8,7 @@ makeSGS : {
 makeSD : {
     module_type : StrawDigisFromStrawGasSteps
     TimeOffsets   : [  @sequence::CommonMC.TimeMaps ]
-    StrawGasStepModule : makeSGS
+    StrawGasStepModule : ""
 }
 #------------------------------------------------------------------------------
 
@@ -17,7 +17,7 @@ TrackerMC : {
 	makeSGS : {@table::makeSGS }
 	makeSD  : { @table::makeSD  }
     }
-    DigiSim : [ makeSGS, makeSD ]
+    DigiSim : [ makeSD ]
 }
 
 END_PROLOG

--- a/TrackerMC/fcl/prolog.fcl
+++ b/TrackerMC/fcl/prolog.fcl
@@ -17,7 +17,9 @@ TrackerMC : {
 	makeSGS : {@table::makeSGS }
 	makeSD  : { @table::makeSD  }
     }
+    StepSim : [ makeSGS ]
     DigiSim : [ makeSD ]
+    StepAndDigiSim : [ makeSGS, makeSD ]
 }
 
 END_PROLOG


### PR DESCRIPTION
This PR makes the necessary fcl changes to write StrawGasSteps out at the end of each individual background frame simulation, and to mix them in the mixing stage. StrawGasSteps were already added to the Mu2eProductMixer in PR#105. This PR would be a breaking change for *-mix jobs that are reading MDC2018 background frames, which contain StepPointMCs. If we still need this functionality, we can reprocess the MDC2018 files to create StrawGasSteps.

I have made this a draft pull request because I want to ask whether it is worth merging this branch with PR#231 and PR#234 to make sure all these related developments work together before merging into master.