### PR TITLE
restore halfLength and position parameters of Tier1 Production Target

### DIFF
--- a/ProductionTargetGeom/src/ProductionTarget.cc
+++ b/ProductionTargetGeom/src/ProductionTarget.cc
@@ -95,6 +95,8 @@ namespace mu2e {
     //having this duplicated is inelegant but when it comes time to rip out Tier 1 I think it will be easier
     _protonBeamRotation.rotateX(rotHaymanX).rotateY(rotHaymanY).rotateZ(rotHaymanZ);
     _protonBeamInverseRotation = _protonBeamRotation.inverse();
+    _halfLength = _productionTargetMotherHalfLength;
+    _prodTargetPosition = _haymanProdTargetPosition;
   }
 
 


### PR DESCRIPTION
A quick fix requested by Andrei to address missing parameters associated with the ProductionTargeet.