### PR TITLE
ProtonBunchTime and event window length

### DIFF
--- a/CaloReco/fcl/prolog_trigger.fcl
+++ b/CaloReco/fcl/prolog_trigger.fcl
@@ -17,7 +17,7 @@ FastCaloRecoDigiFromDigi :
     diagLevel              : 0
     minDigiE 	  	   : 1 
     shiftTime         	   : 19.90
-    EventWindowMarkerLabel : "EWMProducer"
+    ProtonBunchTimeLabel : "EWMProducer"
 }
 
 

--- a/CaloReco/src/FastCaloRecoDigiFromDigi_module.cc
+++ b/CaloReco/src/FastCaloRecoDigiFromDigi_module.cc
@@ -18,7 +18,6 @@
 #include "RecoDataProducts/inc/CaloDigiCollection.hh"
 #include "RecoDataProducts/inc/CaloRecoDigi.hh"
 #include "RecoDataProducts/inc/CaloRecoDigiCollection.hh"
-
 #include "RecoDataProducts/inc/ProtonBunchTime.hh"
 
 #include <iostream>

--- a/CaloReco/src/FastCaloRecoDigiFromDigi_module.cc
+++ b/CaloReco/src/FastCaloRecoDigiFromDigi_module.cc
@@ -19,7 +19,7 @@
 #include "RecoDataProducts/inc/CaloRecoDigi.hh"
 #include "RecoDataProducts/inc/CaloRecoDigiCollection.hh"
 
-#include "DataProducts/inc/EventWindowMarker.hh"
+#include "RecoDataProducts/inc/ProtonBunchTime.hh"
 
 #include <iostream>
 #include <string>
@@ -39,9 +39,9 @@ namespace mu2e {
 		minDigiE_   	    (pset.get<double> ("minDigiE")),
 		shiftTime_          (pset.get<double> ("shiftTime")),
 		diagLevel_          (pset.get<int>    ("diagLevel",0)),
-		ewMarkerTag_(pset.get<art::InputTag>("EventWindowMarkerLabel"))
+		pbtTag_(pset.get<art::InputTag>("ProtonBunchTimeLabel"))
 	     	{
-			consumes<EventWindowMarker>(ewMarkerTag_);
+			consumes<ProtonBunchTime>(pbtTag_);
 	      		produces<CaloRecoDigiCollection>();
 		}
 
@@ -54,9 +54,9 @@ namespace mu2e {
 		double 	 minDigiE_ ;
 		double 	 shiftTime_ ;
 		int      diagLevel_;
-   		art::InputTag ewMarkerTag_;// name of the module that makes eventwindowmarkers
+   		art::InputTag pbtTag_;// name of the module that makes eventwindowmarkers
    
-		void extractRecoDigi(art::ValidHandle<CaloDigiCollection> const& caloDigis, CaloRecoDigiCollection& recoCaloHits, double const& ewOffset);
+		void extractRecoDigi(art::ValidHandle<CaloDigiCollection> const& caloDigis, CaloRecoDigiCollection& recoCaloHits, double const& pbtime);
 
 	};
 
@@ -68,14 +68,14 @@ namespace mu2e {
 		auto const& caloDigisH = event.getValidHandle(caloDigisToken_);
 		auto recoCaloDigiColl = std::make_unique<CaloRecoDigiCollection>();
 		
-		double ewmOffset = 0;
-		art::Handle<EventWindowMarker> ewMarkerHandle;
-		if (event.getByLabel(ewMarkerTag_, ewMarkerHandle)){
-			const EventWindowMarker& ewMarker(*ewMarkerHandle);
-			ewmOffset = ewMarker.timeOffset();
+		double pbtime = 0;
+		art::Handle<ProtonBunchTime> pbtHandle;
+		if (event.getByLabel(pbtTag_, pbtHandle)){
+			const ProtonBunchTime& pbt(*pbtHandle);
+			pbtime = pbt.pbtime_;
 		}
 
-		extractRecoDigi(caloDigisH, *recoCaloDigiColl, ewmOffset);
+		extractRecoDigi(caloDigisH, *recoCaloDigiColl, pbtime);
 
 		if ( diagLevel_ > 0 )std::cout<<"[FastCaloRecoDigiFromDigi::produce] extracted "<<recoCaloDigiColl->size()<<" RecoDigis"<<std::endl;
 		
@@ -87,7 +87,7 @@ namespace mu2e {
 		return;
 	}
 
-	void FastCaloRecoDigiFromDigi::extractRecoDigi(art::ValidHandle<CaloDigiCollection> const& caloDigisHandle, CaloRecoDigiCollection &recoCaloHits, double const& eventWindowOffset)
+	void FastCaloRecoDigiFromDigi::extractRecoDigi(art::ValidHandle<CaloDigiCollection> const& caloDigisHandle, CaloRecoDigiCollection &recoCaloHits, double const& protonBunchTime)
   	{
 		ConditionsHandle<CalorimeterCalibrations> calorimeterCalibrations("ignored");
 		auto const& caloDigis = *caloDigisHandle;
@@ -102,7 +102,7 @@ namespace mu2e {
 			size_t index = &caloDigi - base;
 			art::Ptr<CaloDigi> caloDigiPtr(caloDigisHandle, index);
 
-			double time = t0 + (caloDigi.peakpos()+0.5)*digiSampling_+ eventWindowOffset - shiftTime_; 
+			double time = t0 + (caloDigi.peakpos()+0.5)*digiSampling_ - protonBunchTime - shiftTime_; 
 			double eDep = (caloDigi.waveform().at(caloDigi.peakpos()))*adc2MeV; 
 			if(eDep <  minDigiE_) {continue;}
 			double eDepErr =  0*adc2MeV;

--- a/CommonMC/src/EventWindowMarkerProducer_module.cc
+++ b/CommonMC/src/EventWindowMarkerProducer_module.cc
@@ -14,9 +14,12 @@
 
 #include "art/Framework/Principal/Handle.h"
 
+#include "MCDataProducts/inc/ProtonBunchTimeMC.hh"
+#include "RecoDataProducts/inc/ProtonBunchTime.hh"
 #include "DataProducts/inc/EventWindowMarker.hh"
 
 #include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandGaussQ.h"
 
 #include <iostream>
 #include <string>
@@ -26,7 +29,21 @@ namespace mu2e {
 
   class EventWindowMarkerProducer : public art::EDProducer {
     public:
-      explicit EventWindowMarkerProducer(fhicl::ParameterSet const& pset);
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      struct Config {
+        fhicl::Atom<float> systemClockSpeed{ Name("SystemClockSpeed"), Comment("Detector clock speed in MHz"), 40.0};
+        fhicl::Atom<float> constantOffset{ Name("ConstantTimeOffset"), Comment("Constant time offset correction in ns"), 0.0};
+        fhicl::Atom<unsigned> spillType { Name( "SpillType"), Comment("Whether simulating on or off spill"), EventWindowMarker::SpillType::onspill};
+        fhicl::Atom<unsigned> offSpillLength{ Name("OffSpillEventLength"), Comment("Length of off spill events in clock counts" ),4000};
+        fhicl::Atom<int> onSpillBins{ Name("OnSpillBins"), Comment("Number of microbunches before proton bunch phase repeats"), 5};
+        fhicl::Atom<unsigned> onSpillMaxLength{ Name("OnSpillEventMaxLength"), Comment("Length of longest on spill events in clock counts"),68};
+        fhicl::Atom<bool> recoFromMCTruth{ Name("RecoFromMCTruth"), Comment("Create reco PBT from MC truth"),false};
+        fhicl::Atom<float> recoFromMCTruthErr{ Name("RecoFromMCTruthErr"), Comment("If creating reco PBT from MC truth, smear by this amount in ns"),0};
+      };
+
+      using Parameters = art::EDProducer::Table<Config>;
+      explicit EventWindowMarkerProducer(Parameters const& config);
 
     private:
       void beginJob() override;
@@ -34,23 +51,42 @@ namespace mu2e {
       void produce(art::Event& event) override;
 
       float _systemClockSpeed;
-      float _eventWindowConstantOffset;
+      float _constantOffset;
+      EventWindowMarker::SpillType _spillType;
+      uint16_t _offSpillLength;
+      int _onSpillBins;
+      uint16_t _onSpillMaxLength;
+      bool _recoFromMCTruth;
+      float _recoFromMCTruthErr;
       art::RandomNumberGenerator::base_engine_t& _engine;
+      CLHEP::RandGaussQ _randgauss;
       CLHEP::RandFlat _randflat;
+
+      double _initialPhaseShift;
   };
 
-  EventWindowMarkerProducer::EventWindowMarkerProducer(fhicl::ParameterSet const& pset):
-    art::EDProducer{pset},
-    _systemClockSpeed(pset.get<float>("SystemClockSpeed",40.0)), // MHz
-    _eventWindowConstantOffset(pset.get<float>("EventWindowConstantOffset",0.0)), // ns (is a calibration value to get data/sim agreement)
-    // a positive value means the event window is delayed relative to the StepPointMC timing
+  EventWindowMarkerProducer::EventWindowMarkerProducer(Parameters const& config):
+    art::EDProducer{config},
+    _systemClockSpeed( config().systemClockSpeed()), // MHz
+    _constantOffset( config().constantOffset()), // ns (is a calibration value to get data/sim agreement)
+    _spillType(static_cast<EventWindowMarker::SpillType>( config().spillType())),
+    _offSpillLength( config().offSpillLength()),
+    _onSpillBins( config().onSpillBins()),
+    _onSpillMaxLength( config().onSpillMaxLength()),
+    _recoFromMCTruth( config().recoFromMCTruth()),
+    _recoFromMCTruthErr( config().recoFromMCTruthErr()),
     _engine(createEngine( art::ServiceHandle<SeedService>()->getSeed())),
+    _randgauss( _engine ),
     _randflat( _engine )
   {
     produces<EventWindowMarker>();
+    produces<ProtonBunchTimeMC>();
+    produces<ProtonBunchTime>();
   }
 
   void EventWindowMarkerProducer::beginJob() {
+    // Proton bunch is 0 to 25 ns before event window marker
+    _initialPhaseShift = -1*_randflat.fire(1/_systemClockSpeed*1000);
   }
 
   void EventWindowMarkerProducer::beginRun(art::Run& run) {
@@ -58,10 +94,49 @@ namespace mu2e {
 
   void EventWindowMarkerProducer::produce(art::Event& event) {
       unique_ptr<EventWindowMarker> marker(new EventWindowMarker);
-      marker.get()->_timeOffset = _eventWindowConstantOffset + _randflat.fire(1/_systemClockSpeed*1000) - 1/_systemClockSpeed*1000/2.; // ns
-      event.put(std::move(marker));
-  }
+      unique_ptr<ProtonBunchTimeMC> pbtmc(new ProtonBunchTimeMC);
+      unique_ptr<ProtonBunchTime> pbt(new ProtonBunchTime);
+      marker.get()->_spillType = _spillType;
 
+      double period = 1/_systemClockSpeed*1000;
+
+      if (_spillType == EventWindowMarker::SpillType::offspill){
+        pbtmc.get()->pbtime_ = 0;
+        pbt.get()->pbtime_ = 0;
+        pbt.get()->pbterr_ = 0;
+        marker.get()->_eventLength = _offSpillLength*period;
+      }else{
+        // calculate which bin we are in from event number
+        int bin = event.id().event() % _onSpillBins;
+        // determine phase for this event
+        // each microbunch the proton bunch gets shifted back 5 ns from the event window
+        double shiftPer = -1*period/_onSpillBins;
+        double phaseShift = (_initialPhaseShift + bin*shiftPer);
+        if (phaseShift < -1*period)
+          phaseShift += period;
+        // when phase shift would be > than one clock period by next microbunch
+        // the event window is one clock tick shorter
+        if (phaseShift < -1*period - shiftPer)
+          marker.get()->_eventLength = (_onSpillMaxLength-1)*period;
+        else
+          marker.get()->_eventLength = _onSpillMaxLength*period;
+
+        pbtmc.get()->pbtime_ = _constantOffset + phaseShift;
+        if (_recoFromMCTruth){
+          pbt.get()->pbtime_ = pbtmc.get()->pbtime_;
+          if (_recoFromMCTruthErr > 0)
+            pbt.get()->pbtime_ += _randgauss.fire(0,_recoFromMCTruthErr); 
+          pbt.get()->pbterr_ = _recoFromMCTruthErr;
+        }else{
+          pbt.get()->pbtime_ = -1*period/2.;
+          pbt.get()->pbterr_ = period/sqrt(12);
+        }
+      }
+
+      event.put(std::move(marker));
+      event.put(std::move(pbtmc));
+      event.put(std::move(pbt));
+  }
 }
 
 using mu2e::EventWindowMarkerProducer;

--- a/CommonMC/src/SelectRecoMC_module.cc
+++ b/CommonMC/src/SelectRecoMC_module.cc
@@ -17,6 +17,7 @@
 #include "DataProducts/inc/VirtualDetectorId.hh"
 #include "DataProducts/inc/IndexMap.hh"
 #include "DataProducts/inc/EventWindowMarker.hh"
+#include "MCDataProducts/inc/ProtonBunchTimeMC.hh"
 #include "MCDataProducts/inc/PrimaryParticle.hh"
 #include "MCDataProducts/inc/StrawDigiMC.hh"
 #include "MCDataProducts/inc/CaloShowerSim.hh"
@@ -95,6 +96,8 @@ namespace mu2e {
 	Comment("CaloShowerSim collection")};
       fhicl::Atom<art::InputTag> EWM { Name("EventWindowMarker"),
 	Comment("EventWindowMarker")};
+      fhicl::Atom<art::InputTag> PBTMC { Name("ProtonBunchTimeMC"),
+	Comment("ProtonBunchTimeMC")};
       fhicl::Atom<art::InputTag> PBI { Name("ProtonBunchIntensity"),
 	Comment("ProtonBunchIntensity")};
       fhicl::Atom<double> CCMCDT { Name("CaloClusterMCDTime"),
@@ -129,7 +132,7 @@ namespace mu2e {
        PrimaryParticle const& pp, RecoCount& nrec);
    int _debug;
    bool _saveallenergy, _saveunused, _saveallunused;
-   art::InputTag _pp, _ccc, _crvccc, _sdc, _shfc, _chc, _cdc, _sdmcc, _crvdc, _crvdmcc, _vdspc, _cssc, _ewm, _pbi;
+   art::InputTag _pp, _ccc, _crvccc, _sdc, _shfc, _chc, _cdc, _sdmcc, _crvdc, _crvdmcc, _vdspc, _cssc, _ewm, _pbtmc, _pbi;
    std::vector<std::string> _kff, _mh;
    SimParticleTimeOffset _toff;
    double _ccmcdt, _csme, _ccme;
@@ -157,6 +160,7 @@ namespace mu2e {
     _vdspc(config().VDSPC()),
     _cssc(config().CSSC()),
     _ewm(config().EWM()),
+    _pbtmc(config().PBTMC()),
     _pbi(config().PBI()),
     _kff(config().KFFInstances()),
     _mh(config().MHInstances()),
@@ -177,6 +181,7 @@ namespace mu2e {
     consumes<StrawDigiMCCollection>(_sdmcc);
     consumes<CrvDigiMCCollection>(_crvdmcc);
     consumes<EventWindowMarker>(_ewm);
+    consumes<ProtonBunchTimeMC>(_pbtmc);
     consumes<ProtonBunchIntensity>(_pbi);
     produces <IndexMap>("StrawDigiMap"); 
     produces <IndexMap>("CrvDigiMap"); 
@@ -195,6 +200,7 @@ namespace mu2e {
     produces <CrvCoincidenceClusterCollection>();
     produces <RecoCount>();
     produces <EventWindowMarker>();
+    produces <ProtonBunchTimeMC>();
     produces <ProtonBunchIntensity>();
     if(_debug > 0){
       std::cout << "Using KalSeed collections from ";
@@ -216,6 +222,8 @@ namespace mu2e {
     auto const& pp = *pph;
     auto ewmh = event.getValidHandle<EventWindowMarker>(_ewm);
     auto const& ewm = *ewmh;
+    auto pbtmch = event.getValidHandle<ProtonBunchTimeMC>(_pbtmc);
+    auto const& pbtmc = *pbtmch;
     auto pbih = event.getValidHandle<ProtonBunchIntensity>(_pbi);
     auto const& pbi = *pbih;
     // reco count summary
@@ -231,6 +239,7 @@ namespace mu2e {
     // put output in event
     // rewerite MC values: these are standins for actual reconstruction values FIXME!
     event.put(std::move(std::unique_ptr<EventWindowMarker>(new EventWindowMarker(ewm))));
+    event.put(std::move(std::unique_ptr<ProtonBunchTimeMC>(new ProtonBunchTimeMC(pbtmc))));
     event.put(std::move(std::unique_ptr<ProtonBunchIntensity>(new ProtonBunchIntensity(pbi))));
     event.put(std::move(nrec));
   }

--- a/DataProducts/inc/EventWindowMarker.hh
+++ b/DataProducts/inc/EventWindowMarker.hh
@@ -3,9 +3,14 @@
 
 namespace mu2e {
   struct EventWindowMarker {
-    float timeOffset() const { return _timeOffset;}
+    enum SpillType { offspill=0,onspill=1 }; 
+
+    SpillType spillType() const { return _spillType;}
+    double eventLength() const { return _eventLength;}
     //
-    float _timeOffset;
+    
+    SpillType _spillType; 
+    double _eventLength; // in ns, for on spill should be 1675 or 1700
   };
 }
 

--- a/EventGenerator/src/RPCGun_module.cc
+++ b/EventGenerator/src/RPCGun_module.cc
@@ -45,7 +45,6 @@
 #include "GeneralUtilities/inc/RSNTIO.hh"
 #include "MCDataProducts/inc/FixedTimeMap.hh"
 #include "Mu2eUtilities/inc/ProtonPulseRandPDF.hh"
-#include "DataProducts/inc/EventWindowMarker.hh"
 
 // ROOT includes
 #include "TTree.h"

--- a/Filters/fcl/prolog.fcl
+++ b/Filters/fcl/prolog.fcl
@@ -96,6 +96,8 @@ DigiCompression : {
 		       "keep mu2e::StatusG4_*_*_*",
 		       "keep art::TriggerResults_*_*_*",
 		       "keep mu2e::EventWindowMarker_*_*_*",
+                       "keep mu2e::ProtonBunchTimeMC_*_*_*",
+                       "keep mu2e::ProtonBunchTime_*_*_*",
 		       "keep *_genCounter_*_*",
 		       "keep mu2e::EventWeight_*_*_*",
 		       "keep mu2e::ProtonBunchIntensity_*_*_*" ]

--- a/JobConfig/reco/prolog.fcl
+++ b/JobConfig/reco/prolog.fcl
@@ -111,6 +111,7 @@ Reconstruction : {
        StrawDigiMCCollection : "compressDigiMCs"
        CrvDigiMCCollection : "compressDigiMCs"
        EventWindowMarker : "EWMProducer"
+       ProtonBunchTimeMC : "EWMProducer"
        ProtonBunchIntensity : "protonBunchIntensity"
        KFFInstances  : ["KFFDeM", "KFFDeP", "KFFDmuM", "KFFDmuP",
 		     "KFFUeM", "KFFUeP", "KFFUmuM", "KFFUmuP" ]
@@ -256,6 +257,8 @@ Reconstruction : {
 	    "keep mu2e::PrimaryParticle_*_*_*",
 	    "keep mu2e::ProtonBunchIntensity_protonBunchIntensity_*_*",
 	    "keep mu2e::EventWindowMarker_EWMProducer_*_*",
+            "keep mu2e::ProtonBunchTimeMC_EWMProducer_*_*",
+            "keep mu2e::ProtonBunchTime_EWMProducer_*_*",
 	    "keep *_compressDigiMCs_*_*"
 	    ]
 }

--- a/MCDataProducts/inc/FixedTimeMap.hh
+++ b/MCDataProducts/inc/FixedTimeMap.hh
@@ -2,13 +2,8 @@
 // time instead of after Geant4 simulation. All sim particles from this
 // event will be given the same proton time
 
-#ifndef FixedProtonPulseTimeAssns_hh
-#define FixedProtonPulseTimeAssns_hh
-
-#include <map>
-
-#include "canvas/Persistency/Common/Ptr.h"
-
+#ifndef FixedTimeMap_hh
+#define FixedTimeMap_hh
 
 namespace mu2e {
   class FixedTimeMap {
@@ -26,4 +21,4 @@ namespace mu2e {
 
 }
 
-#endif/*FixedProtonPulseTimeAssns_hh*/
+#endif/*FixedTimeMap_hh*/

--- a/MCDataProducts/inc/ProtonBunchTimeMC.hh
+++ b/MCDataProducts/inc/ProtonBunchTimeMC.hh
@@ -1,0 +1,10 @@
+#ifndef MCDataProducts_ProtonBunchTimeMC_hh
+#define MCDataProducts_ProtonBunchTimeMC_hh
+
+namespace mu2e {
+  struct ProtonBunchTimeMC {
+    float pbtime_;  // time the proton bunch reaches the target in ns since event window marker
+  };
+
+}
+#endif

--- a/MCDataProducts/src/classes.h
+++ b/MCDataProducts/src/classes.h
@@ -38,6 +38,7 @@
 #include "MCDataProducts/inc/PhysicalVolumeInfoCollection.hh"
 #include "MCDataProducts/inc/PhysicalVolumeInfoMultiCollection.hh"
 #include "MCDataProducts/inc/StepFilterMode.hh"
+#include "MCDataProducts/inc/ProtonBunchTimeMC.hh"
 #include "MCDataProducts/inc/ProtonBunchIntensity.hh"
 #include "MCDataProducts/inc/ProtonBunchIntensitySummary.hh"
 #include "MCDataProducts/inc/EventWeight.hh"

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -103,6 +103,8 @@
  <class name="mu2e::EventWeight"/>
  <class name="art::Wrapper<mu2e::EventWeight>"/>
 
+ <class name="mu2e::ProtonBunchTimeMC" />
+ <class name="art::Wrapper<mu2e::ProtonBunchTimeMC>"/>
  <class name="mu2e::ProtonBunchIntensity" />
  <class name="art::Wrapper<mu2e::ProtonBunchIntensity>"/>
  <class name="mu2e::ProtonBunchIntensitySummary" />

--- a/RecoDataProducts/inc/ProtonBunchTime.hh
+++ b/RecoDataProducts/inc/ProtonBunchTime.hh
@@ -1,0 +1,17 @@
+#ifndef RecoDataProducts_ProtonBunchTime_hh
+#define RecoDataProducts_ProtonBunchTime_hh
+//
+//  Data product representing the time of the peak of the proton bunch current at the front face of
+//  the production target WRT the DAQ clock (EventWindowMarker)
+//  of this event.  This can be estimated from early 'beam flash' detector signals.
+//  Original author: Dave Brown (LBNL) 10/1/2020
+//
+namespace mu2e {
+  struct ProtonBunchTime {
+    float pbtime_;  // estimate of the time the proton bunch reaches the target
+    float variance_; // variance on the estimate
+    unsigned nhits_; // number of hits used in this offset determination
+  };
+
+}
+#endif

--- a/RecoDataProducts/inc/ProtonBunchTime.hh
+++ b/RecoDataProducts/inc/ProtonBunchTime.hh
@@ -8,9 +8,8 @@
 //
 namespace mu2e {
   struct ProtonBunchTime {
-    float pbtime_;  // estimate of the time the proton bunch reaches the target
-    float variance_; // variance on the estimate
-    unsigned nhits_; // number of hits used in this offset determination
+    float pbtime_;  // estimated mean time the proton bunch reaches the target
+    float pbterr_; // estimated error on the mean
   };
 
 }

--- a/RecoDataProducts/src/classes.h
+++ b/RecoDataProducts/src/classes.h
@@ -11,6 +11,9 @@
 #include "RecoDataProducts/inc/CosmicTrack.hh" 
 #include "RecoDataProducts/inc/CosmicTrackSeed.hh"
 
+// beam
+#include "RecoDataProducts/inc/ProtonBunchTime.hh"
+
 // calorimeter
 #include "RecoDataProducts/inc/CaloDigi.hh"
 #include "RecoDataProducts/inc/CaloRecoDigiCollection.hh"

--- a/RecoDataProducts/src/classes_def.xml
+++ b/RecoDataProducts/src/classes_def.xml
@@ -10,6 +10,7 @@
 
 <!--  ********* beam  ********* -->
  <class name="mu2e::ProtonBunchTime"/>
+ <class name="art::Wrapper<mu2e::ProtonBunchTime>"/>
 
 <!--  ********* cosmics  ********* -->
  <class name="TrackParams"/>

--- a/RecoDataProducts/src/classes_def.xml
+++ b/RecoDataProducts/src/classes_def.xml
@@ -7,6 +7,10 @@
 <lcgdict>
 
  <class name="std::vector<std::pair<unsigned int, unsigned int> >"/>
+
+<!--  ********* beam  ********* -->
+ <class name="mu2e::ProtonBunchTime"/>
+
 <!--  ********* cosmics  ********* -->
  <class name="TrackParams"/>
  <class name="TrackCov"/>

--- a/TrackerConditions/fcl/prolog.fcl
+++ b/TrackerConditions/fcl/prolog.fcl
@@ -116,9 +116,7 @@ StrawElectronics : {
    TDCResolution : 0.1
    electronicsTimeDelay : 0.0
    eventWindowMarkerROCJitter : 0.5
-   flashStart : 1695.0
    flashEnd : 500.0
-   flashClockSpeed : 0.0
    responseBins : 10000
    sampleRate : 10.0
    saturationSampleFactor : 25

--- a/TrackerConditions/inc/StrawElectronics.hh
+++ b/TrackerConditions/inc/StrawElectronics.hh
@@ -58,8 +58,8 @@ namespace mu2e {
 		      unsigned maxtsep, unsigned tCoince, 
 		      double TDCLSB, unsigned maxTDC, double TOTLSB, unsigned maxTOT, 
 		      double tdcResolution, double electronicsTimeDelay, 
-		      double ewMarkerROCJitter, double flashStart, 
-		      double flashEnd, double flashClockSpeed, 
+		      double ewMarkerROCJitter, 
+		      double flashEnd, 
 		      int responseBins, double sampleRate, int saturationSampleFactor, 
 		      std::vector<double> preampPoles, std::vector<double> preampZeros, 
 		      std::vector<double> adcPoles, std::vector<double> adcZeros, 
@@ -89,8 +89,7 @@ namespace mu2e {
       _TDCLSB(TDCLSB), _maxTDC(maxTDC), _TOTLSB(TOTLSB), _maxTOT(maxTOT), 
       _tdcResolution(tdcResolution), _electronicsTimeDelay(electronicsTimeDelay), 
       _ewMarkerROCJitter(ewMarkerROCJitter), 
-      _flashStart(flashStart), _flashEnd(flashEnd), 
-      _flashClockSpeed(flashClockSpeed),
+      _flashEnd(flashEnd), 
       _responseBins(responseBins), 
       _sampleRate(sampleRate), _saturationSampleFactor(saturationSampleFactor), 
       _preampPoles(preampPoles), _preampZeros(preampZeros), _adcPoles(adcPoles), 
@@ -123,8 +122,8 @@ namespace mu2e {
     TrkTypes::ADCValue adcResponse(StrawId id, double mvolts) const; // ADC response to analog inputs
     TrkTypes::TDCValue tdcResponse(double time) const; // TDC response to a signal input to electronics at a given time (in ns since eventWindowMarker)
     void digitizeWaveform(StrawId id, TrkTypes::ADCVoltages const& wf, TrkTypes::ADCWaveform& adc, TrkTypes::ADCValue &pmp) const; // digitize an array of voltages at the ADC
-    bool digitizeTimes(TrkTypes::TDCTimes const& times,TrkTypes::TDCValues& tdc) const; // times in ns since eventWindowMarker
-    bool digitizeAllTimes(TrkTypes::TDCTimes const& times,double mbtime, TrkTypes::TDCValues& tdcs) const; // for straws which are being read regardless of flash blanking
+    bool digitizeTimes(TrkTypes::TDCTimes const& times,TrkTypes::TDCValues& tdc,TrkTypes::TDCValue const& eventWindowEndTDC) const; // times in ns since eventWindowMarker
+    bool digitizeAllTimes(TrkTypes::TDCTimes const& times,double mbtime, TrkTypes::TDCValues& tdcs, TrkTypes::TDCValue const& eventWindowEndTDC) const; // for straws which are being read regardless of flash blanking
     void uncalibrateTimes(TrkTypes::TDCTimes &times, const StrawId &id) const; // convert time from beam t0 to tracker channel t0
     bool combineEnds(double t1, double t2) const; // are times from 2 ends combined into a single digi?
     // interpretation of digital data
@@ -143,7 +142,6 @@ namespace mu2e {
     size_t nADCPreSamples() const { return _nADCpre; }
     double adcPeriod() const { return _ADCPeriod; } // period of ADC clock in nsec
     double adcOffset() const { return _ADCOffset; } // offset WRT clock edge for digitization
-    double flashStart() const { return _flashStart; } // time flash blanking starts
     double flashEnd() const { return _flashEnd; } // time flash blanking ends
     void adcTimes(double time, TrkTypes::ADCTimes& adctimes) const; // given crossing time, fill sampling times of ADC CHECK THIS IS CORRECT IN DRAC FIXME!
     double saturationVoltage() const { return _vsat; }
@@ -180,8 +178,7 @@ namespace mu2e {
     void setAnalogNoise(std::array<double,npaths> analognoise) 
               { _analognoise = analognoise; }
     void setvthresh(std::vector<double> vthresh) { _vthresh = vthresh;}
-    void setFlashTDC( double flashStartTDC, double flashEndTDC) {
-      _flashStartTDC = flashStartTDC;
+    void setFlashTDC( double flashEndTDC) {
       _flashEndTDC = flashEndTDC;
     }
     void setADCPed( std::vector<uint16_t> ADCped) { _ADCped = ADCped; }
@@ -237,8 +234,8 @@ namespace mu2e {
     double _electronicsTimeDelay; // Absolute time delay in electronics due to firmware signal propagation etc (ns)
     double _ewMarkerROCJitter; // jitter of ewMarker per ROC (ns)
     // electronicsTimeDelay is the time offset between a hit arriving at the electronics and the time that is digitized
-    double _flashStart, _flashEnd, _flashClockSpeed; // flash blanking period (no digitizations during this time!!!) (ns from eventWindowMarker arrival, what will actually be set)
-    TrkTypes::TDCValue _flashStartTDC, _flashEndTDC; // TDC values corresponding to the above. Note ignores electronicsTimeDelay since this is not a digitized signal
+    double _flashEnd; // flash blanking period (no digitizations during this time!!!) (ns from eventWindowMarker arrival, what will actually be set)
+    TrkTypes::TDCValue _flashEndTDC; // TDC values corresponding to the above. Note ignores electronicsTimeDelay since this is not a digitized signal
     // but an actual TDC value that will be compared against
     // helper functions
     static inline double mypow(double,unsigned);

--- a/TrackerConditions/inc/StrawElectronics.hh
+++ b/TrackerConditions/inc/StrawElectronics.hh
@@ -128,7 +128,6 @@ namespace mu2e {
     void uncalibrateTimes(TrkTypes::TDCTimes &times, const StrawId &id) const; // convert time from beam t0 to tracker channel t0
     bool combineEnds(double t1, double t2) const; // are times from 2 ends combined into a single digi?
     // interpretation of digital data
-    void tdcTimes(TrkTypes::TDCValues const& tdc, TrkTypes::TDCTimes& times) const;
     double adcVoltage(StrawId sid, uint16_t adcval) const; // mVolts
     double adcCurrent(StrawId sid, uint16_t adcval) const; // microAmps
     // accessors

--- a/TrackerConditions/src/StrawElectronics.cc
+++ b/TrackerConditions/src/StrawElectronics.cc
@@ -176,25 +176,24 @@ namespace mu2e {
     pmp = peak - (pedestal/(int)_nADCpre);
   }
 
-  bool StrawElectronics::digitizeAllTimes(TDCTimes const& times,double mbtime, TDCValues& tdcs) const {
+  bool StrawElectronics::digitizeAllTimes(TDCTimes const& times,double mbtime, TDCValues& tdcs, TDCValue const& eventWindowEndTDC) const {
     for(size_t itime=0;itime<2;++itime)
       tdcs[itime] = tdcResponse(times[itime]);
     // test these times against time wrapping.  This calculation should be done at construction or init,
     // FIXME!
     bool notwrap(true);
-    for(auto tdc : tdcs){
-      notwrap &= tdc > tdcResponse(_flashStart - mbtime) && tdc < _flashStartTDC;
-    }
+    for(size_t itime=0;itime<2;++itime)
+      notwrap &= times[itime]+_electronicsTimeDelay > 0 && tdcs[itime] < eventWindowEndTDC;
     return notwrap;
   }
 
-  bool StrawElectronics::digitizeTimes(TDCTimes const& times,TDCValues& tdcs) const {
+  bool StrawElectronics::digitizeTimes(TDCTimes const& times,TDCValues& tdcs, TDCValue const& eventWindowEndTDC) const {
     for(size_t itime=0;itime<2;++itime)
       tdcs[itime] = tdcResponse(times[itime]);
     // test bothe these times against the flash blanking. 
     bool notflash(true);
     for(auto tdc : tdcs){
-      notflash &= tdc > _flashEndTDC && tdc < _flashStartTDC;
+      notflash &= tdc > _flashEndTDC && tdc < eventWindowEndTDC;
     }
     return notflash;
   }
@@ -287,10 +286,7 @@ namespace mu2e {
     os << "tdcResolution = " << _tdcResolution << endl;
     os << "electronicsTimeDelay = " << _electronicsTimeDelay << endl;
     os << "ewMarkerROCJitter = " << _ewMarkerROCJitter << endl;
-    os << "flashStart = " << _flashStart << endl;
     os << "flashEnd = " << _flashEnd << endl;
-    os << "flashClockSpeed = " << _flashClockSpeed << endl;
-    os << "flashStartTDC = " << _flashStartTDC << endl;
     os << "flashEndTDC = " << _flashEndTDC << endl;
     os << "responseBins = " << _responseBins << endl;
     os << "sampleRate = " << _sampleRate << endl;

--- a/TrackerConditions/src/StrawElectronicsMaker.cc
+++ b/TrackerConditions/src/StrawElectronicsMaker.cc
@@ -26,7 +26,7 @@ namespace mu2e {
        _config.TDCLSB(), _config.maxTDC(), _config.TOTLSB(), 
        _config.maxTOT(), _config.TDCResolution(), 
        _config.electronicsTimeDelay(), _config.eventWindowMarkerROCJitter(), 
-       _config.flashStart(), _config.flashEnd(), _config.flashClockSpeed(),
+       _config.flashEnd(),
        _config.responseBins(), 
        _config.sampleRate(), _config.saturationSampleFactor(), 
        _config.preampPoles(), _config.preampZeros(), 
@@ -69,8 +69,7 @@ namespace mu2e {
     ptr->setvthresh(vthresh);
 
     // here we start using the partially constructed StrawElectronics *ptr
-    ptr->setFlashTDC( ptr->tdcResponse( _config.flashStart() ),
-		      ptr->tdcResponse( _config.flashEnd()   ) );
+    ptr->setFlashTDC( ptr->tdcResponse( _config.flashEnd()   ) );
 
     std::vector<uint16_t> ADCped(96,0);
     for (int i=0;i<96;i++){

--- a/TrackerConfig/inc/StrawElectronicsConfig.hh
+++ b/TrackerConfig/inc/StrawElectronicsConfig.hh
@@ -72,12 +72,8 @@ namespace mu2e {
       Name("electronicsTimeDelay"), Comment("nsec, Absolute time delay in electronics due to firmware signal propagation etc")};
     fhicl::Atom<double> eventWindowMarkerROCJitter {
       Name("eventWindowMarkerROCJitter"), Comment("ps (jitter per panel per microbuncH)")};
-    fhicl::Atom<double> flashStart {
-      Name("flashStart"), Comment("nsec, flash blanking period")};
     fhicl::Atom<double> flashEnd {
       Name("flashEnd"), Comment("nsec, flash blanking period")};
-    fhicl::Atom<double> flashClockSpeed {
-      Name("flashClockSpeed"), Comment("nsec")};
     fhicl::Atom<int> responseBins {
       Name("responseBins"), Comment("")};
     fhicl::Atom<double> sampleRate {

--- a/TrkDiag/fcl/test_PBT.fcl
+++ b/TrkDiag/fcl/test_PBT.fcl
@@ -21,6 +21,7 @@ physics.analyzers : {
   PBTD : {
     module_type             : ProtonBunchTimeDiag
     ProtonBunchTimeTag : PBTFSD
+    ProtonBunchTimeMCTag : EWMProducer
     EventWindowMarkerTag : EWMProducer
   }
 }

--- a/TrkDiag/fcl/test_PBT.fcl
+++ b/TrkDiag/fcl/test_PBT.fcl
@@ -9,7 +9,7 @@ services : @local::Services.Reco
 physics.producers: {
   PBTFSD : {
     module_type             : ProtonBunchTimeFromStrawDigis
-    debugLevel : 2
+    debugLevel : 0
     diagLevel : 0
     printLevel : 0
     nBins : 30

--- a/TrkDiag/fcl/test_PBT.fcl
+++ b/TrkDiag/fcl/test_PBT.fcl
@@ -9,10 +9,12 @@ services : @local::Services.Reco
 physics.producers: {
   PBTFSD : {
     module_type             : ProtonBunchTimeFromStrawDigis
-    debugLevel : 0
-    diagLevel : 0
-    printLevel : 0
-    nBins : 30
+    DebugLevel : 0
+    DiagLevel : 0
+    PrintLevel : 0
+    MinNHits : 1
+    MaxDigiTime : 200
+    MeanTimeOffset : 99.5
   }
 }
 physics.analyzers : {

--- a/TrkDiag/fcl/test_PBT.fcl
+++ b/TrkDiag/fcl/test_PBT.fcl
@@ -1,0 +1,29 @@
+#include "fcl/standardServices.fcl"
+process_name : TestPBTO
+# augment producers and analyzers
+#
+source : {
+  module_type : RootInput
+}
+services : @local::Services.Reco
+physics.producers: {
+  PBTFSD : {
+    module_type             : ProtonBunchTimeFromStrawDigis
+    debugLevel : 2
+    diagLevel : 0
+    printLevel : 0
+    nBins : 30
+  }
+}
+physics.analyzers : {
+  PBTD : {
+    module_type             : ProtonBunchTimeDiag
+    ProtonBunchTimeTag : PBTFSD
+    EventWindowMarkerTag : EWMProducer
+  }
+}
+
+physics.TriggerPath : [ PBTFSD ]
+physics.EndPath : [ PBTD ]
+
+

--- a/TrkDiag/src/ProtonBunchTimeDiag_module.cc
+++ b/TrkDiag/src/ProtonBunchTimeDiag_module.cc
@@ -23,7 +23,6 @@ namespace mu2e {
       using Comment=fhicl::Comment;
 
       struct Config {
-	fhicl::Atom<unsigned> minnhits{ Name("minNHits"), Comment("Minimum number of hits needed to use result"), 1};
 	fhicl::Atom<art::InputTag> ewMarkerTag{ Name("EventWindowMarkerTag"), Comment("EventWindowMarker producer"),"EWMProducer" };
 	fhicl::Atom<art::InputTag> pbtimeTag{ Name("ProtonBunchTimeTag"), Comment("ProtonBunchTime producer"),"PBTFSD" };
       };
@@ -35,8 +34,8 @@ namespace mu2e {
     private:
       art::InputTag ewmtag_, pbttag_;
       TTree* pbttest_;
-      int iev_, nhits_;
-      float tmean_, tvariance_, ewmoffset_;
+      int iev_;
+      float tmean_, terr_, ewmoffset_;
   };
 
   ProtonBunchTimeDiag::ProtonBunchTimeDiag(Parameters const& config) :
@@ -55,9 +54,8 @@ namespace mu2e {
     art::ServiceHandle<art::TFileService> tfs;
     pbttest_=tfs->make<TTree>("pbtdiag","proton bunch time diagnostics");
     pbttest_->Branch("iev",&iev_,"iev/I");
-    pbttest_->Branch("nhits",&nhits_,"nhits/I");
     pbttest_->Branch("tmean",&tmean_,"tmean/F");
-    pbttest_->Branch("tvariance",&tvariance_,"tvariance/F");
+    pbttest_->Branch("terr",&terr_,"terr/F");
     pbttest_->Branch("ewmoffset",&ewmoffset_,"ewmoffset/F");
   }
 
@@ -68,9 +66,8 @@ namespace mu2e {
     auto const& ewm(*ewmH);
 
     iev_ = event.id().event();
-    nhits_ = pbt.nhits_; 
     tmean_= pbt.pbtime_; 
-    tvariance_ = pbt.variance_; 
+    terr_ = pbt.pbterr_; 
     ewmoffset_ = ewm._timeOffset;
     pbttest_->Fill();
   }

--- a/TrkDiag/src/ProtonBunchTimeDiag_module.cc
+++ b/TrkDiag/src/ProtonBunchTimeDiag_module.cc
@@ -1,0 +1,81 @@
+
+//
+// This module analyzes the proton bunch time reconstruction, comparing
+// it to the MC true EventWindow offset
+//
+// Original author David Brown, 10/1/2020 LBNL
+//
+// framework
+#include "art/Framework/Principal/Event.h"
+#include "art_root_io/TFileService.h"
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "RecoDataProducts/inc/ProtonBunchTime.hh"
+#include "DataProducts/inc/EventWindowMarker.hh"
+#include "TTree.h"
+
+namespace mu2e {
+
+  class ProtonBunchTimeDiag : public art::EDAnalyzer
+  {
+    public:
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+
+      struct Config {
+	fhicl::Atom<unsigned> minnhits{ Name("minNHits"), Comment("Minimum number of hits needed to use result"), 1};
+	fhicl::Atom<art::InputTag> ewMarkerTag{ Name("EventWindowMarkerTag"), Comment("EventWindowMarker producer"),"EWMProducer" };
+	fhicl::Atom<art::InputTag> pbtimeTag{ Name("ProtonBunchTimeTag"), Comment("ProtonBunchTime producer"),"PBTFSD" };
+      };
+      using Parameters = art::EDAnalyzer::Table<Config>;
+      explicit ProtonBunchTimeDiag(Parameters const& config);
+      virtual ~ProtonBunchTimeDiag();
+      void analyze( art::Event const & e) override;
+      void beginJob ( ) override;
+    private:
+      art::InputTag ewmtag_, pbttag_;
+      TTree* pbttest_;
+      int iev_, nhits_;
+      float tmean_, tvariance_, ewmoffset_;
+  };
+
+  ProtonBunchTimeDiag::ProtonBunchTimeDiag(Parameters const& config) :
+    art::EDAnalyzer(config),
+    ewmtag_(config().ewMarkerTag()),
+    pbttag_(config().pbtimeTag()),
+    pbttest_(0)
+  {
+    consumes<EventWindowMarker>(ewmtag_);
+    consumes<ProtonBunchTime>(pbttag_);
+  }
+
+  ProtonBunchTimeDiag::~ProtonBunchTimeDiag() {}
+
+  void ProtonBunchTimeDiag::beginJob(){ 
+    art::ServiceHandle<art::TFileService> tfs;
+    pbttest_=tfs->make<TTree>("pbtdiag","proton bunch time diagnostics");
+    pbttest_->Branch("iev",&iev_,"iev/I");
+    pbttest_->Branch("nhits",&nhits_,"nhits/I");
+    pbttest_->Branch("tmean",&tmean_,"tmean/F");
+    pbttest_->Branch("tvariance",&tvariance_,"tvariance/F");
+    pbttest_->Branch("ewmoffset",&ewmoffset_,"ewmoffset/F");
+  }
+
+  void ProtonBunchTimeDiag::analyze(art::Event const& event) {        
+    auto pbtH = event.getValidHandle<ProtonBunchTime>(pbttag_);
+    auto const& pbt(*pbtH);
+    auto ewmH = event.getValidHandle<EventWindowMarker>(ewmtag_);
+    auto const& ewm(*ewmH);
+
+    iev_ = event.id().event();
+    nhits_ = pbt.nhits_; 
+    tmean_= pbt.pbtime_; 
+    tvariance_ = pbt.variance_; 
+    ewmoffset_ = ewm._timeOffset;
+    pbttest_->Fill();
+  }
+}
+
+using mu2e::ProtonBunchTimeDiag;
+DEFINE_ART_MODULE(ProtonBunchTimeDiag);
+

--- a/TrkDiag/test/PBT.C
+++ b/TrkDiag/test/PBT.C
@@ -1,0 +1,37 @@
+#include "TTree.h"
+#include "TCanvas.h"
+#include "TH2F.h"
+#include "TH1F.h"
+#include "TProfile.h"
+#include "TGraphErrors.h"
+#include "TF1.h"
+
+void PBTO(TTree* tree) {
+  TProfile* meanprof = new TProfile("meanprof","Proton Bunch Mean Time vs EWM Offset;EWM offset (ns);PBTO (ns)",50,-12.5,12.5,-50,50);
+  TH2F* mean2d = new TH2F("mean2d","Proton Bunch Mean Time vs EWM Offset;EWM offset (ns);PBTO (ns)",50,-12.5,12.5,30,-50,50);
+  TH1F* res = new TH1F("res","Proton Bunch Mean Time Resolution;#Delta t (ns)",50,-50,50);
+  TH1F* pull = new TH1F("pull","Proton Bunch Mean Time Pull;#Delta t/#sigma_t",50,-10,10);
+  TH1F* terr = new TH1F("terr","Estimated Error on Proton Bunch Mean Time;$sigma_t (ns)",50,0,30);
+  tree->Project("mean2d","tmean:-ewmoffset");
+  tree->Project("meanprof","tmean:-ewmoffset");
+  tree->Project("res","tmean+ewmoffset");
+  tree->Project("pull","(tmean+ewmoffset)/terr");
+  tree->Project("terr","terr");
+  mean2d->SetStats(0);
+
+  TCanvas* can = new TCanvas("can","can",1600,1200);
+  can->Divide(2,2);
+  can->cd(1);
+  mean2d->Draw("colorz");
+  meanprof->Fit("pol1","","sames");
+  can->cd(2);
+  res->Fit("gaus","","",-20,20);
+  can->cd(3);
+  pull->Fit("gaus");
+  can->cd(4);
+  terr->Draw();
+//  median2d->Draw();
+//  medianprof->Fit("pol1","","sames");
+
+}
+

--- a/TrkDiag/test/PBT_SHD.C
+++ b/TrkDiag/test/PBT_SHD.C
@@ -1,0 +1,39 @@
+
+#include "TTree.h"
+#include "TCanvas.h"
+#include "TH2F.h"
+#include "TH1F.h"
+#include "TProfile.h"
+#include "TGraphErrors.h"
+#include "TF1.h"
+
+void PBTO(TTree* tree) {
+  TProfile* meanprof = new TProfile("meanprof","Early Straw Hit Time vs EWM Offset;EWM offset (ns);PBTO (ns)",30,-12.5,12.5,-50,200);
+  TH2F* mean2d = new TH2F("mean2d","Early Straw Hit Time vs EWM Offset;EWM offset (ns);PBTO (ns)",30,-12.5,12.5,30,-50,200);
+  TH1F* ewmres = new TH1F("ewmres","Early Straw Hit Time Resolution;#Delta t (ns)",30,-50,200);
+  TH1F* mcres = new TH1F("mcres","Early Straw Hit Time Resolution;#Delta t (ns)",30,-50,50);
+  TH1F* mcewmres = new TH1F("mcewmres","MC Hit Time Resolution;#Delta tt (ns)",30,-50,200);
+  TCut earlyhit("correcttime-ewmoffset<200");
+  tree->Project("mean2d","correcttime-ewmoffset:-ewmoffset",earlyhit);
+  tree->Project("meanprof","correcttime-ewmoffset:-ewmoffset",earlyhit);
+  tree->Project("ewmres","correcttime",earlyhit);
+  tree->Project("mcres","correcttime-ewmoffset-mcsptime",earlyhit);
+  tree->Project("mcewmres","mcsptime",earlyhit);
+  mean2d->SetStats(0);
+
+  TCanvas* can = new TCanvas("can","can",1600,1200);
+  can->Divide(2,2);
+  can->cd(1);
+  mean2d->Draw("colorz");
+  meanprof->Fit("pol1","","sames");
+  can->cd(2);
+  ewmres->Fit("gaus");
+  can->cd(3);
+  mcres->Fit("gaus");
+  can->cd(4);
+  mcewmres->Fit("gaus");
+//  median2d->Draw();
+//  medianprof->Fit("pol1","","sames");
+
+}
+

--- a/TrkHitReco/fcl/prolog.fcl
+++ b/TrkHitReco/fcl/prolog.fcl
@@ -11,7 +11,10 @@ makeSH : {
   module_type             : StrawHitReco
   FilterHits              : false
   WriteStrawHitCollection : true
-  ProtonBunchTimeLabel  : "PBTFSD"
+  ProtonBunchTimeTag  : "PBTFSD"
+  StrawDigiCollectionTag  : "makeSD"
+  StrawDigiADCWaveformCollectionTag : "makeSD"
+  CaloClusterCollectionTag  : "CaloClusterFast"
 }
 
 # combine hits in a panel
@@ -102,7 +105,7 @@ SflagBkgHits : {
 TrkHitReco : {
     producers : { 
 	# normal reco
-	PBTOFSD       : { @table::PBTOFSD       }
+	PBTFSD       : { @table::PBTFSD       }
 	makeSH        : { @table::makeSH       }
 	makePH        : { @table::makePH       }
 	makeSTH       : { @table::makeSTH      }
@@ -112,8 +115,8 @@ TrkHitReco : {
 
     # SEQUENCES
     # production sequence to prepare hits for tracking
-    PrepareHits  : [ PBTOFSD, makeSH, makePH, FlagBkgHits ]
-    SPrepareHits : [ PBTOFSD, makeSH, makePH, makeSTH, SflagBkgHits ]
+    PrepareHits  : [ PBTFSD, makeSH, makePH, FlagBkgHits ]
+    SPrepareHits : [ PBTFSD, makeSH, makePH, makeSTH, SflagBkgHits ]
 }
 
 END_PROLOG

--- a/TrkHitReco/fcl/prolog.fcl
+++ b/TrkHitReco/fcl/prolog.fcl
@@ -3,11 +3,15 @@ BEGIN_PROLOG
 # Normal reco seqence module: this produces a hit for every digi, and uses
 # flags to keep track of which hits to use
 # Reconstruct hits: this produces StrawHits and ComboHits
+PBTFSD : {
+  module_type             : ProtonBunchTimeFromStrawDigis
+}
+
 makeSH : {
   module_type             : StrawHitReco
   FilterHits              : false
   WriteStrawHitCollection : true
-  EventWindowMarkerLabel  : "EWMProducer"
+  ProtonBunchTimeLabel  : "PBTFSD"
 }
 
 # combine hits in a panel
@@ -98,6 +102,7 @@ SflagBkgHits : {
 TrkHitReco : {
     producers : { 
 	# normal reco
+	PBTOFSD       : { @table::PBTOFSD       }
 	makeSH        : { @table::makeSH       }
 	makePH        : { @table::makePH       }
 	makeSTH       : { @table::makeSTH      }
@@ -107,8 +112,8 @@ TrkHitReco : {
 
     # SEQUENCES
     # production sequence to prepare hits for tracking
-    PrepareHits  : [ makeSH, makePH, FlagBkgHits ]
-    SPrepareHits : [ makeSH, makePH, makeSTH, SflagBkgHits ]
+    PrepareHits  : [ PBTOFSD, makeSH, makePH, FlagBkgHits ]
+    SPrepareHits : [ PBTOFSD, makeSH, makePH, makeSTH, SflagBkgHits ]
 }
 
 END_PROLOG

--- a/TrkHitReco/fcl/prolog.fcl
+++ b/TrkHitReco/fcl/prolog.fcl
@@ -11,7 +11,7 @@ makeSH : {
   module_type             : StrawHitReco
   FilterHits              : false
   WriteStrawHitCollection : true
-  ProtonBunchTimeTag  : "PBTFSD"
+  ProtonBunchTimeTag  : "EWMProducer"
   StrawDigiCollectionTag  : "makeSD"
   StrawDigiADCWaveformCollectionTag : "makeSD"
   CaloClusterCollectionTag  : "CaloClusterFast"

--- a/TrkHitReco/fcl/prolog_trigger.fcl
+++ b/TrkHitReco/fcl/prolog_trigger.fcl
@@ -83,10 +83,10 @@ TrkHitRecoTrigger : {
     # SEQUENCES
     # production sequence to prepare hits for tracking
     sequences: {
-	TTprepareHits     : [ TTPBTFSD, TTmakeSH, TTmakePH,TTflagBkgHits ]
-	TTprepareHitsUCC  : [ TTPBTFSD, TTmakeSHUCC, TTmakePHUCC, TTflagBkgHitsUCC ]
-	TTmakefastHits    : [ TTPBTFSD, TTmakeSH, TTmakePH ]
-	TTSprepareHits    : [ TTPBTFSD, TTmakeSH, TTSmakePH, TTmakeSTH ,TTSflagBkgHits ]
+	TTprepareHits     : [ TTmakeSH, TTmakePH,TTflagBkgHits ]
+	TTprepareHitsUCC  : [ TTmakeSHUCC, TTmakePHUCC, TTflagBkgHitsUCC ]
+	TTmakefastHits    : [ TTmakeSH, TTmakePH ]
+	TTSprepareHits    : [ TTmakeSH, TTSmakePH, TTmakeSTH ,TTSflagBkgHits ]
     }
 }
 

--- a/TrkHitReco/fcl/prolog_trigger.fcl
+++ b/TrkHitReco/fcl/prolog_trigger.fcl
@@ -12,7 +12,7 @@ TTmakeSH : {
     module_type             : StrawHitReco
     FilterHits              : true
     WriteStrawHitCollection : false
-    ProtonBunchTimeTag      : "TTPBTFSD"
+    ProtonBunchTimeTag      : "EWMProducer"
     StrawDigiCollectionTag  : "makeSD"
     CaloClusterCollectionTag  : "CaloClusterFast"
 }
@@ -28,7 +28,7 @@ TTmakeSHUCC : {
     UseCalorimeter          : true
     FilterHits              : true
     WriteStrawHitCollection : false
-    ProtonBunchTimeTag      : "TTPBTFSD"
+    ProtonBunchTimeTag      : "EWMProducer"
     StrawDigiCollectionTag  : "makeSD"
     CaloClusterCollectionTag  : "CaloClusterFast"
 }

--- a/TrkHitReco/fcl/prolog_trigger.fcl
+++ b/TrkHitReco/fcl/prolog_trigger.fcl
@@ -4,11 +4,17 @@ BEGIN_PROLOG
 # Reconstruct hits: this produces StrawHits and ComboHits
 
 # now trigger-specific versions; these make deep copies
+TTPBTFSD : {
+  module_type             : ProtonBunchTimeFromStrawDigis
+}
+
 TTmakeSH : {
     module_type             : StrawHitReco
     FilterHits              : true
     WriteStrawHitCollection : false
-    EventWindowMarkerLabel  : "EWMProducer"
+    ProtonBunchTimeTag      : "TTPBTFSD"
+    StrawDigiCollectionTag  : "makeSD"
+    CaloClusterCollectionTag  : "CaloClusterFast"
 }
 # combine hits in a panel
 TTmakePH : {
@@ -22,7 +28,9 @@ TTmakeSHUCC : {
     UseCalorimeter          : true
     FilterHits              : true
     WriteStrawHitCollection : false
-    EventWindowMarkerLabel  : "EWMProducer"
+    ProtonBunchTimeTag      : "TTPBTFSD"
+    StrawDigiCollectionTag  : "makeSD"
+    CaloClusterCollectionTag  : "CaloClusterFast"
 }
 # combine hits in a panel
 TTmakePHUCC : {
@@ -60,6 +68,7 @@ TTSflagBkgHits : {
 # combine together
 TrkHitRecoTrigger : { 
     producers : { 
+	TTPBTFSD            : { @table::TTPBTFSD             }
 	TTmakeSH            : { @table::TTmakeSH             }
 	TTmakePH            : { @table::TTmakePH             }
 	TTmakeSHUCC         : { @table::TTmakeSHUCC          }
@@ -74,10 +83,10 @@ TrkHitRecoTrigger : {
     # SEQUENCES
     # production sequence to prepare hits for tracking
     sequences: {
-	TTprepareHits     : [ TTmakeSH, TTmakePH,TTflagBkgHits ]
-	TTprepareHitsUCC  : [ TTmakeSHUCC, TTmakePHUCC, TTflagBkgHitsUCC ]
-	TTmakefastHits    : [ TTmakeSH, TTmakePH ]
-	TTSprepareHits    : [ TTmakeSH, TTSmakePH, TTmakeSTH ,TTSflagBkgHits ]
+	TTprepareHits     : [ TTPBTFSD, TTmakeSH, TTmakePH,TTflagBkgHits ]
+	TTprepareHitsUCC  : [ TTPBTFSD, TTmakeSHUCC, TTmakePHUCC, TTflagBkgHitsUCC ]
+	TTmakefastHits    : [ TTPBTFSD, TTmakeSH, TTmakePH ]
+	TTSprepareHits    : [ TTPBTFSD, TTmakeSH, TTSmakePH, TTmakeSTH ,TTSflagBkgHits ]
     }
 }
 

--- a/TrkHitReco/src/ProtonBunchTimeFromStrawDigis_module.cc
+++ b/TrkHitReco/src/ProtonBunchTimeFromStrawDigis_module.cc
@@ -34,12 +34,12 @@ namespace mu2e {
       using Comment=fhicl::Comment;
 
       struct Config {
-	fhicl::Atom<int> debug{ Name("debugLevel"), Comment("Debug level"), 0};
-	fhicl::Atom<int> diag{ Name("diagLevel"), Comment("Diag level"), 0};
-	fhicl::Atom<int> print{ Name("printLevel"), Comment("Print level"), 0};
-	fhicl::Atom<unsigned> nbins{ Name("nBins"), Comment("Number of bins in time histogram"), 100};
-	fhicl::Atom<unsigned> minnhits{ Name("minNHits"), Comment("Minimum number of hits needed to use result"), 1};
-	fhicl::Atom<float> maxtime { Name("MaxDigiTime"), Comment("Maximum time to accept the digi as 'early' (nsec)"),300.0 };
+	fhicl::Atom<int> debug{ Name("DebugLevel"), Comment("Debug level"), 0};
+	fhicl::Atom<int> diag{ Name("DiagLevel"), Comment("Diag level"), 0};
+	fhicl::Atom<int> print{ Name("PrintLevel"), Comment("Print level"), 0};
+	fhicl::Atom<unsigned> nbins{ Name("NBins"), Comment("Number of bins in time histogram"), 30};
+	fhicl::Atom<unsigned> minnhits{ Name("MinNHits"), Comment("Minimum number of hits needed to use result"), 30};
+	fhicl::Atom<float> maxtime { Name("MaxDigiTime"), Comment("Maximum time to accept the digi as 'early' (nsec)"),200.0 };
 	fhicl::Atom<float> meantime { Name("MeanTimeOffset"), Comment("Mean time offset of 'early' hits (nsec)"),103.0}; // this should come from a database FIXME!
 	fhicl::Atom<art::InputTag> strawDigiTag{ Name("StrawDigiTag"), Comment("StrawDigi producer"),"makeSD" };
       };

--- a/TrkHitReco/src/ProtonBunchTimeFromStrawDigis_module.cc
+++ b/TrkHitReco/src/ProtonBunchTimeFromStrawDigis_module.cc
@@ -90,7 +90,7 @@ namespace mu2e {
     if(debug_ > 1 && event.id().event() < 1000) {
       art::ServiceHandle<art::TFileService> tfs;
       char hname[100];
-      snprintf(hname,100,"PBTO%i",event.id().event());
+      snprintf(hname,100,"PBT%i",event.id().event());
       timeplot = tfs->make<TH1F>(hname,"time spectrum;nsec",nbins_,0.0,maxtime_);
     }
 

--- a/TrkHitReco/src/ProtonBunchTimeFromStrawDigis_module.cc
+++ b/TrkHitReco/src/ProtonBunchTimeFromStrawDigis_module.cc
@@ -1,0 +1,128 @@
+
+//
+// This module looks for early tracker digis (before the flash blanking)
+// and uses them to estimate the proton bunch time of this event WRT
+// the DAQ clock
+//
+// Original author David Brown, 10/1/2020 LBNL
+//
+// framework
+#include "art/Framework/Principal/Event.h"
+#include "art_root_io/TFileService.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "ProditionsService/inc/ProditionsHandle.hh"
+#include "RecoDataProducts/inc/StrawDigi.hh"
+#include "RecoDataProducts/inc/ProtonBunchTime.hh"
+#include "TrackerConditions/inc/StrawResponse.hh"
+#include "TH1F.h"
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/variance.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/accumulators/statistics/mean.hpp>
+
+#include <iostream>
+#include <limits>
+
+namespace mu2e {
+  using namespace TrkTypes;
+
+  class ProtonBunchTimeFromStrawDigis : public art::EDProducer 
+  {
+    public:
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+
+      struct Config {
+	fhicl::Atom<int> debug{ Name("debugLevel"), Comment("Debug level"), 0};
+	fhicl::Atom<int> diag{ Name("diagLevel"), Comment("Diag level"), 0};
+	fhicl::Atom<int> print{ Name("printLevel"), Comment("Print level"), 0};
+	fhicl::Atom<unsigned> nbins{ Name("nBins"), Comment("Number of bins in time histogram"), 100};
+	fhicl::Atom<unsigned> minnhits{ Name("minNHits"), Comment("Minimum number of hits needed to use result"), 1};
+	fhicl::Atom<float> maxtime { Name("MaxDigiTime"), Comment("Maximum time to accept the digi as 'early' (nsec)"),300.0 };
+	fhicl::Atom<float> meantime { Name("MeanTimeOffset"), Comment("Mean time offset of 'early' hits (nsec)"),103.0}; // this should come from a database FIXME!
+	fhicl::Atom<art::InputTag> strawDigiTag{ Name("StrawDigiTag"), Comment("StrawDigi producer"),"makeSD" };
+      };
+      using Parameters = art::EDProducer::Table<Config>;
+      explicit ProtonBunchTimeFromStrawDigis(Parameters const& config);
+      virtual ~ProtonBunchTimeFromStrawDigis();
+      void produce( art::Event& e) override;
+      void beginJob ( ) override;
+    private:
+      int debug_, diag_, print_;
+      unsigned nbins_, minnhits_;
+      float maxtime_, meantime_;
+      art::InputTag ewmtag_, sdtag_;
+      ProditionsHandle<StrawResponse> _strawResponse_h;
+  };
+
+  ProtonBunchTimeFromStrawDigis::ProtonBunchTimeFromStrawDigis(Parameters const& config) :
+    EDProducer(config),
+    debug_(config().debug()),
+    diag_(config().diag()),
+    print_(config().print()),
+    nbins_(config().nbins()),
+    minnhits_(config().minnhits()),
+    maxtime_(config().maxtime()),
+    meantime_(config().meantime()),
+    sdtag_(config().strawDigiTag())
+  {
+    consumes<StrawDigiCollection>(sdtag_);
+    produces<ProtonBunchTime>();
+  }
+
+  ProtonBunchTimeFromStrawDigis::~ProtonBunchTimeFromStrawDigis() {}
+
+  void ProtonBunchTimeFromStrawDigis::beginJob(){ 
+ }
+
+  void ProtonBunchTimeFromStrawDigis::produce(art::Event& event) {        
+    using namespace boost::accumulators;
+    auto const& srep = _strawResponse_h.get(event.id());
+    auto sdH = event.getValidHandle<StrawDigiCollection>(sdtag_);
+    auto const& sdcol(*sdH);
+    std::unique_ptr<ProtonBunchTime> pbto(new ProtonBunchTime());
+// statistics accumulators
+//
+    accumulator_set<float, stats<tag::mean, tag::variance >> meanacc;
+
+    TH1F* timeplot(0);
+    if(debug_ > 1 && event.id().event() < 1000) {
+      art::ServiceHandle<art::TFileService> tfs;
+      char hname[100];
+      snprintf(hname,100,"PBTO%i",event.id().event());
+      timeplot = tfs->make<TH1F>(hname,"time spectrum;nsec",nbins_,0.0,maxtime_);
+    }
+
+    for (size_t isd=0;isd<sdcol.size();++isd) {
+      const StrawDigi& digi = sdcol[isd];
+    // correct to physical time
+      TDCTimes times;
+      srep.calibrateTimes(digi.TDC(),times,digi.strawId());
+      // take the early time
+      float mintime = std::min(times[StrawEnd::hv],times[StrawEnd::cal]);
+      if(mintime < maxtime_){
+      // This can be improved by using TOT to approximately correct for the propagation time, and maybe peak/ped to correct
+      // for time slewing TODO!
+	meanacc(mintime);
+// early hit: accumulate the histogram
+	if(print_ > 1) std::cout << "Early hit time " << mintime << " SID " << digi.strawId() << std::endl;
+	if(timeplot)timeplot->Fill(mintime);
+      }
+    }
+    // if there aren't enought hits, set to 0
+    pbto->nhits_ = extract_result<tag::count>(meanacc);
+    if(pbto->nhits_ < minnhits_){
+      pbto->pbtime_ = - meantime_;
+      pbto->variance_ = 0.0;
+    } else {
+      pbto->pbtime_ = extract_result<tag::mean>(meanacc) - meantime_;
+      pbto->variance_ = extract_result<tag::variance>(meanacc);
+    }
+    event.put(std::move(pbto));
+  }
+}
+
+using mu2e::ProtonBunchTimeFromStrawDigis;
+DEFINE_ART_MODULE(ProtonBunchTimeFromStrawDigis);
+

--- a/TrkHitReco/src/StrawHitReco_module.cc
+++ b/TrkHitReco/src/StrawHitReco_module.cc
@@ -6,7 +6,6 @@
 //
 // framework
 #include "art/Framework/Principal/Event.h"
-#include "fhiclcpp/ParameterSet.h"
 #include "art/Framework/Principal/Handle.h"
 #include "GeometryService/inc/GeomHandle.hh"
 #include "art/Framework/Core/EDProducer.h"
@@ -46,82 +45,100 @@
 namespace mu2e {
   using namespace TrkTypes;
 
-  class StrawHitReco : public art::EDProducer
-  {
-     public:
-       explicit StrawHitReco(fhicl::ParameterSet const& pset);
-       virtual void produce( art::Event& e);
-       virtual void beginRun( art::Run& run );
-       virtual void beginJob();
+  class StrawHitReco : public art::EDProducer {
+    public:
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      struct Config {
+	fhicl::Atom<int> diag{ Name("diagLevel"), Comment("Diag level"), 0};
+	fhicl::Atom<int> print{ Name("printLevel"), Comment("Print level"), 0};
+	fhicl::Atom<int> fittype { Name( "FitType"), Comment("Waveform Fit Type"), TrkHitReco::FitType::peakminuspedavg};
+	fhicl::Atom<bool> usecc{ Name("UseCalorimeter"), Comment("Use Calo cluster times to filter" ),false};
+	fhicl::Atom<float>clusterDt{ Name("clusterDt"), Comment("Calo cluster time 1/2 window"),100};
+	fhicl::Atom<float>minE{ Name("minimumEnergy"), Comment("Minimum straw energy deposit (MeV)"),0.0};
+	fhicl::Atom<float>maxE{ Name("maximumEnergy"), Comment("Maximum straw energy deposit (MeV)"),0.0035};
+	fhicl::Atom<float>ctE{ Name("crossTalkEnergy"), Comment("Energy to filter cross-talk in adajcent straws (MeV)"),0.007};
+	fhicl::Atom<float>ctMinT{ Name("crossTalkMinimumTime"), Comment("Earliest time for cross-talk filter (nsec)"),-1};
+	fhicl::Atom<float>ctMaxT{ Name("crossTalkMaximumTime"), Comment("Latest time for cross-talk filter (nsec)"),100};
+	fhicl::Atom<float>minT{ Name("minimumTime"), Comment("Earliest StrawDigi time to process (nsec)"),500};
+	fhicl::Atom<float>maxT{ Name("maximumTime"), Comment("Latest StrawDigi time to process (nsec)"),2000};
+	fhicl::Atom<bool>filter{ Name("FilterHits"), Comment("Filter hits (alternative is to just flag)") };
+	fhicl::Atom<bool>writesh{ Name("WriteStrawHitCollection"), Comment("Save StrawHitCollection")};
+	fhicl::Atom<bool>flagXT{ Name("FlagCrossTalk"), Comment("Search for cross-talk"),false};
+	fhicl::Atom<art::InputTag> sdcTag{ Name("StrawDigiCollectionTag"), Comment("StrawDigiCollection producer")};
+        fhicl::Atom<art::InputTag> sdadcTag{ Name("StrawDigiADCWaveformCollectionTag"), Comment("StrawDigiADCWaveformCollection producer")};
+	fhicl::Atom<art::InputTag> cccTag{ Name("CaloClusterCollectionTag"), Comment("CaloClusterCollection producer")};
+	fhicl::Atom<art::InputTag> pbttoken{ Name("ProtonBunchTimeTag"), Comment("ProtonBunchTime producer")};
+      };
+
+      using Parameters = art::EDProducer::Table<Config>;
+      explicit StrawHitReco(Parameters const& config);
+      void produce( art::Event& e) override;
+      void beginRun( art::Run& run ) override;
+      void beginJob() override;
 
 
-     private:
-       TrkHitReco::FitType _fittype; // peak Fitter
-       bool   _usecc;                   // use calorimeter cluster filtering
-       float _clusterDt;               // maximum hit-calo lcuster time difference
-       float _minE;             // energy range (MeV)
-       float _maxE;             // energy range (MeV)
-       float _ctE;                     // minimum charge to flag neighbors as cross talk
-       float _ctMinT;                  // time relative to proton hit to flag cross talk (ns)
-       float _ctMaxT;                  // time relative to proton hit to flag cross talk (ns)
-       float _minT, _maxT;             // time range
-       bool   _filter;                // filter the output, or just flag
-       bool  _writesh;                // write straw hits or not
-       bool _flagXT; // flag cross-talk
-       int    _printLevel;
-       int    _diagLevel;
-       StrawIdMask _mask;
-       StrawEnd _end[2]; // helper
-       float _invnpre; // cache
-       float _invgainAvg; // cache
-       float _invgain[96]; // cache
-       unsigned _npre; //cache
+    private:
+      TrkHitReco::FitType _fittype; // peak Fitter
+      bool  _usecc;                   // use calorimeter cluster filtering
+      float _clusterDt;               // maximum hit-calo lcuster time difference
+      float _minE;             // energy range (MeV)
+      float _maxE;             // energy range (MeV)
+      float _ctE;                     // minimum charge to flag neighbors as cross talk
+      float _ctMinT;                  // time relative to proton hit to flag cross talk (ns)
+      float _ctMaxT;                  // time relative to proton hit to flag cross talk (ns)
+      float _minT, _maxT;             // time range
+      bool  _filter;                // filter the output, or just flag
+      bool  _writesh;                // write straw hits or not
+      bool  _flagXT; // flag cross-talk
+      int   _printLevel;
+      int   _diagLevel;
+      StrawIdMask _mask;
+      StrawEnd _end[2]; // helper
+      float _invnpre; // cache
+      float _invgainAvg; // cache
+      float _invgain[96]; // cache
+      unsigned _npre; //cache
 
-       art::ProductToken<StrawDigiCollection> const _sdtoken;
-       art::ProductToken<StrawDigiADCWaveformCollection> const _sdadctoken;
-       art::ProductToken<CaloClusterCollection> const _cctoken;
-       art::InputTag _pbtoTag; // name of the module that makes eventwindowmarkers
-       fhicl::ParameterSet _peakfit;  // peak fit (charge reconstruction) parameters
-       std::unique_ptr<TrkHitReco::PeakFit> _pfit; // peak fitting algorithm
-       // diagnostic
-       TH1F* _maxiter;
-       // helper function
-       float peakMinusPedAvg(TrkTypes::ADCWaveform const& adcData) const;
-       float peakMinusPed(StrawId id, TrkTypes::ADCWaveform const& adcData) const;
-       float peakMinusPedFirmware(StrawId id, TrkTypes::ADCValue const& pmp) const;
-    ProditionsHandle<StrawResponse> _strawResponse_h;
-    ProditionsHandle<TrackerStatus> _trackerStatus_h;
-    ProditionsHandle<Tracker> _alignedTracker_h;
+      art::ProductToken<StrawDigiCollection> const _sdctoken;
+      art::ProductToken<StrawDigiADCWaveformCollection> const _sdadctoken;
+      art::ProductToken<CaloClusterCollection> const _ccctoken;
+      art::ProductToken<ProtonBunchTime> const _pbttoken; // name of the module that makes eventwindowmarkers
+      std::unique_ptr<TrkHitReco::PeakFit> _pfit; // peak fitting algorithm
+      // diagnostic
+      TH1F* _maxiter;
+      // helper function
+      float peakMinusPedAvg(TrkTypes::ADCWaveform const& adcData) const;
+      float peakMinusPed(StrawId id, TrkTypes::ADCWaveform const& adcData) const;
+      float peakMinusPedFirmware(StrawId id, TrkTypes::ADCValue const& pmp) const;
+      ProditionsHandle<StrawResponse> _strawResponse_h;
+      ProditionsHandle<TrackerStatus> _trackerStatus_h;
+      ProditionsHandle<Tracker> _alignedTracker_h;
+  };
 
-
- };
-
-  StrawHitReco::StrawHitReco(fhicl::ParameterSet const& pset) :
-      art::EDProducer{pset},
-      _fittype((TrkHitReco::FitType) pset.get<unsigned>("FitType",TrkHitReco::FitType::peakminuspedavg)),
-      _usecc(pset.get<bool>(         "UseCalorimeter",false)),
-      _clusterDt(pset.get<float>(   "clusterDt",100)),
-      _minE(pset.get<float>(        "minimumEnergy",0.0)), // MeV
-      _maxE(pset.get<float>(        "maximumEnergy",0.0035)), // MeV
-      _ctE(pset.get<float>(         "crossTalkEnergy",0.007)), // MeV
-      _ctMinT(pset.get<float>(      "crossTalkMinimumTime",-1)), // nsec
-      _ctMaxT(pset.get<float>(      "crossTalkMaximumTime",100)), // nsec
-      _minT(pset.get<float>(        "minimumTime",500)), // nsec
-      _maxT(pset.get<float>(        "maximumTime",2000)), // nsec
-      _filter(pset.get<bool>(      "FilterHits")),
-      _writesh(pset.get<bool>(      "WriteStrawHitCollection")),
-      _flagXT(pset.get<bool>(      "FlagCrossTalk",false)),
-      _printLevel(pset.get<int>(     "printLevel",0)),
-      _diagLevel(pset.get<int>(      "diagLevel",0)),
-      _mask("uniquestraw"),      // each hit is a unique straw
-      _end{StrawEnd::cal,StrawEnd::hv}, // this should be in a general place, FIXME!
-      _sdtoken{consumes<StrawDigiCollection>(pset.get<art::InputTag>("StrawDigiCollection","makeSD"))},
-      _sdadctoken{mayConsume<StrawDigiADCWaveformCollection>(pset.get<art::InputTag>("StrawDigiADCWaveformCollection","makeSD"))},
-      _cctoken{mayConsume<CaloClusterCollection>(pset.get<art::InputTag>("caloClusterModuleLabel","CaloClusterFast"))},
-      _pbtoTag(pset.get<art::InputTag>("ProtonBunchTimeLabel")),
-      _peakfit(pset.get<fhicl::ParameterSet>("PeakFitter", {}))
-  {
-      consumes<ProtonBunchTime>(_pbtoTag);
+  StrawHitReco::StrawHitReco(Parameters const& config) :
+    art::EDProducer{config},
+    _fittype((TrkHitReco::FitType) config().fittype()),
+    _usecc(config().usecc()),
+    _clusterDt(config().clusterDt()),
+    _minE(config().minE()),
+    _maxE(config().maxE()),
+    _ctE(config().ctE()),
+    _ctMinT(config().ctMinT()),
+    _ctMaxT(config().ctMaxT()),
+    _minT(config().minT()),
+    _maxT(config().maxT()),
+    _filter(config().filter()),
+    _writesh(config().writesh()),
+    _flagXT(config().flagXT()),
+    _printLevel(config().print()),
+    _diagLevel(config().diag()),
+    _end{StrawEnd::cal,StrawEnd::hv}, // this should be in a general place, FIXME!
+    _sdctoken{consumes<StrawDigiCollection>(config().sdcTag())},
+    _sdadctoken{mayConsume<StrawDigiADCWaveformCollection>(config().sdadcTag())},
+    _ccctoken{mayConsume<CaloClusterCollection>(config().cccTag())},
+    _pbttoken{consumes<ProtonBunchTime>(config().pbttoken())}
+    {
       produces<ComboHitCollection>();
       if(_writesh)produces<StrawHitCollection>();
       if (_printLevel > 0) std::cout << "In StrawHitReco constructor " << std::endl;
@@ -148,12 +165,9 @@ namespace mu2e {
         _invgain[i] = srep.adcLSB()*srep.peakMinusPedestalEnergyScale(dummyId)/srep.strawGain();
       }
 
-      // this must be done here because srep is not accessible at startup and pfit references it
-      if (_fittype == TrkHitReco::FitType::combopeakfit)
-         _pfit = std::unique_ptr<TrkHitReco::PeakFit>(new TrkHitReco::ComboPeakFitRoot(srep,_peakfit) );
-      else if (_fittype == TrkHitReco::FitType::peakfit)
-         _pfit = std::unique_ptr<TrkHitReco::PeakFit>(new TrkHitReco::PeakFitRoot(srep,_peakfit) );
-      if (_printLevel > 0) std::cout << "In StrawHitReco begin Run " << std::endl;
+      // Detailed histogram-based waveform fits are no longer supported TODO!
+      if (_fittype != TrkHitReco::FitType::peakminusped && _fittype != TrkHitReco::FitType::peakminuspedavg)
+	throw cet::exception("RECO")<<"TrkHitReco: Peak fit " << _fittype << " not implemented " <<  std::endl;
   }
 
   //------------------------------------------------------------------------------------------
@@ -166,7 +180,7 @@ namespace mu2e {
       size_t nplanes = tt.nPlanes();
       size_t npanels = tt.getPlane(0).nPanels();
       auto const& srep = _strawResponse_h.get(event.id());
-      auto sdH = event.getValidHandle(_sdtoken);
+      auto sdH = event.getValidHandle(_sdctoken);
       const StrawDigiCollection& sdcol(*sdH);
 
       const StrawDigiADCWaveformCollection *sdadccol(0);
@@ -177,16 +191,15 @@ namespace mu2e {
 
       const CaloClusterCollection* caloClusters(0);
       if(_usecc){
-        auto ccH = event.getValidHandle(_cctoken);
+        auto ccH = event.getValidHandle(_ccctoken);
         caloClusters = ccH.product();
       }
 
-      double pbtoOffset = 0;
-      art::Handle<ProtonBunchTime> pbtoHandle;
-      if (event.getByLabel(_pbtoTag, pbtoHandle)){
-        const ProtonBunchTime& pbto(*pbtoHandle);
-        pbtoOffset = pbto.pbtime_;
-      }
+      double pbtOffset = 0;
+      art::Handle<ProtonBunchTime> pbtHandle;
+      auto pbtH = event.getValidHandle(_pbttoken);
+      const ProtonBunchTime& pbt(*pbtH);
+      pbtOffset = pbt.pbtime_;
 
       std::unique_ptr<StrawHitCollection> shCol;
       if(_writesh){
@@ -219,7 +232,7 @@ namespace mu2e {
 	if(times[StrawEnd::hv] < times[StrawEnd::cal])
 	  eend = StrawEnd(StrawEnd::hv);
 	// take the earliest of the 2 end times
-	float time = times[eend.end()] - pbtoOffset;
+	float time = times[eend.end()] - pbtOffset;
 	if (time < _minT || time > _maxT ){
 	  if(_filter)continue;
 	} else

--- a/TrkHitReco/src/StrawHitReco_module.cc
+++ b/TrkHitReco/src/StrawHitReco_module.cc
@@ -30,7 +30,7 @@
 #include "TrkHitReco/inc/PeakFitFunction.hh"
 #include "TrkHitReco/inc/ComboPeakFitRoot.hh"
 
-#include "DataProducts/inc/EventWindowMarker.hh"
+#include "RecoDataProducts/inc/ProtonBunchTime.hh"
 #include "DataProducts/inc/StrawEnd.hh"
 #include "RecoDataProducts/inc/CaloClusterCollection.hh"
 #include "RecoDataProducts/inc/StrawDigi.hh"
@@ -80,7 +80,7 @@ namespace mu2e {
        art::ProductToken<StrawDigiCollection> const _sdtoken;
        art::ProductToken<StrawDigiADCWaveformCollection> const _sdadctoken;
        art::ProductToken<CaloClusterCollection> const _cctoken;
-       art::InputTag _ewMarkerTag; // name of the module that makes eventwindowmarkers
+       art::InputTag _pbtoTag; // name of the module that makes eventwindowmarkers
        fhicl::ParameterSet _peakfit;  // peak fit (charge reconstruction) parameters
        std::unique_ptr<TrkHitReco::PeakFit> _pfit; // peak fitting algorithm
        // diagnostic
@@ -118,10 +118,10 @@ namespace mu2e {
       _sdtoken{consumes<StrawDigiCollection>(pset.get<art::InputTag>("StrawDigiCollection","makeSD"))},
       _sdadctoken{mayConsume<StrawDigiADCWaveformCollection>(pset.get<art::InputTag>("StrawDigiADCWaveformCollection","makeSD"))},
       _cctoken{mayConsume<CaloClusterCollection>(pset.get<art::InputTag>("caloClusterModuleLabel","CaloClusterFast"))},
-      _ewMarkerTag(pset.get<art::InputTag>("EventWindowMarkerLabel")),
+      _pbtoTag(pset.get<art::InputTag>("ProtonBunchTimeLabel")),
       _peakfit(pset.get<fhicl::ParameterSet>("PeakFitter", {}))
   {
-      consumes<EventWindowMarker>(_ewMarkerTag);
+      consumes<ProtonBunchTime>(_pbtoTag);
       produces<ComboHitCollection>();
       if(_writesh)produces<StrawHitCollection>();
       if (_printLevel > 0) std::cout << "In StrawHitReco constructor " << std::endl;
@@ -181,11 +181,11 @@ namespace mu2e {
         caloClusters = ccH.product();
       }
 
-      double ewmOffset = 0;
-      art::Handle<EventWindowMarker> ewMarkerHandle;
-      if (event.getByLabel(_ewMarkerTag, ewMarkerHandle)){
-        const EventWindowMarker& ewMarker(*ewMarkerHandle);
-        ewmOffset = ewMarker.timeOffset();
+      double pbtoOffset = 0;
+      art::Handle<ProtonBunchTime> pbtoHandle;
+      if (event.getByLabel(_pbtoTag, pbtoHandle)){
+        const ProtonBunchTime& pbto(*pbtoHandle);
+        pbtoOffset = pbto.pbtime_;
       }
 
       std::unique_ptr<StrawHitCollection> shCol;
@@ -219,7 +219,7 @@ namespace mu2e {
 	if(times[StrawEnd::hv] < times[StrawEnd::cal])
 	  eend = StrawEnd(StrawEnd::hv);
 	// take the earliest of the 2 end times
-	float time = times[eend.end()] + ewmOffset;
+	float time = times[eend.end()] - pbtoOffset;
 	if (time < _minT || time > _maxT ){
 	  if(_filter)continue;
 	} else


### PR DESCRIPTION
Splits EventWindowMarker dataproduct into three:
DataProducts/inc/EventWindowMarker.hh with configuration data (event window length and on/off spill)
RecoDataProducts/inc/ProtonBunchTime.hh with measured proton bunch time
MCDataProducts/inc/ProtonBunchTimeMC.hh with true proton bunch time

Modifies reconstruction to use reco data product and simulation to include effects of different event window lengths. The proton bunch time is now correlated with event id modulo 5.

This replaces pull request #260