### PR TITLE
Mu2eII_SM21: Update Mu2e-II era target material density

### DIFF
--- a/Mu2eG4/geom/geom_Mu2eII_2020.txt
+++ b/Mu2eG4/geom/geom_Mu2eII_2020.txt
@@ -22,8 +22,7 @@ int    targetPS.Mu2eII.version = 0; //version of the model
 int PS.verbosityLevel = 0;
 int    targetPS.Mu2eII.conveyor.nballs        = 28; 
 double targetPS.Mu2eII.conveyor.ball.radius   = 7.5;
-double targetPS.Mu2eII.conveyor.ball.gap      = 0.5;
-string targetPS.Mu2eII.conveyor.ball.material = "G4_C";
+string targetPS.Mu2eII.conveyor.ball.material = "ProductionTargetCarbon";
 
 vector<double> targetPS.Mu2eII.conveyor.ball.xs = {
   3962.64071,

--- a/Mu2eG4/src/ConstructMaterials.cc
+++ b/Mu2eG4/src/ConstructMaterials.cc
@@ -1575,6 +1575,13 @@ namespace mu2e {
      ProductionTargetTungstenLa2_O3->AddElement(getElementOrThrow("W"),wPercentage*CLHEP::perCent);
     }
 
+    //Carbon production target with 1.86gcc density (Mu2e-II era conveyor target balls)
+    mat = uniqueMaterialOrThrow("ProductionTargetCarbon");
+    {
+      G4Material* ProductionTargetCarbon = new G4Material(mat.name, 1.86*CLHEP::g/CLHEP::cm3 ,1);
+      ProductionTargetCarbon->AddElement(getElementOrThrow("C"), 1.);
+    }
+
     setBirksConstant(config_);
 
   }


### PR DESCRIPTION
Updating the conveyor production target ball material to be 1.86 gcc, per Vitaly's suggestion.

Validation run:
Compiles
Ran JobConfig/validation/stoppedMuonSingleStage.fcl without issue