### PR TITLE
An option to switch to totalEDep() from the default of visibleEDep()

### DIFF
--- a/CRVResponse/src/CrvStepsFromStepPointMCs_module.cc
+++ b/CRVResponse/src/CrvStepsFromStepPointMCs_module.cc
@@ -59,6 +59,8 @@ namespace mu2e
 	  Comment("Starting size for crvIndex-particle vector"),4};
 	fhicl::Atom<bool> removeNeutralParticles{ Name("removeNeutralParticles"),
 	  Comment("Removes steps of neutral particles"),true};
+	fhicl::Atom<bool> useTotalEDep{ Name("useTotalEDep"),
+	  Comment("Use total energy deposition instead. Visible is a new default"),false};
       };
       using Parameters = art::EDProducer::Table<Config>;
       explicit CrvStepsFromStepPointMCs(const Parameters& conf);
@@ -82,6 +84,7 @@ namespace mu2e
 
       int      _debug, _diag;
       bool     _removeNeutralParticles;
+      bool     _useTotalEDep;
       unsigned _csize, _ssize;
       // StepPointMC selector
       // This selector will select only data products with the given instance name.
@@ -101,6 +104,8 @@ namespace mu2e
     _debug(config().debug()),
     _diag(config().diag()),
     _removeNeutralParticles(config().removeNeutralParticles()),
+    _useTotalEDep(config().useTotalEDep()),
+
     _csize(config().csize()),
     _ssize(config().startSize()),
     _selector(art::ProductInstanceNameSelector(config().stepPointsInstance())),
@@ -260,7 +265,12 @@ namespace mu2e
         first     =spmcptr;
         spmcIndices.emplace_back(i,i);
       }
-      edep   +=spmcptr->visibleEDep();
+
+      if(_useTotalEDep)
+        edep+=spmcptr->totalEDep();
+      else
+        edep+=spmcptr->visibleEDep();
+
       pathlen+=spmcptr->stepLength();
       last    =spmcptr;
       spmcIndices.back().second=i;

--- a/CRVResponse/src/CrvStepsFromStepPointMCs_module.cc
+++ b/CRVResponse/src/CrvStepsFromStepPointMCs_module.cc
@@ -61,6 +61,9 @@ namespace mu2e
 	  Comment("Removes steps of neutral particles"),true};
 	fhicl::Atom<bool> useTotalEDep{ Name("useTotalEDep"),
 	  Comment("Use total energy deposition instead. Visible is a new default"),false};
+	fhicl::Atom<bool> noPostPositionAvailable{ Name("noPostPositionAvailable"),
+	  Comment("No postposition is available for CRY3/4 samples"),false};
+
       };
       using Parameters = art::EDProducer::Table<Config>;
       explicit CrvStepsFromStepPointMCs(const Parameters& conf);
@@ -85,6 +88,7 @@ namespace mu2e
       int      _debug, _diag;
       bool     _removeNeutralParticles;
       bool     _useTotalEDep;
+      bool     _noPostPositionAvailable;
       unsigned _csize, _ssize;
       // StepPointMC selector
       // This selector will select only data products with the given instance name.
@@ -105,7 +109,7 @@ namespace mu2e
     _diag(config().diag()),
     _removeNeutralParticles(config().removeNeutralParticles()),
     _useTotalEDep(config().useTotalEDep()),
-
+    _noPostPositionAvailable(config().noPostPositionAvailable()),
     _csize(config().csize()),
     _ssize(config().startSize()),
     _selector(art::ProductInstanceNameSelector(config().stepPointsInstance())),
@@ -286,6 +290,7 @@ namespace mu2e
         // Define the position at entrance and exit
         CLHEP::Hep3Vector startPos = first->position();
         CLHEP::Hep3Vector endPos   = last->postPosition();
+        if(_noPostPositionAvailable) endPos = last->position() + last->momentum().unit()*last->stepLength();
 
         double startTime = first->time();
         double endTime   = last->time();

--- a/JobConfig/cosmic/cosmic_s2_converter.fcl
+++ b/JobConfig/cosmic/cosmic_s2_converter.fcl
@@ -22,4 +22,5 @@ physics.producers.CrvSteps.stepPointsModuleLabels : ["detectorFilter"]
 physics.producers.compressDetStepMCs.simParticleTag: "detectorFilter"
 physics.producers.compressDetStepMCs.stepPointMCTags : [ "detectorFilter:virtualdetector", "detectorFilter:protonabsorber" ]
 physics.producers.compressDetStepMCs.mcTrajectoryTag: "detectorFilter"
+physics.producers.CrvSteps.useTotalEDep: true
 outputs.Output.fileName        : "sim.owner.cosmic-s2-converter.version.sequencer.art"

--- a/JobConfig/cosmic/cosmic_s2_converter.fcl
+++ b/JobConfig/cosmic/cosmic_s2_converter.fcl
@@ -22,5 +22,8 @@ physics.producers.CrvSteps.stepPointsModuleLabels : ["detectorFilter"]
 physics.producers.compressDetStepMCs.simParticleTag: "detectorFilter"
 physics.producers.compressDetStepMCs.stepPointMCTags : [ "detectorFilter:virtualdetector", "detectorFilter:protonabsorber" ]
 physics.producers.compressDetStepMCs.mcTrajectoryTag: "detectorFilter"
+outputs.Output.fileName        : "dts.owner.cosmic-s2-converter.version.sequencer.art"
+// CRY3 and CRY4 samples don't have visible energy and post step position
 physics.producers.CrvSteps.useTotalEDep: true
-outputs.Output.fileName        : "sim.owner.cosmic-s2-converter.version.sequencer.art"
+physics.producers.CrvSteps.noPostPositionAvailable: true
+


### PR DESCRIPTION
CrvStep uses visibleEDep() by default.
Visible energy is not present in older CRY samples.
This option will be used to convert older CRY samples to CrvStep format.