### PR TITLE
Mu2eII_SM21: Update primary proton gun to work with Mu2e-II targets

### DIFF
--- a/EventGenerator/fcl/prolog.fcl
+++ b/EventGenerator/fcl/prolog.fcl
@@ -109,7 +109,7 @@ PrimaryProtonGun: {
     shape	      : "gaus"
     rmax	      : 100.
     mean	      : -1.
-
+    mu2eii            : true
 }
 
 

--- a/EventGenerator/inc/PrimaryProtonGunImpl.hh
+++ b/EventGenerator/inc/PrimaryProtonGunImpl.hh
@@ -86,6 +86,7 @@ namespace mu2e {
           
       fhicl::Atom<double> rmax {Name("rmax"), Comment("Maximum radius of beam spot for flat distribution"), 100.};
       fhicl::Atom<double> mean {Name("mean"), Comment("Poisson mean; negative for non-random abs(mean)"), -1};
+      fhicl::Atom<bool>   mu2eii {Name("mu2eii"), Comment("Uses a Mu2e-II era target"), false};
     };
       
     explicit PrimaryProtonGunImpl(CLHEP::HepRandomEngine& engine, const PrimaryProtonGunConfig& config);
@@ -94,6 +95,9 @@ namespace mu2e {
 
   private:
       
+    //whether or not Mu2e-II era target
+    bool   _mu2eii;
+
     CLHEP::HepRotation _gunRotation; // rotates target frame to Mu2e frame
     CLHEP::Hep3Vector _gunOrigin;
 
@@ -122,7 +126,8 @@ namespace mu2e {
 
     // radius max, for flat distribution
     double _rmax;
-            
+    
+
     CLHEP::RandPoissonQ _randPoissonQ;
     CLHEP::RandFlat     _randFlat;
     CLHEP::RandGaussQ   _randGaussQ;

--- a/EventGenerator/src/PrimaryProtonGunImpl.cc
+++ b/EventGenerator/src/PrimaryProtonGunImpl.cc
@@ -20,6 +20,7 @@
 #include "GlobalConstantsService/inc/ParticleDataTable.hh"
 #include "GeometryService/inc/GeomHandle.hh"
 #include "ProductionTargetGeom/inc/ProductionTarget.hh"
+#include "ProductionTargetGeom/inc/ProductionTargetMu2eII.hh"
 
 // CLHEP includes.
 #include "CLHEP/Vector/Rotation.h"
@@ -31,8 +32,9 @@ namespace mu2e {
 
     PrimaryProtonGunImpl::PrimaryProtonGunImpl(CLHEP::HepRandomEngine& engine, const PrimaryProtonGunConfig& config):
     
-    _gunRotation(GeomHandle<ProductionTarget>()->protonBeamRotation()),
-    _gunOrigin(GeomHandle<ProductionTarget>()->targetPositionByVersion()
+    _mu2eii(config.mu2eii()),
+    _gunRotation((_mu2eii) ? GeomHandle<ProductionTargetMu2eII>()->protonBeamRotation() : GeomHandle<ProductionTarget>()->protonBeamRotation()),
+    _gunOrigin((_mu2eii) ? GeomHandle<ProductionTargetMu2eII>()->front() : GeomHandle<ProductionTarget>()->targetPositionByVersion()
                + _gunRotation*CLHEP::Hep3Vector(0., 0., GeomHandle<ProductionTarget>()->targetHalfLengthByVersion())),
 
     _proton_mass(GlobalConstantsHandle<ParticleDataTable>()->particle(PDGCode::p_plus).ref().mass().value()),
@@ -48,7 +50,6 @@ namespace mu2e {
     _tmax(config.tmax()),
     _shape(config.shape()),
     _rmax(config.rmax()),
-    
     // For all distributions, use the engine managed by the RandomNumberGenerator.
     _randPoissonQ{engine, std::abs(config.mean())},
     _randFlat{engine},

--- a/GeometryService/src/ProductionTargetMaker.cc
+++ b/GeometryService/src/ProductionTargetMaker.cc
@@ -426,7 +426,23 @@ namespace mu2e {
 						    c.getDouble("productionTarget.yNominal", 0.),
 						    c.getDouble("productionTarget.zNominal")
 						    );
-
+    //figure out the front ball, and then assign the front position as that ball + translation along beam direction
+    if(target->_conveyorNBalls <= 0)
+      target->_prodTargetFrontPosition = target->_prodTargetPosition; //if no balls, use as default
+    else {
+      double xmax = target->_conveyorBallXs[0];
+      double ymax = target->_conveyorBallYs[0];
+      double zmax = target->_conveyorBallZs[0];
+      for(int ball = 0; ball < target->_conveyorNBalls; ++ball) {
+	if(zmax < target->_conveyorBallZs[ball]) {
+	  xmax = target->_conveyorBallXs[ball];
+	  ymax = target->_conveyorBallYs[ball];
+	  zmax = target->_conveyorBallZs[ball];
+	}
+      }
+      target->_prodTargetFrontPosition = CLHEP::Hep3Vector(xmax, ymax, zmax) + 
+	target->_protonBeamRotation*CLHEP::Hep3Vector(0., 0., target->_conveyorBallRadius);
+    }
     return target;
   }
 

--- a/JobConfig/common/geom_mu2ei.txt
+++ b/JobConfig/common/geom_mu2ei.txt
@@ -1,4 +1,4 @@
-#include "JobConfig/common/geom_mu2eii.txt"
+#include "Mu2eG4/geom/geom_2019_PhaseI_hayman_v2.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/JobConfig/common/geom_mu2eii.txt
+++ b/JobConfig/common/geom_mu2eii.txt
@@ -1,0 +1,6 @@
+#include "Mu2eG4/geom/geom_common_current.txt"
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/JobConfig/validation/stoppedMuonsSingleStage_Mu2eI.fcl
+++ b/JobConfig/validation/stoppedMuonsSingleStage_Mu2eI.fcl
@@ -3,6 +3,6 @@
 // JobConfig/beam/beam_nts3tgtstops.fcl on the output to get an ntuple.
 //
 #include "JobConfig/validation/stoppedMuonsSingleStage.fcl"
-physics.producers.generate.mu2eii : true
-services.GeometryService.inputFile : "JobConfig/common/geom_mu2eii.txt"
-services.GlobalConstantsService.inputFile : "Mu2eG4/test/globalConstants_mu2eii.txt"
+physics.producers.generate.mu2eii : false
+services.GeometryService.inputFile : "JobConfig/common/geom_mu2ei.txt"
+services.GlobalConstantsService.inputFile : "Mu2eG4/test/globalConstants_mu2ei.txt"

--- a/JobConfig/validation/stoppedMuonsSingleStage_Mu2eII.fcl
+++ b/JobConfig/validation/stoppedMuonsSingleStage_Mu2eII.fcl
@@ -1,0 +1,8 @@
+// This job starts with protons on target and writes stopped muons
+// into a framework format output file. Run 
+// JobConfig/beam/beam_nts3tgtstops.fcl on the output to get an ntuple.
+//
+#include "JobConfig/validation/stoppedMuonsSingleStage.fcl"
+physics.producers.generate.mu2eii : true
+services.GeometryService.inputFile : "JobConfig/common/geom_mu2eii.txt"
+services.GlobalConstantsService.inputFile : "Mu2eG4/test/globalConstants_mu2eii.txt"

--- a/Mu2eG4/geom/geom_common.txt
+++ b/Mu2eG4/geom/geom_common.txt
@@ -3,7 +3,7 @@
 // The file that is included will be time dependent.
 //
 
-#include "Mu2eG4/geom/geom_common_hayman_v2.txt"
+#include "Mu2eG4/geom/geom_2020_Mu2eII.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/geom_common.txt
+++ b/Mu2eG4/geom/geom_common.txt
@@ -3,7 +3,7 @@
 // The file that is included will be time dependent.
 //
 
-#include "Mu2eG4/geom/geom_2020_Mu2eII.txt"
+#include "Mu2eG4/geom/geom_Mu2eII_2020.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/test/globalConstants_01.txt
+++ b/Mu2eG4/test/globalConstants_01.txt
@@ -99,6 +99,9 @@ vector<double> physicsParams.shankerFcoefficients =
     -6.7013, 1.9329, -0.165584, 5.41126e-3
   };
 
+//Mu2eII_SM21 Specific configuration
+//WARNING do not merge into master!
+#include "Mu2eG4/test/globalConstants_mu2eii.txt"
 // This tells emacs to view this file in c++ mode.
 // Local Variables:
 // mode:c++

--- a/Mu2eG4/test/globalConstants_mu2ei.txt
+++ b/Mu2eG4/test/globalConstants_mu2ei.txt
@@ -1,0 +1,11 @@
+// Changes back the global constants for Mu2e-I specific running
+
+#include "Mu2eG4/test/globalConstants_01.txt"
+
+// Proton Kinetic Energy
+double physicsParams.protonKE = 8000.; // - in MeV
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/test/globalConstants_mu2eii.txt
+++ b/Mu2eG4/test/globalConstants_mu2eii.txt
@@ -1,0 +1,3 @@
+#include "Mu2eG4/test/globalConstants_01.txt"
+// Proton Kinetic Energy
+double physicsParams.protonKE = 800.; // - in MeV

--- a/Mu2eG4/test/globalConstants_mu2eii.txt
+++ b/Mu2eG4/test/globalConstants_mu2eii.txt
@@ -1,3 +1,9 @@
-#include "Mu2eG4/test/globalConstants_01.txt"
+// Changes to the global constants for Mu2e-II specific running
+
 // Proton Kinetic Energy
 double physicsParams.protonKE = 800.; // - in MeV
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/ProductionTargetGeom/inc/ProductionTargetMu2eII.hh
+++ b/ProductionTargetGeom/inc/ProductionTargetMu2eII.hh
@@ -38,6 +38,8 @@ namespace mu2e {
     // in mu2e coordinates
     const CLHEP::Hep3Vector& position() const { return _prodTargetPosition; }
 
+    const CLHEP::Hep3Vector& front() const { return _prodTargetFrontPosition; }
+
     // this is used to transorm particle momentum and position from
     // the PrimaryProtonGun frame to the Mu2e frame
     const CLHEP::HepRotation& protonBeamRotation() const { return _protonBeamRotation; }
@@ -83,6 +85,7 @@ namespace mu2e {
 
 
     CLHEP::Hep3Vector _prodTargetPosition;
+    CLHEP::Hep3Vector _prodTargetFrontPosition;
 
     std::string _type;
     int    _version;


### PR DESCRIPTION
Mu2eII_SM21:
Updating the primary proton gun implementation to work with Mu2e-II era targets.
Also added a few Mu2e-II specific configuration files.

Before this update, using the primary proton gun leads to an exception due to GeomHandle\<ProductionTarget\> not existing:
```
%MSG-s ArtException:  PostEndJob 19-Sep-2020 10:37:58 CDT ModuleEndJob
---- EventProcessorFailure BEGIN
  EventProcessor: an exception occurred during current event processing
  ---- ScheduleExecutionFailure BEGIN
    Path: ProcessingStopped.
    ---- GEOM BEGIN
      Failed to retrieve detector element of type N4mu2e16ProductionTargetE
      The above exception was thrown while processing module PrimaryProtonGun/generate run: 1
    ---- GEOM END
    Exception going through path trigmubeam
  ---- ScheduleExecutionFailure END
---- EventProcessorFailure END
%MSG
```

Validation run:
Compiles
JobConfig/validation/stoppedMuonsSingleStage.fcl runs (uses Mu2e era geometry and proton energy)
JobConfig/validation/stoppedMuonsSingleStage_Mu2eII.fcl runs (uses Conveyor Mu2e-II era target and proton energy)