### PR TITLE
Allow CompressDetStepMCs to take multiple SimParticleCollections

### DIFF
--- a/JobConfig/cosmic/cosmic_s2_resampler.fcl
+++ b/JobConfig/cosmic/cosmic_s2_resampler.fcl
@@ -46,6 +46,7 @@ physics.producers.FindMCPrimary.GenParticles: "dsResample"
 physics.producers.FindMCPrimary.SimParticles: "dsResample"
 physics.producers.generate: @local::physics.filters.dsResample
 physics.TriggerPath: [dsResample, @sequence::Primary.TriggerSequence]
+physics.producers.compressDetStepMCs.simParticleTags : [ "g4run", "dsResample" ]
 
 outputs.Output.fileName        : "sim.owner.cosmic-s2-resampler.version.sequencer.art"
 // Test on the file with events that deposited lower than 14 MeV in CRV

--- a/JobConfig/primary/prolog.fcl
+++ b/JobConfig/primary/prolog.fcl
@@ -27,7 +27,7 @@ Primary: {
       strawGasStepTag : "StrawGasStepMaker"
       caloShowerStepTag : "CaloShowerStepMaker"
       crvStepTag : "CrvSteps"
-      simParticleTag : "g4run"
+      simParticleTags : [ "g4run" ]
       stepPointMCTags : [ "g4run:virtualdetector", "g4run:protonabsorber", "g4run:stoppingtarget" ]
       mcTrajectoryTag : "g4run"
       debugLevel : 0


### PR DESCRIPTION
For cosmic ray resampling, we generate CrvSteps in "dsResample" and StrawGasSteps and CaloShowerSteps in "g4run". For this reason, we need to allow CompressDetStepMCs to take multuple SimParticleCollection tags. This PR implements this feature.

One knock-on effect is that we need to rekey the output SimParticleCollection to avoid SimParticles with the same ID but from different collections overwriting each other. We do the same thing in CompressDigiMCs for mixed datasets through a fhicl parameter. Here I haven't put in the option to turn the rekeying off since I don't see a benefit for keeping the IDs and the cost is extra configuration differences between subtly different jobs. I'm happy to implement a switch if we really need it.

Cheers,
Andy