### PR TITLE
Add MDC2020 unit tests

### DIFF
--- a/Validation/test/ceDigi.fcl
+++ b/Validation/test/ceDigi.fcl
@@ -1,0 +1,16 @@
+#include "JobConfig/digitize/OnSpill.fcl"
+
+services.scheduler.wantSummary: true
+services.TimeTracker.printSummary: true
+
+services.SeedService.baseSeed: 8
+services.SeedService.maxUniqueEngines: 20
+
+services.GeometryService.inputFile : "Mu2eG4/geom/geom_common_current.txt"
+
+# file produced by ceSteps.fcl
+source.fileNames : [ "dts.owner.ceSteps.dsconf.seq.art" ]
+
+outputs.Output.fileName : "dts.owner.ceDigi.dsconf.seq.art"
+
+

--- a/Validation/test/ceMix.fcl
+++ b/Validation/test/ceMix.fcl
@@ -1,0 +1,19 @@
+#include "JobConfig/mixing/Run1.fcl"
+
+services.scheduler.wantSummary: true
+services.TimeTracker.printSummary: true
+
+services.SeedService.baseSeed: 8
+services.SeedService.maxUniqueEngines: 20
+
+services.GeometryService.inputFile : "Mu2eG4/geom/geom_common_current.txt"
+
+# file produced by ceSteps.fcl
+source.fileNames : [ "dts.owner.ceSteps.dsconf.seq.art" ]
+
+# file produced by muSteps.fcl
+physics.filters.mustopMixer.fileNames : ["dts.owner.muSteps.dsconf.seq.art" ]
+
+outputs.Output.fileName : "dig.owner.ceMix.dsconf.seq.art"
+
+

--- a/Validation/test/ceSteps.fcl
+++ b/Validation/test/ceSteps.fcl
@@ -1,0 +1,15 @@
+#include "JobConfig/primary/CeEndpoint.fcl"
+
+source.firstRun: 1000
+source.maxEvents: 1000
+
+services.scheduler.wantSummary: true
+services.TimeTracker.printSummary: true
+
+services.SeedService.baseSeed: 8
+services.SeedService.maxUniqueEngines: 20
+
+services.GeometryService.inputFile : "Mu2eG4/geom/geom_common_current.txt"
+
+
+outputs.Output.fileName : "dts.owner.ceSteps.dsconf.seq.art"

--- a/Validation/test/muSteps.fcl
+++ b/Validation/test/muSteps.fcl
@@ -1,0 +1,15 @@
+#include "JobConfig/pileup/mustop.fcl"
+
+source.firstRun: 1000
+source.maxEvents: 2000
+
+services.scheduler.wantSummary: true
+services.TimeTracker.printSummary: true
+
+services.SeedService.baseSeed: 8
+services.SeedService.maxUniqueEngines: 20
+
+services.GeometryService.inputFile : "Mu2eG4/geom/geom_common_current.txt"
+
+outputs.Output.fileName : "dts.owner.muSteps.dsconf.seq.art"
+


### PR DESCRIPTION
For now these will be unit tests, run for a limited number of events in the nightly
- cdSteps - generate CE, sim to steps
- ceDigi - take ceSteps as input, make digis
- muSteps - generate all daughters of stopped muons, sim to steps
- ceMix  - mix ceSteps and muSteps
