### PR TITLE
AnalysisConditions MVACatalog Fix

### DIFF
--- a/AnalysisConditions/inc/MVACatalog.hh
+++ b/AnalysisConditions/inc/MVACatalog.hh
@@ -16,7 +16,7 @@ namespace mu2e {
 
   template <class T>
   struct MVAEntry {
-    MVAEntry(std::string trainName, std::string xmlFileName, bool calibrated = false) : 
+    MVAEntry(std::string trainName, std::string xmlFileName, bool calibrated = false) :
       _trainName(trainName), _xmlFileName(xmlFileName), _calibrated(calibrated), _mvaTool(_xmlFileName)
     { }
 
@@ -27,23 +27,23 @@ namespace mu2e {
       const auto& labels = _mvaTool.labels();
       _mvaMask = 0;
       for (int i_var = 0; i_var < T::n_vars; ++i_var) {
-	for (const auto& i_label : labels) {
-	  std::string i_varName = T::varName(static_cast<typename T::MVA_varindex>(i_var));
-	  if (i_label.find(i_varName) != std::string::npos) {
-	    _mvaMask ^= (1 << i_var);
-	    break;
-	  }
-	}
+        for (const auto& i_label : labels) {
+          std::string i_varName = T::varName(static_cast<typename T::MVA_varindex>(i_var));
+          if (i_label.find(i_varName) != std::string::npos) {
+            _mvaMask ^= (1 << i_var);
+            break;
+          }
+        }
       }
 
       if (_calibrated) {
-	_mvaTool.getCalib(_effCalib);
+        _mvaTool.getCalib(_effCalib);
       }
     }
 
     float getCutVal(float calib_value) const {
       // Get the lower and upper bound of the requestd value
-      // NB std::map::lower_bound and std::map::upper_bound return the same iterator 
+      // NB std::map::lower_bound and std::map::upper_bound return the same iterator
       // when we search for an interpolated value...
       const auto& upper = _effCalib.upper_bound(calib_value);
       const auto& lower = std::prev(upper); // ...so we have to do this to get the bracketed values
@@ -59,7 +59,7 @@ namespace mu2e {
 
       return result;
     }
-    
+
     std::string _trainName;
     std::string _xmlFileName;
     bool _calibrated;
@@ -81,8 +81,8 @@ namespace mu2e {
 
     // accessors
     std::string const& name() const { return _name; }
-    MVAEntries<T>& modifiableEntries() { return _entries;} 
-    MVAEntries<T> const& entries() const { return _entries;} 
+    MVAEntries<T>& modifiableEntries() { return _entries;}
+    MVAEntries<T> const& entries() const { return _entries;}
 
     const std::string print() const {
       std::stringstream out;
@@ -93,16 +93,16 @@ namespace mu2e {
     void print(std::ostream& os) const {
       os << "Entries in " << _name << ":" << std::endl;
       for (const auto& i_entry : _entries) {
-	os << "Train Name: " << i_entry._trainName << ", XML File: " << i_entry._xmlFileName << std::endl;
+        os << "Train Name: " << i_entry._trainName << ", XML File: " << i_entry._xmlFileName << std::endl;
       }
       os << std::endl;
     }
 
     MVAEntry<T> const& find(std::string name) const {
       for (const auto& i_entry : entries()) {
-	if (i_entry._trainName == name) {
-	  return i_entry;
-	}
+        if (i_entry._trainName == name) {
+          return i_entry;
+        }
       }
       // if we get this far, then we haven't found the MVAEntry requested
       throw cet::exception("MVACatalog") << "MVA training with name " << name << " was not found in this MVACatalog: " << std::endl << print();
@@ -113,7 +113,7 @@ namespace mu2e {
     // typedefs
     typedef std::shared_ptr<MVACatalog<T> > ptr_t;
     typedef std::shared_ptr<const MVACatalog<T> > cptr_t;
-    
+
   private:
     // data
     std::string _name;

--- a/AnalysisConditions/inc/MVACatalog.hh
+++ b/AnalysisConditions/inc/MVACatalog.hh
@@ -17,18 +17,14 @@ namespace mu2e {
   template <class T>
   struct MVAEntry {
     MVAEntry(std::string trainName, std::string xmlFileName, bool calibrated = false) : 
-      _trainName(trainName), _xmlFileName(xmlFileName), _calibrated(calibrated)
+      _trainName(trainName), _xmlFileName(xmlFileName), _calibrated(calibrated), _mvaTool(_xmlFileName)
     { }
-    ~MVAEntry() {
-      delete _mvaTool;
-    }
 
     void initializeMVA() {
-      _mvaTool = new MVATools(_xmlFileName);
-      _mvaTool->initMVA();
+      _mvaTool.initMVA();
 
       // create the MVA mask in case we have removed variables
-      const auto& labels = _mvaTool->labels();
+      const auto& labels = _mvaTool.labels();
       _mvaMask = 0;
       for (int i_var = 0; i_var < T::n_vars; ++i_var) {
 	for (const auto& i_label : labels) {
@@ -41,7 +37,7 @@ namespace mu2e {
       }
 
       if (_calibrated) {
-	_mvaTool->getCalib(_effCalib);
+	_mvaTool.getCalib(_effCalib);
       }
     }
 
@@ -68,7 +64,7 @@ namespace mu2e {
     std::string _xmlFileName;
     bool _calibrated;
 
-    MVATools* _mvaTool;
+    MVATools _mvaTool;
     MVAMask _mvaMask;
     std::map<Float_t, Float_t> _effCalib;
   };

--- a/AnalysisConditions/inc/MVACatalogMaker.hh
+++ b/AnalysisConditions/inc/MVACatalogMaker.hh
@@ -20,7 +20,7 @@ namespace mu2e {
       MVAEntries<T> mvaEntries;
       //      mvaEntries.reserve(_config.mvaConfigs().size()); // need this to avoid a segfault....
       for (const auto& i_entryConf : _config.mvaConfigs()) {
-	mvaEntries.push_back(MVAEntry<T>(i_entryConf.trainName(), i_entryConf.xmlFileName(), i_entryConf.calibrated()));
+        mvaEntries.push_back(MVAEntry<T>(i_entryConf.trainName(), i_entryConf.xmlFileName(), i_entryConf.calibrated()));
       }
 
       auto ptr = std::make_shared<MVACatalog<T> >(mvaEntries);
@@ -31,10 +31,10 @@ namespace mu2e {
     void initializeMVAs(typename MVACatalog<T>::ptr_t ptr) {
       // Now initialize the MVAs
       for (auto& i_mvaEntry : ptr->modifiableEntries()) {
-	i_mvaEntry.initializeMVA();
+        i_mvaEntry.initializeMVA();
       }
       if (_config.verbose() > 0) {
-	ptr->print(std::cout);
+        ptr->print(std::cout);
       }
     }
 
@@ -50,22 +50,22 @@ namespace mu2e {
 
       // Change or add entries to the configuration before we create all the MVATools pointers
       for (const auto& i_row : tqDb->rows()) {
-	for (auto& i_mvaEntry : ptr->modifiableEntries()) {
-	  if (i_row.mvaname() == i_mvaEntry._trainName) {
-	    i_mvaEntry._xmlFileName = i_row.xmlfilename();
-	    i_mvaEntry._calibrated = i_row.calibrated();
-	    break; // break from inner for loop since this entry alread exists
-	  }
-	}
-	// if we get here, then we need to add a new entry
-	ptr->modifiableEntries().push_back(MVAEntry<T>(i_row.mvaname(), i_row.xmlfilename(), i_row.calibrated()));
+        for (auto& i_mvaEntry : ptr->modifiableEntries()) {
+          if (i_row.mvaname() == i_mvaEntry._trainName) {
+            i_mvaEntry._xmlFileName = i_row.xmlfilename();
+            i_mvaEntry._calibrated = i_row.calibrated();
+            break; // break from inner for loop since this entry alread exists
+          }
+        }
+        // if we get here, then we need to add a new entry
+        ptr->modifiableEntries().push_back(MVAEntry<T>(i_row.mvaname(), i_row.xmlfilename(), i_row.calibrated()));
       }
       initializeMVAs(ptr);
       return ptr;
     }
 
   private:
-    // this object needs to be thread safe, 
+    // this object needs to be thread safe,
     // _config should only be initialized once
     const MVACatalogConfig _config;
   };

--- a/AnalysisConditions/inc/MVACatalogMaker.hh
+++ b/AnalysisConditions/inc/MVACatalogMaker.hh
@@ -18,7 +18,7 @@ namespace mu2e {
 
     typename MVACatalog<T>::ptr_t fillEntries() {
       MVAEntries<T> mvaEntries;
-      mvaEntries.reserve(_config.mvaConfigs().size()); // need this to avoid a segfault....
+      //      mvaEntries.reserve(_config.mvaConfigs().size()); // need this to avoid a segfault....
       for (const auto& i_entryConf : _config.mvaConfigs()) {
 	mvaEntries.push_back(MVAEntry<T>(i_entryConf.trainName(), i_entryConf.xmlFileName(), i_entryConf.calibrated()));
       }

--- a/TrkDiag/src/TrackQuality_module.cc
+++ b/TrkDiag/src/TrackQuality_module.cc
@@ -88,7 +88,7 @@ namespace mu2e
     TrkQualEntry const& trkQualEntry = trkQualCatalog.find(_trainName);
 
     if(_printMVA) {
-      trkQualEntry._mvaTool->showMVA();
+      trkQualEntry._mvaTool.showMVA();
     }
 
     // Go through the tracks and calculate their track qualities
@@ -140,7 +140,7 @@ namespace mu2e
 	  trkqual[TrkQual::rmax] = -1*charge*(bestkseg->helix().d0() + 2.0/bestkseg->helix().omega());
 	  
 	  trkqual.setMVAStatus(MVAStatus::calculated);
-	  trkqual.setMVAValue(trkQualEntry._mvaTool->evalMVA(trkqual.values(), trkQualEntry._mvaMask));
+	  trkqual.setMVAValue(trkQualEntry._mvaTool.evalMVA(trkqual.values(), trkQualEntry._mvaMask));
 
 	}
 	else {

--- a/TrkDiag/src/TrackQuality_module.cc
+++ b/TrkDiag/src/TrackQuality_module.cc
@@ -66,7 +66,7 @@ namespace mu2e
 
   TrackQuality::TrackQuality(const Parameters& conf) :
     art::EDProducer{conf},
-    _kalSeedTag(conf().kalSeedTag()), 
+    _kalSeedTag(conf().kalSeedTag()),
     _trainName(conf().trainName()),
     _printMVA(conf().printMVA())
   {
@@ -98,72 +98,72 @@ namespace mu2e
       static TrkFitFlag goodfit(TrkFitFlag::kalmanOK);
       if (i_kalSeed.status().hasAllProperties(goodfit)) {
 
-	// fill the hit count variables
-	TrkInfo tinfo;
-	_infoStructHelper.fillTrkInfoHits(i_kalSeed, tinfo);
-	_infoStructHelper.fillTrkInfoStraws(i_kalSeed, tinfo);
-	trkqual[TrkQual::nactive] = tinfo._nactive;
-	trkqual[TrkQual::factive] = (double) tinfo._nactive / tinfo._nhits;
-	trkqual[TrkQual::fdouble] = (double) tinfo._ndactive / tinfo._nactive;
-	trkqual[TrkQual::fnullambig] = (double) tinfo._nnullambig / tinfo._nactive;
-	trkqual[TrkQual::fstraws] = (double)tinfo._nmatactive / tinfo._nactive;
+        // fill the hit count variables
+        TrkInfo tinfo;
+        _infoStructHelper.fillTrkInfoHits(i_kalSeed, tinfo);
+        _infoStructHelper.fillTrkInfoStraws(i_kalSeed, tinfo);
+        trkqual[TrkQual::nactive] = tinfo._nactive;
+        trkqual[TrkQual::factive] = (double) tinfo._nactive / tinfo._nhits;
+        trkqual[TrkQual::fdouble] = (double) tinfo._ndactive / tinfo._nactive;
+        trkqual[TrkQual::fnullambig] = (double) tinfo._nnullambig / tinfo._nactive;
+        trkqual[TrkQual::fstraws] = (double)tinfo._nmatactive / tinfo._nactive;
 
-	// fill fit consistency and t0 variables
-	if (i_kalSeed.fitConsistency() > FLT_MIN) {
-	  trkqual[TrkQual::log10fitcon] = log10(i_kalSeed.fitConsistency());
-	}
-	else {
-	  trkqual[TrkQual::log10fitcon] = -50.0;
-	}
-	trkqual[TrkQual::t0err] = i_kalSeed.t0().t0Err();
-	
-	// find the best KalSegment and fill variables relating to it
-	KalSegment kseg;
-	std::vector<KalSegment> const& ksegs = i_kalSeed.segments();
-	auto bestkseg = ksegs.begin();
-	double zpos = -1631.11;
-	for(auto ikseg = ksegs.begin(); ikseg != ksegs.end(); ++ikseg){
-	  HelixVal const& hel = ikseg->helix();
-	  // check for a segment whose range includes zpos.  There should be a better way of doing this, FIXME
-	  double sind = hel.tanDip()/sqrt(1.0+hel.tanDip()*hel.tanDip());
-	  if(hel.z0()+sind*ikseg->fmin() < zpos && hel.z0()+sind*ikseg->fmax() > zpos){
-	    bestkseg = ikseg;
-	    break;
-	  }
-	}
-	kseg = *bestkseg;
-	if (bestkseg != ksegs.end()) {
-	  double charge = i_kalSeed.particle().charge();
-	  
-	  trkqual[TrkQual::momerr] = bestkseg->momerr();
-	  trkqual[TrkQual::d0] = -1*charge*bestkseg->helix().d0();
-	  trkqual[TrkQual::rmax] = -1*charge*(bestkseg->helix().d0() + 2.0/bestkseg->helix().omega());
-	  
-	  trkqual.setMVAStatus(MVAStatus::calculated);
-	  trkqual.setMVAValue(trkQualEntry._mvaTool.evalMVA(trkqual.values(), trkQualEntry._mvaMask));
+        // fill fit consistency and t0 variables
+        if (i_kalSeed.fitConsistency() > FLT_MIN) {
+          trkqual[TrkQual::log10fitcon] = log10(i_kalSeed.fitConsistency());
+        }
+        else {
+          trkqual[TrkQual::log10fitcon] = -50.0;
+        }
+        trkqual[TrkQual::t0err] = i_kalSeed.t0().t0Err();
 
-	}
-	else {
-	  trkqual.setMVAStatus(MVAStatus::filled);
-	}
+        // find the best KalSegment and fill variables relating to it
+        KalSegment kseg;
+        std::vector<KalSegment> const& ksegs = i_kalSeed.segments();
+        auto bestkseg = ksegs.begin();
+        double zpos = -1631.11;
+        for(auto ikseg = ksegs.begin(); ikseg != ksegs.end(); ++ikseg){
+          HelixVal const& hel = ikseg->helix();
+          // check for a segment whose range includes zpos.  There should be a better way of doing this, FIXME
+          double sind = hel.tanDip()/sqrt(1.0+hel.tanDip()*hel.tanDip());
+          if(hel.z0()+sind*ikseg->fmin() < zpos && hel.z0()+sind*ikseg->fmax() > zpos){
+            bestkseg = ikseg;
+            break;
+          }
+        }
+        kseg = *bestkseg;
+        if (bestkseg != ksegs.end()) {
+          double charge = i_kalSeed.particle().charge();
+
+          trkqual[TrkQual::momerr] = bestkseg->momerr();
+          trkqual[TrkQual::d0] = -1*charge*bestkseg->helix().d0();
+          trkqual[TrkQual::rmax] = -1*charge*(bestkseg->helix().d0() + 2.0/bestkseg->helix().omega());
+
+          trkqual.setMVAStatus(MVAStatus::calculated);
+          trkqual.setMVAValue(trkQualEntry._mvaTool.evalMVA(trkqual.values(), trkQualEntry._mvaMask));
+
+        }
+        else {
+          trkqual.setMVAStatus(MVAStatus::filled);
+        }
       }
       tqcol->push_back(trkqual);
 
       // Get the efficiency cut that this track passes
       Float_t passCalib = 0.0; // everything will pass a 100% efficient cut
       if (trkQualEntry._calibrated) {
-	//	std::cout << _trainName << " = " << trkqual.MVAValue() << std::endl;
-	for (const auto& i_pair : trkQualEntry._effCalib) {
-	  //	  std::cout << i_pair.first << ", " << i_pair.second << ": ";
-	  if (trkqual.MVAValue() >= i_pair.second) {
-	    //	    std::cout << "PASSES" << std::endl;
-	    passCalib = i_pair.first;
-	  }
-	  else {
-	    //	    std::cout << "FAILS" << std::endl;
-	    break;
-	  }
-	}
+        //      std::cout << _trainName << " = " << trkqual.MVAValue() << std::endl;
+        for (const auto& i_pair : trkQualEntry._effCalib) {
+          //      std::cout << i_pair.first << ", " << i_pair.second << ": ";
+          if (trkqual.MVAValue() >= i_pair.second) {
+            //      std::cout << "PASSES" << std::endl;
+            passCalib = i_pair.first;
+          }
+          else {
+            //      std::cout << "FAILS" << std::endl;
+            break;
+          }
+        }
       }
       rqcol->push_back(RecoQual(trkqual.status(),trkqual.MVAValue(), passCalib));
     }


### PR DESCRIPTION
Hi Everyone,

@macndev was having some jobs fail on the grid and, with @rlcee, worked out that the jobs were crashing at ~MVAEntry(). The crash was not occurring locally. 

It wasn't entirely clear why the jobs were crashing here but there is some dynamically-allocated memory in the code. I've removed all these new/delete/reserve calls and @macndev has successfully run jobs on the grid with these changes so this issue seems to be resolved. This is in commit 4790350.

I've also taken the opportunity to remove problematic whitespace. This is in a separate commit (b3dbf1a) so hopefully it's easier to review the actual changes.

Thanks,
Andy