### PR TITLE
Changed geometry file to geom_common_current.txt

### DIFF
--- a/Mu2eG4/test/geom_SurfaceCheck.txt
+++ b/Mu2eG4/test/geom_SurfaceCheck.txt
@@ -3,7 +3,7 @@
 //
 //
 
-#include "Mu2eG4/geom/geom_common.txt"
+#include "Mu2eG4/geom/geom_common_current.txt"
 
 bool g4.doSurfaceCheck    = true;
 


### PR DESCRIPTION
The standard overlap check fcl file was using geom_common.txt.  The nightly job had code to swap this to geom_common_current.txt.  After discussion with Ray, Krzysztof and Ryun, we decided to change the fcl file to use geom_common_current.txt  .  This will also be used by the overlap check in the CI tests.  