### PR TITLE
e20 std::move() edits and tag edits e20 and BTrk in setup.sh

### DIFF
--- a/GeometryService/src/ProductionTargetMaker.cc
+++ b/GeometryService/src/ProductionTargetMaker.cc
@@ -13,11 +13,11 @@ namespace mu2e {
 
     if (c.getString("targetPS_model") == "MDC2018"){ 
       //     std::cout << "making Tier1 in maker" << std::endl;
-      return std::move(makeTier1(c, solenoidOffset));
+      return makeTier1(c, solenoidOffset);
 	} else 
       if (c.getString("targetPS_model") == "Hayman_v_2_0"){ 
 	//	std::cout << " making Hayman in Maker" << std::endl;
-	return std::move(makeHayman_v_2_0(c, solenoidOffset));
+	return makeHayman_v_2_0(c, solenoidOffset);
 	  } else 
 	{throw cet::exception("GEOM") << " illegal production target version specified = " << c.getInt("targetPS_version")  << std::endl;}
     return 0;
@@ -299,7 +299,7 @@ namespace mu2e {
                       c.getString("targetPS_Hub_materialName"));
 
 
-    return std::move(tgtPS);
+    return tgtPS;
   }
 
   std::unique_ptr<ProductionTarget> ProductionTargetMaker::makeHayman_v_2_0(const SimpleConfig& c, double solenoidOffset){
@@ -387,7 +387,7 @@ namespace mu2e {
       //override old format of the material if new syntax is found
       tgtPS->_spokeMaterial = c.getString("targetPS.supports.spokes.material", tgtPS->_spokeMaterial);
     }
-    return std::move(tgtPS);
+    return tgtPS;
   }
  
  

--- a/Mu2eG4/src/FieldMgr.cc
+++ b/Mu2eG4/src/FieldMgr.cc
@@ -36,7 +36,7 @@ namespace mu2e {
     mgr->_manager     = std::unique_ptr<G4FieldManager>         (new G4FieldManager      ( mgr->field(),
                                                                                            mgr->chordFinder(),
                                                                                            true ));
-    return std::move(mgr);
+    return mgr;
   }
 
   // Factory method to construct a manager for a gradient magnetic field (in DS3).
@@ -61,7 +61,7 @@ namespace mu2e {
     mgr->_manager     = std::unique_ptr<G4FieldManager>         (new G4FieldManager      ( mgr->field(),
                                                                                            mgr->chordFinder(),
                                                                                            true ));
-    return std::move(mgr);
+    return mgr;
   }
 
   // Release all of the objects that this class owns.

--- a/setup.sh
+++ b/setup.sh
@@ -102,7 +102,7 @@ build=$($MU2E_BASE_RELEASE/buildopts --build)
 # products that need qualifiers.  Note it includes the '+' character
 # and is therefore different from the value shown in
 # SETUP_<productname> environment vars, or by the "ups active" command.
-export MU2E_UPS_QUALIFIERS=+e19:+${build}
+export MU2E_UPS_QUALIFIERS=+e20:+${build}
 export MU2E_ART_SQUALIFIER=s101
 
 MU2E_G4_GRAPHICS_QUALIFIER=''
@@ -137,7 +137,7 @@ fi
 setup -B mu2e_artdaq_core v1_05_00 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
 
 setup -B heppdt   v03_04_02 -q${MU2E_UPS_QUALIFIERS}
-setup -B BTrk   v1_02_27  -q${MU2E_UPS_QUALIFIERS}:p383b
+setup -B BTrk   v1_02_28  -q${MU2E_UPS_QUALIFIERS}:p383b
 setup -B cry   v1_7n  -q${MU2E_UPS_QUALIFIERS}
 setup -B gsl v2_6a
 setup curl v7_64_1


### PR DESCRIPTION
e20 update required removal of calls to std::move() in several places and edits of e20 compiler tag and BTrk tag