### PR TITLE
A fix to make test job filenames match the Mu2e convention.

### DIFF
--- a/Mu2eG4/fcl/g4test_stage0ST.fcl
+++ b/Mu2eG4/fcl/g4test_stage0ST.fcl
@@ -56,7 +56,7 @@ physics : {
 outputs: {
    fullOutput : {
       module_type : RootOutput
-      fileName    : "sim.owner.g4test_stage0.ver.seq.root"
+      fileName    : "sim.owner.g4test_stage0.ver.seq.art"
    }
 }
 

--- a/Mu2eG4/fcl/g4test_stage1ST.fcl
+++ b/Mu2eG4/fcl/g4test_stage1ST.fcl
@@ -13,7 +13,7 @@ process_name : g4tests1
 # Start form an empty source
 source : {
    module_type : RootInput
-   fileNames: [ "sim.owner.g4test_stage0.ver.seq.root"]
+   fileNames: [ "sim.owner.g4test_stage0.ver.seq.art"]
 }
 
 services : { @table::Services.Sim }


### PR DESCRIPTION
Fix a filename in a fhicl. No effect on validation.