### PR TITLE
Corsika campaign

### DIFF
--- a/CampaignConfig/corsika.cfg
+++ b/CampaignConfig/corsika.cfg
@@ -20,13 +20,19 @@ streamname = only
 fcl_list = override_me
 stage_name = override_me
 project_name = corsika_dsstop
-tardir = /pnfs/mu2e/resilient/users/%(account)/gridexport/tmp.J0XFFWlueU/
-date = 20200420
-release = Offline
+tardir = dropbox:///pnfs/mu2e/persistent/users/srsoleti/gridScripts.tar.bz
+date = 20200916v2
+release = v09_09_00
+output_dataset = override_me
+artRoot_dataset = override_me
+histRoot_dataset = override_me
 
 [env_pass]
 IFDH_DEBUG = 1
 SAM_EXPERIMENT = %(experiment)s
+OUTPUT_DATASET = %(output_dataset)s
+ARTROOT_DATASET = %(artRoot_dataset)s
+HISTROOT_DATASET = %(histRoot_dataset)s
 
 [submit]
 debug = True
@@ -39,25 +45,26 @@ e_3 = POMS4_CAMPAIGN_STAGE_NAME
 resource-provides = usage_model=DEDICATED,OPPORTUNISTIC
 generate-email-summary = True
 expected-lifetime = 23h
-OS = SL7
 memory = 2000MB
 email-to = %(account)s@fnal.gov
-tar_file_name = %(tardir)s/Code.tar.bz
-
+tar_file_name = dropbox:///mu2e/app/users/srsoleti/gridScripts.tar.bz
+use-cvmfs-dropbox = True
+l = '+SingularityImage=\"/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest\"'
+append_condor_requirements='(TARGET.HAS_SINGULARITY=?=true)'
 
 [job_setup]
 debug = True
 find_setups = False
 source_1 = /cvmfs/%(experiment)s.opensciencegrid.org/setup%(experiment)s-art.sh
-source_2 = ${_CONDOR_JOB_IWD}/Code/Offline/setup.sh
+source_2 = /cvmfs/mu2e.opensciencegrid.org/Offline/v09_09_00/SLF7/prof/Offline/setup.sh
 setup_1 = mu2egrid
 setup_2 = dhtools
-setup_3 = ifdh_art v2_10_00 -q e19:prof
+setup_3 = ifdh_art v2_11_03 -q e19:prof
 setup_4 = mu2etools
 setup_5 = mu2efiletools
 setup_6 = corsika
-prescript_1 = LD_LIBRARY_PATH=${_CONDOR_JOB_IWD}/Code/Offline/vendor_perl/lib64/Digest/SHA:$LD_LIBRARY_PATH
-prescript_2 = PERL5LIB=${_CONDOR_JOB_IWD}/Code/Offline/vendor_perl/:$PERL5LIB
+prescript_1 = LD_LIBRARY_PATH=${CONDOR_DIR_INPUT}/gridScripts/vendor_perl/lib64/Digest/SHA:$LD_LIBRARY_PATH
+prescript_2 = PERL5LIB=${CONDOR_DIR_INPUT}/gridScripts/vendor_perl/:$PERL5LIB
 ifdh_art = True
 
 [sam_consumer]
@@ -70,21 +77,15 @@ appname = test
 [job_output]
 addoutput = *.art
 # rename = unique
+dataset_exclude = *truncated*
 dest = %(outdir)s
 declare_metadata = True
 metadata_extractor = jsonMaker -x -f usr-sim
 add_location = True
-filter_metadata = checksum
+filter_metadata = checksum,parents
 # filter_metadata = data_stream,file_format,art.first_event,art.last_event,art.process_name,art.file_format_version,art.file_format_era,checksum
 add_metadata = file_format=art
 hash = 2
-
-[job_output_2]
-addoutput = %(treename)s*.root
-# rename = unique
-dest = %(outdir)s
-hash = 2
-declare_metadata = False
 
 [job_output_1]
 addoutput = *.fcl
@@ -93,215 +94,265 @@ dest = %(outdir)s
 declare_metadata = True
 metadata_extractor = json
 add_location = True
-filter_metadata = checksum
-# filter_metadata = data_stream,file_format,art.first_event,art.last_event,art.process_name,art.file_format_version,art.file_format_era,checksum
+filter_metadata = checksum,parents
+;filter_metadata = data_stream,file_format,art.first_event,art.last_event,art.process_name,art.file_format_version,art.file_format_era,checksum
 add_metadata = file_format=fcl
 hash = 2
 
+[job_output_2]
+addoutput = *.tbz
+dest = %(outdir)s
+declare_metadata = True
+metadata_extractor = jsonMaker -x -f usr-etc
+add_location = True
+filter_metadata = checksum,parents
+add_metadata = file_format=tbz
+hash = 2
+
+[job_output_3]
+addoutput = *truncated*.art
+dest = %(outdir)s
+declare_metadata = True
+metadata_extractor = jsonMaker -x -f usr-sim
+add_location = True
+filter_metadata = checksum,parents
+add_metadata = file_format=art
+hash = 2
+
 [stage_gen_fcl]
-job_output_1.add_to_dataset = _poms_analysis
-job_output_1.filter_metadata = checksum,parents
-job_setup.prescript_3 = printf '#include "JobConfig/cosmic/cosmic_s1_dsstops_corsika.fcl"\n' > template.fcl
-job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/fileNamesGenerator.sh 2000 %(account) > filenames.txt
-job_setup.prescript_5 = generate_fcl --description=corsika_dsstops --dsconf=%(date)s --inputs=filenames.txt --merge-factor=1 --embed template.fcl
-job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
-job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
-job_setup.prescript_8 = mv 000/* .
-job_setup.prescript_9 = rm template.fcl
+job_output_1.add_to_dataset = cnf.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/fileNamesGenerator.sh 20 %(account)s > filenames.txt
+executable.name = generate_fcl
+executable.arg_1 = --description=cosmic_s1_dsstops_corsika
+executable.arg_2 = --dsconf=%(date)s
+executable.arg_3 = --inputs=filenames.txt
+executable.arg_4 = --merge-factor=1
+executable.arg_5 = --embed
+executable.arg_6 = JobConfig/cosmic/cosmic_s1_dsstops_corsika.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
+job_setup.postscript_3 = mv */*.fcl .
 job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_s1_fcl_%(date)s
-executable.name = true
 
 [stage_gen]
-# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
-# and followup with it to propagate it as input of next stage
-job_output.add_to_dataset = _poms_analysis
-job_output.dataset_exclude = *truncated*
-job_output_2.add_to_dataset = %(account)_gen_root_test
+job_output.add_to_dataset = sim.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.art
+job_output_2.add_to_dataset = bck.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.tbz
+job_output_3.add_to_dataset = sim.%(account)s.cosmic_s1_dsstops_corsika_truncated.%(date)s.art
+
+global.artRoot_dataset = sim.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.art,sim.%(account)s.cosmic_s1_dsstops_corsika_truncated.%(date)s.art
+global.output_dataset = bck.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_s1_%(date)s
+
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = %(dataset)s
-executable.name = \\\\\${_CONDOR_JOB_IWD}/Code/Offline/getFilename.sh
-job_setup.postscript = CORSIKA_EXE=`which corsika77100Linux_QGSJET_fluka`
+submit.dataset = cnf.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.fcl
+executable.name = \\\\\${CONDOR_DIR_INPUT}/gridScripts/getFilename.sh
+
+job_setup.postscript = CORSIKA_EXE=`which corsika77400Linux_QGSJET_fluka`
 job_setup.postscript_2 = DATDIR=`dirname $CORSIKA_EXE`
-job_setup.postscript_3 = sed -e "s:_DATDIR_:$DATDIR/:" -e "s:_DIRECT_:`pwd`/:" -e "s:_SEED1_:`cat seed.txt`:" -e "s:_SEED2_:`cat seed.txt`:" -e "s:_NSHOW_:2000000:" ${_CONDOR_JOB_IWD}/Code/Offline/corsika_input_nolongi_TEMPLATE > corsika_conf.txt
+job_setup.postscript_3 = sed -e "s:_DATDIR_:$DATDIR/:" -e "s:_DIRECT_:`pwd`/:" -e "s:_SEED1_:`cat seed.txt`:" -e "s:_SEED2_:`cat seed.txt`:" -e "s:_NSHOW_:5000:" ${CONDOR_DIR_INPUT}/gridScripts/corsika_input_nolongi_TEMPLATE > corsika_conf.txt
 job_setup.postscript_4 = cat corsika_conf.txt
-job_setup.postscript_5 = corsika77100Linux_QGSJET_fluka < corsika_conf.txt > corsika_log.txt
+job_setup.postscript_5 = corsika77400Linux_QGSJET_fluka < corsika_conf.txt > corsika_log.txt
 job_setup.postscript_6 = mv DAT* `cat filename.txt`
-job_setup.postscript_7 = mu2e -c torun.fcl --sam-data-tier=Output:sim
-job_setup.postscript_8 = rm torun.fcl
+job_setup.postscript_7 = ${CONDOR_DIR_INPUT}/gridScripts/loggedMu2e.sh --sam-data-tier=Output:sim -c `cat torun.txt`
+job_setup.postscript_8 = rm seed.txt
+job_setup.postscript_9 = rm filename.txt
+job_setup.postscript_10 = rm torun.txt
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_resampler_hi_fcl]
-job_output_1.add_to_dataset = _poms_analysis
-job_setup.prescript_3 = printf '#include "JobConfig/cosmic/dsstops_resampler_hi.fcl"\n' >> template.fcl
-job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
-job_setup.prescript_5 = generate_fcl --description=corsika_resampler_hi --dsconf=%(date)s --aux=1:physics.filters.dsResample.fileNames:inputs.txt --run-number=1 --events-per-job=200000 -njobs=2000 --embed template.fcl
-job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
-job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
-job_setup.prescript_8 = mv 000/* .
-job_setup.prescript_9 = rm template.fcl
+job_output_1.add_to_dataset = cnf.%(account)s.corsika_dsstops_resampler_hi.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.art > inputs.txt
+executable.name = generate_fcl
+executable.arg_1 = --description=dsstops_resampler_hi_corsika
+executable.arg_2 = --dsconf=%(date)s
+executable.arg_3 = --aux=1:physics.filters.dsResample.fileNames:inputs.txt
+executable.arg_4 = --run-number=1
+executable.arg_5 = --events-per-job=500000
+executable.arg_6 = --njobs=1000
+executable.arg_7 = --embed
+executable.arg_8 = JobConfig/cosmic/dsstops_resampler_hi.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
+job_setup.postscript_3 = mv */*.fcl .
 job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_hi_fcl_%(date)s
-executable.name = true
 
 [stage_resampler_hi]
-# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
-# and followup with it to propagate it as input of next stage
-job_output.add_to_dataset = _poms_analysis
-job_output.dataset_exclude = *truncated*
-job_output_2.add_to_dataset = %(account)_resampler_hi_root
+job_output.add_to_dataset = sim.%(account)s.corsika_dsstops_resampler_hi.%(date)s.art
+job_output_2.add_to_dataset = bck.%(account)s.corsika_dsstops_resampler_hi.%(date)s.tbz
+job_output_3.add_to_dataset = sim.%(account)s.corsika_dsstops_resampler_hi_truncated.%(date)s.art
+
+global.artRoot_dataset = sim.%(account)s.corsika_dsstops_resampler_hi.%(date)s.art,sim.%(account)s.corsika_dsstops_resampler_hi_truncated.%(date)s.art
+global.output_dataset = bck.%(account)s.corsika_dsstops_resampler_hi.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_hi_%(date)s
+
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = %(dataset)s
+submit.dataset = cnf.%(account)s.corsika_dsstops_resampler_hi.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:sim
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_digi_hi_fcl]
-job_output_1.add_to_dataset = _poms_analysis
-job_setup.prescript_3 = printf '#include "JobConfig/primary/CORSIKA-offspill.fcl"\n' >> template.fcl
-job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
-job_setup.prescript_5 = generate_fcl --desc=corsika_digi_hi --dsconf=%(date)s --inputs=inputs.txt --merge=10 --embed template.fcl
-job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
-job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
-job_setup.prescript_8 = mv 000/* .
-job_setup.prescript_9 = rm template.fcl
+job_output_1.add_to_dataset = cnf.%(account)s.corsika_digi_hi.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.corsika_dsstops_resampler_hi.%(date)s.art > inputs.txt
+executable.name = generate_fcl
+executable.arg_1 = --desc=corsika_digi_hi
+executable.arg_2 = --dsconf=%(date)s
+executable.arg_3 = --inputs=inputs.txt
+executable.arg_4 = --merge=10
+executable.arg_5 = --embed
+executable.arg_6 = JobConfig/primary/CRY-offspill.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
+job_setup.postscript_3 = sed -i "s/CRY-cosmic-general/CORSIKA-hi/g" */*.fcl
+job_setup.postscript_4 = mv */*.fcl .
 job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_hi_fcl_%(date)s
-executable.name = true
 
 [stage_digi_hi]
-# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
-# and followup with it to propagate it as input of next stage
-job_output.add_to_dataset = _poms_analysis
-job_output.dataset_exclude = *truncated*
-job_output_2.add_to_dataset = %(account)_digi_hi_root
+job_output.add_to_dataset = dig.%(account)s.corsika_digi_hi.%(date)s.art
+job_output_2.add_to_dataset = bck.%(account)s.corsika_digi_hi.%(date)s.tbz
+global.artRoot_dataset = dig.%(account)s.corsika_digi_hi.%(date)s.art
+global.output_dataset = bck.%(account)s.corsika_digi_hi.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_hi_%(date)s
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = %(dataset)s
+submit.dataset = cnf.%(account)s.corsika_digi_hi.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:dig
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_reco_hi_fcl]
-job_output_1.add_to_dataset = _poms_analysis
-job_setup.prescript_3 = printf '#include "JobConfig/reco/CORSIKA-cosmic-general-mix.fcl"\n' >> template.fcl
-job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
-job_setup.prescript_5 = generate_fcl --desc=corsika_reco_hi --dsconf=%(date)s --inputs=inputs.txt --merge=10 --embed template.fcl
-job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
-job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
-job_setup.prescript_8 = mv 000/* .
-job_setup.prescript_9 = rm template.fcl
+job_output_1.add_to_dataset = cnf.%(account)s.corsika_reco_hi.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh dig.%(account)s.corsika_digi_hi.%(date)s.art > inputs.txt
+executable.name = generate_fcl
+executable.arg_1 = --desc=corsika_reco_hi
+executable.arg_2 = --dsconf=%(date)s
+executable.arg_3 = --inputs=inputs.txt
+executable.arg_4 = --merge=10
+executable.arg_5 = --embed
+executable.arg_6 = JobConfig/reco/CRY-cosmic-general-mix.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
+job_setup.postscript_3 = sed -i "s/CRY-cosmic-general-mix/CORSIKA-reco-hi/g" */*.fcl
+job_setup.postscript_4 = mv */*.fcl .
 job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_hi_fcl_%(date)s
-executable.name = true
 
 [stage_reco_hi]
-# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
-# and followup with it to propagate it as input of next stage
-job_output.add_to_dataset = _poms_analysis
-job_output.dataset_exclude = *truncated*
-job_output_2.add_to_dataset = %(account)_reco_hi_root
+job_output.add_to_dataset = mcs.%(account)s.corsika_reco_hi.%(date)s.art
+job_output_2.add_to_dataset = bck.%(account)s.corsika_reco_hi.%(date)s.tbz
+global.artRoot_dataset = mcs.%(account)s.corsika_reco_hi.%(date)s.art
+global.output_dataset = bck.%(account)s.corsika_reco_hi.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_hi_%(date)s
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = %(dataset)s
+submit.dataset = cnf.%(account)s.corsika_reco_hi.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:mcs
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_resampler_lo_fcl]
-job_output_1.add_to_dataset = _poms_analysis
-job_setup.prescript_3 = printf '#include "JobConfig/cosmic/dsstops_resampler_lo.fcl"\n' >> template.fcl
-job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
-job_setup.prescript_5 = generate_fcl --description=corsika_resampler_lo --dsconf=%(date)s --aux=1:physics.filters.dsResample.fileNames:inputs.txt --run-number=1 --events-per-job=200000 -njobs=2000 --embed template.fcl
-job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
-job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
-job_setup.prescript_8 = mv 000/* .
-job_setup.prescript_9 = rm template.fcl
+job_output_1.add_to_dataset = cnf.%(account)s.corsika_dsstops_resampler_lo.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.art > inputs.txt
+executable.name = generate_fcl
+executable.arg_1 = --description=dsstops_resampler_lo_corsika
+executable.arg_2 = --dsconf=%(date)s
+executable.arg_3 = --aux=1:physics.filters.dsResample.fileNames:inputs.txt
+executable.arg_4 = --run-number=1
+executable.arg_5 = --events-per-job=500000
+executable.arg_6 = --njobs=1000
+executable.arg_7 = --embed
+executable.arg_8 = JobConfig/cosmic/dsstops_resampler_lo.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
+job_setup.postscript_3 = mv */*.fcl .
 job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_lo_fcl_%(date)s
-executable.name = true
 
 [stage_resampler_lo]
-# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
-# and followup with it to propagate it as input of next stage
-job_output.add_to_dataset = _poms_analysis
-job_output.dataset_exclude = *truncated*
-job_output_2.add_to_dataset = %(account)_resampler_lo_root
+job_output.add_to_dataset = sim.%(account)s.corsika_dsstops_resampler_lo.%(date)s.art
+job_output_2.add_to_dataset = bck.%(account)s.corsika_dsstops_resampler_lo.%(date)s.tbz
+global.artRoot_dataset = sim.%(account)s.corsika_dsstops_resampler_lo.%(date)s.art
+global.output_dataset = bck.%(account)s.corsika_dsstops_resampler_lo.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_lo_%(date)s
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = %(dataset)s
+submit.dataset = cnf.%(account)s.corsika_dsstops_resampler_lo.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:sim
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_digi_lo_fcl]
-job_output_1.add_to_dataset = _poms_analysis
-job_setup.prescript_3 = printf '#include "JobConfig/primary/CORSIKA-offspill.fcl"\n' >> template.fcl
-job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
-job_setup.prescript_5 = generate_fcl --desc=corsika_digi_lo --dsconf=%(date)s --inputs=inputs.txt --merge=10 --embed template.fcl
-job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
-job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
-job_setup.prescript_8 = mv 000/* .
-job_setup.prescript_9 = rm template.fcl
+job_output_1.add_to_dataset = cnf.%(account)s.corsika_digi_lo.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.corsika_dsstops_resampler_lo.%(date)s.art > inputs.txt
+executable.name = generate_fcl
+executable.arg_1 = --desc=corsika_digi_lo
+executable.arg_2 = --dsconf=%(date)s
+executable.arg_3 = --inputs=inputs.txt
+executable.arg_4 = --merge=20
+executable.arg_5 = --embed
+executable.arg_6 = JobConfig/primary/CRY-offspill.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
+job_setup.postscript_3 = sed -i "s/CRY-cosmic-general/CORSIKA-lo/g" */*.fcl
+job_setup.postscript_4 = mv */*.fcl .
 job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_lo_fcl_%(date)s
-executable.name = true
 
 [stage_digi_lo]
-# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
-# and followup with it to propagate it as input of next stage
-job_output.add_to_dataset = _poms_analysis
-job_output.dataset_exclude = *truncated*
-job_output_2.add_to_dataset = %(account)_digi_lo_root
+job_output.add_to_dataset = dig.%(account)s.corsika_digi_lo.%(date)s.art
+job_output_2.add_to_dataset = bck.%(account)s.corsika_digi_lo.%(date)s.tbz
+global.artRoot_dataset = dig.%(account)s.corsika_digi_lo.%(date)s.art
+global.output_dataset = bck.%(account)s.corsika_digi_lo.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_lo_%(date)s
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = %(dataset)s
+submit.dataset = cnf.%(account)s.corsika_digi_lo.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:dig
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_reco_lo_fcl]
-job_output_1.add_to_dataset = _poms_analysis
-job_setup.prescript_3 = printf '#include "JobConfig/reco/CORSIKA-cosmic-general-mix.fcl"\n' >> template.fcl
-job_setup.prescript_4 = ${_CONDOR_JOB_IWD}/Code/Offline/listFiles.sh %(dataset)s > inputs.txt
-job_setup.prescript_5 = generate_fcl --desc=corsika_reco_lo --dsconf=%(date)s --inputs=inputs.txt --merge=10 --embed template.fcl
-job_setup.prescript_6 = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" 000/*.fcl
-job_setup.prescript_7 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" 000/*.fcl
-job_setup.prescript_8 = mv 000/* .
-job_setup.prescript_9 = rm template.fcl
+job_output_1.add_to_dataset = cnf.%(account)s.corsika_reco_lo.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh dig.%(account)s.corsika_digi_lo.%(date)s.art > inputs.txt
+executable.name = generate_fcl
+executable.arg_1 = --desc=corsika_reco_lo
+executable.arg_2 = --dsconf=%(date)s
+executable.arg_3 = --inputs=inputs.txt
+executable.arg_4 = --merge=20
+executable.arg_5 = --embed
+executable.arg_6 = JobConfig/reco/CRY-cosmic-general-mix.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
+job_setup.postscript_3 = sed -i "s/CRY-cosmic-general-mix/CORSIKA-reco-lo/g" */*.fcl
+job_setup.postscript_4 = mv */*.fcl .
 job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_lo_fcl_%(date)s
-executable.name = true
 
 [stage_reco_lo]
-# _poms_analysis is a keyword for POMS to instruct it to make its own dataset
-# and followup with it to propagate it as input of next stage
-job_output.add_to_dataset = _poms_analysis
-job_output.dataset_exclude = *truncated*
-job_output_2.add_to_dataset = %(account)_reco_lo_root
+job_output.add_to_dataset = mcs.%(account)s.corsika_reco_lo.%(date)s.art
+job_output_2.add_to_dataset = bck.%(account)s.corsika_reco_lo.%(date)s.tbz
+global.artRoot_dataset = mcs.%(account)s.corsika_reco_lo.%(date)s.art
+global.output_dataset = bck.%(account)s.corsika_reco_lo.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_lo_%(date)s
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = %(dataset)s
+submit.dataset =  cnf.%(account)s.corsika_reco_lo.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:mcs
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [executable]
-name = mu2e
+name = \\\\\${CONDOR_DIR_INPUT}/gridScripts/loggedMu2e.sh

--- a/CampaignConfig/corsika.cfg
+++ b/CampaignConfig/corsika.cfg
@@ -2,7 +2,7 @@
 group = mu2e
 experiment = mu2e
 wrapper = file:///${FIFE_UTILS_DIR}/libexec/fife_wrap
-account = srsoleti
+account = mu2epro
 file_type = mc
 run_type = physics
 b_name = %(project_name)s
@@ -13,15 +13,13 @@ fcl = override_me
 numevents = override_me
 numjobs = override_me
 startevent = 1
-description = corsika_dsstop
 outdir = override_me
 logdir = override_me
 streamname = only
 fcl_list = override_me
 stage_name = override_me
 project_name = corsika_dsstop
-tardir = dropbox:///pnfs/mu2e/persistent/users/srsoleti/gridScripts.tar.bz
-date = 20200916v2
+date = 20201006
 release = v09_09_00
 output_dataset = override_me
 artRoot_dataset = override_me
@@ -45,8 +43,8 @@ e_3 = POMS4_CAMPAIGN_STAGE_NAME
 resource-provides = usage_model=DEDICATED,OPPORTUNISTIC
 generate-email-summary = True
 expected-lifetime = 23h
-memory = 2000MB
-email-to = %(account)s@fnal.gov
+memory = 4000MB
+email-to = srsoleti@fnal.gov
 tar_file_name = dropbox:///mu2e/app/users/srsoleti/gridScripts.tar.bz
 use-cvmfs-dropbox = True
 l = '+SingularityImage=\"/cvmfs/singularity.opensciencegrid.org/fermilab/fnal-wn-sl7:latest\"'
@@ -59,7 +57,7 @@ source_1 = /cvmfs/%(experiment)s.opensciencegrid.org/setup%(experiment)s-art.sh
 source_2 = /cvmfs/mu2e.opensciencegrid.org/Offline/v09_09_00/SLF7/prof/Offline/setup.sh
 setup_1 = mu2egrid
 setup_2 = dhtools
-setup_3 = ifdh_art v2_11_03 -q e19:prof
+setup_3 = ifdh_art v2_11_03 -q +e19:+prof
 setup_4 = mu2etools
 setup_5 = mu2efiletools
 setup_6 = corsika
@@ -120,8 +118,8 @@ add_metadata = file_format=art
 hash = 2
 
 [stage_gen_fcl]
-job_output_1.add_to_dataset = cnf.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.fcl
-job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/fileNamesGenerator.sh 20 %(account)s > filenames.txt
+job_output_1.add_to_dataset = cnf.%(experiment)s.cosmic_s1_dsstops_corsika.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/fileNamesGenerator.sh 20 %(experiment)s > filenames.txt
 executable.name = generate_fcl
 executable.arg_1 = --description=cosmic_s1_dsstops_corsika
 executable.arg_2 = --dsconf=%(date)s
@@ -129,30 +127,30 @@ executable.arg_3 = --inputs=filenames.txt
 executable.arg_4 = --merge-factor=1
 executable.arg_5 = --embed
 executable.arg_6 = JobConfig/cosmic/cosmic_s1_dsstops_corsika.fcl
-job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(experiment)s/g" */*.fcl
 job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
 job_setup.postscript_3 = mv */*.fcl .
 job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_s1_fcl_%(date)s
 
 [stage_gen]
-job_output.add_to_dataset = sim.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.art
-job_output_2.add_to_dataset = bck.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.tbz
-job_output_3.add_to_dataset = sim.%(account)s.cosmic_s1_dsstops_corsika_truncated.%(date)s.art
+job_output.add_to_dataset = sim.%(experiment)s.cosmic_s1_dsstops_corsika.%(date)s.art
+job_output_2.add_to_dataset = bck.%(experiment)s.cosmic_s1_dsstops_corsika.%(date)s.tbz
+job_output_3.add_to_dataset = sim.%(experiment)s.cosmic_s1_dsstops_corsika_truncated.%(date)s.art
 
-global.artRoot_dataset = sim.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.art,sim.%(account)s.cosmic_s1_dsstops_corsika_truncated.%(date)s.art
-global.output_dataset = bck.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.tbz
+global.artRoot_dataset = sim.%(experiment)s.cosmic_s1_dsstops_corsika.%(date)s.art,sim.%(experiment)s.cosmic_s1_dsstops_corsika_truncated.%(date)s.art
+global.output_dataset = bck.%(experiment)s.cosmic_s1_dsstops_corsika.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_s1_%(date)s
 
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = cnf.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.fcl
+submit.dataset = cnf.%(experiment)s.cosmic_s1_dsstops_corsika.%(date)s.fcl
 executable.name = \\\\\${CONDOR_DIR_INPUT}/gridScripts/getFilename.sh
 
 job_setup.postscript = CORSIKA_EXE=`which corsika77400Linux_QGSJET_fluka`
 job_setup.postscript_2 = DATDIR=`dirname $CORSIKA_EXE`
-job_setup.postscript_3 = sed -e "s:_DATDIR_:$DATDIR/:" -e "s:_DIRECT_:`pwd`/:" -e "s:_SEED1_:`cat seed.txt`:" -e "s:_SEED2_:`cat seed.txt`:" -e "s:_NSHOW_:5000:" ${CONDOR_DIR_INPUT}/gridScripts/corsika_input_nolongi_TEMPLATE > corsika_conf.txt
+job_setup.postscript_3 = sed -e "s:_DATDIR_:$DATDIR/:" -e "s:_DIRECT_:`pwd`/:" -e "s:_SEED1_:`cat seed.txt`:" -e "s:_SEED2_:`cat seed.txt`:" -e "s:_NSHOW_:3000000:" ${CONDOR_DIR_INPUT}/gridScripts/corsika_input_nolongi_TEMPLATE > corsika_conf.txt
 job_setup.postscript_4 = cat corsika_conf.txt
 job_setup.postscript_5 = corsika77400Linux_QGSJET_fluka < corsika_conf.txt > corsika_log.txt
 job_setup.postscript_6 = mv DAT* `cat filename.txt`
@@ -164,43 +162,44 @@ job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_resampler_hi_fcl]
-job_output_1.add_to_dataset = cnf.%(account)s.corsika_dsstops_resampler_hi.%(date)s.fcl
-job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.art > inputs.txt
+job_output_1.add_to_dataset = cnf.%(experiment)s.corsika_dsstops_resampler_hi.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(experiment)s.cosmic_s1_dsstops_corsika.%(date)s.art > inputs.txt
 executable.name = generate_fcl
 executable.arg_1 = --description=dsstops_resampler_hi_corsika
 executable.arg_2 = --dsconf=%(date)s
 executable.arg_3 = --aux=1:physics.filters.dsResample.fileNames:inputs.txt
 executable.arg_4 = --run-number=1
-executable.arg_5 = --events-per-job=500000
-executable.arg_6 = --njobs=1000
+executable.arg_5 = --events-per-job=300000
+executable.arg_6 = --njobs=100
 executable.arg_7 = --embed
 executable.arg_8 = JobConfig/cosmic/dsstops_resampler_hi.fcl
-job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(experiment)s/g" */*.fcl
 job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
-job_setup.postscript_3 = mv */*.fcl .
+job_setup.postscript_3 = sed -i "s/s2-dsstops-resampler/s2-corsika-dsstops-resampler-hi/g" */*.fcl
+job_setup.postscript_4 = mv */*.fcl .
 job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_hi_fcl_%(date)s
 
 [stage_resampler_hi]
-job_output.add_to_dataset = sim.%(account)s.corsika_dsstops_resampler_hi.%(date)s.art
-job_output_2.add_to_dataset = bck.%(account)s.corsika_dsstops_resampler_hi.%(date)s.tbz
-job_output_3.add_to_dataset = sim.%(account)s.corsika_dsstops_resampler_hi_truncated.%(date)s.art
+job_output.add_to_dataset = sim.%(experiment)s.corsika_dsstops_resampler_hi.%(date)s.art
+job_output_2.add_to_dataset = bck.%(experiment)s.corsika_dsstops_resampler_hi.%(date)s.tbz
+job_output_3.add_to_dataset = sim.%(experiment)s.corsika_dsstops_resampler_hi_truncated.%(date)s.art
 
-global.artRoot_dataset = sim.%(account)s.corsika_dsstops_resampler_hi.%(date)s.art,sim.%(account)s.corsika_dsstops_resampler_hi_truncated.%(date)s.art
-global.output_dataset = bck.%(account)s.corsika_dsstops_resampler_hi.%(date)s.tbz
+global.artRoot_dataset = sim.%(experiment)s.corsika_dsstops_resampler_hi.%(date)s.art,sim.%(experiment)s.corsika_dsstops_resampler_hi_truncated.%(date)s.art
+global.output_dataset = bck.%(experiment)s.corsika_dsstops_resampler_hi.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_hi_%(date)s
 
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = cnf.%(account)s.corsika_dsstops_resampler_hi.%(date)s.fcl
+submit.dataset = cnf.%(experiment)s.corsika_dsstops_resampler_hi.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:sim
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_digi_hi_fcl]
-job_output_1.add_to_dataset = cnf.%(account)s.corsika_digi_hi.%(date)s.fcl
-job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.corsika_dsstops_resampler_hi.%(date)s.art > inputs.txt
+job_output_1.add_to_dataset = cnf.%(experiment)s.corsika_digi_hi.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(experiment)s.corsika_dsstops_resampler_hi.%(date)s.art > inputs.txt
 executable.name = generate_fcl
 executable.arg_1 = --desc=corsika_digi_hi
 executable.arg_2 = --dsconf=%(date)s
@@ -208,7 +207,7 @@ executable.arg_3 = --inputs=inputs.txt
 executable.arg_4 = --merge=10
 executable.arg_5 = --embed
 executable.arg_6 = JobConfig/primary/CRY-offspill.fcl
-job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(experiment)s/g" */*.fcl
 job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
 job_setup.postscript_3 = sed -i "s/CRY-cosmic-general/CORSIKA-hi/g" */*.fcl
 job_setup.postscript_4 = mv */*.fcl .
@@ -216,22 +215,22 @@ job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_hi_fcl_%(date)s
 
 [stage_digi_hi]
-job_output.add_to_dataset = dig.%(account)s.corsika_digi_hi.%(date)s.art
-job_output_2.add_to_dataset = bck.%(account)s.corsika_digi_hi.%(date)s.tbz
-global.artRoot_dataset = dig.%(account)s.corsika_digi_hi.%(date)s.art
-global.output_dataset = bck.%(account)s.corsika_digi_hi.%(date)s.tbz
+job_output.add_to_dataset = dig.%(experiment)s.corsika_digi_hi.%(date)s.art
+job_output_2.add_to_dataset = bck.%(experiment)s.corsika_digi_hi.%(date)s.tbz
+global.artRoot_dataset = dig.%(experiment)s.corsika_digi_hi.%(date)s.art
+global.output_dataset = bck.%(experiment)s.corsika_digi_hi.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_hi_%(date)s
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = cnf.%(account)s.corsika_digi_hi.%(date)s.fcl
+submit.dataset = cnf.%(experiment)s.corsika_digi_hi.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:dig
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_reco_hi_fcl]
-job_output_1.add_to_dataset = cnf.%(account)s.corsika_reco_hi.%(date)s.fcl
-job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh dig.%(account)s.corsika_digi_hi.%(date)s.art > inputs.txt
+job_output_1.add_to_dataset = cnf.%(experiment)s.corsika_reco_hi.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh dig.%(experiment)s.corsika_digi_hi.%(date)s.art > inputs.txt
 executable.name = generate_fcl
 executable.arg_1 = --desc=corsika_reco_hi
 executable.arg_2 = --dsconf=%(date)s
@@ -239,7 +238,7 @@ executable.arg_3 = --inputs=inputs.txt
 executable.arg_4 = --merge=10
 executable.arg_5 = --embed
 executable.arg_6 = JobConfig/reco/CRY-cosmic-general-mix.fcl
-job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(experiment)s/g" */*.fcl
 job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
 job_setup.postscript_3 = sed -i "s/CRY-cosmic-general-mix/CORSIKA-reco-hi/g" */*.fcl
 job_setup.postscript_4 = mv */*.fcl .
@@ -247,54 +246,55 @@ job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_hi_fcl_%(date)s
 
 [stage_reco_hi]
-job_output.add_to_dataset = mcs.%(account)s.corsika_reco_hi.%(date)s.art
-job_output_2.add_to_dataset = bck.%(account)s.corsika_reco_hi.%(date)s.tbz
-global.artRoot_dataset = mcs.%(account)s.corsika_reco_hi.%(date)s.art
-global.output_dataset = bck.%(account)s.corsika_reco_hi.%(date)s.tbz
+job_output.add_to_dataset = mcs.%(experiment)s.corsika_reco_hi.%(date)s.art
+job_output_2.add_to_dataset = bck.%(experiment)s.corsika_reco_hi.%(date)s.tbz
+global.artRoot_dataset = mcs.%(experiment)s.corsika_reco_hi.%(date)s.art
+global.output_dataset = bck.%(experiment)s.corsika_reco_hi.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_hi_%(date)s
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = cnf.%(account)s.corsika_reco_hi.%(date)s.fcl
+submit.dataset = cnf.%(experiment)s.corsika_reco_hi.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:mcs
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_resampler_lo_fcl]
-job_output_1.add_to_dataset = cnf.%(account)s.corsika_dsstops_resampler_lo.%(date)s.fcl
-job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.cosmic_s1_dsstops_corsika.%(date)s.art > inputs.txt
+job_output_1.add_to_dataset = cnf.%(experiment)s.corsika_dsstops_resampler_lo.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(experiment)s.cosmic_s1_dsstops_corsika.%(date)s.art > inputs.txt
 executable.name = generate_fcl
 executable.arg_1 = --description=dsstops_resampler_lo_corsika
 executable.arg_2 = --dsconf=%(date)s
 executable.arg_3 = --aux=1:physics.filters.dsResample.fileNames:inputs.txt
 executable.arg_4 = --run-number=1
-executable.arg_5 = --events-per-job=500000
-executable.arg_6 = --njobs=1000
+executable.arg_5 = --events-per-job=300000
+executable.arg_6 = --njobs=100
 executable.arg_7 = --embed
 executable.arg_8 = JobConfig/cosmic/dsstops_resampler_lo.fcl
-job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(experiment)s/g" */*.fcl
 job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
-job_setup.postscript_3 = mv */*.fcl .
+job_setup.postscript_3 = sed -i "s/s2-dsstops-resampler/s2-corsika-dsstops-resampler-lo/g" */*.fcl
+job_setup.postscript_4 = mv */*.fcl .
 job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_lo_fcl_%(date)s
 
 [stage_resampler_lo]
-job_output.add_to_dataset = sim.%(account)s.corsika_dsstops_resampler_lo.%(date)s.art
-job_output_2.add_to_dataset = bck.%(account)s.corsika_dsstops_resampler_lo.%(date)s.tbz
-global.artRoot_dataset = sim.%(account)s.corsika_dsstops_resampler_lo.%(date)s.art
-global.output_dataset = bck.%(account)s.corsika_dsstops_resampler_lo.%(date)s.tbz
+job_output.add_to_dataset = sim.%(experiment)s.corsika_dsstops_resampler_lo.%(date)s.art
+job_output_2.add_to_dataset = bck.%(experiment)s.corsika_dsstops_resampler_lo.%(date)s.tbz
+global.artRoot_dataset = sim.%(experiment)s.corsika_dsstops_resampler_lo.%(date)s.art
+global.output_dataset = bck.%(experiment)s.corsika_dsstops_resampler_lo.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_lo_%(date)s
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = cnf.%(account)s.corsika_dsstops_resampler_lo.%(date)s.fcl
+submit.dataset = cnf.%(experiment)s.corsika_dsstops_resampler_lo.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:sim
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_concat_lo_fcl]
-job_output_1.add_to_dataset = cnf.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.fcl
-job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.corsika_dsstops_resampler_lo.%(date)s.art > inputs.txt
+job_output_1.add_to_dataset = cnf.%(experiment)s.corsika_dsstops_resampler_lo_concat.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(experiment)s.corsika_dsstops_resampler_lo.%(date)s.art > inputs.txt
 job_setup.prescript_4 = echo '#include "JobConfig/common/artcat.fcl"' >> template.fcl
 job_setup.prescript_5 = echo 'outputs.out.fileName: "sim.DSOWNER.corsika_dsstops_resampler_lo_concat.DSCONF.SEQ.art"' >> template.fcl
 executable.name = generate_fcl
@@ -304,36 +304,37 @@ executable.arg_3 = --merge=20
 executable.arg_4 = --inputs=inputs.txt
 executable.arg_5 = --embed
 executable.arg_6 = template.fcl
-job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(experiment)s/g" */*.fcl
 job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
 job_setup.postscript_3 = mv */*.fcl .
 job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_lo_fcl_%(date)s
 
 [stage_concat_lo]
-job_output.add_to_dataset = sim.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.art
-job_output_2.add_to_dataset = bck.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.tbz
-global.artRoot_dataset = sim.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.art
-global.output_dataset = bck.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.tbz
+job_output.add_to_dataset = sim.%(experiment)s.corsika_dsstops_resampler_lo_concat.%(date)s.art
+job_output_2.add_to_dataset = bck.%(experiment)s.corsika_dsstops_resampler_lo_concat.%(date)s.tbz
+global.artRoot_dataset = sim.%(experiment)s.corsika_dsstops_resampler_lo_concat.%(date)s.art
+global.output_dataset = bck.%(experiment)s.corsika_dsstops_resampler_lo_concat.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_lo_concat_%(date)s
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = cnf.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.fcl
+submit.dataset = cnf.%(experiment)s.corsika_dsstops_resampler_lo_concat.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:sim
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_digi_lo_fcl]
-job_output_1.add_to_dataset = cnf.%(account)s.corsika_digi_lo.%(date)s.fcl
-job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.art > inputs.txt
+job_output_1.add_to_dataset = cnf.%(experiment)s.corsika_digi_lo.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(experiment)s.corsika_dsstops_resampler_lo_concat.%(date)s.art > inputs.txt
 executable.name = generate_fcl
 executable.arg_1 = --desc=corsika_digi_lo
 executable.arg_2 = --dsconf=%(date)s
 executable.arg_3 = --inputs=inputs.txt
-executable.arg_4 = --embed
-executable.arg_5 = JobConfig/primary/CRY-offspill.fcl
-job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+executable.arg_4 = --merge-factor=1
+executable.arg_5 = --embed
+executable.arg_6 = JobConfig/primary/CRY-offspill.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(experiment)s/g" */*.fcl
 job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
 job_setup.postscript_3 = sed -i "s/CRY-cosmic-general/CORSIKA-lo/g" */*.fcl
 job_setup.postscript_4 = mv */*.fcl .
@@ -341,30 +342,30 @@ job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_lo_fcl_%(date)s
 
 [stage_digi_lo]
-job_output.add_to_dataset = dig.%(account)s.corsika_digi_lo.%(date)s.art
-job_output_2.add_to_dataset = bck.%(account)s.corsika_digi_lo.%(date)s.tbz
-global.artRoot_dataset = dig.%(account)s.corsika_digi_lo.%(date)s.art
-global.output_dataset = bck.%(account)s.corsika_digi_lo.%(date)s.tbz
+job_output.add_to_dataset = dig.%(experiment)s.corsika_digi_lo.%(date)s.art
+job_output_2.add_to_dataset = bck.%(experiment)s.corsika_digi_lo.%(date)s.tbz
+global.artRoot_dataset = dig.%(experiment)s.corsika_digi_lo.%(date)s.art
+global.output_dataset = bck.%(experiment)s.corsika_digi_lo.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_digi_lo_%(date)s
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset = cnf.%(account)s.corsika_digi_lo.%(date)s.fcl
+submit.dataset = cnf.%(experiment)s.corsika_digi_lo.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:dig
 job_setup.multifile = False
 job_setup.setup_local = True
 
 [stage_reco_lo_fcl]
-job_output_1.add_to_dataset = cnf.%(account)s.corsika_reco_lo.%(date)s.fcl
-job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh dig.%(account)s.corsika_digi_lo.%(date)s.art > inputs.txt
+job_output_1.add_to_dataset = cnf.%(experiment)s.corsika_reco_lo.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh dig.%(experiment)s.corsika_digi_lo.%(date)s.art > inputs.txt
 executable.name = generate_fcl
 executable.arg_1 = --desc=corsika_reco_lo
 executable.arg_2 = --dsconf=%(date)s
 executable.arg_3 = --inputs=inputs.txt
-executable.arg_4 = --merge=20
+executable.arg_4 = --merge-factor=20
 executable.arg_5 = --embed
 executable.arg_6 = JobConfig/reco/CRY-cosmic-general-mix.fcl
-job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(experiment)s/g" */*.fcl
 job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
 job_setup.postscript_3 = sed -i "s/CRY-cosmic-general-mix/CORSIKA-reco-lo/g" */*.fcl
 job_setup.postscript_4 = mv */*.fcl .
@@ -372,15 +373,15 @@ job_setup.ifdh_art = False
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_lo_fcl_%(date)s
 
 [stage_reco_lo]
-job_output.add_to_dataset = mcs.%(account)s.corsika_reco_lo.%(date)s.art
-job_output_2.add_to_dataset = bck.%(account)s.corsika_reco_lo.%(date)s.tbz
-global.artRoot_dataset = mcs.%(account)s.corsika_reco_lo.%(date)s.art
-global.output_dataset = bck.%(account)s.corsika_reco_lo.%(date)s.tbz
+job_output.add_to_dataset = mcs.%(experiment)s.corsika_reco_lo.%(date)s.art
+job_output_2.add_to_dataset = bck.%(experiment)s.corsika_reco_lo.%(date)s.tbz
+global.artRoot_dataset = mcs.%(experiment)s.corsika_reco_lo.%(date)s.art
+global.output_dataset = bck.%(experiment)s.corsika_reco_lo.%(date)s.tbz
 global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_reco_lo_%(date)s
 job_setup.getconfig = True
 submit.n_files_per_job = 1
 sam_consumer.limit = 1
-submit.dataset =  cnf.%(account)s.corsika_reco_lo.%(date)s.fcl
+submit.dataset =  cnf.%(experiment)s.corsika_reco_lo.%(date)s.fcl
 executable.arg_1 = --sam-data-tier=Output:mcs
 job_setup.multifile = False
 job_setup.setup_local = True

--- a/CampaignConfig/corsika.cfg
+++ b/CampaignConfig/corsika.cfg
@@ -292,16 +292,47 @@ executable.arg_1 = --sam-data-tier=Output:sim
 job_setup.multifile = False
 job_setup.setup_local = True
 
+[stage_concat_lo_fcl]
+job_output_1.add_to_dataset = cnf.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.fcl
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.corsika_dsstops_resampler_lo.%(date)s.art > inputs.txt
+job_setup.prescript_4 = echo '#include "JobConfig/common/artcat.fcl"' >> template.fcl
+job_setup.prescript_5 = echo 'outputs.out.fileName: "sim.DSOWNER.corsika_dsstops_resampler_lo_concat.DSCONF.SEQ.art"' >> template.fcl
+executable.name = generate_fcl
+executable.arg_1 = --description=dsstops_resampler_lo_corsika_concat
+executable.arg_2 = --dsconf=%(date)s
+executable.arg_3 = --merge=20
+executable.arg_4 = --inputs=inputs.txt
+executable.arg_5 = --embed
+executable.arg_6 = template.fcl
+job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
+job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
+job_setup.postscript_3 = mv */*.fcl .
+job_setup.ifdh_art = False
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_lo_fcl_%(date)s
+
+[stage_concat_lo]
+job_output.add_to_dataset = sim.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.art
+job_output_2.add_to_dataset = bck.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.tbz
+global.artRoot_dataset = sim.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.art
+global.output_dataset = bck.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.tbz
+global.outdir = /pnfs/mu2e/scratch/users/%(account)s/workflow/%(project_name)s_resampler_lo_concat_%(date)s
+job_setup.getconfig = True
+submit.n_files_per_job = 1
+sam_consumer.limit = 1
+submit.dataset = cnf.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.fcl
+executable.arg_1 = --sam-data-tier=Output:sim
+job_setup.multifile = False
+job_setup.setup_local = True
+
 [stage_digi_lo_fcl]
 job_output_1.add_to_dataset = cnf.%(account)s.corsika_digi_lo.%(date)s.fcl
-job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.corsika_dsstops_resampler_lo.%(date)s.art > inputs.txt
+job_setup.prescript_3 = ${CONDOR_DIR_INPUT}/gridScripts/listFiles.sh sim.%(account)s.corsika_dsstops_resampler_lo_concat.%(date)s.art > inputs.txt
 executable.name = generate_fcl
 executable.arg_1 = --desc=corsika_digi_lo
 executable.arg_2 = --dsconf=%(date)s
 executable.arg_3 = --inputs=inputs.txt
-executable.arg_4 = --merge=20
-executable.arg_5 = --embed
-executable.arg_6 = JobConfig/primary/CRY-offspill.fcl
+executable.arg_4 = --embed
+executable.arg_5 = JobConfig/primary/CRY-offspill.fcl
 job_setup.postscript = sed -i "s/MU2EGRIDDSOWNER/%(account)s/g" */*.fcl
 job_setup.postscript_2 = sed -i "s/MU2EGRIDDSCONF/%(date)s/g" */*.fcl
 job_setup.postscript_3 = sed -i "s/CRY-cosmic-general/CORSIKA-lo/g" */*.fcl

--- a/CampaignConfig/corsika.ini
+++ b/CampaignConfig/corsika.ini
@@ -1,204 +1,87 @@
 [campaign]
 experiment = mu2e
 poms_role = analysis
-name = corsika
-campaign_stage_list = gen_fcl, gen, resampler_hi_fcl, resampler_hi, resampler_lo_fcl, resampler_lo, digi_hi_fcl, digi_hi, digi_lo_fcl, digi_lo, reco_hi_fcl, reco_hi, reco_lo_fcl, reco_lo
+name = corsika_dsstop
+campaign_stage_list = gen_fcl, gen, resampler_hi_fcl, resampler_hi, resampler_lo_fcl, resampler_lo, digi_hi_fcl, digi_hi, digi_lo_fcl, digi_lo, reco_hi_fcl reco_hi, reco_lo_fcl, reco_lo
 
 [campaign_defaults]
-vo_role = Analysis
-state = Active
-software_version = v1_0
-dataset_or_split_data = from_parent
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = "[]"
-test_param_overrides = "[]"
-login_setup = user_login
-job_type = mu2e_jobtype
+vo_role=Analysis
+software_version=Offline
+dataset_or_split_data=None
+cs_split_type=None
+completion_type=complete
+completion_pct=95
+param_overrides="[]"
+test_param_overrides="[]"
+merge_overrides=False
+login_setup=user_login
+job_type=mu2e_corsika_jobtype
+stage_type=regular
+output_ancestor_depth=1
 
 [campaign_stage gen_fcl]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
 param_overrides = [["--stage ", "gen_fcl"]]
 test_param_overrides = [["--stage ", "gen_fcl"]]
-login_setup = user_login
-job_type = generate_fcl_jobtype
+job_type = generate_fcl_corsika_jobtype
 
 [campaign_stage resampler_lo_fcl]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "resampler_lo_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "resampler_lo_fcl"]]
 test_param_overrides = [["--stage ", "resampler_lo_fcl"]]
-login_setup = user_login
-job_type = generate_fcl_jobtype
+job_type = generate_fcl_corsika_jobtype
 
 [campaign_stage resampler_hi_fcl]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "resampler_hi_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "resampler_hi_fcl"]]
 test_param_overrides = [["--stage ", "resampler_hi_fcl"]]
-login_setup = user_login
-job_type = generate_fcl_jobtype
+job_type = generate_fcl_corsika_jobtype
 
 [campaign_stage digi_lo_fcl]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "digi_lo_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "digi_lo_fcl"]]
 test_param_overrides = [["--stage ", "digi_lo_fcl"]]
-login_setup = user_login
-job_type = generate_fcl_jobtype
+job_type = generate_fcl_corsika_jobtype
 
 [campaign_stage digi_hi_fcl]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "digi_hi_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "digi_hi_fcl"]]
 test_param_overrides = [["--stage ", "digi_hi_fcl"]]
-login_setup = user_login
-job_type = generate_fcl_jobtype
+job_type = generate_fcl_corsika_jobtype
 
 [campaign_stage reco_lo_fcl]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "reco_lo_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "reco_lo_fcl"]]
 test_param_overrides = [["--stage ", "reco_lo_fcl"]]
-login_setup = user_login
-job_type = generate_fcl_jobtype
+job_type = generate_fcl_corsika_jobtype
 
 [campaign_stage reco_hi_fcl]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "reco_hi_fcl"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "reco_hi_fcl"]]
 test_param_overrides = [["--stage ", "reco_hi_fcl"]]
-login_setup = user_login
-job_type = generate_fcl_jobtype
+job_type = generate_fcl_corsika_jobtype
 
 [campaign_stage reco_lo]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "reco_lo"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "reco_lo"]]
 test_param_overrides = [["--stage ", "reco_lo"]]
-login_setup = user_login
-job_type = mu2e_jobtype
 
 [campaign_stage reco_hi]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "reco_hi"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "reco_hi"]]
 test_param_overrides = [["--stage ", "reco_hi"]]
-login_setup = user_login
-job_type = mu2e_jobtype
 
 [campaign_stage digi_lo]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "digi_lo"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "digi_lo"]]
 test_param_overrides = [["--stage ", "digi_lo"]]
-login_setup = user_login
-job_type = mu2e_jobtype
-
 
 [campaign_stage digi_hi]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "digi_hi"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "digi_hi"]]
 test_param_overrides = [["--stage ", "digi_hi"]]
-login_setup = user_login
-job_type = mu2e_jobtype
 
 [campaign_stage gen]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "gen"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "gen"]]
 test_param_overrides = [["--stage ", "gen"]]
-login_setup = user_login
 job_type = corsika_jobtype
 
 [campaign_stage resampler_hi]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "resampler_hi"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "resampler_hi"]]
 test_param_overrides = [["--stage ", "resampler_hi"]]
-login_setup = user_login
-job_type = mu2e_jobtype
 
 [campaign_stage resampler_lo]
-vo_role = Analysis
-state = Active
-software_version = Offline
-dataset_or_split_data = None
-cs_split_type = None
-completion_type = complete
-completion_pct = 95
-param_overrides = [["--stage ", "resampler_lo"], ["-Oglobal.dataset=", "%(dataset)s"]]
+param_overrides = [["--stage ", "resampler_lo"]]
 test_param_overrides = [["--stage ", "resampler_lo"]]
-login_setup = user_login
-job_type = mu2e_jobtype
 
 [dependencies gen]
 campaign_stage_1 = gen_fcl
@@ -244,7 +127,6 @@ file_pattern_1 = %.art
 campaign_stage_1 = reco_hi_fcl
 file_pattern_1 = %.fcl
 
-
 [dependencies reco_lo_fcl]
 campaign_stage_1 = digi_lo
 file_pattern_1 = %.art
@@ -258,17 +140,17 @@ host = pomsgpvm01.fnal.gov
 account = poms_launcher
 setup = source /grid/fermiapp/products/common/etc/setups.sh;setup fife_utils v3_3
 
-[job_type mu2e_jobtype]
+[job_type mu2e_corsika_jobtype]
 launch_script = fife_launch
-parameters = [["-c ", "$UPLOADS/corsika.cfg"]]
+parameters = [["-c ", "$UPLOADS/srsoleti_corsika.cfg"]]
 output_file_patterns = %.art
 
-[job_type generate_fcl_jobtype]
+[job_type generate_fcl_corsika_jobtype]
 launch_script = fife_launch
-parameters = [["-c ", "$UPLOADS/corsika.cfg"]]
+parameters = [["-c ", "$UPLOADS/srsoleti_corsika.cfg"]]
 output_file_patterns = %.root
 
 [job_type corsika_jobtype]
 launch_script = fife_launch
-parameters = [["-c ", "$UPLOADS/corsika.cfg"]]
+parameters = [["-c ", "$UPLOADS/srsoleti_corsika.cfg"]]
 output_file_patterns = %.art

--- a/CampaignConfig/corsika.ini
+++ b/CampaignConfig/corsika.ini
@@ -2,7 +2,7 @@
 experiment = mu2e
 poms_role = analysis
 name = corsika_dsstop
-campaign_stage_list = gen_fcl, gen, resampler_hi_fcl, resampler_hi, resampler_lo_fcl, resampler_lo, digi_hi_fcl, digi_hi, digi_lo_fcl, digi_lo, reco_hi_fcl reco_hi, reco_lo_fcl, reco_lo
+campaign_stage_list = gen_fcl, gen, resampler_hi_fcl, resampler_hi, resampler_lo_fcl, resampler_lo, concat_lo_fcl, concat_lo, digi_hi_fcl, digi_hi, digi_lo_fcl, digi_lo, reco_hi_fcl reco_hi, reco_lo_fcl, reco_lo
 
 [campaign_defaults]
 vo_role=Analysis
@@ -27,6 +27,11 @@ job_type = generate_fcl_corsika_jobtype
 [campaign_stage resampler_lo_fcl]
 param_overrides = [["--stage ", "resampler_lo_fcl"]]
 test_param_overrides = [["--stage ", "resampler_lo_fcl"]]
+job_type = generate_fcl_corsika_jobtype
+
+[campaign_stage concat_lo_fcl]
+param_overrides = [["--stage ", "concat_lo_fcl"]]
+test_param_overrides = [["--stage ", "concat_lo_fcl"]]
 job_type = generate_fcl_corsika_jobtype
 
 [campaign_stage resampler_hi_fcl]
@@ -57,6 +62,10 @@ job_type = generate_fcl_corsika_jobtype
 [campaign_stage reco_lo]
 param_overrides = [["--stage ", "reco_lo"]]
 test_param_overrides = [["--stage ", "reco_lo"]]
+
+[campaign_stage concat_lo]
+param_overrides = [["--stage ", "concat_lo"]]
+test_param_overrides = [["--stage ", "concat_lo"]]
 
 [campaign_stage reco_hi]
 param_overrides = [["--stage ", "reco_hi"]]
@@ -111,8 +120,16 @@ file_pattern_1 = %.art
 campaign_stage_1 = digi_hi_fcl
 file_pattern_1 = %.fcl
 
-[dependencies digi_lo_fcl]
+[dependencies concat_lo_fcl]
 campaign_stage_1 = resampler_lo
+file_pattern_1 = %.art
+
+[dependencies concat_lo]
+campaign_stage_1 = concat_lo_fcl
+file_pattern_1 = %.fcl
+
+[dependencies digi_lo_fcl]
+campaign_stage_1 = concat_lo
 file_pattern_1 = %.art
 
 [dependencies digi_lo]

--- a/CampaignConfig/corsika.ini
+++ b/CampaignConfig/corsika.ini
@@ -1,11 +1,11 @@
 [campaign]
 experiment = mu2e
-poms_role = analysis
-name = corsika_dsstop
+poms_role = production
+name = corsika_production_campaign
 campaign_stage_list = gen_fcl, gen, resampler_hi_fcl, resampler_hi, resampler_lo_fcl, resampler_lo, concat_lo_fcl, concat_lo, digi_hi_fcl, digi_hi, digi_lo_fcl, digi_lo, reco_hi_fcl reco_hi, reco_lo_fcl, reco_lo
 
 [campaign_defaults]
-vo_role=Analysis
+vo_role=Production
 software_version=Offline
 dataset_or_split_data=None
 cs_split_type=None
@@ -14,50 +14,50 @@ completion_pct=95
 param_overrides="[]"
 test_param_overrides="[]"
 merge_overrides=False
-login_setup=user_login
-job_type=mu2e_corsika_jobtype
+login_setup=mu2epro_login
+job_type=mu2e_corsika_production_jobtype
 stage_type=regular
 output_ancestor_depth=1
 
 [campaign_stage gen_fcl]
 param_overrides = [["--stage ", "gen_fcl"]]
 test_param_overrides = [["--stage ", "gen_fcl"]]
-job_type = generate_fcl_corsika_jobtype
+job_type = generate_fcl_corsika_production_jobtype
 
 [campaign_stage resampler_lo_fcl]
 param_overrides = [["--stage ", "resampler_lo_fcl"]]
 test_param_overrides = [["--stage ", "resampler_lo_fcl"]]
-job_type = generate_fcl_corsika_jobtype
+job_type = generate_fcl_corsika_production_jobtype
 
 [campaign_stage concat_lo_fcl]
 param_overrides = [["--stage ", "concat_lo_fcl"]]
 test_param_overrides = [["--stage ", "concat_lo_fcl"]]
-job_type = generate_fcl_corsika_jobtype
+job_type = generate_fcl_corsika_production_jobtype
 
 [campaign_stage resampler_hi_fcl]
 param_overrides = [["--stage ", "resampler_hi_fcl"]]
 test_param_overrides = [["--stage ", "resampler_hi_fcl"]]
-job_type = generate_fcl_corsika_jobtype
+job_type = generate_fcl_corsika_production_jobtype
 
 [campaign_stage digi_lo_fcl]
 param_overrides = [["--stage ", "digi_lo_fcl"]]
 test_param_overrides = [["--stage ", "digi_lo_fcl"]]
-job_type = generate_fcl_corsika_jobtype
+job_type = generate_fcl_corsika_production_jobtype
 
 [campaign_stage digi_hi_fcl]
 param_overrides = [["--stage ", "digi_hi_fcl"]]
 test_param_overrides = [["--stage ", "digi_hi_fcl"]]
-job_type = generate_fcl_corsika_jobtype
+job_type = generate_fcl_corsika_production_jobtype
 
 [campaign_stage reco_lo_fcl]
 param_overrides = [["--stage ", "reco_lo_fcl"]]
 test_param_overrides = [["--stage ", "reco_lo_fcl"]]
-job_type = generate_fcl_corsika_jobtype
+job_type = generate_fcl_corsika_production_jobtype
 
 [campaign_stage reco_hi_fcl]
 param_overrides = [["--stage ", "reco_hi_fcl"]]
 test_param_overrides = [["--stage ", "reco_hi_fcl"]]
-job_type = generate_fcl_corsika_jobtype
+job_type = generate_fcl_corsika_production_jobtype
 
 [campaign_stage reco_lo]
 param_overrides = [["--stage ", "reco_lo"]]
@@ -82,7 +82,7 @@ test_param_overrides = [["--stage ", "digi_hi"]]
 [campaign_stage gen]
 param_overrides = [["--stage ", "gen"]]
 test_param_overrides = [["--stage ", "gen"]]
-job_type = corsika_jobtype
+job_type = corsika_production_jobtype
 
 [campaign_stage resampler_hi]
 param_overrides = [["--stage ", "resampler_hi"]]
@@ -152,22 +152,22 @@ file_pattern_1 = %.art
 campaign_stage_1 = reco_lo_fcl
 file_pattern_1 = %.fcl
 
-[login_setup user_login]
-host = pomsgpvm01.fnal.gov
-account = poms_launcher
-setup = source /grid/fermiapp/products/common/etc/setups.sh;setup fife_utils v3_3
-
-[job_type mu2e_corsika_jobtype]
+[job_type mu2e_corsika_production_jobtype]
 launch_script = fife_launch
-parameters = [["-c ", "$UPLOADS/srsoleti_corsika.cfg"]]
+parameters = [["-c ", "/cvmfs/mu2e.opensciencegrid.org/Offline/v09_09_00/SLF7/prof/Offline/CampaignConfig/corsika.cfg"]]
 output_file_patterns = %.art
 
-[job_type generate_fcl_corsika_jobtype]
+[job_type corsika_production_jobtype]
 launch_script = fife_launch
-parameters = [["-c ", "$UPLOADS/srsoleti_corsika.cfg"]]
-output_file_patterns = %.root
-
-[job_type corsika_jobtype]
-launch_script = fife_launch
-parameters = [["-c ", "$UPLOADS/srsoleti_corsika.cfg"]]
+parameters = [["-c ", "/cvmfs/mu2e.opensciencegrid.org/Offline/v09_09_00/SLF7/prof/Offline/CampaignConfig/corsika.cfg"]]
 output_file_patterns = %.art
+
+[job_type generate_fcl_corsika_production_jobtype]
+launch_script = fife_launch
+parameters = [["-c ", "/cvmfs/mu2e.opensciencegrid.org/Offline/v09_09_00/SLF7/prof/Offline/CampaignConfig/corsika.cfg"]]
+output_file_patterns = %.fcl
+
+[login_setup mu2epro_login]
+host=mu2egpvm01.fnal.gov
+account=mu2epro
+setup=export X509_USER_PROXY=/opt/mu2epro/mu2epro.Production.proxy;setup fife_utils v3_3, poms_client, poms_jobsub_wrapper;

--- a/JobConfig/cosmic/cosmic_s1_dsstops.fcl
+++ b/JobConfig/cosmic/cosmic_s1_dsstops.fcl
@@ -1,6 +1,6 @@
 // This configuration propogates cosmics from the surface towards DS.
 // Cosmics hitting crvStage1End volumes are stopped and saved for later resampling.
-// 
+//
 // Yuri Oksuzian, 2019
 
 #include "fcl/minimalMessageService.fcl"
@@ -12,17 +12,17 @@ BEGIN_PROLOG
 #----------------------------------------------------------------
 # Mu2eG4 cuts
 
-crvStage1End: 
+crvStage1End:
 {
    type: inVolume
    pars: [DSOuterCryoShell, DSInnerCryoShell, DSFront, DSUpEndWallShell, TS5OuterCryoShell, TS5CryoInsVac, TS5Vacuum, Coll51, DS1Vacuum, DS2Vacuum, DS3Vacuum]
    write: crvStage1
 }
 
-crvOuterBox: 
+crvOuterBox:
 {
    type: union
-   pars: 
+   pars:
    [
       // Upstream plane
       { type: plane normal: [  0, 0, -1 ] point : [ 0, 0, -3400 ] },
@@ -44,10 +44,10 @@ crvOuterBox:
    ]
 }
 
-crvInnerBox: 
+crvInnerBox:
 {
    type: intersection
-   pars: 
+   pars:
    [
       // Upstream plane
       { type: plane normal: [  0, 0, 1 ] point : [ 0, 0, -2200 ] },
@@ -69,27 +69,27 @@ crvInnerBox:
    ]
 }
 
-cosmicKineticEnergyCuts: 
+cosmicKineticEnergyCuts:
 {
    type: union
    pars:
    [
       {
         type: intersection
-        pars: 
-        [ 
+        pars:
+        [
           { type: union pars: [ @local::crvOuterBox, @local::crvInnerBox ] },
-          { type: kineticEnergy cut: 10.0 }, 
+          { type: kineticEnergy cut: 10.0 },
           { type: pdgId pars: [ 22, 2112 ] }
         ]
       },
       {
       // 5 MeV can only make a hit in 1 CRV layer
         type: intersection
-        pars: 
-        [ 
+        pars:
+        [
           { type: union pars: [ @local::crvOuterBox, @local::crvInnerBox ] },
-          { type: kineticEnergy cut: 5.0 }, 
+          { type: kineticEnergy cut: 5.0 },
           { type: pdgId pars: [ 2212, 11, -11 ] }
         ]
       }
@@ -102,13 +102,13 @@ END_PROLOG
 # Give this job a name.
 process_name :  cosmics1
 
-source : 
+source :
 {
    module_type : EmptyEvent
    maxEvents : @nil
 }
 
-services : 
+services :
 {
 
    message               : @local::default_message
@@ -122,51 +122,51 @@ services :
    SeedService            : @local::automaticSeeds
 }
 
-physics : 
+physics :
 {
-   analyzers: 
+   analyzers:
    {
-      genCountLogger: 
-      { 
-         module_type: GenEventCountReader 
+      genCountLogger:
+      {
+         module_type: GenEventCountReader
       }
 
-      collectionSizes: 
+      collectionSizes:
       {
 	 module_type: CollectionSizeAnalyzer
-         useModuleLabel: true 
-         useInstanceName: true 
+         useModuleLabel: true
+         useInstanceName: true
          useProcessName: false
       }
 
       statusG4: { module_type: StatusG4Analyzer input: g4run }
    }
 
-   producers: 
+   producers:
    {
-      generate: 
+      generate:
       {
          module_type          : EventGenerator
          # inputfile is defined in top level fcl files
       }
 
-      genCounter: 
+      genCounter:
       {
          module_type: GenEventCounter
       }
 
-      g4run : 
+      g4run :
       {
          module_type: Mu2eG4
          physics: @local::mu2eg4DefaultPhysics
          ResourceLimits: @local::mu2eg4DefaultResourceLimits
-	 TrajectoryControl: @local::mu2eg4DefaultTrajectories 
+	 TrajectoryControl: @local::mu2eg4DefaultTrajectories
          debug: @local::mu2eg4DefaultDebug
          visualization: @local::mu2eg4NoVisualization
 
          generatorModuleLabel: generate
 
-         SDConfig: 
+         SDConfig:
          {
             enableSD: [ CRV ]  // activate just the explicitly listed SDs  //for the StepPoints which will be stored
             TimeVD: { times: [] }
@@ -180,10 +180,10 @@ physics :
          // The first match wins.  For the "intersection"
          // type, the first false stops the evaluation.
          // For the "union" type the first true stops the evaluation.
-         Mu2eG4CommonCut: 
+         Mu2eG4CommonCut:
          {
             type: union
-            pars: 
+            pars:
             [
                @local::cosmicKineticEnergyCuts,
                @local::crvStage1End,
@@ -195,7 +195,7 @@ physics :
          }
       }
 
-      compressPV : 
+      compressPV :
       {
          module_type: CompressPhysicalVolumes
          volumesInput : "g4run"
@@ -203,7 +203,7 @@ physics :
          particleInputs : [ "cosmicFilter" ]
       }
 
-      compressPVFull : 
+      compressPVFull :
       {
          module_type: CompressPhysicalVolumes
          volumesInput : "g4run"
@@ -212,16 +212,16 @@ physics :
       }
    }
 
-   filters: 
+   filters:
    {
-      stepPointMomentumFilter: 
+      stepPointMomentumFilter:
       {
         module_type: FilterStepPointMomentum
         inputs : [ "g4run:crvStage1" ]
         cutMomentumMin: 0. // Filter all particles that hit DS region
       }
 
-      cosmicFilter: 
+      cosmicFilter:
       {
          module_type: FilterG4Out
          mainHitInputs : [ "g4run:crvStage1", "g4run:CRV" ]
@@ -230,7 +230,7 @@ physics :
          vetoDaughters: []
       }
 
-      g4status: 
+      g4status:
       {
          module_type: FilterStatusG4
          input: "g4run"
@@ -252,34 +252,36 @@ physics :
    end_paths: [outputs, an]
 }
 
-outputs: 
+outputs:
 {
 
-   filteredOutput : 
+   filteredOutput :
    {
       module_type : RootOutput
       SelectEvents: ["trigFilter"]
-      outputCommands:   
-      [ 
+      outputCommands:
+      [
          "drop *_*_*_*",
          "keep mu2e::GenParticles_*_*_*",
          "keep mu2e::GenEventCount_*_*_*",
          "keep mu2e::StatusG4_*_*_*",
+         "keep mu2e::CosmicLivetime_*_*_*",
          "keep *_cosmicFilter_*_*",
          "keep *_compressPV_*_*"
       ]
    }
 
-   truncatedEvtsOutput : 
+   truncatedEvtsOutput :
    {
       module_type : RootOutput
       SelectEvents: ["g4StatusFilter"]
-      outputCommands:   
-      [ 
+      outputCommands:
+      [
          "drop *_*_*_*",
          "keep mu2e::GenParticles_*_*_*",
          "keep mu2e::GenEventCount_*_*_*",
          "keep mu2e::StatusG4_*_*_*",
+         "keep mu2e::CosmicLivetime_*_*_*",
          "keep *_g4run_*_*",
          "drop uintmu2e::PhysicalVolumeInfomvstd::pairs_g4run_*_*",
          "keep *_compressPVFull_*_*"


### PR DESCRIPTION
This updated campaign configuration includes:
- A concatenation stage after `resampler_lo`
- Use of Offline tagged version v09_09_00
- Updated CORSIKA version
- Login information to run in production mode as `mu2epro`

Also, we keep the `CosmicLivetime` data product in `JobConfig/cosmic/cosmic_s1_dsstops.fcl` containing the amount of simulated livetime.