### PR TITLE
fix HelixSeed sorting algorithm instability

### DIFF
--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -148,7 +148,7 @@ namespace mu2e {
       if(h1.caloCluster().isNonnull() && h2.caloCluster().isNull())
 	retval = first;
       else if( h2.caloCluster().isNonnull() && h1.caloCluster().isNull())
-	retval = first;
+	retval = second;
 	// then compare active StrawHit counts
       else if(nh1 > nh2)
 	retval = first;


### PR DESCRIPTION
fix HelixSeed sorting algorithm that, combined with random ordering of seeds, sometimes selects random seeds.  In initial tests, this fixes the current serious instability in ceSimReco when run locally, and may also fix the long-term small instability in the nightly validation results.