### PR TITLE
Make phony targets Muse-ready

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -134,40 +134,6 @@ env.SConscript(ss)
 if ( GetOption('clean') and not COMMAND_LINE_TARGETS):
     sch.extraCleanup()
 
-#
-# create targets that are only built on demand
-#
-
-# make a copy of env with the full build environmentals so it can run exe's
-build_env = env.Clone()
-build_env.Append(ENV=os.environ)
-# a text file of how packages depend on each other: run with 'scons DEPS'
-pts = []
-pts = pts + sch.PhonyTarget(build_env,'DEPS','gen/txt/deps.txt',
-                            'scripts/build/bin/procs.sh DEPS')
-# make the gdml file
-pts = pts + sch.PhonyTarget(build_env,'GDML','gen/gdml/mu2e.gdml',
-                            'scripts/build/bin/procs.sh GDML' )
-# run root fast overlaps check
-pts = pts + sch.PhonyTarget(build_env,'ROVERLAPS',[],
-                            'scripts/build/bin/procs.sh ROVERLAPS' )
-Depends(pts[-1], pts[-2]) # root check requires gdml
-# run g4test_03
-pts = pts + sch.PhonyTarget(build_env,'TEST03',[],
-                            'scripts/build/bin/procs.sh TEST03' )
-# pack git records
-pts = pts + sch.PhonyTarget(build_env,'GITPACK',[],
-                            'scripts/build/bin/procs.sh GITPACK' )
-# remove tmp and intermediate .so files
-pts = pts + sch.PhonyTarget(build_env,'RMSO',[],
-                            'scripts/build/bin/procs.sh RMSO' )
-# a standard validation file (~20min to run)
-pts = pts + sch.PhonyTarget(build_env,'VAL0','gen/val/ceSimReco_5000.root',
-                'scripts/build/bin/procs.sh VAL0' )
-# combine the targets into one
-pt_rel = env.AlwaysBuild(env.Alias('RELEASE', [], '#echo completed release targets'))
-Depends(pt_rel, pts)
-
 
 # This tells emacs to view this file in python mode.
 # Local Variables:

--- a/scripts/build/SConscript
+++ b/scripts/build/SConscript
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+#
+#
+import os
+Import('env')
+
+# make a copy of env with the full build environmentals so it can run exe's
+exe_env = env.Clone()
+exe_env.Append(ENV=os.environ)
+
+# if building in Muse, default dir will be above Offline
+command="scripts/build/bin/procs.sh "
+if 'MUSE_WORK_DIR' in env:
+    command = "Offline/"+command
+
+# each of these generates a useful file or runs a test
+targets = ["DEPS","GDML","ROVERLAPS","TEST03","GITPACK","RMSO","VAL0"]
+
+for target in targets:
+    exe_env.AlwaysBuild(exe_env.Alias(target, [], 
+                                      command+target))
+
+# the RELEASE target runs all the above generators and tests
+
+exe_env.AlwaysBuild(env.Alias('RELEASE', [], '#echo completed release targets'))
+Depends('RELEASE', targets)
+
+
+# This tells emacs to view this file in python mode.
+# Local Variables:
+# mode:python
+# End:
+# vi:syntax=python
+

--- a/scripts/build/python/mu2e_helper.py
+++ b/scripts/build/python/mu2e_helper.py
@@ -185,3 +185,4 @@ class mu2e_helper:
         for t in target :
             topTargets.append("#/"+t)
         self.env.GenericBuild( topTargets, topSources, COMMAND=command)
+

--- a/scripts/build/python/sconstruct_helper.py
+++ b/scripts/build/python/sconstruct_helper.py
@@ -169,23 +169,6 @@ def makeSubDirs(mu2eOpts):
     for mdir in [mu2eOpts[d] for d in ['libdir','bindir','tmpdir', 'gendir']]:
         os.makedirs(mdir, exist_ok=True)
 
-#
-# a method for creating build-on-demand targets
-#
-def PhonyTarget(env,name,targets,action):
-    if not isinstance(targets,list):
-        targets = [targets]
-    if env.GetOption('clean'):
-        for t in targets:
-            if os.path.isfile(t):
-                os.remove(t)
-    else:
-        for t in targets:
-            d = os.path.dirname(t)
-            if not os.path.isdir(d):
-                os.makedirs(d)
-    return env.AlwaysBuild(env.Alias(name, [], action))
-
 
 # with -c, scons will remove all dependant files it knows about
 # but when a source file is deleted:


### PR DESCRIPTION
Move phony targets to a better location, simplify, and include Muse paths. These targets on used only one place - when a release is built and packaged for cvmfs. 