### PR TITLE
Trkgeom2

### DIFF
--- a/CosmicReco/src/CosmicFitDisplay_module.cc
+++ b/CosmicReco/src/CosmicFitDisplay_module.cc
@@ -238,7 +238,7 @@ Below here are a series of macros -  they are not glamorous but they produce use
 		      
         	      GeomHandle<Tracker> th; 
 		      const Tracker* tracker = th.get(); 
-        	      TubsParams envelope(tracker->getInnerTrackerEnvelopeParams());
+        	      TubsParams envelope(tracker->g4Tracker()->getInnerTrackerEnvelopeParams());
 		      //double zlimit{envelope.zHalfLength()};
         	      if (doDisplay_) {
               
@@ -570,7 +570,7 @@ Below here are a series of macros -  they are not glamorous but they produce use
         GeomHandle<Plane> plane;     
         GeomHandle<Panel> panel;     
         // Annulus of a cylinder that bounds the tracker/straw info:
-        TubsParams envelope(tracker->getInnerTrackerEnvelopeParams());
+        TubsParams envelope(tracker->g4Tracker()->getInnerTrackerEnvelopeParams());
          
         if (doDisplay_) {
               
@@ -991,7 +991,7 @@ Below here are a series of macros -  they are not glamorous but they produce use
        	    GeomHandle<Tracker> th;
        	    const Tracker* tracker = th.get(); 
             // Annulus of a cylinder that bounds the tracker/straw info:
-            TubsParams envelope(tracker->getInnerTrackerEnvelopeParams());
+            TubsParams envelope(tracker->g4Tracker()->getInnerTrackerEnvelopeParams());
             if (doDisplay_) {
                 TPolyMarker poly, wirecentre;
 	      	TBox   box;
@@ -1078,7 +1078,7 @@ Below here are a series of macros -  they are not glamorous but they produce use
         GeomHandle<Tracker> tracker;
 
         // Annulus of a cylinder that bounds the tracker
-        TubsParams envelope(tracker->getInnerTrackerEnvelopeParams());
+        TubsParams envelope(tracker->g4Tracker()->getInnerTrackerEnvelopeParams());
 
 	std::vector<double> x, y, z, a0, a1, b0, b1;
 	std::vector<XYZVec> xprimes, yprimes, zprimes, initial_track_direction;
@@ -1223,7 +1223,7 @@ Below here are a series of macros -  they are not glamorous but they produce use
         GeomHandle<Tracker> tracker;
 
         // Annulus of a cylinder that bounds the tracker
-        TubsParams envelope(tracker->getInnerTrackerEnvelopeParams());
+        TubsParams envelope(tracker->g4Tracker()->getInnerTrackerEnvelopeParams());
 
 	std::vector<double> x, y, z, a0, a1, b0, b1;
 	std::vector<XYZVec> xprimes, yprimes, zprimes, initial_track_direction;
@@ -1380,7 +1380,7 @@ Below here are a series of macros -  they are not glamorous but they produce use
           GeomHandle<Tracker> tracker;
  
           // Annulus of a cylinder that bounds the tracker
-          TubsParams envelope(tracker->getInnerTrackerEnvelopeParams());
+          TubsParams envelope(tracker->g4Tracker()->getInnerTrackerEnvelopeParams());
           
 	  // Draw the frame for the cylinders in plot:
           double zlimit{envelope.zHalfLength()};

--- a/EventDisplay/src/DataInterface.cc
+++ b/EventDisplay/src/DataInterface.cc
@@ -264,9 +264,9 @@ void DataInterface::fillGeometry()
     }
 
 //Support Structure
-    double innerRadius=tracker->getSupportParams().innerRadius();
-    double outerRadius=tracker->getSupportParams().outerRadius();
-    double zHalfLength=tracker->getInnerTrackerEnvelopeParams().zHalfLength();
+    double innerRadius=tracker->g4Tracker()->getSupportParams().innerRadius();
+    double outerRadius=tracker->g4Tracker()->getSupportParams().outerRadius();
+    double zHalfLength=tracker->g4Tracker()->getInnerTrackerEnvelopeParams().zHalfLength();
     findBoundaryP(_trackerMinmax, outerRadius, outerRadius, zHalfLength);
     findBoundaryP(_trackerMinmax, -outerRadius, -outerRadius, -zHalfLength);
 
@@ -284,9 +284,9 @@ void DataInterface::fillGeometry()
     _supportstructures.push_back(shape);
 
 //Envelope
-    innerRadius=tracker->getInnerTrackerEnvelopeParams().innerRadius();
-    outerRadius=tracker->getInnerTrackerEnvelopeParams().outerRadius();
-    zHalfLength=tracker->getInnerTrackerEnvelopeParams().zHalfLength();
+    innerRadius=tracker->g4Tracker()->getInnerTrackerEnvelopeParams().innerRadius();
+    outerRadius=tracker->g4Tracker()->getInnerTrackerEnvelopeParams().outerRadius();
+    zHalfLength=tracker->g4Tracker()->getInnerTrackerEnvelopeParams().zHalfLength();
 
     boost::shared_ptr<ComponentInfo> infoEnvelope(new ComponentInfo());
     infoEnvelope->setName("Tracker Envelope");

--- a/GeometryService/src/TrackerMaker.cc
+++ b/GeometryService/src/TrackerMaker.cc
@@ -412,8 +412,8 @@ namespace mu2e {
     computeManifoldEdgeExcessSpace();
     // fill their content
     makeStraws(allStraws);
-    // create an empty G4Tracker: this gets filled further down
-    auto g4trackerptr = shared_ptr<G4Tracker>(new G4Tracker);
+    // create an empty TrackerG4Info: this gets filled further down
+    auto g4trackerptr = shared_ptr<TrackerG4Info>(new TrackerG4Info);
     // see which planes actually exist.  This is deprecated, TrackerStatus should be used instead  FIXME!
     std::array<bool,StrawId::_nplanes> planeExists;
     for ( int ipln=0; ipln<StrawId::_nplanes; ++ipln ){

--- a/GeometryService/src/TrackerMaker.cc
+++ b/GeometryService/src/TrackerMaker.cc
@@ -581,7 +581,7 @@ namespace mu2e {
   void TrackerMaker::makePanel( const PanelId& pnlId ){
 
     auto const& panel = _tt->getPlane(pnlId).getPanel(pnlId);
-    auto g4tt = _tt->g4Tracker().get();
+    auto g4tt = _tt->g4Tracker();
 
     // check if the opposite panels do not overlap
     static double const tolerance = 1.e-6; // this should be in a config file

--- a/GeometryService/src/TrackerMaker.cc
+++ b/GeometryService/src/TrackerMaker.cc
@@ -412,10 +412,18 @@ namespace mu2e {
     computeManifoldEdgeExcessSpace();
     // fill their content
     makeStraws(allStraws);
+    // create an empty G4Tracker: this gets filled further down
+    auto g4trackerptr = shared_ptr<G4Tracker>(new G4Tracker);
+    // see which planes actually exist.  This is deprecated, TrackerStatus should be used instead  FIXME!
+    std::array<bool,StrawId::_nplanes> planeExists;
+    for ( int ipln=0; ipln<StrawId::_nplanes; ++ipln ){
+      planeExists[ipln] =  ( find ( _nonExistingPlanes.begin(), _nonExistingPlanes.end(), ipln) == _nonExistingPlanes.end() );
+    }
     // build tracker with these
-    _tt = unique_ptr<Tracker>(new Tracker(allStraws,strawprops));
+    _tt = unique_ptr<Tracker>(new Tracker(allStraws,strawprops,g4trackerptr,planeExists));
+    auto g4tt = _tt->g4Tracker();
 
-// now G4 stuff.  This should be factorized away, preferably to a different class FIXME
+// now G4 stuff
     for ( int ipln=0; ipln<StrawId::_nplanes; ++ipln ){
       makePlane(StrawId(ipln,0,0));
     }
@@ -423,7 +431,7 @@ namespace mu2e {
     makeMother();
 
 
-    _tt->_supportModel = _supportModel;
+    g4tt->_supportModel = _supportModel;
 
     // Fill information about the new style, fully detailed support structure.
     if ( _supportModel == SupportModel::detailedv0 ) {
@@ -431,24 +439,23 @@ namespace mu2e {
     }
 
     // Fill the information about the, old style minimal supports.
-    _tt->_supportParams = Support( _innerSupportRadius,
+    g4tt->_supportParams = Support( _innerSupportRadius,
                                    _outerSupportRadius,
                                    _supportHalfThickness,
                                    _supportMaterial);
 
-    _tt->_z0                  = _zCenter;
-    _tt->_envelopeInnerRadius = _envelopeInnerRadius;
-    _tt->_manifoldHalfLengths = _manifoldHalfLengths; // is this needed????
-    _tt->_envelopeMaterial    = _envelopeMaterial;
+    g4tt->_z0                  = _zCenter;
+    g4tt->_envelopeMaterial    = _envelopeMaterial;
 
-    _tt->_wallMaterialName    = _strawMaterials[0];
-    _tt->_outerMetalMaterial  = _wallOuterMetalMaterial;
-    _tt->_innerMetal1Material = _wallInnerMetal1Material;
-    _tt->_innerMetal2Material = _wallInnerMetal2Material;
-    _tt->_gasMaterialName     = _strawMaterials[1];
-    _tt->_wireMaterialName    = _strawMaterials[2];
-    _tt->_wirePlateMaterial   = _wirePlateMaterial;
-
+    g4tt->_wallMaterialName    = _strawMaterials[0];
+    g4tt->_outerMetalMaterial  = _wallOuterMetalMaterial;
+    g4tt->_innerMetal1Material = _wallInnerMetal1Material;
+    g4tt->_innerMetal2Material = _wallInnerMetal2Material;
+    g4tt->_gasMaterialName     = _strawMaterials[1];
+    g4tt->_wireMaterialName    = _strawMaterials[2];
+    g4tt->_wirePlateMaterial   = _wirePlateMaterial;
+// the following is needed by the Detail constructor
+    g4tt->_panelZOffset        = _panelZOffset;
 
 
     //computeStrawHalfLengths();
@@ -463,14 +470,15 @@ namespace mu2e {
     finalCheck();
 
     if ( _verbosityLevel > 0 ) {
-      cout << "Tracker Support Structure: \n" << _tt->_supportStructure << endl;
+      cout << "Tracker Support Structure: \n" << g4tt->_supportStructure << endl;
     }
 
   } //end TrackerMaker::buildIt.
 
   void TrackerMaker::makeMother(){
+    auto g4tt = _tt->g4Tracker();
 
-    _tt->_mother = PlacedTubs ( "TrackerMother",
+    g4tt->_mother = PlacedTubs ( "TrackerMother",
                                 TubsParams( _motherRIn, _motherROut, _motherHalfLength),
                                 CLHEP::Hep3Vector( _xCenter, 0., _motherZ0),
                                 _envelopeMaterial );
@@ -523,15 +531,14 @@ namespace mu2e {
   void TrackerMaker::makePlane( const StrawId& planeId ){
     //std::cout << "->->-> makePlane\n";
     int ipln = planeId.getPlane();
-    auto& planes = _tt->_planes;
-    Plane& plane = planes.at(ipln);
+    auto const& planes = _tt->planes();
+    auto const& plane = planes.at(ipln);
 
     if (_verbosityLevel>2) {
       cout << __func__ << " making plane " <<  ipln;
     }
-    _tt->_planeExists[ipln] =  ( find ( _nonExistingPlanes.begin(), _nonExistingPlanes.end(), ipln) == _nonExistingPlanes.end() );
     if (_verbosityLevel>2) {
-      cout << ", exists " <<  _tt->_planeExists[ipln] << endl;
+      cout << ", exists " <<  _tt->planeExists(planeId) << endl;
     }
     for ( int ipnl=0; ipnl<StrawId::_npanels; ++ipnl ){
       makePanel ( StrawId(ipln,ipnl,0));
@@ -574,6 +581,7 @@ namespace mu2e {
   void TrackerMaker::makePanel( const PanelId& pnlId ){
 
     auto const& panel = _tt->getPlane(pnlId).getPanel(pnlId);
+    auto g4tt = _tt->g4Tracker().get();
 
     // check if the opposite panels do not overlap
     static double const tolerance = 1.e-6; // this should be in a config file
@@ -715,21 +723,21 @@ namespace mu2e {
     // Alignment of angle of full plane
 
 
-    _tt->_panelEB._EBKey       = TubsParams(_EBKeyInnerRadius,
+    g4tt->_panelEB._EBKey       = TubsParams(_EBKeyInnerRadius,
                                     _EBKeyOuterRadius,
                                     _EBKeyHalfLength,
                                     0.,
                                     _EBKeyPhiRange);
 
-    _tt->_panelEB._EBKeyShield = TubsParams(_EBKeyInnerRadius,
+    g4tt->_panelEB._EBKeyShield = TubsParams(_EBKeyInnerRadius,
                                     _EBKeyOuterRadius,
                                     _EBKeyShieldHalfLength,
                                     0.,
                                     _EBKeyPhiRange);
 
-    _tt->_panelEB._EBKeyMaterial         = _EBKeyMaterial;
-    _tt->_panelEB._EBKeyShieldMaterial   = _EBKeyShieldMaterial;
-    _tt->_panelEB._EBKeyPhiExtraRotation = _EBKeyPhiExtraRotation;
+    g4tt->_panelEB._EBKeyMaterial         = _EBKeyMaterial;
+    g4tt->_panelEB._EBKeyShieldMaterial   = _EBKeyShieldMaterial;
+    g4tt->_panelEB._EBKeyPhiExtraRotation = _EBKeyPhiExtraRotation;
 
   }  // end makePanel
 
@@ -939,9 +947,9 @@ namespace mu2e {
 
   // Identify the neighbour straws for all straws in the tracker
   void TrackerMaker::makeSupportStructure(){
+    auto g4tt = _tt->g4Tracker();
 
-    SupportStructure& sup  = _tt->_supportStructure;
-    _tt->_panelZOffset = _panelZOffset;
+    SupportStructure& sup  = g4tt->_supportStructure;
 
     // Positions for the next few objects in Mu2e coordinates.
     TubsParams endRingTubs( _endRingInnerRadius, _endRingOuterRadius, _endRingHalfLength);
@@ -1300,7 +1308,8 @@ namespace mu2e {
 
   // This needs to know the z positions of the support rings
   void TrackerMaker::makeThinSupportRings(){
-    SupportStructure& sup  = _tt->_supportStructure;
+    auto g4tt = _tt->g4Tracker();
+    SupportStructure& sup  = g4tt->_supportStructure;
 
     TubsParams thinRingTubs ( _endRingInnerRadius, _outerRingOuterRadius, _midRingHalfLength,
                               _midRingPhi0, _midRingdPhi); // by default, half rings, on the bottom part, but user-configurable
@@ -1333,29 +1342,30 @@ namespace mu2e {
 
   // Envelope that holds one plane ("TrackerPlaneEnvelope")
   void TrackerMaker::computePlaneEnvelope(){
+    auto g4tt = _tt->g4Tracker();
 
     if ( _supportModel == SupportModel::simple ){
-      double halfThick = _tt->_supportParams.halfThickness() +
-	2.*_tt->_manifoldHalfLengths[2];
-      _tt->_planeEnvelopeParams = TubsParams( _tt->_envelopeInnerRadius,
-					      _tt->_supportParams.outerRadius(),
+      double halfThick = g4tt->_supportParams.halfThickness() +
+	2.*_manifoldHalfLengths[2];
+      g4tt->_planeEnvelopeParams = TubsParams( _envelopeInnerRadius,
+					      g4tt->_supportParams.outerRadius(),
 					      halfThick);
     } else if ( _supportModel == SupportModel::detailedv0 ){
       // This is new for version 5, its existence doesn't affect earlier
       // versions.
-      _tt->_panelEnvelopeParams = TubsParams( _envelopeInnerRadius,
+      g4tt->_panelEnvelopeParams = TubsParams( _envelopeInnerRadius,
                                                _outerRingOuterRadius,
                                                _innerRingHalfLength
 					      + _panelPadding,
 					      0., _panelPhi);
       if ( _ttVersion > 3 ) {
-	_tt->_planeEnvelopeParams = TubsParams( _envelopeInnerRadius,
+	g4tt->_planeEnvelopeParams = TubsParams( _envelopeInnerRadius,
 						_outerRingOuterRadius,
 						2.0 * (_innerRingHalfLength
 						       + _panelPadding )
 						+ _planePadding );
       } else {
-	_tt->_planeEnvelopeParams = TubsParams( _envelopeInnerRadius,
+	g4tt->_planeEnvelopeParams = TubsParams( _envelopeInnerRadius,
 						_outerRingOuterRadius,
 						_innerRingHalfLength);
       } // end of if on version in assigning plane envelope params
@@ -1369,29 +1379,29 @@ namespace mu2e {
 
   // Envelope that holds the full Tracker ("TrackerMother")
   void TrackerMaker::computeTrackerEnvelope(){
-
+    auto g4tt = _tt->g4Tracker();
     if ( _supportModel == SupportModel::simple ){
 
       // Envelope of a single plane.
-      TubsParams planeEnvelope = _tt->getPlaneEnvelopeParams();
+      TubsParams planeEnvelope = _tt->g4Tracker()->getPlaneEnvelopeParams();
 
       // Full length from center to center of the first and last planes.
-      double fullLength = _tt->_planes.back().origin().z()-_tt->_planes.front().origin().z();
+      double fullLength = _tt->planes().back().origin().z()-_tt->planes().front().origin().z();
 
       // Remember the thickness of the planes.
       double halfLength = fullLength/2. + planeEnvelope.zHalfLength();
 
-      _tt->_innerTrackerEnvelopeParams = TubsParams( planeEnvelope.innerRadius(),
+      g4tt->_innerTrackerEnvelopeParams = TubsParams( planeEnvelope.innerRadius(),
                                                      planeEnvelope.outerRadius(),
                                                      halfLength);
 
     } else if ( _supportModel == SupportModel::detailedv0 ){
 
-      double fullLength = _tt->_planes.back().origin().z()-_tt->_planes.front().origin().z();
-      double halfLength = fullLength/2. + _tt->getPlaneEnvelopeParams().zHalfLength();
+      double fullLength = _tt->planes().back().origin().z()-_tt->planes().front().origin().z();
+      double halfLength = fullLength/2. + _tt->g4Tracker()->getPlaneEnvelopeParams().zHalfLength();
 
       TubsParams val( _envelopeInnerRadius, _outerRingOuterRadius, halfLength);
-      _tt->_innerTrackerEnvelopeParams = val;
+      g4tt->_innerTrackerEnvelopeParams = val;
 
     } else{
 

--- a/GeometryService/src/VirtualDetectorMaker.cc
+++ b/GeometryService/src/VirtualDetectorMaker.cc
@@ -206,7 +206,7 @@ namespace mu2e {
         }
 
         Tracker const & tracker = *(GeomHandle<Tracker>());
-        Hep3Vector ttOffset(-solenoidOffset,0.,tracker.z0());
+        Hep3Vector ttOffset(-solenoidOffset,0.,tracker.g4Tracker()->z0());
 
         // VD TT_Mid is placed inside the tracker mother volume in the
         // middle of the tracker shifted by the half length of vd
@@ -236,10 +236,10 @@ namespace mu2e {
         //       }
 
         // Global position is in Mu2e coordinates; local position in the detector system.
-        double zFrontGlobal = tracker.mother().position().z()-tracker.mother().tubsParams().zHalfLength()-vdHL;
-        double zBackGlobal  = tracker.mother().position().z()+tracker.mother().tubsParams().zHalfLength()+vdHL;
-        double zFrontLocal  = zFrontGlobal - tracker.z0();
-        double zBackLocal   = zBackGlobal  - tracker.z0();
+        double zFrontGlobal = tracker.g4Tracker()->mother().position().z()-tracker.g4Tracker()->mother().tubsParams().zHalfLength()-vdHL;
+        double zBackGlobal  = tracker.g4Tracker()->mother().position().z()+tracker.g4Tracker()->mother().tubsParams().zHalfLength()+vdHL;
+        double zFrontLocal  = zFrontGlobal - tracker.g4Tracker()->z0();
+        double zBackLocal   = zBackGlobal  - tracker.g4Tracker()->z0();
 
         Hep3Vector vdTTFrontOffset(0.,
                                    0.,
@@ -282,7 +282,7 @@ namespace mu2e {
         // these next two detectors are also thin, but they are not disks but cylinders
         // placed on the inner and outer surface of the tracker envelope
 
-        Hep3Vector vdTTOutSurfOffset(0.,0.,tracker.mother().position().z()-tracker.z0());
+        Hep3Vector vdTTOutSurfOffset(0.,0.,tracker.g4Tracker()->mother().position().z()-tracker.g4Tracker()->z0());
 
         vd->addVirtualDetector( VirtualDetectorId::TT_OutSurf,
                                  ttOffset, 0, vdTTOutSurfOffset);

--- a/Mu2eG4/inc/ConstructTrackerDetail5.hh
+++ b/Mu2eG4/inc/ConstructTrackerDetail5.hh
@@ -9,8 +9,9 @@
 //
 
 #include "G4Helper/inc/VolumeInfo.hh"
-
 #include "G4RotationMatrix.hh"
+#include "GeomPrimitives/inc/TubsParams.hh"
+#include "DataProducts/inc/StrawId.hh"
 
 #include <vector>
 
@@ -28,6 +29,16 @@ namespace mu2e {
                               SimpleConfig const& config );
 
     VolumeInfo motherInfo() { return _motherInfo; }
+
+    // Return G4TUBS parameters for straws, includes
+    // wire, gas and straw materials.
+    TubsParams strawOuterTubsParams(StrawId const& id , Tracker const& tracker) const;
+    TubsParams strawWallMother(StrawId const& id , Tracker const& tracker) const;
+    TubsParams strawWallOuterMetal(StrawId const& id , Tracker const& tracker)  const;
+    TubsParams strawWallInnerMetal1(StrawId const& id , Tracker const& tracker) const;
+    TubsParams strawWallInnerMetal2(StrawId const& id , Tracker const& tracker) const;
+    TubsParams strawWireMother(StrawId const& id , Tracker const& tracker) const;
+    TubsParams strawWirePlate(StrawId const& id , Tracker const& tracker) const;
 
 
   private:

--- a/Mu2eG4/src/ConstructTrackerDetail5.cc
+++ b/Mu2eG4/src/ConstructTrackerDetail5.cc
@@ -101,7 +101,7 @@ namespace mu2e {
 // coordinate system of the mother.
 CLHEP::Hep3Vector
 mu2e::ConstructTrackerDetail5::computeOffset(){
-  return CLHEP::Hep3Vector(0., 0., _tracker.z0()-_tracker.mother().position().z() );
+  return CLHEP::Hep3Vector(0., 0., _tracker.g4Tracker()->z0()-_tracker.g4Tracker()->mother().position().z() );
 }
 // *****************************************************
 
@@ -113,7 +113,7 @@ void
 mu2e::ConstructTrackerDetail5::constructMother(){
 
   // Parameters of the new style mother volume ( replaces the envelope volume ).
-  PlacedTubs const& mother = _tracker.mother();
+  PlacedTubs const& mother = _tracker.g4Tracker()->mother();
 
   static int const newPrecision = 8;
   static int const newWidth = 14;
@@ -143,7 +143,7 @@ mu2e::ConstructTrackerDetail5::constructMother(){
   }
 
   // All mother/envelope volumes are made of this material.
-  G4Material* envelopeMaterial = findMaterialOrThrow(_tracker.envelopeMaterial());
+  G4Material* envelopeMaterial = findMaterialOrThrow(_tracker.g4Tracker()->envelopeMaterial());
 
   _motherInfo = nestTubs( "TrackerMother",
                           mother.tubsParams(),
@@ -188,7 +188,7 @@ mu2e::ConstructTrackerDetail5::constructMother(){
 void
 mu2e::ConstructTrackerDetail5::constructMainSupports(){
 
-  SupportStructure const& sup = _tracker.getSupportStructure();
+  SupportStructure const& sup = _tracker.g4Tracker()->getSupportStructure();
 
   const auto geomOptions = art::ServiceHandle<GeometryService>()->geomOptions();
   geomOptions->loadEntry( _config, "trackerSupport", "tracker.support" );
@@ -431,7 +431,7 @@ mu2e::ConstructTrackerDetail5::constructPlanes(){
   // Here is where the support material for each plane has historically been
   // built.
 
-  TubsParams planeEnvelopeParams = _tracker.getPlaneEnvelopeParams();
+  TubsParams planeEnvelopeParams = _tracker.g4Tracker()->getPlaneEnvelopeParams();
   
   const auto geomOptions = art::ServiceHandle<GeometryService>()->geomOptions();
   geomOptions->loadEntry( _config, "trackerPlaneEnvelope", "tracker.planeEnvelope" );
@@ -439,7 +439,7 @@ mu2e::ConstructTrackerDetail5::constructPlanes(){
   const bool planeEnvelopeVisible = geomOptions->isVisible("trackerPlaneEnvelope");
   const bool planeEnvelopeSolid   = geomOptions->isSolid("trackerPlaneEnvelope");
 
-  G4Material* envelopeMaterial = findMaterialOrThrow(_tracker.envelopeMaterial());
+  G4Material* envelopeMaterial = findMaterialOrThrow(_tracker.g4Tracker()->envelopeMaterial());
 
   double dPhiPanel = panelHalfAzimuth();
 
@@ -570,8 +570,8 @@ mu2e::ConstructTrackerDetail5::preparePanel(const int& iPlane,
   // and electronics associated with what we actually construct and call
   // a "panel."
 
-  TubsParams panEnvParams = _tracker.getPanelEnvelopeParams();
-  //  SupportStructure const& sup     = _tracker.getSupportStructure();
+  TubsParams panEnvParams = _tracker.g4Tracker()->getPanelEnvelopeParams();
+  //  SupportStructure const& sup     = _tracker.g4Tracker()->getSupportStructure();
 
   // Panels are identical other than placement - so get required properties from plane 0, panel 0.
   Panel const& panel(_tracker.getPanel(PanelId(iPlane,iPanel,0)));
@@ -625,7 +625,7 @@ mu2e::ConstructTrackerDetail5::preparePanel(const int& iPlane,
          << endl;
   }
 
-  G4Material* envelopeMaterial = findMaterialOrThrow(_tracker.envelopeMaterial());
+  G4Material* envelopeMaterial = findMaterialOrThrow(_tracker.g4Tracker()->envelopeMaterial());
 
   // *****************
   // Here we make the envelope for everything in one panel, including
@@ -687,8 +687,8 @@ mu2e::ConstructTrackerDetail5::prepareStrawPanel() {
   // all of the panels in all of the planes in all the world.
 
 
-  //  TubsParams planeEnvelopeParams = _tracker.getPlaneEnvelopeParams();
-  SupportStructure const& sup     = _tracker.getSupportStructure();
+  //  TubsParams planeEnvelopeParams = _tracker.g4Tracker()->getPlaneEnvelopeParams();
+  SupportStructure const& sup     = _tracker.g4Tracker()->getSupportStructure();
 
   // Straw Panels are identical other than placement - so get required
   // properties from plane 0, panel 0.
@@ -734,8 +734,8 @@ mu2e::ConstructTrackerDetail5::prepareStrawPanel() {
   //                          0.,
   //                          phiMax);
 
-  TubsParams panEnvParams = _tracker.getPanelEnvelopeParams();
-  double zCorrection = panEnvParams.zHalfLength() - _tracker.panelOffset();
+  TubsParams panEnvParams = _tracker.g4Tracker()->getPanelEnvelopeParams();
+  double zCorrection = panEnvParams.zHalfLength() - _tracker.g4Tracker()->panelOffset();
 
   if (_verbosityLevel>0) {
     cout << __func__
@@ -755,7 +755,7 @@ mu2e::ConstructTrackerDetail5::prepareStrawPanel() {
 
 
   G4Material* envelopeMaterial = findMaterialOrThrow(
-						_tracker.envelopeMaterial());
+						_tracker.g4Tracker()->envelopeMaterial());
 
   VolumeInfo spnl0Info = nestTubs( "StrawPanelEnvelope",
                                   panEnvParams,
@@ -837,8 +837,8 @@ mu2e::ConstructTrackerDetail5::prepareStrawPanel() {
       // The enclosing volume for the straw is made of gas.  
       // The walls and the wire will be placed inside.
       VolumeInfo strawVol =  nestTubs( straw.name("TrackerStrawGas_"),
-                                       _tracker.strawOuterTubsParams(straw.id()),
-                                       findMaterialOrThrow(_tracker.gasMaterialName()),
+                                       strawOuterTubsParams(straw.id(),_tracker),
+                                       findMaterialOrThrow(_tracker.g4Tracker()->gasMaterialName()),
                                        panelRotation,
                                        mid,
                                        spnl0Info.logical,
@@ -854,8 +854,8 @@ mu2e::ConstructTrackerDetail5::prepareStrawPanel() {
       // Wall has 4 layers; the three metal layers sit inside the plastic layer.
       // The plastic layer sits inside the gas.
       VolumeInfo wallVol =  nestTubs( straw.name("TrackerStrawWall_"),
-                                      _tracker.strawWallMother(straw.id()),
-                                      findMaterialOrThrow(_tracker.wallMaterialName()),
+                                      strawWallMother(straw.id(),_tracker),
+                                      findMaterialOrThrow(_tracker.g4Tracker()->wallMaterialName()),
                                       noRotation,
                                       zeroVector,
                                       strawVol.logical,
@@ -870,8 +870,8 @@ mu2e::ConstructTrackerDetail5::prepareStrawPanel() {
 
 
       VolumeInfo outerMetalVol =  nestTubs( straw.name("TrackerStrawWallOuterMetal_"),
-                                            _tracker.strawWallOuterMetal(straw.id()),
-                                            findMaterialOrThrow(_tracker.wallOuterMetalMaterialName()),
+                                            strawWallOuterMetal(straw.id(),_tracker),
+                                            findMaterialOrThrow(_tracker.g4Tracker()->wallOuterMetalMaterialName()),
                                             noRotation,
                                             zeroVector,
                                             wallVol.logical,
@@ -886,8 +886,8 @@ mu2e::ConstructTrackerDetail5::prepareStrawPanel() {
 
 
       VolumeInfo innerMetal1Vol =  nestTubs( straw.name("TrackerStrawWallInnerMetal1_"),
-					     _tracker.strawWallInnerMetal1(straw.id()),
-                                             findMaterialOrThrow(_tracker.wallInnerMetal1MaterialName()),
+					     strawWallInnerMetal1(straw.id(),_tracker),
+                                             findMaterialOrThrow(_tracker.g4Tracker()->wallInnerMetal1MaterialName()),
                                              noRotation,
                                              zeroVector,
                                              wallVol.logical,
@@ -902,8 +902,8 @@ mu2e::ConstructTrackerDetail5::prepareStrawPanel() {
 
 
       VolumeInfo innerMetal2Vol =  nestTubs( straw.name("TrackerStrawWallInnerMetal2_"),
-					     _tracker.strawWallInnerMetal2(straw.id()),
-                                             findMaterialOrThrow(_tracker.wallInnerMetal2MaterialName()),
+					     strawWallInnerMetal2(straw.id(),_tracker),
+                                             findMaterialOrThrow(_tracker.g4Tracker()->wallInnerMetal2MaterialName()),
                                              noRotation,
                                              zeroVector,
                                              wallVol.logical,
@@ -918,8 +918,8 @@ mu2e::ConstructTrackerDetail5::prepareStrawPanel() {
 
 
       VolumeInfo wireVol =  nestTubs( straw.name("TrackerWireCore_"),
-				      _tracker.strawWireMother(straw.id()),
-                                      findMaterialOrThrow(_tracker.wireCoreMaterialName()),
+				      strawWireMother(straw.id(),_tracker),
+                                      findMaterialOrThrow(_tracker.g4Tracker()->wireCoreMaterialName()),
                                       noRotation,
                                       zeroVector,
                                       strawVol.logical,
@@ -934,8 +934,8 @@ mu2e::ConstructTrackerDetail5::prepareStrawPanel() {
 
 
       VolumeInfo platingVol =  nestTubs( straw.name("TrackerWirePlate_"),
-					 _tracker.strawWirePlate(straw.id()),
-                                         findMaterialOrThrow(_tracker.wirePlateMaterialName()),
+					 strawWirePlate(straw.id(),_tracker),
+                                         findMaterialOrThrow(_tracker.g4Tracker()->wirePlateMaterialName()),
                                          noRotation,
                                          zeroVector,
                                          wireVol.logical,
@@ -1233,11 +1233,11 @@ mu2e::ConstructTrackerDetail5::prepareEBKey(bool keyItself){
   // Internally all keys are the same.
   // Create one logical volume for now, do not place it.
   
-  TubsParams  keyParams  = keyItself ? _tracker.panelElectronicsBoard().getEBKeyParams() : _tracker.panelElectronicsBoard().getEBKeyShieldParams();
+  TubsParams  keyParams  = keyItself ? _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyParams() : _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyShieldParams();
 
   G4Material* keyMaterial = findMaterialOrThrow( keyItself ?
-                                                 _tracker.panelElectronicsBoard().getEBKeyMaterial() :
-                                                 _tracker.panelElectronicsBoard().getEBKeyShieldMaterial() );
+                                                 _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyMaterial() :
+                                                 _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyShieldMaterial() );
 
   VolumeInfo key0Info = keyItself ? nestTubs("PanelEBKey",
                                              keyParams,
@@ -1308,7 +1308,7 @@ mu2e::ConstructTrackerDetail5::constructAxes(){
   int isSolid(true);
   int edgeVisible(true);
 
-  G4Material* envelopeMaterial = findMaterialOrThrow(_tracker.envelopeMaterial());
+  G4Material* envelopeMaterial = findMaterialOrThrow(_tracker.g4Tracker()->envelopeMaterial());
 
   // A box marking the x-axis.
   double halfDimX[3];
@@ -1401,7 +1401,7 @@ mu2e::ConstructTrackerDetail5::addPanelsAndEBKeys(VolumeInfo& baseStrawPanel,
 //  Panel const& panel(_tracker.getPanel(StrawId(0,0,0)));
 
   // to prevent the overlaps
-  SupportStructure const& sup = _tracker.getSupportStructure();
+  SupportStructure const& sup = _tracker.g4Tracker()->getSupportStructure();
 
   int pnlDraw = _config.getInt ("tracker.pnlDraw",-1);
 
@@ -1409,7 +1409,7 @@ mu2e::ConstructTrackerDetail5::addPanelsAndEBKeys(VolumeInfo& baseStrawPanel,
   int baseCopyNo = ipln * _tracker.getPlane(0).nPanels();
 
   // The panel will be placed in the middle of the channel.
-  //  PlacedTubs const& chanUp(_tracker.getSupportStructure().innerChannelUpstream());
+  //  PlacedTubs const& chanUp(_tracker.g4Tracker()->getSupportStructure().innerChannelUpstream());
 
   // Place the panel envelope into the plane envelope, one placement per panel.
   for ( size_t ipnl=0; ipnl<pln.nPanels(); ++ipnl){
@@ -1426,8 +1426,8 @@ mu2e::ConstructTrackerDetail5::addPanelsAndEBKeys(VolumeInfo& baseStrawPanel,
     double phimid = mid.phi();
     if ( phimid < 0 ) phimid += 2.*M_PI;
 
-    //    double theZOffset = _tracker.panelOffset();
-    double theZOffset = _tracker.getPanelEnvelopeParams().zHalfLength();
+    //    double theZOffset = _tracker.g4Tracker()->panelOffset();
+    double theZOffset = _tracker.g4Tracker()->getPanelEnvelopeParams().zHalfLength();
 
     // Is this panel on the front(+) or back(-) face of the plane?
     double sign   = ((mid.z() - pln.origin().z())>0. ? 1.0 : -1.0 );
@@ -1490,20 +1490,20 @@ mu2e::ConstructTrackerDetail5::addPanelsAndEBKeys(VolumeInfo& baseStrawPanel,
     // Now placing the EBkey
 
     // see comment above about panel phi0
-    double keyAngShift = _tracker.panelElectronicsBoard().getEBKeyParams().phiMax()*0.5;
+    double keyAngShift = _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyParams().phiMax()*0.5;
 
     // additional rotation to place some of the keys at the top of the tracker
 
-    double keyPhi0 = keyAngShift - phimid - _tracker.panelElectronicsBoard().getEBKeyPhiExtraRotation(); // as it needs to placed per geant4
+    double keyPhi0 = keyAngShift - phimid - _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyPhiExtraRotation(); // as it needs to placed per geant4
     if ( sign > 0 ) {
-      keyPhi0 = keyAngShift + M_PI + phimid + _tracker.panelElectronicsBoard().getEBKeyPhiExtraRotation();
+      keyPhi0 = keyAngShift + M_PI + phimid + _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyPhiExtraRotation();
     }
 
     keyPhi0 = getWithinZeroTwoPi(keyPhi0);
 
     bool willOverlap = false;
 
-    double keyNominalPhi0 =  getWithinZeroTwoPi(phimid + _tracker.panelElectronicsBoard().getEBKeyPhiExtraRotation());
+    double keyNominalPhi0 =  getWithinZeroTwoPi(phimid + _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyPhiExtraRotation());
 
     for ( auto const& sbeam : sup.beamBody() ) {
 
@@ -1513,8 +1513,8 @@ mu2e::ConstructTrackerDetail5::addPanelsAndEBKeys(VolumeInfo& baseStrawPanel,
       double diffEdge1 = diffWithinZeroTwoPi(keyNominalPhi0,sbeam.phi0());
       double diffEdge2 = diffWithinZeroTwoPi(keyNominalPhi0,phiEnd);
 
-      if ( ( diffEdge1 < _tracker.panelElectronicsBoard().getEBKeyParams().phiMax() ) ||
-           ( diffEdge2 < _tracker.panelElectronicsBoard().getEBKeyParams().phiMax() ) ) {
+      if ( ( diffEdge1 < _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyParams().phiMax() ) ||
+           ( diffEdge2 < _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyParams().phiMax() ) ) {
         willOverlap = true;
       }
 
@@ -1536,7 +1536,7 @@ mu2e::ConstructTrackerDetail5::addPanelsAndEBKeys(VolumeInfo& baseStrawPanel,
               << ", keyPhi0 "
               << keyPhi0/M_PI*180.
               << ", span "
-              << _tracker.panelElectronicsBoard().getEBKeyParams().phiMax()
+              << _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyParams().phiMax()
               << ", keyAngShift "
               << keyAngShift/M_PI*180.
                << endl;
@@ -1567,7 +1567,7 @@ mu2e::ConstructTrackerDetail5::addPanelsAndEBKeys(VolumeInfo& baseStrawPanel,
       // keys/shield depending on the key location wrt to the plane
 
       CLHEP::Hep3Vector keyPosition =  panelPosition + pln.origin()+ _offset +
-        CLHEP::Hep3Vector(0., 0., _tracker.panelElectronicsBoard().getEBKeyShieldParams().zHalfLength());
+        CLHEP::Hep3Vector(0., 0., _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyShieldParams().zHalfLength());
 
       if (_verbosityLevel>1) {
         cout << __func__
@@ -1609,7 +1609,7 @@ mu2e::ConstructTrackerDetail5::addPanelsAndEBKeys(VolumeInfo& baseStrawPanel,
       }
 
       CLHEP::Hep3Vector keyShieldPosition =  panelPosition + pln.origin()+ _offset -
-        CLHEP::Hep3Vector(0., 0., _tracker.panelElectronicsBoard().getEBKeyShieldParams().zHalfLength());
+        CLHEP::Hep3Vector(0., 0., _tracker.g4Tracker()->panelElectronicsBoard().getEBKeyShieldParams().zHalfLength());
 
       // EBKeyShield
       G4VPhysicalVolume* keyShieldPhysVol = new G4PVPlacement(keyRotation,
@@ -1636,7 +1636,7 @@ mu2e::ConstructTrackerDetail5::addPanelsAndEBKeys(VolumeInfo& baseStrawPanel,
 double
 mu2e::ConstructTrackerDetail5::panelHalfAzimuth(){
 
-  SupportStructure const& sup     = _tracker.getSupportStructure();
+  SupportStructure const& sup     = _tracker.g4Tracker()->getSupportStructure();
   return sup.panelPhiRange()/2.0;
 
 }
@@ -1656,3 +1656,40 @@ double mu2e::ConstructTrackerDetail5::diffWithinZeroTwoPi (double phi1, double p
   double diff = fabs(phi1 - phi2);
   return fmin(diff,2.*M_PI - diff);
 }
+
+mu2e::TubsParams mu2e::ConstructTrackerDetail5::strawOuterTubsParams(StrawId const& id , Tracker const& tracker) const {
+  return mu2e::TubsParams ( 0., tracker.strawProperties().strawOuterRadius(), tracker.getStraw(id).halfLength() );
+}
+mu2e::TubsParams mu2e::ConstructTrackerDetail5::strawWallMother(StrawId const& id , Tracker const& tracker)      const {
+  return TubsParams( tracker.strawProperties().strawInnerRadius(), 
+      tracker.strawProperties().strawOuterRadius(), tracker.getStraw(id).halfLength() );
+}
+mu2e::TubsParams mu2e::ConstructTrackerDetail5::strawWallOuterMetal(StrawId const& id , Tracker const& tracker)  const {
+  double rIn = tracker.strawProperties().strawOuterRadius() - tracker.strawProperties().outerMetalThickness();
+  return TubsParams( rIn, tracker.strawProperties().strawOuterRadius() , 
+      tracker.getStraw(id).halfLength() );
+}
+mu2e::TubsParams mu2e::ConstructTrackerDetail5::strawWallInnerMetal1(StrawId const& id , Tracker const& tracker) const {
+  double rIn  = tracker.strawProperties().strawInnerRadius() + tracker.strawProperties().innerMetal2Thickness();
+  double rOut = rIn + tracker.strawProperties().innerMetal1Thickness();
+  return mu2e::TubsParams (rIn,rOut,
+      tracker.getStraw(id).halfLength());
+}
+mu2e::TubsParams mu2e::ConstructTrackerDetail5::strawWallInnerMetal2(StrawId const& id , Tracker const& tracker) const {
+  double rIn  = tracker.strawProperties().strawInnerRadius();
+  double rOut = rIn + tracker.strawProperties().innerMetal2Thickness();
+  return mu2e::TubsParams (rIn,rOut,
+      tracker.getStraw(id).halfLength());
+}
+mu2e::TubsParams mu2e::ConstructTrackerDetail5::strawWireMother(StrawId const& id , Tracker const& tracker) const {
+  return mu2e::TubsParams (0.,tracker.strawProperties().wireRadius(),
+      tracker.getStraw(id).halfLength());
+}
+mu2e::TubsParams mu2e::ConstructTrackerDetail5::strawWirePlate(StrawId const& id , Tracker const& tracker) const {
+  double rIn = tracker.strawProperties().wireRadius() - tracker.strawProperties().wirePlateThickness();
+  double rOut = tracker.strawProperties().wireRadius();
+  return mu2e::TubsParams (rIn,rOut,
+      tracker.getStraw(id).halfLength());
+}
+
+

--- a/Mu2eG4/src/StrawSD.cc
+++ b/Mu2eG4/src/StrawSD.cc
@@ -81,7 +81,7 @@ namespace mu2e {
       _planesft = StrawId::_planesft;
 
       _verbosityLevel = max(verboseLevel,config.getInt("tracker.verbosityLevel",0)); // Geant4 SD verboseLevel
-      _supportModel   = tracker->getSupportModel();
+      _supportModel   = tracker->g4Tracker()->getSupportModel();
 
       if ( _TrackerVersion < 3 ) {
         throw cet::exception("StrawSD")

--- a/Mu2eG4/src/constructVirtualDetectors.cc
+++ b/Mu2eG4/src/constructVirtualDetectors.cc
@@ -431,11 +431,11 @@ namespace mu2e {
 
         // the radius of tracker mother
         Tracker const & tracker = *(GeomHandle<Tracker>());
-        double orvd = tracker.mother().tubsParams().outerRadius();
-        double irvd = tracker.mother().tubsParams().innerRadius();
+        double orvd = tracker.g4Tracker()->mother().tubsParams().outerRadius();
+        double irvd = tracker.g4Tracker()->mother().tubsParams().innerRadius();
 
-        if ( tracker.getSupportModel() == SupportModel::detailedv0 ) {
-          auto const& beams =  tracker.getSupportStructure().beamBody();
+        if ( tracker.g4Tracker()->getSupportModel() == SupportModel::detailedv0 ) {
+          auto const& beams =  tracker.g4Tracker()->getSupportStructure().beamBody();
           if ( beams.empty() ){
             throw cet::exception("GEOM")
               << "Cannot create virtual detector " << VirtualDetectorId(vdId).name()
@@ -541,7 +541,7 @@ namespace mu2e {
 
           // the radius of tracker mother
           Tracker const & tracker = *(GeomHandle<Tracker>());
-          double orvd = tracker.mother().tubsParams().outerRadius();
+          double orvd = tracker.g4Tracker()->mother().tubsParams().outerRadius();
           double vdZ  = vdg->getGlobal(vdId).z();
 
           if ( verbosityLevel > 0) {
@@ -767,7 +767,7 @@ namespace mu2e {
 
           // the radius of tracker mother
           Tracker const & tracker = *(GeomHandle<Tracker>());
-          double orvd = tracker.mother().tubsParams().outerRadius();
+          double orvd = tracker.g4Tracker()->mother().tubsParams().outerRadius();
           double vdZ  = vdg->getGlobal(vdId).z();
 
           if ( verbosityLevel > 0) {
@@ -813,7 +813,7 @@ namespace mu2e {
         }
         // the radius of tracker mother
         Tracker const & tracker = *(GeomHandle<Tracker>());
-        double orvd = tracker.mother().tubsParams().outerRadius();
+        double orvd = tracker.g4Tracker()->mother().tubsParams().outerRadius();
         double vdZ  = vdg->getGlobal(vdId).z();
 
         if ( verbosityLevel > 0) {
@@ -859,7 +859,7 @@ namespace mu2e {
 
         // the radius of tracker mother
         Tracker const & tracker = *(GeomHandle<Tracker>());
-        TubsParams const& motherParams = tracker.mother().tubsParams();
+        TubsParams const& motherParams = tracker.g4Tracker()->mother().tubsParams();
         double orvd = motherParams.outerRadius();
         double vdZ  = vdg->getGlobal(vdId).z();
 
@@ -908,7 +908,7 @@ namespace mu2e {
 
         // the radius of tracker mother
         Tracker const & tracker = *(GeomHandle<Tracker>());
-        TubsParams const& motherParams = tracker.mother().tubsParams();
+        TubsParams const& motherParams = tracker.g4Tracker()->mother().tubsParams();
         double irvd = motherParams.innerRadius();
         double vdZ  = vdg->getGlobal(vdId).z();
 

--- a/Mu2eUtilities/src/HelixTool.cc
+++ b/Mu2eUtilities/src/HelixTool.cc
@@ -24,8 +24,8 @@ namespace mu2e {
   HelixTool::HelixTool(const HelixSeed *Helix, const mu2e::Tracker*MyTracker) :
     _tracker(MyTracker) {
     _hel = Helix;
-    _trackerRIn    = _tracker->getInnerTrackerEnvelopeParams().innerRadius();
-    _trackerROut   = _tracker->getInnerTrackerEnvelopeParams().outerRadius();
+    _trackerRIn    = _tracker->g4Tracker()->getInnerTrackerEnvelopeParams().innerRadius();
+    _trackerROut   = _tracker->g4Tracker()->getInnerTrackerEnvelopeParams().outerRadius();
 
     //initialize
     _meanHitRadialDist = 0.;

--- a/TEveEventDisplay/src/TEveMu2eTracker.cc
+++ b/TEveEventDisplay/src/TEveMu2eTracker.cc
@@ -10,7 +10,7 @@ namespace mu2e{
     void TEveMu2eTracker::DrawTrackerDetector(art::Run const& run, TGeoVolume* topvol, TEveElementList *orthodet){
       GeomHandle<Tracker> trkr;
 
-      TubsParams envelope(trkr->getInnerTrackerEnvelopeParams());
+      TubsParams envelope(trkr->g4Tracker()->getInnerTrackerEnvelopeParams());
 
       TGeoMaterial *mat = new TGeoMaterial("Mylar", 12,6,1.4);
       TGeoMedium *My = new TGeoMedium("Mylar",2, mat);

--- a/TrackerGeom/inc/G4Tracker.hh
+++ b/TrackerGeom/inc/G4Tracker.hh
@@ -1,0 +1,78 @@
+#ifndef TrackerGeom_G4Tracker_hh
+#define TrackerGeom_G4Tracker_hh
+///
+// Tracker geometry content specific to building the G4 model
+// Extracted from the original Tracker
+//
+#include "GeomPrimitives/inc/TubsParams.hh"
+#include "GeomPrimitives/inc/PlacedTubs.hh"
+#include "TrackerGeom/inc/PanelEB.hh"
+#include "TrackerGeom/inc/Manifold.hh"
+#include "TrackerGeom/inc/Support.hh"
+#include "TrackerGeom/inc/SupportModel.hh"
+#include "TrackerGeom/inc/SupportStructure.hh"
+
+namespace mu2e {
+  class G4Tracker {
+    friend class TrackerMaker; 
+    public:
+    // electronics board
+    const PanelEB& panelElectronicsBoard() const { return _panelEB;}
+    const SupportModel& getSupportModel() const{ return _supportModel; }
+    const Support& getSupportParams () const{ return _supportParams; }
+    const SupportStructure& getSupportStructure() const{ return _supportStructure; }
+    const TubsParams& getPlaneEnvelopeParams() const{ return _planeEnvelopeParams; }
+    const TubsParams& getPanelEnvelopeParams() const{ return _panelEnvelopeParams; }
+    const TubsParams& getInnerTrackerEnvelopeParams() const{ return _innerTrackerEnvelopeParams; }
+    const PlacedTubs& mother() const{ return _mother; }
+    std::string const& wallMaterialName()            const{ return _wallMaterialName; }
+    std::string const& wallCoreMaterialName()        const{ return  wallMaterialName();  }
+    std::string const& wallOuterMetalMaterialName()  const{ return _outerMetalMaterial;  }
+    std::string const& wallInnerMetal1MaterialName() const{ return _innerMetal1Material; }
+    std::string const& wallInnerMetal2MaterialName() const{ return _innerMetal2Material; }
+    std::string const& gasMaterialName()             const{ return _gasMaterialName; }
+    std::string const& wireMaterialName()            const{ return _wireMaterialName; }
+    std::string const& wireCoreMaterialName()        const{ return  wireMaterialName();  }
+    std::string const& wirePlateMaterialName()       const{ return _wirePlateMaterial;   }
+    std::string const& envelopeMaterial()	     const { return _envelopeMaterial; }
+
+    double panelOffset() const { return _panelZOffset; }
+    double z0()   const { return _z0;} // in Mu2e coordinates 
+
+    private:
+    std::string _wallMaterialName;
+    std::string _outerMetalMaterial;
+    std::string _innerMetal1Material;
+    std::string _innerMetal2Material;
+    std::string _gasMaterialName;
+    std::string _wireMaterialName;
+    std::string _wirePlateMaterial;
+    std::string _envelopeMaterial;
+
+    // Outer envelope that holds the new style support structure.
+    PlacedTubs _mother;
+    // The envelope that holds all of the planes in the tracker,
+    // including the plane supports.
+    TubsParams _innerTrackerEnvelopeParams;
+    // The envelope that holds all of the pieces in one plane, including supports.
+    TubsParams _planeEnvelopeParams;
+    // Ditto for Panel
+    TubsParams _panelEnvelopeParams;
+    // Which level of detail is present in the model of the support structure?
+    SupportModel _supportModel;
+    // All supports are the same shape; only relevant for _supportModel=="simple"
+    Support _supportParams;
+
+    // A more detailed model of the supports; again each plane has identical supports.
+    // only relevant for _supportModel == "detailedv0".
+    SupportStructure _supportStructure;
+   // Electronics board
+    PanelEB _panelEB;
+
+    double _panelZOffset; // introduced for version 5
+    // Position of the center of the tracker, in the Mu2e coordinate system.
+    double _z0;
+
+ };
+}
+#endif

--- a/TrackerGeom/inc/Panel.hh
+++ b/TrackerGeom/inc/Panel.hh
@@ -80,7 +80,6 @@ namespace mu2e {
     StrawId _id; // only the plane and panel fields are used to define a panel
     xyzVec _udir, _vdir, _wdir; // direction vectors in DS frame 
     HepTransform  _UVWtoDS; // transform from this panel's frame to the DS frame
-//    HepTransform _align; // local alignment of this this panel
     // indirection to straws
     StrawCollection _straws;
     static StrawIdMask _sidmask; // mask to panel level

--- a/TrackerGeom/inc/StrawProperties.hh
+++ b/TrackerGeom/inc/StrawProperties.hh
@@ -10,6 +10,15 @@ namespace mu2e {
     double _innerMetal2Thickness;
     double _wireRadius;
     double _wirePlateThickness;
+    double strawInnerRadius() const{ return _strawInnerRadius; }
+    double strawOuterRadius() const{ return _strawOuterRadius; }
+    double strawWallThickness() const{ return _strawWallThickness; }
+    double outerMetalThickness() const{ return _outerMetalThickness; }
+    double innerMetal1Thickness() const{ return _innerMetal1Thickness; }
+    double innerMetal2Thickness() const{ return _innerMetal2Thickness; }
+    double wireRadius()           const { return _wireRadius; }
+    double wirePlateThickness()   const { return _wirePlateThickness; }
+
   };
 }
 #endif

--- a/TrackerGeom/inc/Tracker.hh
+++ b/TrackerGeom/inc/Tracker.hh
@@ -25,7 +25,7 @@
 #include "TrackerGeom/inc/Plane.hh"
 #include "TrackerGeom/inc/Panel.hh"
 #include "TrackerGeom/inc/StrawProperties.hh"
-#include "TrackerGeom/inc/G4Tracker.hh"
+#include "TrackerGeom/inc/TrackerG4Info.hh"
 
 namespace mu2e {
   class Tracker : public Detector, public ProditionsEntity {
@@ -33,7 +33,7 @@ namespace mu2e {
     public:
     typedef std::shared_ptr<Tracker> ptr_t;
     typedef std::shared_ptr<const Tracker> cptr_t;
-    using G4TrackerPtr = std::shared_ptr<G4Tracker>;
+    using TrackerG4InfoPtr = std::shared_ptr<TrackerG4Info>;
     using PlaneCollection = std::array<Plane,StrawId::_nplanes>;
     using PanelCollection = std::array<Panel,StrawId::_nupanels>;
     using StrawCollection = std::array<Straw,StrawId::_nustraws>;
@@ -45,7 +45,7 @@ namespace mu2e {
 
     constexpr static const char* cxname = {"Tracker"};
     // construct from a set of straws and their global properties.
-    Tracker(StrawCollection const& straws, StrawProperties const& sprops,const G4TrackerPtr& g4tracker, PEType const& pexists);
+    Tracker(StrawCollection const& straws, StrawProperties const& sprops,const TrackerG4InfoPtr& g4tracker, PEType const& pexists);
 
     // accessors
     // origin in nominal tracker coordinate system
@@ -67,9 +67,9 @@ namespace mu2e {
     const Panel& panel( const StrawId& id ) const{ return _panels.at(id.uniquePanel()); }
     const Straw& straw( const StrawId& id) const{ return _straws[strawIndex(id)]; }
 
-    // access the G4Tracker
-    G4Tracker const* g4Tracker() const { return _g4tracker.get(); }
-    G4Tracker* g4Tracker() { return _g4tracker.get(); }
+    // access the TrackerG4Info
+    TrackerG4Info const* g4Tracker() const { return _g4tracker.get(); }
+    TrackerG4Info* g4Tracker() { return _g4tracker.get(); }
 
     // deprecated interface: do not write new code using these, and replace existing calls opportunistically
     const Plane& getPlane( const StrawId& id ) const{ return _planes.at(id.getPlane()); }
@@ -107,7 +107,7 @@ namespace mu2e {
     // plane existence: use cases of this should switch to using TrackerStatus and this should be removed FIXME!!
     PEType _planeExists;
     // g4 content
-    G4TrackerPtr _g4tracker;
+    TrackerG4InfoPtr _g4tracker;
     // allow TrackerMaker non-const access to G4 content
   };
 

--- a/TrackerGeom/inc/Tracker.hh
+++ b/TrackerGeom/inc/Tracker.hh
@@ -33,6 +33,7 @@ namespace mu2e {
     public:
     typedef std::shared_ptr<Tracker> ptr_t;
     typedef std::shared_ptr<const Tracker> cptr_t;
+    using G4TrackerPtr = std::shared_ptr<G4Tracker>;
     using PlaneCollection = std::array<Plane,StrawId::_nplanes>;
     using PanelCollection = std::array<Panel,StrawId::_nupanels>;
     using StrawCollection = std::array<Straw,StrawId::_nustraws>;
@@ -47,7 +48,7 @@ namespace mu2e {
     Tracker(const Tracker& other);
     // construct from a set of straws and their global properties.  It would be better to take ownership of
     // existing straws via std::move, but the need for the copy constructor above precludes that
-    Tracker(StrawCollection const& straws, StrawProperties const& sprops,const std::shared_ptr<G4Tracker>& g4tracker,
+    Tracker(StrawCollection const& straws, StrawProperties const& sprops,const G4TrackerPtr& g4tracker,
     PEType const& pexists);
 
     // accessors
@@ -71,7 +72,7 @@ namespace mu2e {
     const Straw& straw( const StrawId& id) const{ return _straws[strawIndex(id)]; }
 
     // access the G4Tracker
-    const std::shared_ptr<G4Tracker>& g4Tracker() const { return _g4tracker; }
+    const G4TrackerPtr& g4Tracker() const { return _g4tracker; }
 
     // deprecated interface: do not write new code using these, and replace existing calls opportunistically
     const Plane& getPlane( const StrawId& id ) const{ return _planes.at(id.getPlane()); }
@@ -109,7 +110,7 @@ namespace mu2e {
     // plane existence: use cases of this should switch to using TrackerStatus and this should be removed FIXME!!
     PEType _planeExists;
     // g4 content
-    std::shared_ptr<G4Tracker> _g4tracker;
+    G4TrackerPtr _g4tracker;
   };
 
 } //namespace mu2e

--- a/TrackerGeom/inc/Tracker.hh
+++ b/TrackerGeom/inc/Tracker.hh
@@ -44,12 +44,8 @@ namespace mu2e {
     // default constructor results in non-functional object, but is required by proditions service
 
     constexpr static const char* cxname = {"Tracker"};
-    // copy constructor
-    Tracker(const Tracker& other);
-    // construct from a set of straws and their global properties.  It would be better to take ownership of
-    // existing straws via std::move, but the need for the copy constructor above precludes that
-    Tracker(StrawCollection const& straws, StrawProperties const& sprops,const G4TrackerPtr& g4tracker,
-    PEType const& pexists);
+    // construct from a set of straws and their global properties.
+    Tracker(StrawCollection const& straws, StrawProperties const& sprops,const G4TrackerPtr& g4tracker, PEType const& pexists);
 
     // accessors
     // origin in nominal tracker coordinate system
@@ -72,7 +68,8 @@ namespace mu2e {
     const Straw& straw( const StrawId& id) const{ return _straws[strawIndex(id)]; }
 
     // access the G4Tracker
-    const G4TrackerPtr& g4Tracker() const { return _g4tracker; }
+    G4Tracker const* g4Tracker() const { return _g4tracker.get(); }
+    G4Tracker* g4Tracker() { return _g4tracker.get(); }
 
     // deprecated interface: do not write new code using these, and replace existing calls opportunistically
     const Plane& getPlane( const StrawId& id ) const{ return _planes.at(id.getPlane()); }
@@ -111,6 +108,7 @@ namespace mu2e {
     PEType _planeExists;
     // g4 content
     G4TrackerPtr _g4tracker;
+    // allow TrackerMaker non-const access to G4 content
   };
 
 } //namespace mu2e

--- a/TrackerGeom/inc/Tracker.hh
+++ b/TrackerGeom/inc/Tracker.hh
@@ -21,8 +21,6 @@
 
 #include "Mu2eInterfaces/inc/Detector.hh"
 #include "Mu2eInterfaces/inc/ProditionsEntity.hh"
-#include "GeneralUtilities/inc/HepTransform.hh"
-#include "TrackerGeom/G4Tracker.hh"
 
 #include "TrackerGeom/inc/Plane.hh"
 #include "TrackerGeom/inc/Panel.hh"
@@ -32,14 +30,16 @@
 namespace mu2e {
   class Tracker : public Detector, public ProditionsEntity {
     using xyzVec = CLHEP::Hep3Vector; // switch to root XYZVec TODO
-
     public:
     typedef std::shared_ptr<Tracker> ptr_t;
     typedef std::shared_ptr<const Tracker> cptr_t;
     using PlaneCollection = std::array<Plane,StrawId::_nplanes>;
     using PanelCollection = std::array<Panel,StrawId::_nupanels>;
     using StrawCollection = std::array<Straw,StrawId::_nustraws>;
-    using StrawIndexMap = std::array<uint16_t,StrawId::_maxval>; 
+    using StrawIndexMap = std::array<uint16_t,StrawId::_maxval>;
+
+    using PEType = std::array<bool,StrawId::_nplanes>;
+
     // default constructor results in non-functional object, but is required by proditions service
 
     constexpr static const char* cxname = {"Tracker"};
@@ -47,18 +47,10 @@ namespace mu2e {
     Tracker(const Tracker& other);
     // construct from a set of straws and their global properties.  It would be better to take ownership of
     // existing straws via std::move, but the need for the copy constructor above precludes that
-    Tracker(StrawCollection const& straws, StrawProperties const& sprops);
+    Tracker(StrawCollection const& straws, StrawProperties const& sprops,const std::shared_ptr<G4Tracker>& g4tracker,
+    PEType const& pexists);
 
     // accessors
-    // geometry parameters used only by G4.  These should be factorized out FIXME!
-    double z0()   const { return _z0;} // in Mu2e coordinates (everything else is in Tracker coordiates).
-    double zHalfLength() const;
-
-    // Tracker Element Accessors
-    size_t nPlanes() const { return _planes.size(); }
-    size_t nPanels() const { return _panels.size(); }
-    size_t nStraws() const { return _straws.size(); }
-
     // origin in nominal tracker coordinate system
     const xyzVec& origin() const { return _origin; }
 
@@ -66,62 +58,29 @@ namespace mu2e {
     const StrawProperties& strawProperties() const { return _strawprops; }
 
     // constituent access
-    const Plane& plane( const StrawId& id ) const{
-      return _planes.at(id.getPlane());
-    }
+    size_t nPlanes() const { return _planes.size(); }
+    size_t nPanels() const { return _panels.size(); }
+    size_t nStraws() const { return _straws.size(); }
+    PlaneCollection const& planes() const { return _planes; }
+    PanelCollection const& panels() const{ return _panels; }
+    StrawCollection const& straws() const{ return _straws; }
+    // fast indexed lookup by StrawId through indirect map
+    uint16_t strawIndex(const StrawId& id) const { return _strawindex.at(id.asUint16()); }
+    const Plane& plane( const StrawId& id ) const{ return _planes.at(id.getPlane()); }
+    const Panel& panel( const StrawId& id ) const{ return _panels.at(id.uniquePanel()); }
+    const Straw& straw( const StrawId& id) const{ return _straws[strawIndex(id)]; }
 
-    PlaneCollection const& planes() const {
-      return _planes;
-    }
-    PanelCollection const& panels() const{
-      return _panels;
-    }
-    StrawCollection const& straws() const{
-      return _straws;
-    }
+    // access the G4Tracker
+    const std::shared_ptr<G4Tracker>& g4Tracker() const { return _g4tracker; }
 
-    const Panel& panel( const StrawId& id ) const{
-      return _panels.at(id.uniquePanel());
-    }
-
-    uint16_t strawIndex(const StrawId& id) const {
-      return _strawindex.at(id.asUint16());
-    }
-
-    const Straw& straw( const StrawId& id) const{
-      return _straws[strawIndex(id)];
-    }
-
-// deprecated interface 
-    const Plane& getPlane( const StrawId& id ) const{
-      return _planes.at(id.getPlane());
-    }
-    
-    const Plane& getPlane( uint16_t n ) const{
-      return _planes.at(n);
-    }
-
-    PlaneCollection const& getPlanes() const {
-      return _planes;
-    }
-
-    const Panel& getPanel( const StrawId& id ) const{
-      return _panels.at(id.uniquePanel());
-    }
-
-    const Straw& getStraw( const StrawId& id) const{
-      return _straws[strawIndex(id)];
-    }
-
-    Straw& getStraw( const StrawId& id) {
-      return _straws[strawIndex(id)];
-    }
-    
-    StrawCollection const& getStraws() const{
-      return _straws;
-    }
-
-
+    // deprecated interface: do not write new code using these, and replace existing calls opportunistically
+    const Plane& getPlane( const StrawId& id ) const{ return _planes.at(id.getPlane()); }
+    const Plane& getPlane( uint16_t n ) const{ return _planes.at(n); }
+    PlaneCollection const& getPlanes() const { return _planes; }
+    const Panel& getPanel( const StrawId& id ) const{ return _panels.at(id.uniquePanel()); }
+    const Straw& getStraw( const StrawId& id) const{ return _straws[strawIndex(id)]; }
+    Straw& getStraw( const StrawId& id) { return _straws[strawIndex(id)]; }
+    StrawCollection const& getStraws() const{ return _straws; }
     // the following are deprecated: access should be through StrawProperties
     double strawInnerRadius() const{ return _strawprops._strawInnerRadius; }
     double strawOuterRadius() const{ return _strawprops._strawOuterRadius; }
@@ -132,85 +91,25 @@ namespace mu2e {
     double wireRadius()           const { return _strawprops._wireRadius; }
     double wirePlateThickness()   const { return _strawprops._wirePlateThickness; }
 
-// depracted 'exists' interface: should switch to TrackerStatus FIXME!
+    // depracted 'exists' interface: should switch to TrackerStatus FIXME!
+    auto const& planesExist() const { return _planeExists; }
     bool planeExists(StrawId const& id) const { return _planeExists[id.plane()]; }
 
-//Mu2eG4 specific interface: these should be factored out TODO
-
-    // electronics board
-    const PanelEB& panelElectronicsBoard() const { return _panelEB;}
-//    double rOut() const { return _rOut;}
-    double panelOffset() const { return _panelZOffset; }
-// why does this return by value??? FIXME!
-    SupportModel getSupportModel() const{
-      return _supportModel;
-    }
-
-    const Support& getSupportParams () const{
-      return _supportParams;
-    }
-
-    const SupportStructure& getSupportStructure() const{
-      return _supportStructure;
-    }
-// why do these return by value????? FIXME
-    TubsParams getPlaneEnvelopeParams() const{
-      return _planeEnvelopeParams;
-    }
-
-    TubsParams getPanelEnvelopeParams() const{
-      return _panelEnvelopeParams;
-    }
-
-    const TubsParams& getInnerTrackerEnvelopeParams() const{
-      return _innerTrackerEnvelopeParams;
-    }
-
-    PlacedTubs mother() const{
-      return _mother;
-    }
-
-    // Return G4TUBS parameters for straws, includes
-    // wire, gas and straw materials.
-    TubsParams strawOuterTubsParams(StrawId const& id) const;
-    TubsParams strawWallMother(StrawId const& id) const;
-    TubsParams strawWallOuterMetal(StrawId const& id)  const;
-    TubsParams strawWallInnerMetal1(StrawId const& id) const;
-    TubsParams strawWallInnerMetal2(StrawId const& id) const;
-    TubsParams strawWireMother(StrawId const& id) const;
-    TubsParams strawWirePlate(StrawId const& id) const;
-  protected:
-  // G4-specific variables, set in TrackerMaker.  These should all go to G4Tracker FIXME!
-    // Position of the center of the tracker, in the Mu2e coordinate system.
-    double _z0;
-    // Outer radius of a logical volume that will just contain the entire tracker.
-    double _rOut; // is this ever used?  I think not
-
-   // Deprecated: these will go away soon.
-    std::vector<double> _manifoldHalfLengths;
-    double _panelZOffset; // introduced for version 5
-
-    // Inner radius of inside edge of innermost straw.
-    double _envelopeInnerRadius;
-
-   // Electronics board
-    PanelEB _panelEB;
-
-    // non-G4 content; this is the core of the class.  These are kept when the G4 content is factorized away to a separate class FIXME!
-  private:
+    private:
     xyzVec _origin;
-    HepTransform _tracker_to_tnom; // transform to NOMINAL tracker coordinate system.  This is a null transform for the nominal tracker
     // global straw properties
     StrawProperties _strawprops;
     // Dense arrays
     PlaneCollection _planes;
     PanelCollection _panels;
+    // fundamental geometric content is in the following
+    StrawCollection _straws;
     // indirection from StrawId, for efficient lookup
     StrawIndexMap _strawindex;
     // plane existence: use cases of this should switch to using TrackerStatus and this should be removed FIXME!!
-    std::array<bool,StrawId::_nplanes> _planeExists;
-    // fundamental content is in the following
-    StrawCollection _straws;
+    PEType _planeExists;
+    // g4 content
+    std::shared_ptr<G4Tracker> _g4tracker;
   };
 
 } //namespace mu2e

--- a/TrackerGeom/inc/Tracker.hh
+++ b/TrackerGeom/inc/Tracker.hh
@@ -5,9 +5,8 @@
 // a Tracker.  This is intended as a "data only" class.
 //  Note that the only 'aligned' information is implicit in the individual straws
 //
-// An un-aligned version can be made by GeometryService
-// and an aligned verison can be made by ProditionsService
-// by copying then adding alignment to the GeometryService version
+// An un-aligned version is provided by GeometryService
+// and an aligned verison is provided  by ProditionsService
 //
 // Original author Rob Kutschke
 //
@@ -22,23 +21,17 @@
 
 #include "Mu2eInterfaces/inc/Detector.hh"
 #include "Mu2eInterfaces/inc/ProditionsEntity.hh"
-#include "TrackerGeom/inc/Manifold.hh"
-#include "TrackerGeom/inc/Support.hh"
-#include "TrackerGeom/inc/SupportModel.hh"
-#include "TrackerGeom/inc/SupportStructure.hh"
 #include "GeneralUtilities/inc/HepTransform.hh"
+#include "TrackerGeom/G4Tracker.hh"
 
 #include "TrackerGeom/inc/Plane.hh"
 #include "TrackerGeom/inc/Panel.hh"
-#include "GeomPrimitives/inc/TubsParams.hh"
-#include "GeomPrimitives/inc/PlacedTubs.hh"
-#include "TrackerGeom/inc/PanelEB.hh"
 #include "TrackerGeom/inc/StrawProperties.hh"
+#include "TrackerGeom/inc/G4Tracker.hh"
 
 namespace mu2e {
   class Tracker : public Detector, public ProditionsEntity {
-    friend class TrackerMaker; // remove after factorizing out the G4 stuff FIXME!
-    using xyzVec = CLHEP::Hep3Vector; // switch to XYZVec TODO
+    using xyzVec = CLHEP::Hep3Vector; // switch to root XYZVec TODO
 
     public:
     typedef std::shared_ptr<Tracker> ptr_t;
@@ -66,8 +59,11 @@ namespace mu2e {
     size_t nPanels() const { return _panels.size(); }
     size_t nStraws() const { return _straws.size(); }
 
-    // origin: defines nominal tracker coordinate system
+    // origin in nominal tracker coordinate system
     const xyzVec& origin() const { return _origin; }
+
+    // common straw attributes that don't depend on the specific element
+    const StrawProperties& strawProperties() const { return _strawprops; }
 
     // constituent access
     const Plane& plane( const StrawId& id ) const{
@@ -126,8 +122,6 @@ namespace mu2e {
     }
 
 
-    // common attributes that don't depend on the specific element
-    const StrawProperties& strawProperties() const { return _strawprops; }
     // the following are deprecated: access should be through StrawProperties
     double strawInnerRadius() const{ return _strawprops._strawInnerRadius; }
     double strawOuterRadius() const{ return _strawprops._strawOuterRadius; }
@@ -140,18 +134,6 @@ namespace mu2e {
 
 // depracted 'exists' interface: should switch to TrackerStatus FIXME!
     bool planeExists(StrawId const& id) const { return _planeExists[id.plane()]; }
-
-    // G4 stuff: this should be factorized out TODO!
-    std::string const& wallMaterialName()            const{ return _wallMaterialName; }
-    std::string const& wallCoreMaterialName()        const{ return  wallMaterialName();  }
-    std::string const& wallOuterMetalMaterialName()  const{ return _outerMetalMaterial;  }
-    std::string const& wallInnerMetal1MaterialName() const{ return _innerMetal1Material; }
-    std::string const& wallInnerMetal2MaterialName() const{ return _innerMetal2Material; }
-    std::string const& gasMaterialName()             const{ return _gasMaterialName; }
-    std::string const& wireMaterialName()            const{ return _wireMaterialName; }
-    std::string const& wireCoreMaterialName()        const{ return  wireMaterialName();  }
-    std::string const& wirePlateMaterialName()       const{ return _wirePlateMaterial;   }
-    std::string const& envelopeMaterial()	     const { return _envelopeMaterial; }
 
 //Mu2eG4 specific interface: these should be factored out TODO
 
@@ -204,35 +186,7 @@ namespace mu2e {
     // Outer radius of a logical volume that will just contain the entire tracker.
     double _rOut; // is this ever used?  I think not
 
-    // these should be in a struct FIXME!
-    std::string _wallMaterialName;
-    std::string _outerMetalMaterial;
-    std::string _innerMetal1Material;
-    std::string _innerMetal2Material;
-    std::string _gasMaterialName;
-    std::string _wireMaterialName;
-    std::string _wirePlateMaterial;
-    std::string _envelopeMaterial;
-
-    // Outer envelope that holds the new style support structure.
-    PlacedTubs _mother;
-    // The envelope that holds all of the planes in the tracker,
-    // including the plane supports.
-    TubsParams _innerTrackerEnvelopeParams;
-    // The envelope that holds all of the pieces in one plane, including supports.
-    TubsParams _planeEnvelopeParams;
-    // Ditto for Panel
-    TubsParams _panelEnvelopeParams;
-    // Which level of detail is present in the model of the support structure?
-    SupportModel _supportModel;
-    // All supports are the same shape; only relevant for _supportModel=="simple"
-    Support _supportParams;
-
-    // A more detailed model of the supports; again each plane has identical supports.
-    // only relevant for _supportModel == "detailedv0".
-    SupportStructure _supportStructure;
-
-    // Deprecated: these will go away soon.
+   // Deprecated: these will go away soon.
     std::vector<double> _manifoldHalfLengths;
     double _panelZOffset; // introduced for version 5
 

--- a/TrackerGeom/inc/TrackerG4Info.hh
+++ b/TrackerGeom/inc/TrackerG4Info.hh
@@ -1,5 +1,5 @@
-#ifndef TrackerGeom_G4Tracker_hh
-#define TrackerGeom_G4Tracker_hh
+#ifndef TrackerGeom_TrackerG4Info_hh
+#define TrackerGeom_TrackerG4Info_hh
 ///
 // Tracker geometry content specific to building the G4 model
 // Extracted from the original Tracker
@@ -13,7 +13,7 @@
 #include "TrackerGeom/inc/SupportStructure.hh"
 
 namespace mu2e {
-  class G4Tracker {
+  class TrackerG4Info {
     friend class TrackerMaker; 
     public:
     // electronics board

--- a/TrackerGeom/src/Tracker.cc
+++ b/TrackerGeom/src/Tracker.cc
@@ -14,7 +14,7 @@ using namespace std;
 namespace mu2e {
 
   Tracker::Tracker(StrawCollection const& straws, StrawProperties const& sprops, 
-      const G4TrackerPtr& g4tracker, PEType const& pexists) :
+      const TrackerG4InfoPtr& g4tracker, PEType const& pexists) :
     ProditionsEntity(cxname), _strawprops(sprops), _straws(straws) , _strawindex{}, 
     _planeExists(pexists), _g4tracker(g4tracker) {
       // create the fast lookup map

--- a/TrackerGeom/src/Tracker.cc
+++ b/TrackerGeom/src/Tracker.cc
@@ -41,11 +41,4 @@ namespace mu2e {
 
   }
 
-// the following copies the core tracker plus all the elements built outside this class by TrackerMaker
-// A default copy doesn't work as the panels etc have pointers back to the straws
-  Tracker::Tracker(const Tracker& other) : Tracker(other.straws(), other.strawProperties(), other.g4Tracker(),
-  other.planesExist()) {
-   // other variables: these should be removed or move into the functional constructor from straws FIXME!
-    _origin = other._origin;
-  }
 } // namespace mu2e

--- a/TrackerGeom/src/Tracker.cc
+++ b/TrackerGeom/src/Tracker.cc
@@ -13,10 +13,12 @@ using namespace std;
 
 namespace mu2e {
 
-  Tracker::Tracker(StrawCollection const& straws, StrawProperties const& sprops) :
-  ProditionsEntity(cxname), _strawprops(sprops), _strawindex{}, _straws(straws) {
-    // create the fast lookup map
-    for(uint16_t plane=0; plane < StrawId::_nplanes; plane++){
+  Tracker::Tracker(StrawCollection const& straws, StrawProperties const& sprops, 
+      const std::shared_ptr<G4Tracker>& g4tracker,     PEType const& pexists) :
+    ProditionsEntity(cxname), _strawprops(sprops), _straws(straws) , _strawindex{}, 
+    _planeExists(pexists), _g4tracker(g4tracker) {
+      // create the fast lookup map
+      for(uint16_t plane=0; plane < StrawId::_nplanes; plane++){
       for(uint16_t panel = 0;panel < StrawId::_npanels; panel++){
 	for(uint16_t straw = 0; straw < StrawId::_nstraws; straw++){
 	  StrawId sid(plane,panel,straw);
@@ -39,69 +41,11 @@ namespace mu2e {
 
   }
 
-// the following copies the core tracker plus all the elements built outside this class by TrackerMaker: this design needs to be refactored FIXME
-  Tracker::Tracker(const Tracker& other) : Tracker(other.straws(), other.strawProperties()) {
-// copy all the G4 variables by hand.  These should never be needed by this copy
-    _z0 = other._z0;
-    _rOut = other._rOut;
-    _envelopeMaterial = other._envelopeMaterial;
-    _wallMaterialName = other._wallMaterialName;
-    _outerMetalMaterial = other._outerMetalMaterial;
-    _innerMetal1Material = other._innerMetal1Material;
-    _innerMetal2Material = other._innerMetal2Material;
-    _gasMaterialName = other._gasMaterialName;
-    _wireMaterialName = other._wireMaterialName;
-    _wirePlateMaterial = other._wirePlateMaterial;
-    _mother = other._mother;
-    _innerTrackerEnvelopeParams = other._innerTrackerEnvelopeParams;
-    _planeEnvelopeParams = other._planeEnvelopeParams;
-    _panelEnvelopeParams = other._panelEnvelopeParams;
-    _supportModel = other._supportModel;
-    _supportParams = other._supportParams;
-    _panelZOffset = other._panelZOffset;
-    _supportStructure = other._supportStructure;
-    _manifoldHalfLengths = other._manifoldHalfLengths;
-    _envelopeInnerRadius = other._envelopeInnerRadius;
-    _panelEB = other._panelEB;
-    // other variables: these should move into the functional constructor from straws FIXME!
-    _planeExists = other._planeExists;
+// the following copies the core tracker plus all the elements built outside this class by TrackerMaker
+// A default copy doesn't work as the panels etc have pointers back to the straws
+  Tracker::Tracker(const Tracker& other) : Tracker(other.straws(), other.strawProperties(), other.g4Tracker(),
+  other.planesExist()) {
+   // other variables: these should be removed or move into the functional constructor from straws FIXME!
     _origin = other._origin;
   }
-
-  // G4 accessors: deprecated: FIXME!
-  TubsParams Tracker::strawOuterTubsParams(StrawId const& id) const {
-    return TubsParams ( 0., strawOuterRadius(), getStraw(id).halfLength() );
-  }
-  TubsParams Tracker::strawWallMother(StrawId const& id)      const {
-    return TubsParams( strawInnerRadius(), 
-	strawOuterRadius(), getStraw(id).halfLength() );
-  }
-  TubsParams Tracker::strawWallOuterMetal(StrawId const& id)  const {
-    double rIn = strawOuterRadius() - outerMetalThickness();
-    return TubsParams( rIn, strawOuterRadius() , 
-		       getStraw(id).halfLength() );
-  }
-  TubsParams Tracker::strawWallInnerMetal1(StrawId const& id) const {
-    double rIn  = strawInnerRadius() + innerMetal2Thickness();
-    double rOut = rIn + innerMetal1Thickness();
-    return TubsParams (rIn,rOut,
-		       getStraw(id).halfLength());
-  }
-  TubsParams Tracker::strawWallInnerMetal2(StrawId const& id) const {
-    double rIn  = strawInnerRadius();
-    double rOut = rIn + innerMetal2Thickness();
-    return TubsParams (rIn,rOut,
-		       getStraw(id).halfLength());
-  }
-  TubsParams Tracker::strawWireMother(StrawId const& id) const {
-    return TubsParams (0.,wireRadius(),
-		       getStraw(id).halfLength());
-  }
-  TubsParams Tracker::strawWirePlate(StrawId const& id) const {
-    double rIn = wireRadius() - wirePlateThickness();
-    double rOut = wireRadius();
-    return TubsParams (rIn,rOut,
-		       getStraw(id).halfLength());
-  }
-
 } // namespace mu2e

--- a/TrackerGeom/src/Tracker.cc
+++ b/TrackerGeom/src/Tracker.cc
@@ -14,7 +14,7 @@ using namespace std;
 namespace mu2e {
 
   Tracker::Tracker(StrawCollection const& straws, StrawProperties const& sprops, 
-      const std::shared_ptr<G4Tracker>& g4tracker,     PEType const& pexists) :
+      const G4TrackerPtr& g4tracker, PEType const& pexists) :
     ProditionsEntity(cxname), _strawprops(sprops), _straws(straws) , _strawindex{}, 
     _planeExists(pexists), _g4tracker(g4tracker) {
       // create the fast lookup map

--- a/TrkHitReco/fcl/prolog_trigger.fcl
+++ b/TrkHitReco/fcl/prolog_trigger.fcl
@@ -17,7 +17,7 @@ TTmakeSH : {
     StrawDigiCollectionTag  : "makeSD"
     CaloClusterCollectionTag  : "CaloClusterFast"
     StrawDigiADCWaveformCollectionTag : "notUsed"
-    ProtonBunchTimeTag                : "makeSD"
+#    ProtonBunchTimeTag                : "makeSD"
 }
 # combine hits in a panel
 TTmakePH : {

--- a/TrkHitReco/fcl/prolog_trigger.fcl
+++ b/TrkHitReco/fcl/prolog_trigger.fcl
@@ -17,7 +17,6 @@ TTmakeSH : {
     StrawDigiCollectionTag  : "makeSD"
     CaloClusterCollectionTag  : "CaloClusterFast"
     StrawDigiADCWaveformCollectionTag : "notUsed"
-#    ProtonBunchTimeTag                : "makeSD"
 }
 # combine hits in a panel
 TTmakePH : {

--- a/TrkReco/src/KalFit.cc
+++ b/TrkReco/src/KalFit.cc
@@ -572,7 +572,8 @@ namespace mu2e
     double ymin = s0origin.y() - strawradius;
     double ymax = s95origin.y() + strawradius;
     double umax = straw0.halfLength() + strawradius;
-    double rmax = tracker.getSupportParams().innerRadius() + strawradius;
+    // use the outermost straw end to set the max hit radius
+    double rmax = straw95.wireEnd(StrawEnd::cal).mag() + strawradius;
     double spitch = (StrawId::_nstraws-1)/(ymax-ymin);
     // storage of potential straws
     StrawFlightComp strawcomp(_maxmatfltdiff);

--- a/TrkReco/src/KalFit.cc
+++ b/TrkReco/src/KalFit.cc
@@ -561,19 +561,19 @@ namespace mu2e
     const Tracker& tracker = *_tracker;
     // general properties; these should be computed once/job and stored FIXME!
     double strawradius = tracker.strawOuterRadius();
-    auto const& plane0 = tracker.planes().front();
-    auto const& panel0 = plane0.getPanel(0);
-    auto const& straw0 = panel0.getStraw(0);
-    auto const& straw95 = panel0.getStraw(StrawId::_nstraws-1);
+    auto const& frontplane = tracker.planes().front();
+    auto const& firstpanel = frontplane.getPanel(0);
+    auto const& innerstraw = firstpanel.getStraw(0);
+    auto const& outerstraw = firstpanel.getStraw(StrawId::_nstraws-1);
     // compute limits: add some buffer for the finite size of the straw
-    auto DStoP = panel0.dsToPanel();
-    auto s0origin = DStoP*straw0.origin();
-    auto s95origin = DStoP*straw95.origin();
-    double ymin = s0origin.y() - strawradius;
-    double ymax = s95origin.y() + strawradius;
-    double umax = straw0.halfLength() + strawradius;
+    auto DStoP = firstpanel.dsToPanel();
+    auto innerstraw_origin = DStoP*innerstraw.origin();
+    auto outerstraw_origin = DStoP*outerstraw.origin();
+    double ymin = innerstraw_origin.y() - strawradius;
+    double ymax = outerstraw_origin.y() + strawradius;
+    double umax = innerstraw.halfLength() + strawradius;
     // use the outermost straw end to set the max hit radius
-    double rmax = straw95.wireEnd(StrawEnd::cal).mag() + strawradius;
+    double rmax = outerstraw.wireEnd(StrawEnd::cal).mag() + strawradius;
     double spitch = (StrawId::_nstraws-1)/(ymax-ymin);
     // storage of potential straws
     StrawFlightComp strawcomp(_maxmatfltdiff);


### PR DESCRIPTION
Move the Geant4-related content out of Tracker into the new G4Tracker object, and move the Geant-4 related functions into Mu2eG4.  Downstream codes were updated appropriately.  CeSimReco produces bit-identical results on 100 events.  This migration exposed the fact that some analysis and reco codes are using G4-related content, which may not function as expected when working with the aligned tracker.