### PR TITLE
flag to turn off csv cache

### DIFF
--- a/DbService/inc/DbEngine.hh
+++ b/DbService/inc/DbEngine.hh
@@ -18,7 +18,7 @@ namespace mu2e {
   class DbEngine {
   public:
 
-    DbEngine():_verbose(0),_initialized(false),
+    DbEngine():_verbose(0),_saveCsv(true),_initialized(false),
 	       _lockWaitTime(0),_lockTime(0) {}
     // the big read of the IOV structure is done in beginJob
     int beginJob();
@@ -31,6 +31,8 @@ namespace mu2e {
     // add tables directly - optionally set before beginJob
     void addOverride(DbTableCollection const& coll);
     void setVerbose(int verbose = 0) { _verbose = verbose; }
+    // whether to save the csv text content when loading a table
+    void setSaveCsv(bool saveCsv) { _saveCsv = saveCsv; }
     // these should only be called in single-threaded startup
     std::shared_ptr<DbValCache>& valCache() {return _vcache;}
     std::vector<int> gids() { return _gids; }
@@ -64,6 +66,7 @@ namespace mu2e {
     DbReader _reader;
     DbVersion _version;
     int _verbose;
+    bool _saveCsv;
     DbTableCollection _override;
     DbCache _cache;
     std::shared_ptr<DbValCache> _vcache;

--- a/DbService/inc/DbReader.hh
+++ b/DbService/inc/DbReader.hh
@@ -63,6 +63,7 @@ namespace mu2e {
     void setCacheLifetime(int clt=0) { _cacheLifetime = clt; }
     void setVerbose(int verbose) { _verbose = verbose; }
     void setTimeVerbose(int timeVerbose) { _timeVerbose = timeVerbose; }
+    void setSaveCsv(bool saveCsv) { _saveCsv = saveCsv; }
 
   private:
 
@@ -92,6 +93,7 @@ namespace mu2e {
     int _cacheLifetime;
     int _verbose;
     int _timeVerbose;
+    bool _saveCsv;
   };
 }
 #endif

--- a/DbService/inc/DbService.hh
+++ b/DbService/inc/DbService.hh
@@ -33,6 +33,8 @@ namespace mu2e {
 	  Comment("list of text files containing override table data")};
       fhicl::Atom<int> verbose{Name("verbose"), 
 	  Comment("verbose flag, 0 to 10"),0};
+      fhicl::Atom<bool> saveCsv{Name("saveCsv"), 
+	  Comment("save csv content in tables, default false"),false};
       fhicl::OptionalAtom<bool> fastStart{Name("fastStart"), 
 	  Comment("read the DB immedatiately, not on first use")};
       fhicl::OptionalAtom<int> cacheLifetime{Name("cacheLifetime"), 

--- a/DbService/src/DbEngine.cc
+++ b/DbService/src/DbEngine.cc
@@ -17,7 +17,7 @@ int mu2e::DbEngine::beginJob() {
   _reader.setDbId(_id);
   _reader.setVerbose(_verbose);
   _reader.setTimeVerbose(_verbose);
-
+  _reader.setSaveCsv(_saveCsv);
 
   // this is used to assign nominal tid's and cid's to tables that
   // are read in through a file, and are not declared in the database

--- a/DbService/src/DbReader.cc
+++ b/DbService/src/DbReader.cc
@@ -12,7 +12,7 @@ using namespace std;
 mu2e::DbReader::DbReader(const DbId& id):_id(id),_curl_handle(nullptr),
 		_timeout(3600),_totalTime(0),_removeHeader(true),
 	        _abortOnFail(true),_useCache(true),_cacheLifetime(0),
-		_verbose(0),_timeVerbose(0) {
+					 _verbose(0),_timeVerbose(0),_saveCsv(true) {
 
   // allocates memory for curl
   curl_global_init(CURL_GLOBAL_ALL);
@@ -75,7 +75,7 @@ int mu2e::DbReader::fillTableByCid(DbTable::ptr_t ptr, int cid) {
   std::string where="cid:eq:"+std::to_string(cid);
   int rc = query(csv,ptr->query(),ptr->dbname(),where);
   if(rc!=0) return rc;
-  ptr->fill(csv);
+  ptr->fill(csv,_saveCsv);
   return 0;
 }
 
@@ -129,37 +129,37 @@ int mu2e::DbReader::fillValTables(DbValCache& vcache) {
   rc = multiQuery(qfv);
   if(rc!=0) return rc;
 
-  tables.fill(qfv[0].csv);
+  tables.fill(qfv[0].csv,_saveCsv);
   vcache.setValTables(tables);
   
-  calibrations.fill(qfv[1].csv);
+  calibrations.fill(qfv[1].csv,_saveCsv);
   vcache.setValCalibrations(calibrations);
 
-  iovs.fill(qfv[2].csv);
+  iovs.fill(qfv[2].csv,_saveCsv);
   vcache.setValIovs(iovs);
 
-  groups.fill(qfv[3].csv);
+  groups.fill(qfv[3].csv,_saveCsv);
   vcache.setValGroups(groups);
 
-  grouplists.fill(qfv[4].csv);
+  grouplists.fill(qfv[4].csv,_saveCsv);
   vcache.setValGroupLists(grouplists);
 
-  purposes.fill(qfv[5].csv);
+  purposes.fill(qfv[5].csv,_saveCsv);
   vcache.setValPurposes(purposes);
 
-  lists.fill(qfv[6].csv);
+  lists.fill(qfv[6].csv,_saveCsv);
   vcache.setValLists(lists);
 
-  tablelists.fill(qfv[7].csv);
+  tablelists.fill(qfv[7].csv,_saveCsv);
   vcache.setValTableLists(tablelists);
 
-  versions.fill(qfv[8].csv);
+  versions.fill(qfv[8].csv,_saveCsv);
   vcache.setValVersions(versions);
 
-  extensions.fill(qfv[9].csv);
+  extensions.fill(qfv[9].csv,_saveCsv);
   vcache.setValExtensions(extensions);
 
-  extensionlists.fill(qfv[10].csv);
+  extensionlists.fill(qfv[10].csv,_saveCsv);
   vcache.setValExtensionLists(extensionlists);
 
   auto end_time = std::chrono::high_resolution_clock::now();

--- a/DbService/src/DbService_service.cc
+++ b/DbService/src/DbService_service.cc
@@ -39,6 +39,7 @@ namespace mu2e {
 
     // the engine which will read db, hold calibrations, deliver them
     _engine.setVerbose(_verbose);
+    _engine.setSaveCsv(_config.saveCsv());
 
     _engine.setDbId( DbId(_config.dbName()) );
     _engine.setVersion( _version );
@@ -50,7 +51,7 @@ namespace mu2e {
     for(auto ss : files ) {
       if(_verbose>1) std::cout << "DbService::beginJob reading file "<<
 		       ss <<std::endl;
-      auto coll = DbUtil::readFile(ss);
+      auto coll = DbUtil::readFile(ss,_config.saveCsv());
       if(_verbose>1) {
 	for(auto const& lt : coll) {
 	  std::cout << "  read table " << lt.table().name() <<std::endl;

--- a/DbTables/inc/DbUtil.hh
+++ b/DbTables/inc/DbUtil.hh
@@ -10,7 +10,7 @@ namespace mu2e {
   class DbUtil {
   public:
 
-    static DbTableCollection readFile(std::string const& fn);
+    static DbTableCollection readFile(std::string const& fn, bool saveCsv=true);
     static void writeFile(std::string const& fn, DbTableCollection const& coll);
 
     // split a csv string into lines on \n

--- a/DbTables/src/DbUtil.cc
+++ b/DbTables/src/DbUtil.cc
@@ -22,7 +22,7 @@
 //   the table line may have IOV information (see wiki for formats):
 // TABLE tablename start_run:start_sr-end_run:end_sr
 // # can include comment lines with hash as first char
-mu2e::DbTableCollection mu2e::DbUtil::readFile(std::string const& fn) {
+mu2e::DbTableCollection mu2e::DbUtil::readFile(std::string const& fn, bool saveCsv) {
   if(fn.size()<=0) {
     throw cet::exception("DBFILE_NO_FILE_NAME") 
       << "DbUtil::read called with no file name\n";
@@ -51,7 +51,7 @@ mu2e::DbTableCollection mu2e::DbUtil::readFile(std::string const& fn) {
       // first fill the table based on the csv string 
       // then add it to the vector as a DbLiveTable
       if(current.get()!=nullptr) {
-	current->fill(csv);
+	current->fill(csv,saveCsv);
 	coll.emplace_back(iov,current,-1,-1);
       }
 
@@ -104,7 +104,7 @@ mu2e::DbTableCollection mu2e::DbUtil::readFile(std::string const& fn) {
   // first fill the table based on the csv string 
   // then add it tothe vector as a DbLiveTable
   if(current.get()!=nullptr) {
-    current->fill(csv);
+    current->fill(csv,saveCsv);
     coll.emplace_back(iov,current);
   }
 


### PR DESCRIPTION
Finish installing the flag to turn off saving the csv version of tables.  This saves 30-40% of memory or so.  Run with the csv save turned off in art, but on in bins like dbTool where is it most likely needed to write out tables as they are in the database.