### PR TITLE
(CI test) upgraded to python 3

### DIFF
--- a/TrkPatRec/src/SConscript
+++ b/TrkPatRec/src/SConscript
@@ -5,6 +5,9 @@
 # Original author Rob Kutschke.
 #
 
+
+
+
 import os
 Import('env')
 Import('mu2e_helper')


### PR DESCRIPTION
Much to my surprise, the CI scripts were not being run in python 3, but in python 2.7 (which is not very stable in the long-term) and were being run with old versions of github api libraries

Should be fixed soon, just testing it out here