### PR TITLE
Update stable geometry to the most recent test geometry.

### DIFF
--- a/Mu2eG4/geom/geom_common.txt
+++ b/Mu2eG4/geom/geom_common.txt
@@ -1,9 +1,9 @@
 //
-// Redirection to the current Mu2e top level geometry file.
+// Redirection to the current stable Mu2e top level geometry file.
 // The file that is included will be time dependent.
 //
 
-#include "Mu2eG4/geom/geom_common_hayman_v2.txt"
+#include "Mu2eG4/geom/geom_2021_PhaseI.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:


### PR DESCRIPTION
With this PR geom_common.txt now points to the same file as does geom_common_currnent:  

     Mu2eG4/geom/geom_2021_PhaseI.txt

We need to discuss timing of merging this PR and  tagging. 

Note that JobConfig/common/geom_baseline.txt includes Mu2eG4/geom/geom_common.txt

For the record here are the geometries used by the validation various jobs:

<pre>
ceSimReco        geom_common_current
transportOnly    geom_common
PS               geom_common               via geom_baseline
g4study          g4study_Tube_geom
cosmicSimReco    geom_common_current
rootOverlaps     geom_common
g4surfaceCheck   geom_common_current       via geom_SurfaceCheck
g4test_03MT      geom_common
reco             geom_common               via geom_baseline
potsim           geom_common_current
</pre>
