### PR TITLE
deeper check on Ptr, NonNull can still be unuseable

### DIFF
--- a/Print/src/PrimaryParticlePrinter.cc
+++ b/Print/src/PrimaryParticlePrinter.cc
@@ -57,7 +57,7 @@ mu2e::PrimaryParticlePrinter::Print(const mu2e::PrimaryParticle& obj, int ind, s
   sprint_.PrintListHeader(os);
   for(size_t isp = 0; isp < obj.primarySimParticles().size(); isp++){
     auto const& spp = obj.primarySimParticles()[isp];
-    if(spp.isNonnull()) sprint_.Print(spp,isp,os);
+    if(spp.isAvailable()) sprint_.Print(spp,isp,os);
   }
 }
 


### PR DESCRIPTION
NonNull checks that the Ptr has a number in it, isAvailable also checks if the object it points to exists, and therefore the Ptr can be used.  bool() operator is the same as isAvailable(). @brownd1978 and @AndrewEdmonds11 might want to check why this pointer is in this state.  I hit this problem in the reco validation job output file.