### PR TITLE
reorganize trigger option

### DIFF
--- a/Mu2eG4/src/SConscript
+++ b/Mu2eG4/src/SConscript
@@ -6,6 +6,10 @@
 import os, re
 Import('env')
 
+# if building for the trigger exe, don't build this lib
+if env['TRIGGER'] == 'on':
+    Return()
+
 Import('mu2e_helper')
 
 helper=mu2e_helper(env)

--- a/SConstruct
+++ b/SConstruct
@@ -103,6 +103,7 @@ env.Append( BUILD = mu2eOpts["build"] )
 env.Append( G4VIS = mu2eOpts["g4vis"] )
 env.Append( G4VG = mu2eOpts["g4vg"] )
 env.Append( G4MT = mu2eOpts["g4mt"] )
+env.Append( TRIGGER = mu2eOpts["trigger"] )
 
 # make the scons environment visible to all SConscript files (Import('env'))
 Export('env')

--- a/Sandbox/src/SConscript
+++ b/Sandbox/src/SConscript
@@ -7,6 +7,11 @@
 
 import os
 Import('env')
+
+# if building for the trigger exe, don't build this lib
+if env['TRIGGER'] == 'on':
+    Return()
+
 Import('mu2e_helper')
 
 helper=mu2e_helper(env);

--- a/scripts/build/python/sconstruct_helper.py
+++ b/scripts/build/python/sconstruct_helper.py
@@ -162,15 +162,6 @@ def sconscriptList(mu2eOpts):
         if 'SConscript' in files:
             ss_append(os.path.join(root[2:], 'SConscript'))
 
-    # If we are making a build for the trigger, do not build everything.
-    if mu2eOpts["trigger"] == 'on':
-        notNeeded = ["Mu2eG4/src/SConscript",
-                     #"CRVResponse/src/SConscript",
-                     "Sandbox/src/SConscript"]
-        for x in notNeeded:
-            if x in ss:
-                ss.remove(x)
-
     return ss
 
 # Make sure the build directories are created


### PR DESCRIPTION
This takes the implementation of the Trigger buildopt option out of the control script and into the SConscripts.  I think this is a bit simpler, more transparent, and trivially Muse-ready.