### PR TITLE
fix bug in text override

### DIFF
--- a/DbService/src/DbEngine.cc
+++ b/DbService/src/DbEngine.cc
@@ -300,8 +300,7 @@ mu2e::DbLiveTable mu2e::DbEngine::update(int tid, uint32_t run,
   // loop over override tables
   for(size_t iover=0; iover<_override.size(); iover++) {
     auto& oltab = _override[iover];
-    int otid = _overrideTids[oltab.table().name()];
-    if(otid==tid) { // if override table is the right type
+    if(oltab.tid()==tid) { // if override table is the right type
       if(oltab.iov().inInterval(run,subrun)) { // and in valid interval
 	auto dblt = oltab;
 	if(_verbose>9) cout << "DbEngine::update table found " 


### PR DESCRIPTION
The code worked for tables which were only in code and text, but did not work for the case of a text file actually overriding a database-supplied table.  The failure mode was to not override.   My guess is that when I tested this before I checked too superficially, and didn't see that the override failed silently.  Thanks and apologies to Richie.
