### PR TITLE
Fix data races due to FHiCL validation and StepInstanceName

### DIFF
--- a/MCDataProducts/src/StepInstanceName.cc
+++ b/MCDataProducts/src/StepInstanceName.cc
@@ -19,6 +19,18 @@ using namespace std;
 
 namespace mu2e {
 
+  auto step_instance_names(StepInstanceName::enum_type const begin,
+                           StepInstanceName::enum_type const end)
+  {
+    std::vector<StepInstanceName> values;
+    // NB - implicit conversion from enum_type to size_t to allow for
+    //      incrementation (++i).
+    for (size_t i = begin, e = end; i != e; ++i) {
+      values.emplace_back(i);
+    }
+    return values;
+  }
+
   void StepInstanceName::printAll( std::ostream& ost){
     ost << "List of names of instances for StepPointMCCollections Id codes: "
         << endl;
@@ -73,13 +85,8 @@ namespace mu2e {
 
   // Get all values, as class instances; this includes the unknown value.
   std::vector<StepInstanceName> const& StepInstanceName::allValues(){
-
-    static std::vector<StepInstanceName> values;
-    for ( size_t i=unknown; i<lastEnum; ++i ){
-      values.push_back(StepInstanceName(i));
-    }
+    static auto const values = step_instance_names(unknown, lastEnum);
     return values;
-
   } // end StepInstanceName::allValues
 
 

--- a/Mu2eG4/src/Mu2eG4MultiStageParameters.cc
+++ b/Mu2eG4/src/Mu2eG4MultiStageParameters.cc
@@ -1,5 +1,23 @@
 #include "Mu2eG4/inc/Mu2eG4MultiStageParameters.hh"
 
+namespace {
+  // Because a Mu2eG4MultiStageParameters object can be created from
+  // multiple threads and because it uses configuration validation,
+  // which is not thread-safe, there exists the possibility of data
+  // races.
+  //
+  // To avoid this, we create a global configuration struct, which
+  // does all of the thread-unsafe manipulations upon construction
+  // (namely adjusting FHiCL's table-member and name-stack
+  // registries). We then copy the struct in the body of the c'tor,
+  // where they copy operation does not use the name-stack registry.
+  //
+  // NB - This is an expert-only workaround which should arguably go
+  //      away if fhiclcpp decides to adopt thread-local registries
+  //      for configuration validation.
+  mu2e::Mu2eG4Config::MultiStageParameters_ const global_msp;
+}
+
 namespace mu2e {
   Mu2eG4MultiStageParameters::Mu2eG4MultiStageParameters(const Mu2eG4Config::Top& conf)
     : multiStage_(false)
@@ -9,7 +27,7 @@ namespace mu2e {
     , inputPhysVolumeMultiInfo_{""}
     , genInputHits_{std::vector<art::InputTag>()}
   {
-    Mu2eG4Config::MultiStageParameters_ msp;
+    auto msp = global_msp;
     multiStage_ = conf.MultiStageParameters(msp);
     if(multiStage_) {
       simParticleNumberOffset_ = msp.simParticleNumberOffset();


### PR DESCRIPTION
I've implemented a couple workarounds due to limitations in `fhiclcpp`'s configuration validation.  I request that you open a feature request so that such workarounds might not be necessary in the future:

https://cdcvs.fnal.gov/redmine/projects/fhicl-cpp/issues/new

I also resolved a data race in the `StepInstanceName` implementation.