### PR TITLE
Added back in tracker digitization deadtime, adjusted to 400 ns

### DIFF
--- a/TrackerConditions/fcl/prolog.fcl
+++ b/TrackerConditions/fcl/prolog.fcl
@@ -93,7 +93,7 @@ StrawElectronics : {
    defaultAdcdVdI : 1.528e6
    adcdVdI : []
    deadTimeAnalog : 100.0
-   deadTimeDigital : 100.0
+   deadTimeDigital : 400.0
    saturationVoltage : 140.0
    defaultDiscriminatorThreshold : 12.0
    discriminatorThreshold : []


### PR DESCRIPTION
Current sims only include TDC deadtime and not the time required to fully digitize a tracker hit. This adds back in the digital deadtime of 400 ns, which causes an approximately 3% loss of hits for CeEndpointMix (both signal and background hits), and an approximately 3% loss of efficiency for signal tracks in the same sample.