### PR TITLE
Remove definitions of PACKAGE_SOURCE and BUILD_BASE 

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -165,8 +165,3 @@ export PATH=`dropit -p $PATH -sf $MU2E_BASE_RELEASE/bin`
 # root6 needs a path to include files to prevent some runtime warnings
 export ROOT_INCLUDE_PATH=`dropit -p $ROOT_INCLUDE_PATH -sf $MU2E_BASE_RELEASE`
 
-# Environment variables used by the test build system.
-export PACKAGE_SOURCE=${MU2E_BASE_RELEASE}
-export BUILD_BASE=${MU2E_BASE_RELEASE}
-
-#


### PR DESCRIPTION
These were from an ancient and abandoned attempt at using the SCD house build system, cetbuildtools, which is a layer on top of cmake.
