### PR TITLE
Trkstatusdb

### DIFF
--- a/DataProducts/inc/StrawStatus.hh
+++ b/DataProducts/inc/StrawStatus.hh
@@ -1,5 +1,5 @@
-#ifndef TrackerConditions_StrawStatus_hh
-#define TrackerConditions_StrawStatus_hh
+#ifndef DataProducts_StrawStatus_hh
+#define DataProducts_StrawStatus_hh
 //
 // Class to describe flag bits used for defining straw (or panel or plane) status
 // 

--- a/DataProducts/src/StrawStatus.cc
+++ b/DataProducts/src/StrawStatus.cc
@@ -4,7 +4,7 @@
 // Original author David Brown (7/2020)
 //
 // Mu2e includes
-#include "TrackerConditions/inc/StrawStatus.hh"
+#include "DataProducts/inc/StrawStatus.hh"
 #include <stdexcept>
 #include <iostream>
 #include <stdio.h>

--- a/DbTables/inc/TrkElementStatus.hh
+++ b/DbTables/inc/TrkElementStatus.hh
@@ -1,0 +1,95 @@
+//
+// tables for tracker element status.  An
+// element is a straw, panel, or plane
+//  These tables list just defects, so are variable length
+//  Original author: Dave Brown (LBNL)
+
+#ifndef DbTables_TrkElementStatus_hh
+#define DbTables_TrkElementStatus_hh
+
+#include <string>
+#include <iomanip>
+#include <sstream>
+#include <map>
+#include "DataProducts/inc/StrawId.hh"
+#include "DataProducts/inc/StrawIdMask.hh"
+#include "DataProducts/inc/StrawStatus.hh"
+#include "DbTables/inc/DbTable.hh"
+
+namespace mu2e {
+
+  class TrkElementStatus : public DbTable {
+  public:
+
+    // define a struct for each table row
+    struct TrkElementStatusRow {
+      int _index;//  I'm unclear what value this provides to a variable-length table, but the interface requires this
+      StrawId _sid;
+      StrawStatus _status;
+      int index() const { return _index; }
+      StrawId const& id() const { return _sid; }
+      StrawStatus const& status() const { return _status; }
+      TrkElementStatusRow(int index, StrawId const& sid, StrawStatus const& status) : _index(index), _sid(sid), _status(status) {}
+    };
+
+    typedef std::shared_ptr<TrkElementStatus> ptr_t;
+    typedef std::shared_ptr<const TrkElementStatus> cptr_t;
+
+    TrkElementStatus(const char* Name, const char* DbName, StrawIdMask sidmask, StrawStatus statusmask):
+      DbTable(Name,DbName, "index,strawid,strawstatus"), _sidmask(sidmask), _statusmask(statusmask) {}
+    const TrkElementStatusRow& rowAt(const std::size_t index) const { return _rows.at(index);}
+    std::vector<TrkElementStatusRow> const& rows() const {return _rows;}
+    std::size_t nrow() const override { return _rows.size(); };
+    // this is a variable-size tabale, so no nrowFix()
+    size_t size() const override { return baseSize() + nrow()*sizeof(TrkElementStatusRow); }
+    // table-specific info
+    StrawIdMask const& sidMask() const { return _sidmask; }
+    StrawStatus const& statusMask() const { return _statusmask; }
+
+    void addRow(const std::vector<std::string>& columns) override {
+      _rows.emplace_back(std::stoi(columns[0]),
+			 StrawId(columns[1]),
+			 StrawStatus(columns[2]));
+    }
+
+    void rowToCsv(std::ostringstream& sstream, std::size_t irow) const override {
+      TrkElementStatusRow const& r = _rows.at(irow);
+      sstream << r.index()<<",";
+      sstream << r.id().plane() << "_" << r.id().panel() << "_" << r.id().straw() << ",";
+      sstream << r.status().hex();
+    }
+
+    void clear() override { baseClear(); _rows.clear(); }
+
+  private:
+    StrawIdMask _sidmask; // defines matching for this element
+    StrawStatus _statusmask; // status bits allowed for this element
+    std::vector<TrkElementStatusRow> _rows;
+  };
+
+// unique classes for Db usage.  Each defines a mask and for StrawId and the StrawStatus
+  class TrkPanelStatus : public TrkElementStatus {
+    public:
+      constexpr static const char* cxname = "TrkPanelStatus";
+      TrkPanelStatus() : TrkElementStatus(cxname,"trk.panelstatus", StrawIdMask("panel"), StrawStatus("Absent:NoHV:NoGas:NoLV:LowGasGain")) {}
+  };
+
+  class TrkPlaneStatus : public TrkElementStatus {
+    public:
+      constexpr static const char* cxname = "TrkPlaneStatus";
+      TrkPlaneStatus() : TrkElementStatus(cxname,"trk.planestatus", StrawIdMask("plane"), StrawStatus("Absent")) {}
+  };
+ // split individual straw status tables in 2: one for short-term, one for long-term 
+  class TrkStrawStatusShort : public TrkElementStatus {
+    public:
+      constexpr static const char* cxname = "TrkStrawStatusShort";
+      TrkStrawStatusShort() : TrkElementStatus(cxname,"trk.strawstatusshort", StrawIdMask("straw"), StrawStatus("Sparking:Suppress:Noise:Pickup")) {}
+  };
+  class TrkStrawStatusLong : public TrkElementStatus {
+    public:
+      constexpr static const char* cxname = "TrkStrawStatusLong";
+      TrkStrawStatusLong() : TrkElementStatus(cxname,"trk.strawstatuslong", StrawIdMask("straw"), StrawStatus("Absent:NoWire:NoHV:NoPreamp:NoADC:NoTDC")) {}
+  };
+  
+};
+#endif

--- a/DbTables/inc/TrkElementStatus.hh
+++ b/DbTables/inc/TrkElementStatus.hh
@@ -24,20 +24,18 @@ namespace mu2e {
 
     // define a struct for each table row
     struct TrkElementStatusRow {
-      int _index;// AFAIK this is never used
       StrawId _sid;
       StrawStatus _status;
-      int index() const { return _index; }
       StrawId const& id() const { return _sid; }
       StrawStatus const& status() const { return _status; }
-      TrkElementStatusRow(int index, StrawId const& sid, StrawStatus const& status) : _index(index), _sid(sid), _status(status) {}
+      TrkElementStatusRow(StrawId const& sid, StrawStatus const& status) : _sid(sid), _status(status) {}
     };
 
     typedef std::shared_ptr<TrkElementStatus> ptr_t;
     typedef std::shared_ptr<const TrkElementStatus> cptr_t;
 
     TrkElementStatus(const char* Name, const char* DbName, StrawIdMask sidmask, StrawStatus statusmask):
-      DbTable(Name,DbName, "index,strawid,strawstatus"), _sidmask(sidmask), _statusmask(statusmask) {}
+      DbTable(Name,DbName, "strawid,strawstatus"), _sidmask(sidmask), _statusmask(statusmask) {}
     const TrkElementStatusRow& rowAt(const std::size_t index) const { return _rows.at(index);}
     std::vector<TrkElementStatusRow> const& rows() const {return _rows;}
     std::size_t nrow() const override { return _rows.size(); };
@@ -48,16 +46,14 @@ namespace mu2e {
     StrawStatus const& statusMask() const { return _statusmask; }
     // build from text table format
     void addRow(const std::vector<std::string>& columns) override {
-      auto index = std::stoi(columns[0]);
-      auto sid = StrawId(columns[1]);
-      StrawStatus status(columns[2]);
-      _rows.emplace_back(TrkElementStatusRow(index,sid,status));
+      auto sid = StrawId(columns[0]);
+      StrawStatus status(columns[1]);
+      _rows.emplace_back(TrkElementStatusRow(sid,status));
     }
     // printout, used to fill db content (?)
     void rowToCsv(std::ostringstream& sstream, std::size_t irow) const override {
       TrkElementStatusRow const& r = _rows.at(irow);
-      sstream << r.index()<<",";
-      sstream << r.id().plane() << "_" << r.id().panel() << "_" << r.id().straw() << ","; // should this be asUInt()?? FIXME!
+      sstream << r.id().plane() << "_" << r.id().panel() << "_" << r.id().straw() << ","; 
       sstream << r.status().hex(); // should this be the text string??
     }
 

--- a/DbTables/inc/TrkElementStatus.hh
+++ b/DbTables/inc/TrkElementStatus.hh
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <map>
 #include <regex>
+#include "cetlib_except/exception.h"
 #include "DataProducts/inc/StrawId.hh"
 #include "DataProducts/inc/StrawIdMask.hh"
 #include "DataProducts/inc/StrawStatus.hh"
@@ -48,6 +49,9 @@ namespace mu2e {
     void addRow(const std::vector<std::string>& columns) override {
       auto sid = StrawId(columns[0]);
       StrawStatus status(columns[1]);
+      // verify the status is allowed
+      if(!_statusmask.hasAllProperties(status))
+	throw cet::exception(name()) << ": Illegal status specified " << status << std::endl;
       _rows.emplace_back(TrkElementStatusRow(sid,status));
     }
     // printout, used to fill db content (?)

--- a/DbTables/src/DbTableFactory.cc
+++ b/DbTables/src/DbTableFactory.cc
@@ -10,6 +10,7 @@
 #include "DbTables/inc/TrkThresholdRStraw.hh"
 #include "DbTables/inc/TrkAlignElement.hh"
 #include "DbTables/inc/TrkAlignStraw.hh"
+#include "DbTables/inc/TrkElementStatus.hh"
 #include "DbTables/inc/AnaTrkQualDb.hh"
 
 #include "DbTables/inc/SimEfficiencies.hh"
@@ -37,6 +38,14 @@ mu2e::DbTable::ptr_t mu2e::DbTableFactory::newTable(std::string const& name) {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkAlignPanel());
   } else if (name=="TrkAlignStraw") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkAlignStraw());
+  } else if (name=="TrkPlaneStatus") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkPlaneStatus());
+  } else if (name=="TrkPanelStatus") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkPanelStatus());
+  } else if (name=="TrkStrawStatusLong") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkStrawStatusLong());
+  } else if (name=="TrkStrawStatusShort") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkStrawStatusShort());
   } else if (name=="AnaTrkQualDb") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::AnaTrkQualDb());
   } else if (name=="SimEfficiencies") {

--- a/GeneralUtilities/inc/BitMap.hh
+++ b/GeneralUtilities/inc/BitMap.hh
@@ -287,9 +287,17 @@ namespace mu2e {
 	mask |= j->second;
       }
       if(invalid){
-      // try to interpret as a (text) hex string
-	mask = std::stoul(name,0,16);
-	if(!isValid(mask)){
+      // try to interpret as a (text) hex string; make sure to edit out spaces first!
+	std::string cname(name);
+	cname.erase(cname.begin(), std::find_if(cname.begin(), cname.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+	if(cname.compare(0,2,"0x") == 0 || cname.compare(0,2,"0X") == 0){
+	  mask = std::stoul(name,0,16);
+	  if((isValid(mask)) && mask != 0){
+	    invalid = false;
+	  }
+	}
+	// if it's still invalid, throw
+	if(invalid){
 	  std::ostringstream os;
 	  os << DETAIL::typeName() << " invalid mask name : " << name;
 	  throw std::out_of_range( os.str() );

--- a/GeneralUtilities/inc/BitMap.hh
+++ b/GeneralUtilities/inc/BitMap.hh
@@ -273,6 +273,7 @@ namespace mu2e {
 
     mask_type findMaskByNameOrThrow( std::string const& name ){
       mask_type mask(0);
+      bool invalid(false);
       const std::regex separator("[^\\s,:]+"); // begining or separator
       auto sbegin = std::sregex_iterator(name.begin(), name.end(), separator);
       auto send = std::sregex_iterator();
@@ -280,11 +281,19 @@ namespace mu2e {
 	std::string subname = match->str();
 	typename map_type::const_iterator j = bitNames().find(subname);
 	if ( j == bitNames().end() ){
+	  invalid = true;
+	  break;
+	}
+	mask |= j->second;
+      }
+      if(invalid){
+      // try to interpret as a (text) hex string
+	mask = std::stoul(name,0,16);
+	if(!isValid(mask)){
 	  std::ostringstream os;
 	  os << DETAIL::typeName() << " invalid mask name : " << name;
 	  throw std::out_of_range( os.str() );
 	}
-	mask |= j->second;
       }
       return mask;
     }
@@ -300,7 +309,6 @@ namespace mu2e {
       }
       return tmp;
     }
-
   };
 
   template < class DETAIL >

--- a/TrackerConditions/data/TrackerStatusTest.txt
+++ b/TrackerConditions/data/TrackerStatusTest.txt
@@ -1,0 +1,31 @@
+#
+# Tracker status test; these aren't real values for Mu2e, but they span the space of realistic values
+#
+#
+TABLE TrkPlaneStatus
+0, 0_0_0, Absent
+1, 35_0_0, Absent
+#
+#
+#
+TABLE TrkPanelStatus
+0, 10_2_0, Absent
+1, 15_4_0, NoHV
+2, 34_1_0, NoGas:NoHV:NoLV
+3, 7_5_0, LowGasGain
+#
+#
+TABLE TrkStrawStatusLong
+0, 21_4_11, Absent
+1, 19_1_88, NoWire
+2, 28_3_3, NoHV
+#
+#
+#
+TABLE TrkStrawStatusShort
+0, 21_4_1, Noise:Sparking
+1, 3_0_38, Noise:Sparking
+2, 3_0_39, Suppress:Pickup
+3, 14_4_66, 0x600  
+
+

--- a/TrackerConditions/data/TrackerStatusTest.txt
+++ b/TrackerConditions/data/TrackerStatusTest.txt
@@ -3,29 +3,29 @@
 #
 #
 TABLE TrkPlaneStatus
-0, 0_0_0, Absent
-1, 35_0_0, Absent
+0_0_0, Absent
+35_0_0, Absent
 #
 #
 #
 TABLE TrkPanelStatus
-0, 10_2_0, Absent
-1, 15_4_0, NoHV
-2, 34_1_0, NoGas:NoHV:NoLV
-3, 7_5_0, LowGasGain
+10_2_0, Absent
+15_4_0, NoHV
+34_1_0, NoGas:NoHV:NoLV
+7_5_0, LowGasGain
 #
 #
 TABLE TrkStrawStatusLong
-0, 21_4_11, Absent
-1, 19_1_88, NoWire
-2, 28_3_3, NoHV
+21_4_11, Absent
+19_1_88, NoWire
+28_3_3, NoHV
 #
 #
 #
 TABLE TrkStrawStatusShort
-0, 21_4_1, Noise:Sparking
-1, 3_0_38, Noise:Sparking
-2, 3_0_39, Suppress:Pickup
-3, 14_4_66, 0x600  
+21_4_1, Noise:Sparking
+3_0_38, Noise:Sparking
+3_0_39, Suppress:Pickup
+14_4_66, 0x600
 
 

--- a/TrackerConditions/inc/TrackerStatus.hh
+++ b/TrackerConditions/inc/TrackerStatus.hh
@@ -7,7 +7,7 @@
 // Mu2e includes
 #include "DataProducts/inc/StrawId.hh"
 #include "DataProducts/inc/StrawIdMask.hh"
-#include "TrackerConditions/inc/StrawStatus.hh"
+#include "DataProducts/inc/StrawStatus.hh"
 #include "Mu2eInterfaces/inc/ProditionsEntity.hh"
 #include "fhiclcpp/type_traits.h"
 
@@ -39,9 +39,9 @@ namespace mu2e {
 
     void print( std::ostream& ) const override;
     // convenience operators for some common situations
-    bool noSignal(StrawId const& sid) const;    // return 'true' if we expect no usable signal from this straw
+    bool noSignal(StrawId const& sid) const;    // return 'true' if we expect no signal from this straw
     bool suppress(StrawId const& sid) const;  // This straw may produce a signal, but it should be suppressed as it is inaccurate 
-    bool noMaterial(StrawId const& sid) const;  // starw doesn't contribut to scattering or energy loss
+    bool noMaterial(StrawId const& sid) const;  // straw doesn't contribute to scattering or energy loss
 
     // Net status of an individual Straw.  If the straw is in a plane or panel with status, that will be aggregated
     StrawStatus strawStatus(StrawId const& sid) const;

--- a/TrackerConditions/inc/TrackerStatusCache.hh
+++ b/TrackerConditions/inc/TrackerStatusCache.hh
@@ -2,6 +2,8 @@
 #define TrackerConditions_TrackerStatusCache_hh
 
 #include "Mu2eInterfaces/inc/ProditionsCache.hh"
+#include "DbService/inc/DbHandle.hh"
+#include "DbTables/inc/TrkElementStatus.hh"
 #include "TrackerConditions/inc/TrackerStatusMaker.hh"
 
 
@@ -14,20 +16,51 @@ namespace mu2e {
 
 
     void initialize() {
+      if(_useDb) {
+	_tpls_p = std::make_unique<DbHandle<TrkPlaneStatus>>();
+	_tpas_p = std::make_unique<DbHandle<TrkPanelStatus>>();
+	_tssl_p = std::make_unique<DbHandle<TrkStrawStatusLong>>(); 
+	_tsss_p = std::make_unique<DbHandle<TrkStrawStatusShort>>();
+      }
     }
 
     set_t makeSet(art::EventID const& eid) {
-      return ProditionsEntity::set_t();
+      // get the tables up to date
+      ProditionsEntity::set_t cids;
+      if(_useDb) {
+	_tpls_p->get(eid);
+	_tpas_p->get(eid);
+	_tssl_p->get(eid);
+	_tsss_p->get(eid);
+	cids.insert(_tpls_p->cid());
+	cids.insert(_tpas_p->cid());
+	cids.insert(_tssl_p->cid());
+	cids.insert(_tsss_p->cid());
+      }
+      return cids;
     }
 
     DbIoV makeIov(art::EventID const& eid) {
       DbIoV iov;
-      iov.setMax();
+      iov.setMax(); // start with full IOV range
+      if(_useDb) {
+	iov.overlap(_tpls_p->iov());
+	iov.overlap(_tpas_p->iov());
+	iov.overlap(_tssl_p->iov());
+	iov.overlap(_tsss_p->iov());
+      }
       return iov;
     }
 
     ProditionsEntity::ptr makeEntity(art::EventID const& eid) {
-      return _maker.fromFcl();
+      if(_useDb) {
+	return _maker.fromDb( _tpls_p->getPtr(eid),
+	    _tpas_p->getPtr(eid), 
+	    _tssl_p->getPtr(eid),
+	    _tsss_p->getPtr(eid) );
+      } else {
+	return _maker.fromFcl();
+      }
     }
 
 
@@ -35,6 +68,10 @@ namespace mu2e {
     bool _useDb;
     TrackerStatusMaker _maker;
 
+    std::unique_ptr<DbHandle<TrkPlaneStatus>>       _tpls_p;
+    std::unique_ptr<DbHandle<TrkPanelStatus>>       _tpas_p;
+    std::unique_ptr<DbHandle<TrkStrawStatusLong>>   _tssl_p;
+    std::unique_ptr<DbHandle<TrkStrawStatusShort>>  _tsss_p;
   };
 };
 

--- a/TrackerConditions/inc/TrackerStatusMaker.hh
+++ b/TrackerConditions/inc/TrackerStatusMaker.hh
@@ -8,6 +8,7 @@
 // Mu2e includes
 #include "TrackerConditions/inc/TrackerStatus.hh"
 #include "TrackerConfig/inc/TrackerStatusConfig.hh"
+#include "DbTables/inc/TrkElementStatus.hh"
 
 // C++ includes
 #include <set>
@@ -20,7 +21,11 @@ namespace mu2e {
   public:
     TrackerStatusMaker(TrackerStatusConfig const& config):config_(config) {}
     TrackerStatus::ptr_t fromFcl();
-    TrackerStatus::ptr_t fromDb( /* db tables will go here*/ ); //TODO!!!
+    TrackerStatus::ptr_t fromDb(
+      TrkPlaneStatus::cptr_t tpls_p,
+      TrkPanelStatus::cptr_t   tpas_p,
+      TrkStrawStatusLong::cptr_t   tssl_p,
+      TrkStrawStatusShort::cptr_t   tsss_p ); // construct from plane, panel, long-term straw and short-term straw status tables
   private:
     // this object needs to be thread safe, config_ should only be initialized once
     const TrackerStatusConfig config_;

--- a/TrackerConditions/src/TrackerStatus.cc
+++ b/TrackerConditions/src/TrackerStatus.cc
@@ -3,6 +3,7 @@
 
 // Mu2e includes
 #include "TrackerConditions/inc/TrackerStatus.hh"
+#include "DbTables/inc/TrkElementStatus.hh"
 #include <sstream>
 
 using namespace std;

--- a/TrackerConditions/src/TrackerStatusMaker.cc
+++ b/TrackerConditions/src/TrackerStatusMaker.cc
@@ -9,6 +9,7 @@
 
 // Mu2e includes
 #include "TrackerConditions/inc/TrackerStatusMaker.hh"
+#include "cetlib_except/exception.h"
 
 using namespace std;
 
@@ -59,6 +60,16 @@ namespace mu2e {
     for (auto const& row : tpas_p->rows()) estatus.insert(TrackerElementStatus(row.id(),tpas_p->sidMask(),row.status()));
     for (auto const& row : tssl_p->rows()) estatus.insert(TrackerElementStatus(row.id(),tssl_p->sidMask(),row.status()));
     for (auto const& row : tsss_p->rows()) estatus.insert(TrackerElementStatus(row.id(),tsss_p->sidMask(),row.status()));
+
+    // check for consistency
+    //
+    unsigned ntotal = tpls_p->rows().size() + tpas_p->rows().size() + tssl_p->rows().size() + tsss_p->rows().size();
+    if(estatus.size() != ntotal){
+      throw cet::exception("TrackerStatus BadTable")
+	<< "input table size inconsistency "<< ntotal 
+	<< " " << estatus.size()  << "\n";
+
+    }
 
     if ( settings.verbose() > 1 ) {
       cout << "Elements have status " << endl;

--- a/TrackerConditions/src/TrackerStatusMaker.cc
+++ b/TrackerConditions/src/TrackerStatusMaker.cc
@@ -40,7 +40,10 @@ namespace mu2e {
   }
 
   TrackerStatus::ptr_t TrackerStatusMaker::fromDb() {
-    return fromFcl(); // TODO!!!
+    return fromFcl(); // start with the Fcl version
+
+
+
   }
 
   } // namespace mu2e

--- a/TrackerConditions/src/TrackerStatusMaker.cc
+++ b/TrackerConditions/src/TrackerStatusMaker.cc
@@ -39,11 +39,38 @@ namespace mu2e {
     return std::make_shared<TrackerStatus>(estats);
   }
 
-  TrackerStatus::ptr_t TrackerStatusMaker::fromDb() {
-    return fromFcl(); // start with the Fcl version
+  TrackerStatus::ptr_t TrackerStatusMaker::fromDb(
+      TrkPlaneStatus::cptr_t tpls_p,
+      TrkPanelStatus::cptr_t   tpas_p,
+      TrkStrawStatusLong::cptr_t   tssl_p,
+      TrkStrawStatusShort::cptr_t   tsss_p ) {
+    // convert the tables to TrackerElementStatus sets
+    TrackerStatus::estat_t estatus;
+    auto const& settings = config_.settings();
+    if ( settings.verbose() > 1 ) {
+      cout << "TrackerStatus fromDb, with tables:" << endl;
+      cout << "Plane table has " << tpls_p->rows().size() << " rows " << endl;
+      cout << "Panel table has " << tpas_p->rows().size() << " rows " << endl;
+      cout << "Long-term Straw table has " << tssl_p->rows().size() << " rows " << endl;
+      cout << "Short-term Straw table has " << tsss_p->rows().size() << " rows " << endl;
+    }
 
+    for (auto const& row : tpls_p->rows()) estatus.insert(TrackerElementStatus(row.id(),tpls_p->sidMask(),row.status()));
+    for (auto const& row : tpas_p->rows()) estatus.insert(TrackerElementStatus(row.id(),tpas_p->sidMask(),row.status()));
+    for (auto const& row : tssl_p->rows()) estatus.insert(TrackerElementStatus(row.id(),tssl_p->sidMask(),row.status()));
+    for (auto const& row : tsss_p->rows()) estatus.insert(TrackerElementStatus(row.id(),tsss_p->sidMask(),row.status()));
 
+    if ( settings.verbose() > 1 ) {
+      cout << "Elements have status " << endl;
+      for(auto const& estat : estatus){
+	std::cout << "Tracker Element Id " << estat.sid_
+	  << " level " << estat.mask_.levelName()  
+	  << " mask " << estat.mask_.mask()  
+	  << " status " << estat.status_ << std::endl;
+      }
+    }
 
+    return std::make_shared<TrackerStatus>(estatus);
   }
 
-  } // namespace mu2e
+} // namespace mu2e

--- a/TrackerConfig/inc/TrackerStatusConfig.hh
+++ b/TrackerConfig/inc/TrackerStatusConfig.hh
@@ -26,7 +26,7 @@ namespace mu2e {
     TSSTable settings { Name("Settings") };
     TSSequence status { Name("Status"),
       Comment("Provide in order: StrawId contained by the element in'plane_panel_straw' format \n"
-	  "Level of the elemtn ('station', 'plane', 'panel', 'uniquepanel', 'straw', 'uniquestraw') \n"
+	  "Level of the element ('station', 'plane', 'panel', 'uniquepanel', 'straw', 'uniquestraw') \n"
 	  "Colon-separated status bits to set for the element(see StrawStatus for details)") };
   };
 

--- a/TrkDiag/src/SConscript
+++ b/TrkDiag/src/SConscript
@@ -69,6 +69,7 @@ helper.make_plugins( [
    'mu2e_GeometryService',
    'mu2e_BFieldGeom',
    'mu2e_Mu2eHallGeom',
+   'mu2e_TrackerConditions',
    'mu2e_TrackerGeom',
    'mu2e_CalorimeterGeom',
    'mu2e_MCDataProducts',

--- a/TrkDiag/src/TrkGeomTest_module.cc
+++ b/TrkDiag/src/TrkGeomTest_module.cc
@@ -10,6 +10,7 @@
 #include "art/Framework/Core/ModuleMacros.h"
 #include "GeometryService/inc/GeomHandle.hh"
 #include "ProditionsService/inc/ProditionsHandle.hh"
+#include "TrackerConditions/inc/TrackerStatus.hh"
 #include "TrackerGeom/inc/Tracker.hh"
 #include "TTree.h"
 #include <iostream>
@@ -87,6 +88,11 @@ namespace mu2e {
 
   void TrkGeomTest::analyze(art::Event const& event) {
     if(first_){
+    // fetch tracker status
+      ProditionsHandle<TrackerStatus> trackerstatus_h;
+      auto const& trkstatus = trackerstatus_h.get(event.id());
+      std::cout << "TrackerStatus ";
+      trkstatus.print(std::cout);
       // fetch aligned and nominal tracker objects
       GeomHandle<Tracker> nominalTracker_h;
       auto const& ntracker = *nominalTracker_h;

--- a/TrkDiag/src/TrkGeomTest_module.cc
+++ b/TrkDiag/src/TrkGeomTest_module.cc
@@ -87,6 +87,7 @@ namespace mu2e {
   }
 
   void TrkGeomTest::analyze(art::Event const& event) {
+  // this is a test module, so only a single event is processed.
     if(first_){
     // fetch tracker status
       ProditionsHandle<TrackerStatus> trackerstatus_h;


### PR DESCRIPTION
Add tables for storing TrackerStatus in the proditions database, with corresponding changes to TrackerStatusMaker, etc.  Add functionality to construct a BitMap object from a hex number in string format, to allow efficient and consistent DB storage.