### PR TITLE
Refactor VMMonitor_module.cc to move VMInfo to GeneralUtilties.

### DIFF
--- a/Analyses/src/VMMonitor_module.cc
+++ b/Analyses/src/VMMonitor_module.cc
@@ -2,6 +2,8 @@
 //
 // Rob Kutschke, 2015
 
+#include "GeneralUtilities/inc/VMInfo.hh"
+
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -12,100 +14,6 @@
 #include "art/Framework/Core/EDAnalyzer.h"
 #include "art/Framework/Core/ModuleMacros.h"
 
-namespace {
-
-  // A subset of the information from /proc/pid/status
-  struct VMInfo {
-    VMInfo():
-      vmPeak(0), vmSize(0), vmHWM(0), vmRSS(0){
-    }
-
-    bool allOK() const {
-      return haveVMPeak && haveVMSize && haveVMHWM && haveRSS;
-    }
-
-    void set ( std::string const& name, long val){
-      if ( name == "VmPeak" ){
-        vmPeak     = val;
-        haveVMPeak = true;
-      } else if ( name == "VmSize" ){
-        vmSize     = val;
-        haveVMSize = true;
-      } else if ( name == "VmHWM"  ) {
-        vmHWM      = val;
-        haveVMHWM  = true;
-      } else if ( name == "VmRSS"  ){
-        vmRSS      = val;
-        haveRSS    = true;
-      }else{
-        throw std::runtime_error( "VMMonitor: unrecognized name: " + name );
-      }
-
-    }
-
-    long vmPeak;  // Peak virtual size
-    long vmSize;  // Current virtual size
-    long vmHWM;   // Max RSS ( high water mark )
-    long vmRSS;   // Current RSS (Resident Set Size)
-
-    bool haveVMPeak = false;
-    bool haveVMSize = false;
-    bool haveVMHWM  = false;
-    bool haveRSS    = false;
-  };
-
-  // A helper class to populate and object of type VMInfo and serve information.
-  class ProcStatus {
-  public:
-    ProcStatus();
-
-    VMInfo const& info() const { return _proc; }
-
-  private:
-    long   _pageSize   = 0;
-    size_t _maxVM      = 0;
-    size_t _maxRSS     = 0;
-    bool   _everyEvent = false;    // Info on every event or just on event with an increase.
-    VMInfo _proc;
-    int    _MB         = 1048576;  // Number of bytes in one MB.
-
-  };
-
-  // helper function
-  long parseLine ( std::string const& line,
-                   std::string const& keyExpected, 
-                   std::string const& unitExpected ){
-    std::istringstream is(line);
-    std::string key, unit;
-    long val;
-    is >> key >> val >> unit;
-    if ( unit!=unitExpected ){
-      throw std::runtime_error( "VMMonitor: cannot parse: " + line );
-    }
-    return val;
-  }
-
-  // The c'tor does all of the work.
-  // Extra info from /proc and populate the class member data.
-  ProcStatus::ProcStatus(){
-    std::ifstream  proc("/proc/self/status");
-    std::array<std::string,4> wanted{ "VmPeak", "VmSize", "VmHWM", "VmRSS"};
-    while ( proc ){
-      std::string line;
-      getline( proc, line);
-      if ( !proc ) return;
-      for ( auto const& name: wanted ){
-        if ( line.find(name) != std::string::npos ){
-          long val = parseLine( line , name, "kB");
-          _proc.set(name,val);
-          break;
-        }
-      }
-    }
-  }
-
-} // end anonymous namespace
-
 namespace mu2e {
 
   class VMMonitor : public art::EDAnalyzer {
@@ -115,7 +23,6 @@ namespace mu2e {
     void endJob() override;
 
   private:
-    long   _pageSize   = 0;        // Memory page size, in bytes.
     long   _kSize      = 1024;     // 1 kByte, in bytes.
     size_t _maxVM      = 0;        // Peak virtual size.
     size_t _maxRSS     = 0;        // Maximum resident set size.
@@ -130,22 +37,17 @@ mu2e::VMMonitor::VMMonitor(const fhicl::ParameterSet& pset)
   : art::EDAnalyzer(pset),
     _fuzz(pset.get<int>("fuzz",0)),
     _everyEvent(pset.get<bool>("everyEvent",false))
-{
-  _pageSize = sysconf(_SC_PAGESIZE);
-  if ( _pageSize == 0 ){
-    throw std::runtime_error("Page size is zero!\n");
-  }
-}
+{}
 
 void mu2e::VMMonitor::analyze(const art::Event& event) {
 
   // Extract virtual memory information from /proc/self/status
   // Convert to MBytes from kBytes
-  ProcStatus vm;
-  size_t vmPeak = (vm.info().vmPeak * _kSize)/_MB;
-  size_t vmHWM  = (vm.info().vmHWM  * _kSize)/_MB;
-  size_t vmSize = (vm.info().vmSize * _kSize)/_MB;
-  size_t vmRSS  = (vm.info().vmRSS  * _kSize)/_MB;
+  VMInfo vm;
+  size_t vmPeak = (vm.vmPeak * _kSize)/_MB;
+  size_t vmHWM  = (vm.vmHWM  * _kSize)/_MB;
+  size_t vmSize = (vm.vmSize * _kSize)/_MB;
+  size_t vmRSS  = (vm.vmRSS  * _kSize)/_MB;
 
   long deltaVM  = vmPeak - _maxVM;
   long deltaHWM = vmHWM  - _maxRSS;

--- a/GeneralUtilities/inc/VMInfo.hh
+++ b/GeneralUtilities/inc/VMInfo.hh
@@ -1,0 +1,23 @@
+#ifndef Mu2eUtilities_VMInfo_hh
+#define Mu2eUtilities_VMInfo_hh
+
+// Information about virtual memory usage.
+// A subset of the information from /proc/pid/status.
+//
+// Original Author Rob Kutschke, December 2020
+
+namespace mu2e {
+
+  struct VMInfo {
+    VMInfo();
+
+    long vmPeak = 0;  // Peak virtual size, in KiB
+    long vmSize = 0;  // Current virtual size, in KiB
+    long vmHWM  = 0;  // Max RSS ( Virtual Memory High Water Mark ), in KiB
+    long vmRSS  = 0;  // Current Resident Set Size, in KiB
+
+  }; // struct VMInfo
+
+} // namespace mu2e
+
+#endif // Mu2eUtilities_VMInfo_hh

--- a/GeneralUtilities/src/VMInfo.cc
+++ b/GeneralUtilities/src/VMInfo.cc
@@ -1,0 +1,53 @@
+#include "GeneralUtilities/inc/VMInfo.hh"
+
+#include <array>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <unistd.h>
+
+namespace {
+
+  // Helper function to check the units and return the value.
+  long parseLine ( std::string const& line,
+                   std::string const& unitExpected ){
+    std::istringstream is(line);
+    std::string key, unit;
+    long val;
+    is >> key >> val >> unit;
+    if ( unit!=unitExpected ){
+      throw std::runtime_error( "ProcStatus: cannot parse: " + line );
+    }
+    return val;
+  }
+
+} // end anonymous namespace
+
+// The c'tor does all of the work.
+mu2e::VMInfo::VMInfo(){
+
+  // The information we want.
+  std::array<std::string,4> wanted{ "VmPeak", "VmSize", "VmHWM", "VmRSS"};
+
+  // Parse the information to get what we need.
+  std::ifstream  proc("/proc/self/status");
+  std::map<std::string,long> values;
+  while ( proc ){
+    std::string line;
+    getline( proc, line);
+    if ( !proc ) break;
+    for ( auto const& name: wanted ){
+      if ( line.find(name) != std::string::npos ){
+        long val = parseLine( line,  "kB");
+        values[name] = val;
+        break;
+      }
+    }
+  }
+
+  vmPeak = values["VmPeak"];
+  vmSize = values["VmSize"];
+  vmHWM  = values["VmHWM"];
+  vmRSS  = values["VmRSS"];
+}


### PR DESCRIPTION
Extracted the piece of VMMonitor_module that was a helper class in an anonymous namespace and put it into:

GeneralUtilities/inc/VMInfo.hh
GeneralUtilities/src/VMInfo.cc

Then rewrote VMMonitor_module to use this new class. 

The VMInfo class can be used standalone.
