### PR TITLE
Mu2eII_SM21: Add Mu2e-II era target and remove pbar absorbers

### DIFF
--- a/GeometryService/inc/GeometryService.hh
+++ b/GeometryService/inc/GeometryService.hh
@@ -34,6 +34,8 @@ namespace mu2e {
   class Mu2eG4Study;
   class Mu2eHall;
   class G4GeometryOptions;
+  class ProductionTarget;
+  class ProductionTargetMu2eII;
 
   class GeometryService {
 public:

--- a/GeometryService/inc/ProductionTargetMaker.hh
+++ b/GeometryService/inc/ProductionTargetMaker.hh
@@ -8,21 +8,30 @@
 #include <vector>
 
 namespace mu2e { class SimpleConfig; }
-namespace mu2e { class ProductionTarget; }
+namespace mu2e { 
+  class ProductionTarget; 
+  class ProductionTargetMu2eII;
+}
 
 namespace mu2e {
   class ProductionTargetMaker {
   public:
 
 
-    static std::unique_ptr<ProductionTarget> make(const SimpleConfig& config, double solenoidOffset);
+    static std::unique_ptr<ProductionTarget>       make(const SimpleConfig& config, double solenoidOffset);
+    static std::unique_ptr<ProductionTargetMu2eII> makeMu2eII(const SimpleConfig& config, double solenoidOffset);
     static const int tier1{1};
     // version 2 is the low density hayman
     static const int hayman_v_2_0{3};
- 
+    //enums for identifying Mu2eII target configurations, starting from hayman_v_2_0
+    enum {mu2eii_conveyor = 4, mu2eii_rotating = 5};
  
     static std::unique_ptr<ProductionTarget> makeTier1(const SimpleConfig& config, double solenoidOffset);
     static std::unique_ptr<ProductionTarget> makeHayman_v_2_0(const SimpleConfig& config, double solenoidOffset);
+
+    //different target object for Mu2e-II designs
+    static std::unique_ptr<ProductionTargetMu2eII> makeMu2eIIConveyor(const SimpleConfig& config, double solenoidOffset);
+    static std::unique_ptr<ProductionTargetMu2eII> makeMu2eIIRotating(const SimpleConfig& config, double solenoidOffset);
 
 
 

--- a/GeometryService/src/GeometryService_service.cc
+++ b/GeometryService/src/GeometryService_service.cc
@@ -30,6 +30,7 @@
 #include "GeometryService/src/DetectorSystemMaker.hh"
 #include "Mu2eHallGeom/inc/Mu2eHall.hh"
 #include "ProductionTargetGeom/inc/ProductionTarget.hh"
+#include "ProductionTargetGeom/inc/ProductionTargetMu2eII.hh"
 #include "GeometryService/inc/ProductionTargetMaker.hh"
 #include "ProductionSolenoidGeom/inc/ProductionSolenoid.hh"
 #include "GeometryService/inc/ProductionSolenoidMaker.hh"
@@ -210,9 +211,19 @@ namespace mu2e {
     const Beamline& beamline = *tmpBeamline.get();
     addDetector(std::move(tmpBeamline));
 
-    std::unique_ptr<ProductionTarget> tmpProdTgt(ProductionTargetMaker::make(*_config, beamline.solenoidOffset()));
-    const ProductionTarget& prodTarget = *tmpProdTgt.get();
-    addDetector(std::move(tmpProdTgt));
+    //for target, need to check the model and if it's a Mu2e-II model
+    bool Mu2eIITarget = _config->getBool("targetPS.Mu2eII.build", false);
+    const ProductionTarget* prodTarget = nullptr;
+    const ProductionTargetMu2eII* prodTargetMu2eII = nullptr;
+    if(!Mu2eIITarget) {
+      std::unique_ptr<ProductionTarget> tmpProdTgt(ProductionTargetMaker::make(*_config, beamline.solenoidOffset()));
+      prodTarget = tmpProdTgt.get();
+      addDetector(std::move(tmpProdTgt));
+    } else {
+      std::unique_ptr<ProductionTargetMu2eII> tmpProdTgt(ProductionTargetMaker::makeMu2eII(*_config, beamline.solenoidOffset()));
+      prodTargetMu2eII = tmpProdTgt.get();
+      addDetector(std::move(tmpProdTgt));
+    }
 
     std::unique_ptr<ProductionSolenoid>
       tmpProductionSolenoid(ProductionSolenoidMaker(*_config, beamline.solenoidOffset()).getProductionSolenoidPtr());
@@ -231,19 +242,19 @@ namespace mu2e {
 
     addDetector(PSVacuumMaker::make(*_config, ps, pse, vacPS_TS_z));
 
-    //addDetector(PSShieldMaker::make(*_config, ps.psEndRefPoint(), prodTarget.position()));
+    if(Mu2eIITarget) 
+      addDetector(PSShieldMaker::make(*_config, ps.psEndRefPoint(), prodTargetMu2eII->position()));
+    else if (_config->getString("targetPS_model") == "MDC2018"){ 
+      addDetector(PSShieldMaker::make(*_config, ps.psEndRefPoint(), prodTarget->position()));
+    } else if (_config->getString("targetPS_model") == "Hayman_v_2_0"){ 
+      addDetector(PSShieldMaker::make(*_config, ps.psEndRefPoint(), prodTarget->haymanProdTargetPosition()));
+    } else {
+      throw cet::exception("GEOM") << " " << __func__ 
+				   << " illegal production target version specified in GeometryService_service = "
+				   << _config->getString("targetPS_model")  << std::endl;
+    }
 
-   if (_config->getString("targetPS_model") == "MDC2018"){ 
-     //      std::cout << "adding Tier1 in GeometryService" << std::endl;
-      addDetector(PSShieldMaker::make(*_config, ps.psEndRefPoint(), prodTarget.position()));
-	} else 
-      if (_config->getString("targetPS_model") == "Hayman_v_2_0"){ 
-	//	std::cout << " adding Hayman in GeometryService" << std::endl;
-	addDetector(PSShieldMaker::make(*_config, ps.psEndRefPoint(), prodTarget.haymanProdTargetPosition()));
-	  } else 
-	{throw cet::exception("GEOM") << " " << __func__ << " illegal production target version specified in GeometryService_service = " << _config->getString("targetPS_model")  << std::endl;}
-
-
+    
 
 
 

--- a/GeometryService/src/ProductionTargetMaker.cc
+++ b/GeometryService/src/ProductionTargetMaker.cc
@@ -3,6 +3,7 @@
 #include "CLHEP/Units/SystemOfUnits.h"
 #include "ConfigTools/inc/SimpleConfig.hh"
 #include "ProductionTargetGeom/inc/ProductionTarget.hh"
+#include "ProductionTargetGeom/inc/ProductionTargetMu2eII.hh"
 #include <iostream>
 #include <algorithm>
 
@@ -10,18 +11,30 @@ namespace mu2e {
 
   std::unique_ptr<ProductionTarget> ProductionTargetMaker::make(const SimpleConfig& c, double solenoidOffset) {
 
-
-    if (c.getString("targetPS_model") == "MDC2018"){ 
-      //     std::cout << "making Tier1 in maker" << std::endl;
+    std::string model = c.getString("targetPS_model");
+    if ( model == "MDC2018")
       return std::move(makeTier1(c, solenoidOffset));
-	} else 
-      if (c.getString("targetPS_model") == "Hayman_v_2_0"){ 
-	//	std::cout << " making Hayman in Maker" << std::endl;
-	return std::move(makeHayman_v_2_0(c, solenoidOffset));
-	  } else 
-	{throw cet::exception("GEOM") << " illegal production target version specified = " << c.getInt("targetPS_version")  << std::endl;}
-    return 0;
+    else if (model == "Hayman_v_2_0")
+      return std::move(makeHayman_v_2_0(c, solenoidOffset));
+    
+    throw cet::exception("GEOM") << " illegal production target version specified = " 
+				 << model.c_str() << " version = " 
+				 << c.getInt("targetPS_version")  << std::endl;
+    return nullptr;
+  }
 
+  std::unique_ptr<ProductionTargetMu2eII> ProductionTargetMaker::makeMu2eII(const SimpleConfig& c, double solenoidOffset) {
+
+    std::string model = c.getString("targetPS_model");
+    if ( model == "Conveyor")
+      return std::move(makeMu2eIIConveyor(c, solenoidOffset));
+    else if (model == "Rotating")
+      return std::move(makeMu2eIIRotating(c, solenoidOffset));
+    
+    throw cet::exception("GEOM") << " illegal (Mu2eII) production target version specified = " 
+				 << model.c_str() << " version = " 
+				 << c.getInt("targetPS_version")  << std::endl;
+    return nullptr;
   }
 
   std::unique_ptr<ProductionTarget> ProductionTargetMaker::makeTier1(const SimpleConfig& c, double solenoidOffset){
@@ -390,5 +403,52 @@ namespace mu2e {
     return std::move(tgtPS);
   }
  
+  //make a Conveyor Mu2e-II type target
+  std::unique_ptr<ProductionTargetMu2eII> ProductionTargetMaker::makeMu2eIIConveyor(const SimpleConfig& c, double solenoidOffset){
+    std::string model = c.getString("targetPS_model");
+    int version = c.getInt("targetPS.Mu2eII.version", 0); //version of the model
+    std::unique_ptr<ProductionTargetMu2eII> target(new ProductionTargetMu2eII(model, version));
+
+    target->_isConveyor = true;
+    target->_conveyorBallRadius   = c.getDouble("targetPS.Mu2eII.conveyor.ball.radius");
+    target->_conveyorBallMaterial = c.getString("targetPS.Mu2eII.conveyor.ball.material");
+    target->_conveyorNBalls       = c.getInt   ("targetPS.Mu2eII.conveyor.nballs");
+    c.getVectorDouble("targetPS.Mu2eII.conveyor.ball.xs", target->_conveyorBallXs, target->_conveyorNBalls);
+    c.getVectorDouble("targetPS.Mu2eII.conveyor.ball.ys", target->_conveyorBallYs, target->_conveyorNBalls);
+    c.getVectorDouble("targetPS.Mu2eII.conveyor.ball.zs", target->_conveyorBallZs, target->_conveyorNBalls);
+
+    target->_beamRotX = c.getDouble("targetPS_rotX") * CLHEP::degree;
+    target->_beamRotY = c.getDouble("targetPS_rotY") * CLHEP::degree;
+    target->_beamRotZ = c.getDouble("targetPS_rotZ") * CLHEP::degree;
+    target->_protonBeamRotation.rotateX(target->_beamRotX).rotateY(target->_beamRotY).rotateZ(target->_beamRotZ);
+    target->_protonBeamInverseRotation = target->_protonBeamRotation.inverse();
+    target->_prodTargetPosition = CLHEP::Hep3Vector(solenoidOffset + c.getDouble("productionTarget.xNominal", 0.),
+						    c.getDouble("productionTarget.yNominal", 0.),
+						    c.getDouble("productionTarget.zNominal")
+						    );
+
+    return target;
+  }
+
+  //make a Rotating Mu2e-II type target
+  std::unique_ptr<ProductionTargetMu2eII> ProductionTargetMaker::makeMu2eIIRotating(const SimpleConfig& c, double solenoidOffset){
+    std::string model = c.getString("targetPS_model");
+    int version = c.getInt("targetPS.Mu2eII.version", 0); //version of the model
+    std::unique_ptr<ProductionTargetMu2eII> target(new ProductionTargetMu2eII(model, version));
+    target->_isRotating = true;
+    target->_rotatingNRods = c.getInt("targetPS.Mu2eII.rotating.nrods");
+    target->_beamRotX = c.getDouble("targetPS_rotX") * CLHEP::degree;
+    target->_beamRotY = c.getDouble("targetPS_rotY") * CLHEP::degree;
+    target->_beamRotZ = c.getDouble("targetPS_rotZ") * CLHEP::degree;
+    target->_protonBeamRotation.rotateX(target->_beamRotX).rotateY(target->_beamRotY).rotateZ(target->_beamRotZ);
+    target->_protonBeamInverseRotation = target->_protonBeamRotation.inverse();
+    target->_prodTargetPosition = CLHEP::Hep3Vector(solenoidOffset + c.getDouble("productionTarget.xNominal", 0.),
+						    c.getDouble("productionTarget.yNominal", 0.),
+						    c.getDouble("productionTarget.zNominal")
+						    );
+
+    std::cout << __PRETTY_FUNCTION__ << ": Target implementation not fully added yet!\n";
+    return nullptr;
+  }
  
 } // namespace mu2e

--- a/Mu2eG4/geom/geom_Mu2eII_2020.txt
+++ b/Mu2eG4/geom/geom_Mu2eII_2020.txt
@@ -1,0 +1,129 @@
+// Updated to be used in the 2020 Mu2e-II studes, starting from the 2020 CRY campaign geometry
+// Important differences:
+// No pbar absorber elements
+// Alternate production target
+
+#include "Mu2eG4/geom/geom_2019_PhaseI_hayman_v2.txt"
+
+///////////////////////////////////////
+//     Turn off pbar elements        //
+///////////////////////////////////////
+bool pbar.build = false;
+
+///////////////////////////////////////
+//     Change production target      //
+///////////////////////////////////////
+bool   targetPS.Mu2eII.build   = true;
+string targetPS_model          = "Conveyor"; //options are "Conveyor" or "Rotating"
+int    targetPS_version        = 4; //duplicate model control (4 = conveyor, 5 = rotating)
+int    targetPS.Mu2eII.version = 0; //version of the model
+
+//Conveyor type target parameters
+int PS.verbosityLevel = 0;
+int    targetPS.Mu2eII.conveyor.nballs        = 28; 
+double targetPS.Mu2eII.conveyor.ball.radius   = 7.5;
+double targetPS.Mu2eII.conveyor.ball.gap      = 0.5;
+string targetPS.Mu2eII.conveyor.ball.material = "G4_C";
+
+vector<double> targetPS.Mu2eII.conveyor.ball.xs = {
+  3962.64071,
+  3958.99672,
+  3955.3688 ,
+  3951.73431,
+  3948.10744,
+  3944.47969,
+  3940.83876,
+  3937.21477,
+  3933.59959,
+  3929.99381,
+  3926.38463,
+  3922.78401,
+  3919.1802 ,
+  3915.58815,
+  3912.01708,
+  3908.45724,
+  3904.88333,
+  3901.33749,
+  3897.7963 ,
+  3894.2761 ,
+  3890.75986,
+  3887.25583,
+  3883.76988,
+  3880.29837,
+  3876.83904,
+  3873.40081,
+  3869.98556,
+  3866.58285
+};
+vector<double> targetPS.Mu2eII.conveyor.ball.ys = {
+  0.00575,
+  0.05198,
+  0.14417,
+  0.28301,
+  0.46821,
+  0.70038,
+  0.98093,
+  1.30782,
+  1.68167,
+  2.10246,
+  2.57199,
+  3.08906,
+  3.65576,
+  4.27005,
+  4.93023,
+  5.638  ,
+  6.39903,
+  7.20469,
+  8.06025,
+  8.96188,
+  9.91411,
+  10.9150,
+  11.9632,
+  13.0597,
+  14.2054,
+  15.3976,
+  16.6354,
+  17.92281
+};
+vector<double> targetPS.Mu2eII.conveyor.ball.zs = {
+  -5922.72534,
+  -5937.34174,
+  -5951.89771,
+  -5966.48572,
+  -5981.05176,
+  -5995.63245,
+  -6010.27997,
+  -6024.87531,
+  -6039.45386,
+  -6054.01624,
+  -6068.61646,
+  -6083.20874,
+  -6097.84375,
+  -6112.4635 ,
+  -6127.0332 ,
+  -6141.59497,
+  -6156.25562,
+  -6170.84515,
+  -6185.46246,
+  -6200.04315,
+  -6214.66077,
+  -6229.28387,
+  -6243.8905 ,
+  -6258.49957,
+  -6273.12299,
+  -6287.72656,
+  -6302.3042 ,
+  -6316.90381
+};
+//
+//
+// End notes:
+//
+// 1) Sources of information:
+//
+//
+//
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_current.txt
+++ b/Mu2eG4/geom/geom_common_current.txt
@@ -3,7 +3,7 @@
 // and features that will eventually become default - 
 // the latest for testing..
 
-#include "Mu2eG4/geom/geom_2019_PhaseI_hayman_v2.txt"
+#include "Mu2eG4/geom/geom_Mu2eII_2020.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/inc/constructTargetPS.hh
+++ b/Mu2eG4/inc/constructTargetPS.hh
@@ -17,7 +17,8 @@ namespace mu2e {
   class SimpleConfig;
 
   void constructTargetPS(VolumeInfo const & parent, SimpleConfig const & _config);
-
+  void constructMu2eIIConveyor(VolumeInfo const & parent, SimpleConfig const & _config);
+  void constructMu2eIIRotating(VolumeInfo const & parent, SimpleConfig const & _config);
 }
 
 #endif /* Mu2eG4_constructTargetPS_hh */

--- a/Mu2eG4/src/constructPS.cc
+++ b/Mu2eG4/src/constructPS.cc
@@ -316,7 +316,11 @@ namespace mu2e {
     } else if (targetPS_model == "Hayman_v_2_0"){
       verbosityLevel> 0 && std::cout << __func__ << "Hayman 2.0 target" << std::endl;
       constructTargetPS(psVacuumInfo, _config );
-    } else{
+    } else if(targetPS_model == "Conveyor" || targetPS_model == "Rotating") { //Mu2e-II target designs
+      verbosityLevel> 0 && std::cout << __func__ << " " << targetPS_model.c_str() 
+				     << " target" << std::endl;
+      constructTargetPS(psVacuumInfo, _config );
+    } else {
       throw cet::exception("CONFIG")
         << "In constructPS.cc unrecognized production target model name: "
         << targetPS_model

--- a/Mu2eG4/src/constructTS.cc
+++ b/Mu2eG4/src/constructTS.cc
@@ -761,7 +761,9 @@ namespace mu2e {
     // Build outer portion of support for TS3 antiproton stopping window
     // Will model for now as solid tubes
 
-    int pbarAbsTS3Version = config.getInt("pbar.version",1);
+    bool buildPbar = config.getBool("pbar.build", true);
+    if(buildPbar) {
+      int pbarAbsTS3Version = config.getInt("pbar.version",1);
       if ( pbarAbsTS3Version > 1 ) {
 
 	std::ostringstream PabsSupOutName;
@@ -805,7 +807,7 @@ namespace mu2e {
 		  );
 
       } //end of " if pbarAbsTS3Version..."
-
+    } //end if buildPbar
 
 
 
@@ -1580,6 +1582,9 @@ namespace mu2e {
     //   "stairstep" structure.
     // ******* In Version 4, do the same as version 3 except allow the steps to have different
     //   thicknesses.  This will allow us to implement the geometry of doc-db 17519 p. 34
+
+    bool buildPbar = config.getBool("pbar.build", true);
+    if(!buildPbar) return;
 
     G4GeometryOptions* geomOptions = art::ServiceHandle<GeometryService>()->geomOptions();
     geomOptions->loadEntry( config, "PbarAbs", "pbar" );

--- a/Mu2eG4/src/constructTargetPS.cc
+++ b/Mu2eG4/src/constructTargetPS.cc
@@ -24,6 +24,7 @@
 #include "GeometryService/inc/GeometryService.hh"
 #include "GeometryService/inc/GeomHandle.hh"
 #include "ProductionTargetGeom/inc/ProductionTarget.hh"
+#include "ProductionTargetGeom/inc/ProductionTargetMu2eII.hh"
 #include "Mu2eG4/inc/findMaterialOrThrow.hh"
 #include "Mu2eG4/inc/constructTargetPS.hh"
 #include "Mu2eG4/inc/nestTubs.hh"
@@ -50,6 +51,7 @@
 #include "G4Tubs.hh"
 #include "G4VPhysicalVolume.hh"
 #include "G4PVPlacement.hh"
+#include "G4Sphere.hh"
 
 #include "G4UnionSolid.hh"
 #include "G4IntersectionSolid.hh"
@@ -78,12 +80,100 @@ namespace mu2e {
     boxWithTubsCutoutInfo.solid = new G4SubtractionSolid(name,boxCutout,tubsCutout, rotOverall, offset);
     finishNesting(boxWithTubsCutoutInfo,material,rotAngle,translation,parent.logical,copyNo,color,lookupToken,verbose);
   }
+  
+  //construct a conveyor of balls for a Mu2e-II type production target
+  void constructMu2eIIConveyor(VolumeInfo const & parent, SimpleConfig const & _config) {
+    
+    if(_config.getInt("targetPS_version") != ProductionTargetMaker::mu2eii_conveyor)
+      throw cet::exception("CONFIG") << "Calling " << __func__ << " without the corresponding target version!";
+
+    int verbosityLevel                  = _config.getInt("PS.verbosityLevel");
+    verbosityLevel >0 &&
+      cout << __PRETTY_FUNCTION__ << " verbosityLevel: " << verbosityLevel  << endl;
+
+    G4ThreeVector _parentOriginInMu2e = parent.centerInMu2e();
+
+
+    // Build the production target.
+    GeomHandle<ProductionTargetMu2eII> target;
+    const double ballRadius = target->conveyorBallRadius();
+    const int    nBalls     = target->conveyorNBalls();
+    const std::vector<double> ballXs = target->conveyorBallXs();
+    const std::vector<double> ballYs = target->conveyorBallYs();
+    const std::vector<double> ballZs = target->conveyorBallZs();
+    double xmin(ballXs[0]), xmax(ballXs[0]), ymin(ballYs[0]), ymax(ballYs[0]), zmin(ballZs[0]), zmax(ballZs[0]);
+    for(int ball = 1; ball < nBalls; ++ball) {
+      if(ballXs[ball] < xmin) xmin = ballXs[ball];
+      else if(ballXs[ball] > xmax) xmax = ballXs[ball];
+      if(ballYs[ball] < ymin) ymin = ballYs[ball];
+      else if(ballYs[ball] > ymax) ymax = ballYs[ball];
+      if(ballZs[ball] < zmin) zmin = ballZs[ball];
+      else if(ballZs[ball] > zmax) zmax = ballZs[ball];
+    }
+    double motherLength = (zmax-zmin);
+    double motherRadius = sqrt((xmax-xmin)*(xmax-xmin) + (ymax-ymin)*(ymax-ymin));    
+    CLHEP::Hep3Vector targetCenter((xmax+xmin)/2., (ymax+ymin)/2., (zmax+zmin)/2.);
+    TubsParams prodTargetMotherParams( 0., motherRadius, motherLength/2.);
+    if(verbosityLevel > 0)
+      std::cout << "Target center = " << targetCenter << ", parent center = " << parent.centerInMu2e() << std::endl;
+    VolumeInfo prodTargetMotherInfo   = nestTubs( "ProductionTargetMother",
+						    prodTargetMotherParams,
+						    parent.logical->GetMaterial(),
+						    0,
+						    targetCenter - parent.centerInMu2e(),
+						    parent,
+						    0,
+						    G4Colour::Blue(),
+						    "PS"
+						    );
+    //add the balls to the model
+    G4Material* ballMaterial = findMaterialOrThrow(target->conveyorBallMaterial());    
+    for(int ball = 0; ball < nBalls; ++ball) {
+      VolumeInfo ballInfo;
+      ballInfo.name = "ProductionTarget_ball_" + std::to_string(ball);
+      ballInfo.solid = new G4Sphere(ballInfo.name, 0., ballRadius, 0., CLHEP::twopi, 0., CLHEP::pi);
+      finishNesting(ballInfo,
+		    ballMaterial,
+		    nullptr,
+		    CLHEP::Hep3Vector(ballXs[ball], ballYs[ball], ballZs[ball]) - targetCenter,
+		    prodTargetMotherInfo.logical,
+		    0,
+		    G4Colour::Blue(),
+		    "PS"
+		    );
+    }
+    
+  }
+
+  //construct a rotating target for a Mu2e-II type production target
+  void constructMu2eIIRotating(VolumeInfo const & parent, SimpleConfig const & _config) {
+    
+    if(_config.getInt("targetPS_version") != ProductionTargetMaker::mu2eii_rotating)
+      throw cet::exception("CONFIG") << "Calling " << __func__ << " without the corresponding target version!";
+
+    int verbosityLevel = _config.getInt("PS.verbosityLevel");
+    verbosityLevel >0 &&
+      cout << __PRETTY_FUNCTION__ << " verbosityLevel                   : " << verbosityLevel  << endl;
+
+    G4ThreeVector _hallOriginInMu2e = parent.centerInMu2e();
+    
+
+    // Build the production target.
+    GeomHandle<ProductionTargetMu2eII> tgt;
+    
+  }
 
   void constructTargetPS(VolumeInfo const & parent, SimpleConfig const & _config) {
 
     //
     // which target am I building?
-    if (_config.getInt("targetPS_version") == ProductionTargetMaker::tier1){
+    if(_config.getInt("targetPS_version") == ProductionTargetMaker::mu2eii_conveyor) {
+      constructMu2eIIConveyor(parent, _config);
+      return;
+    } else if(_config.getInt("targetPS_version") == ProductionTargetMaker::mu2eii_rotating) {
+      constructMu2eIIRotating(parent, _config);
+      return;
+    } else if (_config.getInt("targetPS_version") == ProductionTargetMaker::tier1){
       int verbosityLevel                  = _config.getInt("PS.verbosityLevel");
 
       //G4Material* psVacVesselMaterial = findMaterialOrThrow(psVacVesselInnerParams.materialName());
@@ -93,7 +183,7 @@ namespace mu2e {
 
       //bool psVacuumSensitive = _config.getBool("PS.Vacuum.Sensitive", false);
 
-      G4ThreeVector _hallOriginInMu2e = parent.centerInMu2e();
+      G4ThreeVector _hallOriginInMu2e = parent.centerInMu2e(); //NOTE: parent != hall here, but production solenoid
 
 
       // Build the production target.

--- a/Mu2eG4/src/constructTargetPS.cc
+++ b/Mu2eG4/src/constructTargetPS.cc
@@ -110,8 +110,8 @@ namespace mu2e {
       if(ballZs[ball] < zmin) zmin = ballZs[ball];
       else if(ballZs[ball] > zmax) zmax = ballZs[ball];
     }
-    double motherLength = (zmax-zmin);
-    double motherRadius = sqrt((xmax-xmin)*(xmax-xmin) + (ymax-ymin)*(ymax-ymin));    
+    double motherLength = (zmax-zmin) + ballRadius*2.;
+    double motherRadius = sqrt((xmax-xmin)*(xmax-xmin) + (ymax-ymin)*(ymax-ymin)) + ballRadius*2.;
     CLHEP::Hep3Vector targetCenter((xmax+xmin)/2., (ymax+ymin)/2., (zmax+zmin)/2.);
     TubsParams prodTargetMotherParams( 0., motherRadius, motherLength/2.);
     if(verbosityLevel > 0)

--- a/ProductionTargetGeom/inc/ProductionTargetMu2eII.hh
+++ b/ProductionTargetGeom/inc/ProductionTargetMu2eII.hh
@@ -1,0 +1,119 @@
+// Geometry of the Mu2e-II production target. 
+// This also defines the proton beam direction.
+//
+// Based on Andrei Gaponenko, 2011 ProductionTarget.hh
+// Created by Michael MacKenzie, 2020
+
+
+#ifndef PRODUCTIONTARGETMU2EII_HH
+#define PRODUCTIONTARGETMU2EII_HH
+
+#include <map>
+
+#include "canvas/Persistency/Common/Wrapper.h"
+
+#include "CLHEP/Vector/ThreeVector.h"
+#include "CLHEP/Vector/Rotation.h"
+
+#include "GeomPrimitives/inc/Polycone.hh"
+#include "Mu2eInterfaces/inc/Detector.hh"
+
+namespace mu2e {
+
+  class ProductionTargetMaker;
+
+  class ProductionTargetMu2eII : virtual public Detector {
+  public:
+
+    // cylinder parameters
+    int    version() const { return _version; }
+    // double rOut() const { return _rOut; }
+    // double halfLength() const { return _halfLength; }
+    // double envHalfLength() const { return _envelHalfLength; }
+
+    bool   isRotating() const {return _isRotating;}
+    bool   isConveyor() const {return _isConveyor;}
+
+
+    // in mu2e coordinates
+    const CLHEP::Hep3Vector& position() const { return _prodTargetPosition; }
+
+    // this is used to transorm particle momentum and position from
+    // the PrimaryProtonGun frame to the Mu2e frame
+    const CLHEP::HepRotation& protonBeamRotation() const { return _protonBeamRotation; }
+
+    // "passive" rotation, used for placing the production target.
+    // This is the inverse of protonBeamRotation.
+    const CLHEP::HepRotation& productionTargetRotation() const { return _protonBeamInverseRotation; }
+
+    //Conveyor parameters
+    double      conveyorBallRadius   () const { return _conveyorBallRadius  ; }
+    double      conveyorBallGap      () const { return _conveyorBallGap     ; }
+    std::string conveyorBallMaterial () const { return _conveyorBallMaterial; }
+    int         conveyorNBalls       () const { return _conveyorNBalls      ; }
+    const std::vector<double>& conveyorBallXs() const { return _conveyorBallXs; }
+    const std::vector<double>& conveyorBallYs() const { return _conveyorBallYs; }
+    const std::vector<double>& conveyorBallZs() const { return _conveyorBallZs; }
+
+
+    //Rotating parameters
+    int rotatingNRods () const { return _rotatingNRods; }
+
+    
+    ~ProductionTargetMu2eII() {}
+
+
+    std::string targetCoreMaterial()         const  {return _targetCoreMaterial;}
+    std::string targetVacuumMaterial()       const  {return _targetVacuumMaterial;}
+
+
+
+    //----------------------------------------------------------------
+
+  private:
+    friend class ProductionTargetMaker;
+
+    // Private ctr: the class should be only obtained via ProductionTargetFNAL::ProductionTargetMaker.
+    ProductionTargetMu2eII(std::string type, int version);
+
+    CLHEP::HepRotation _protonBeamRotation;
+
+    // can't return by const ref if invert on the fly so need to store redundant data
+    CLHEP::HepRotation _protonBeamInverseRotation;// FIXME: should be transient
+
+
+    CLHEP::Hep3Vector _prodTargetPosition;
+
+    std::string _type;
+    int    _version;
+    bool   _isRotating;
+    bool   _isConveyor;
+
+    std::string _targetCoreMaterial;
+    std::string _targetVacuumMaterial;
+
+    //conveyor parameters
+    int         _conveyorNBalls;
+    double      _conveyorBallRadius;
+    double      _conveyorBallGap;
+    std::string _conveyorBallMaterial;
+    std::vector<double> _conveyorBallXs; //ball centers
+    std::vector<double> _conveyorBallYs;
+    std::vector<double> _conveyorBallZs;
+
+    //rotating paramerters
+    double _rotatingNRods;
+    
+    //beam parameters
+    double _beamRotX;
+    double _beamRotY;
+    double _beamRotZ;
+
+    
+    // Needed for persistency
+    template<class T> friend class art::Wrapper;
+    ProductionTargetMu2eII() {}
+  };
+}
+
+#endif/*PRODUCTIONTARGETMU2UII_HH*/

--- a/ProductionTargetGeom/src/ProductionTargetMu2eII.cc
+++ b/ProductionTargetGeom/src/ProductionTargetMu2eII.cc
@@ -1,0 +1,16 @@
+#include "ProductionTargetGeom/inc/ProductionTargetMu2eII.hh"
+
+namespace mu2e {
+  ProductionTargetMu2eII::ProductionTargetMu2eII(std::string type, int version)
+    : _protonBeamRotation(CLHEP::HepRotation::IDENTITY)
+    , _prodTargetPosition(CLHEP::Hep3Vector())
+    , _type(type)
+    , _version(version)
+    , _isRotating(false)
+    , _isConveyor(false)
+  {
+    // _protonBeamRotation.rotateX(rotX).rotateY(rotY);
+    // _protonBeamInverseRotation = _protonBeamRotation.inverse();
+  }
+
+}


### PR DESCRIPTION
Mu2eII_SM21:
Add a Mu2e-II era target configuration (conveyor), with a placeholder for a second target type (rotating).
Also add a flag to remove pbar absorber elements, which are not needed for 800 MeV proton beams.
The target implementation is preliminary, but gives a starting point for understanding POT in the PIP-II era.
Updated geometry is by default on in Mu2eG4/geom/geom_common_current.txt (which includes Mu2eG4/geom/geom_Mu2eII_2020.txt).

Validation run:
ROOT overlap checker on gdml file, G4 overlap checker