### PR TITLE
s105 tag changes in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -103,7 +103,7 @@ build=$($MU2E_BASE_RELEASE/buildopts --build)
 # and is therefore different from the value shown in
 # SETUP_<productname> environment vars, or by the "ups active" command.
 export MU2E_UPS_QUALIFIERS=+e20:+${build}
-export MU2E_ART_SQUALIFIER=s104
+export MU2E_ART_SQUALIFIER=s105
 
 MU2E_G4_GRAPHICS_QUALIFIER=''
 if [[ $($MU2E_BASE_RELEASE/buildopts --g4vis) == qt ]]; then
@@ -124,7 +124,7 @@ export MU2E_G4_EXTRA_QUALIFIER=''
 
 # Setup the framework and its dependent products
 setup -B art v3_06_03 -q${MU2E_UPS_QUALIFIERS}
-setup -B art_root_io v1_05_00 -q${MU2E_UPS_QUALIFIERS}
+setup -B art_root_io v1_05_01 -q${MU2E_UPS_QUALIFIERS}
 
 # Geant4 and its cross-section files.
 if [[ $($MU2E_BASE_RELEASE/buildopts --trigger) == "off" ]]; then
@@ -134,10 +134,10 @@ else
 fi
 
 # Get access to raw data formats.
-setup -B mu2e_artdaq_core v1_05_03 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
+setup -B mu2e_artdaq_core v1_05_04 -q${MU2E_UPS_QUALIFIERS}:+${MU2E_ART_SQUALIFIER}:offline
 
 setup -B heppdt   v03_04_02 -q${MU2E_UPS_QUALIFIERS}
-setup -B BTrk   v1_02_29  -q${MU2E_UPS_QUALIFIERS}:p383b
+setup -B BTrk   v1_02_30  -q${MU2E_UPS_QUALIFIERS}:p383b
 setup -B cry   v1_7n  -q${MU2E_UPS_QUALIFIERS}
 setup -B gsl v2_6a
 setup curl v7_64_1


### PR DESCRIPTION
Hello, I have made the relevant tag updates in setup.sh for the new mu distribution v3_06_03b with s105 support. There were no compilation issues and ceSimReco tests had 267 perfectly matched validation histograms with a fresh reference pull. Let me know if any more tests should be run!