### PR TITLE
temporary fix due to PR398 + added TriggerInfoMerger module (with config tested) + clean up

### DIFF
--- a/CaloFilters/fcl/prolog_trigger.fcl
+++ b/CaloFilters/fcl/prolog_trigger.fcl
@@ -385,14 +385,14 @@ CaloFilters : { @table::CaloFilters
 	caloMVAMixedCE   : [ caloMVAMixedEventPrescale, caloMVAMixedCDCountFilter, @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 			     CaloTrigger, caloMVAMixedFilter ] 
 	
-	caloCalibCosmic  : [ caloCalibCosmicEventPrescale, caloCalibCosmicCDCountFilter, CaloClusterFast, caloCalibCosmicFilter] 
+	caloCalibCosmic  : [ caloCalibCosmicEventPrescale, caloCalibCosmicCDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits, CaloClusterFast, caloCalibCosmicFilter] 
 
-	caloLHCE         : [ caloLHCEEventPrescale, caloLHCECDCountFilter, CaloClusterFast, caloLHCEFilter] 
+	caloLHCE         : [ caloLHCEEventPrescale, caloLHCECDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits, CaloClusterFast, caloLHCEFilter] 
 
 	#FIX ME! THIS IS JUST A PLACE HOLDER
-	caloPhoton       : [ caloPhotonEventPrescale, caloPhotonCDCountFilter, CaloClusterFast, caloPhotonFilter] 
+	caloPhoton       : [ caloPhotonEventPrescale, caloPhotonCDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits, CaloClusterFast, caloPhotonFilter] 
 
-	caloPhoton       : [ caloMVANNCEEventPrescale, caloMVANNCECDCountFilter, CaloClusterFast,caloMVANNCEFilter ] 
+	caloPhoton       : [ caloMVANNCEEventPrescale, caloMVANNCECDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits, CaloClusterFast,caloMVANNCEFilter ] 
 
     }
 }

--- a/CaloReco/fcl/prolog_trigger.fcl
+++ b/CaloReco/fcl/prolog_trigger.fcl
@@ -32,7 +32,7 @@ FastCaloHitMaker:
 CaloHitRecoTrigger : 
 {
    producers : {
-     CaloRecoDigiMaker  : @local::FastCaloRecoDigiMaker
+     FastCaloRecoDigiMaker  : @local::FastCaloRecoDigiMaker
      CaloHitMaker       : @local::FastCaloHitMaker
    }
 

--- a/CaloReco/fcl/prolog_trigger.fcl
+++ b/CaloReco/fcl/prolog_trigger.fcl
@@ -32,11 +32,11 @@ FastCaloHitMaker:
 CaloHitRecoTrigger : 
 {
    producers : {
-     FastCaloRecoDigiMaker  : @local::FastCaloRecoDigiMaker
-     FastCaloHitMaker       : @local::FastCaloHitMaker
+     CaloRecoDigiMaker  : @local::FastCaloRecoDigiMaker
+     CaloHitMaker       : @local::FastCaloHitMaker
    }
 
-   Reco : [ FastCaloRecoDigiMaker , FastCaloHitMaker ]
+   prepareHits : [ FastCaloRecoDigiMaker , CaloHitMaker ]
 }
 
 END_PROLOG

--- a/Trigger/data/caloCalibCosmic/main_caloCalibCosmicPrescale.fcl
+++ b/Trigger/data/caloCalibCosmic/main_caloCalibCosmicPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.caloCalibCosmicPrescale.nPrescale         : 10000
-physics.filters.caloCalibCosmicPrescale.useFilteredEvents : true
-physics.filters.caloCalibCosmicPrescale.triggerFlag       : ["PrescaleGoodEvents"]

--- a/Trigger/data/caloLHCE/main_caloLHCEPrescale.fcl
+++ b/Trigger/data/caloLHCE/main_caloLHCEPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.caloLHCEPrescale.nPrescale    : 1
-physics.filters.caloLHCEPrescale.useFilteredEvents : true
-physics.filters.caloLHCEPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/caloMVACE/main_caloMVACEPrescale.fcl
+++ b/Trigger/data/caloMVACE/main_caloMVACEPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.caloMVACEPrescale.nPrescale    : 1
-physics.filters.caloMVACEPrescale.useFilteredEvents : true
-physics.filters.caloMVACEPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/caloMVAMixedCE/main_caloMVACEPrescale.fcl
+++ b/Trigger/data/caloMVAMixedCE/main_caloMVACEPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.caloMVACEPrescale.nPrescale    : 10000
-physics.filters.caloMVACEPrescale.useFilteredEvents : true
-physics.filters.caloMVACEPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/caloPhoton/main_caloPhotonPrescale.fcl
+++ b/Trigger/data/caloPhoton/main_caloPhotonPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.caloPhotonPrescale.nPrescale    : 1
-physics.filters.caloPhotonPrescale.useFilteredEvents : true
-physics.filters.caloPhotonPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/cprCosmicSeedDeM/main_cprCosmicSeedDeMPrescale.fcl
+++ b/Trigger/data/cprCosmicSeedDeM/main_cprCosmicSeedDeMPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.cprCosmicSeedDeMPrescale.nPrescale    : 1
-physics.filters.cprCosmicSeedDeMPrescale.useFilteredEvents : true
-physics.filters.cprCosmicSeedDeMPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/cprCosmicSeedDeP/main_cprCosmicSeedDePPrescale.fcl
+++ b/Trigger/data/cprCosmicSeedDeP/main_cprCosmicSeedDePPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.cprCosmicSeedDePPrescale.nPrescale    : 1
-physics.filters.cprCosmicSeedDePPrescale.useFilteredEvents : true
-physics.filters.cprCosmicSeedDePPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/cprLowPSeedDeM/main_cprLowPSeedDeMPrescale.fcl
+++ b/Trigger/data/cprLowPSeedDeM/main_cprLowPSeedDeMPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.cprLowPSeedDeMPrescale.nPrescale    : 1
-physics.filters.cprLowPSeedDeMPrescale.useFilteredEvents : true
-physics.filters.cprLowPSeedDeMPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/cprLowPSeedDeP/main_cprLowPSeedDePPrescale.fcl
+++ b/Trigger/data/cprLowPSeedDeP/main_cprLowPSeedDePPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.cprLowPSeedDePPrescale.nPrescale    : 1
-physics.filters.cprLowPSeedDePPrescale.useFilteredEvents : true
-physics.filters.cprLowPSeedDePPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/cprSeedDeM/main_cprSeedDeMPrescale.fcl
+++ b/Trigger/data/cprSeedDeM/main_cprSeedDeMPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.cprSeedDeMPrescale.nPrescale    : 1
-physics.filters.cprSeedDeMPrescale.useFilteredEvents : true
-physics.filters.cprSeedDeMPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/cprSeedDeP/main_cprSeedDePPrescale.fcl
+++ b/Trigger/data/cprSeedDeP/main_cprSeedDePPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.cprSeedDePPrescale.nPrescale    : 1
-physics.filters.cprSeedDePPrescale.useFilteredEvents : true
-physics.filters.cprSeedDePPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/largeCDCount/main_largeCDCountPrescale.fcl
+++ b/Trigger/data/largeCDCount/main_largeCDCountPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.largeCDCountPrescale.nPrescale    : 10000
-physics.filters.largeCDCountPrescale.useFilteredEvents : true
-physics.filters.largeCDCountPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/largeSDCount/main_largeSDCountPrescale.fcl
+++ b/Trigger/data/largeSDCount/main_largeSDCountPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.largeSDCountPrescale.nPrescale    : 10000
-physics.filters.largeSDCountPrescale.useFilteredEvents : true
-physics.filters.largeSDCountPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/minimumbiasCDCount/main_minimumbiasCDCountPrescale.fcl
+++ b/Trigger/data/minimumbiasCDCount/main_minimumbiasCDCountPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.minimumbiasCDCountPrescale.nPrescale    : 10000
-physics.filters.minimumbiasCDCountPrescale.useFilteredEvents : true
-physics.filters.minimumbiasCDCountPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/minimumbiasSDCount/main_minimumbiasSDCountPrescale.fcl
+++ b/Trigger/data/minimumbiasSDCount/main_minimumbiasSDCountPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.minimumbiasSDCountPrescale.nPrescale    : 10000
-physics.filters.minimumbiasSDCountPrescale.useFilteredEvents : true
-physics.filters.minimumbiasSDCountPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/tprCosmicSeedDeM/main_tprCosmicSeedDeMPrescale.fcl
+++ b/Trigger/data/tprCosmicSeedDeM/main_tprCosmicSeedDeMPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.tprCosmicSeedDeMPrescale.nPrescale    : 1
-physics.filters.tprCosmicSeedDeMPrescale.useFilteredEvents : true
-physics.filters.tprCosmicSeedDeMPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/tprCosmicSeedDeP/main_tprCosmicSeedDePPrescale.fcl
+++ b/Trigger/data/tprCosmicSeedDeP/main_tprCosmicSeedDePPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.tprCosmicSeedDePPrescale.nPrescale    : 1
-physics.filters.tprCosmicSeedDePPrescale.useFilteredEvents : true
-physics.filters.tprCosmicSeedDePPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/tprHelixCalibIPADeM/main_tprHelixCalibIPADeMPrescale.fcl
+++ b/Trigger/data/tprHelixCalibIPADeM/main_tprHelixCalibIPADeMPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.tprHelixCalibIPADeMPrescale.nPrescale    : 1
-physics.filters.tprHelixCalibIPADeMPrescale.useFilteredEvents : true
-physics.filters.tprHelixCalibIPADeMPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/tprHelixIPADeM/main_tprHelixIPADeMPrescale.fcl
+++ b/Trigger/data/tprHelixIPADeM/main_tprHelixIPADeMPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.tprHelixIPADeMPrescale.nPrescale    : 1
-physics.filters.tprHelixIPADeMPrescale.useFilteredEvents : true
-physics.filters.tprHelixIPADeMPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/tprLowPSeedDeM/main_tprLowPSeedDeMPrescale.fcl
+++ b/Trigger/data/tprLowPSeedDeM/main_tprLowPSeedDeMPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.tprLowPSeedDeMPrescale.nPrescale    : 1
-physics.filters.tprLowPSeedDeMPrescale.useFilteredEvents : true
-physics.filters.tprLowPSeedDeMPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/tprLowPSeedDeP/main_tprLowPSeedDePPrescale.fcl
+++ b/Trigger/data/tprLowPSeedDeP/main_tprLowPSeedDePPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.tprLowPSeedDePPrescale.nPrescale    : 1
-physics.filters.tprLowPSeedDePPrescale.useFilteredEvents : true
-physics.filters.tprLowPSeedDePPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/tprSeedDeM/main_tprSeedDeMPrescale.fcl
+++ b/Trigger/data/tprSeedDeM/main_tprSeedDeMPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.tprSeedDeMPrescale.nPrescale    : 1
-physics.filters.tprSeedDeMPrescale.useFilteredEvents : true
-physics.filters.tprSeedDeMPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/tprSeedDeP/main_tprSeedDePPrescale.fcl
+++ b/Trigger/data/tprSeedDeP/main_tprSeedDePPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.tprSeedDePPrescale.nPrescale    : 1
-physics.filters.tprSeedDePPrescale.useFilteredEvents : true
-physics.filters.tprSeedDePPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/data/unbiased/main_unbiasedEventPrescale.fcl
+++ b/Trigger/data/unbiased/main_unbiasedEventPrescale.fcl
@@ -1,0 +1,3 @@
+physics.filters.unbiasedEventPrescale.nPrescale    : 10000
+physics.filters.unbiasedEventPrescale.useFilteredEvents : true
+physics.filters.unbiasedEventPrescale.triggerFlag  : ["PrescaleRandom"]

--- a/Trigger/data/unbiased/main_unbiasedPrescale.fcl
+++ b/Trigger/data/unbiased/main_unbiasedPrescale.fcl
@@ -1,3 +1,0 @@
-physics.filters.unbiasedPrescale.nPrescale    : 10000
-physics.filters.unbiasedPrescale.useFilteredEvents : true
-physics.filters.unbiasedPrescale.triggerFlag  : ["PrescaleGoodEvents"]

--- a/Trigger/fcl/prolog_trigger.fcl
+++ b/Trigger/fcl/prolog_trigger.fcl
@@ -164,19 +164,19 @@ Trigger : {
 	@table::CstTrigger.sequences
 
 	#unbiased filter. It selects the events based on their event id
-	unbiased           : [ unbiasedEventPrescale ]
+	unbiased           : [ unbiasedEventPrescale, unbiasedTriggerInfoMerger ]
 
 	#minimum bias filters. So far, a filter based on the StrawDigi occupancy
-	minimumbiasSDCount : [ minimumbiasSDCountEventPrescale, minimumbiasSDCountFilter]
+	minimumbiasSDCount : [ minimumbiasSDCountEventPrescale, minimumbiasSDCountFilter, minimumbiasSDCountTriggerInfoMerger]
 
 	#filter to select events with large occupancy in the tracker
-	largeSDCount       : [ largeSDCountEventPrescale, largeSDCountFilter]
+	largeSDCount       : [ largeSDCountEventPrescale, largeSDCountFilter, largeSDCountTriggerInfoMerger]
 	
 	#minimum bias filters. So far, a filter based on the StrawDigi occupancy
-	minimumbiasCDCount : [ minimumbiasCDCountEventPrescale, minimumbiasCDCountFilter]
+	minimumbiasCDCount : [ minimumbiasCDCountEventPrescale, minimumbiasCDCountFilter, minimumbiasCDCountTriggerInfoMerger]
 
 	#filter to select events with large occupancy in the tracker
-	largeCDCount       : [ largeCDCountEventPrescale, largeCDCountFilter]
+	largeCDCount       : [ largeCDCountEventPrescale, largeCDCountFilter, largeCDCountTriggerInfoMerger]
     }
     
     outputs: {

--- a/Trigger/fcl/prolog_trigger.fcl
+++ b/Trigger/fcl/prolog_trigger.fcl
@@ -28,7 +28,6 @@ Trigger : {
 	@table::CstTrigger.producers
 	@table::TprTrigger.producers
 	@table::CprTrigger.producers
-	
     }
 
     filters : {
@@ -38,7 +37,7 @@ Trigger : {
 	@table::CstTrigger.filters
 
 	#used to select 1 event out of N
-	unbiasedPrescale : {
+	unbiasedEventPrescale : {
 	    module_type : PrescaleEvent
 	    nPrescale         : 10000 
 	    triggerPath        : "unbiased"
@@ -53,14 +52,6 @@ Trigger : {
 	    triggerFlag   : ["PrescaleRandom"]	    
 	}
 	
-	minimumbiasSDCountPrescale      : {
-	    module_type : PrescaleEvent
-	    nPrescale         : 1
-	    useFilteredEvents : true
-	    triggerPath        : "minBiasStrawDigiCount"
-	    triggerFlag       : ["PrescaleGoodEvents"]	    
-	}
-
 	#prescaler for the strawDigi large-occupancy filter
 	largeSDCountEventPrescale : {
 	    module_type : PrescaleEvent
@@ -69,14 +60,6 @@ Trigger : {
 	    triggerFlag   : ["PrescaleRandom"]	    
 	}
 	
-	largeSDCountPrescale      : {
-	    module_type : PrescaleEvent
-	    nPrescale         : 1
-	    useFilteredEvents : true
-	    triggerPath        : "largeStrawDigiCount"	    
-	    triggerFlag       : ["PrescaleGoodEvents"]	    
-	}
-
 	#filters based on the strawDigi occupancy:
 
 	# LargeSDCountFilter: we need this filter to select strange events 
@@ -120,14 +103,6 @@ Trigger : {
 	    triggerFlag   : ["PrescaleRandom"]	    
 	}
 	
-	minimumbiasCDCountPrescale      : {
-	    module_type : PrescaleEvent
-	    nPrescale         : 1 
-	    useFilteredEvents : true
-	    triggerPath        : "minBiasCaloDigiCount"	    	    
-	    triggerFlag       : ["PrescaleGoodEvents"]	    
-	}
-
 	#prescaler for the strawDigi large-occupancy filter
 	largeCDCountEventPrescale : {
 	    module_type : PrescaleEvent
@@ -136,14 +111,6 @@ Trigger : {
 	    triggerFlag   : ["PrescaleRandom"]	    
 	}
 	
-	largeCDCountPrescale      : {
-	    module_type : PrescaleEvent
-	    nPrescale         : 1 
-	    useFilteredEvents : true
-	    triggerPath        : "largeCaloDigiCount"	    	    
-	    triggerFlag       : ["PrescaleGoodEvents"]	    
-	}
-
 	#filters based on the strawDigi occupancy:
 
 	# LargeCDCountFilter: we need this filter to select strange events 
@@ -197,7 +164,7 @@ Trigger : {
 	@table::CstTrigger.sequences
 
 	#unbiased filter. It selects the events based on their event id
-	unbiased           : [ unbiasedPrescale ]
+	unbiased           : [ unbiasedEventPrescale ]
 
 	#minimum bias filters. So far, a filter based on the StrawDigi occupancy
 	minimumbiasSDCount : [ minimumbiasSDCountEventPrescale, minimumbiasSDCountFilter]

--- a/Trigger/python/genTriggerFcl.py
+++ b/Trigger/python/genTriggerFcl.py
@@ -103,18 +103,18 @@ def appendEpilog(trig_path, relProjectDir, outDir, srcDir, verbose, doWrite, sou
             subEpilogFile.write(epilog)
 
     #now create the instance for the TriggerInfo Merger
-    trigInfoMergerName         = trig_path + "TriggerInfoMerger"
-    subSubEpilogMergerFileName = subEpilogDirName + "/main_" + trigInfoMergerName + '.fcl'
-    if verbose:
-        print("Creating {}".format(subSubEpilogMergerFileName))
-    subSubEpilogMergerFile     = open(subSubEpilogMergerFileName,"w")
-    subSubEpilogMergerFile.write("physics.producers."+trigInfoMergerName+" : { module_type : MergeTriggerInfo }");
-    subSubEpilogMergerFile.close();
+    if  doWrite :
+        trigInfoMergerName         = trig_path + "TriggerInfoMerger"
+        subSubEpilogMergerFileName = subEpilogDirName + "/main_" + trigInfoMergerName + '.fcl'
+        if verbose:
+            print("Creating {}".format(subSubEpilogMergerFileName))
+        subSubEpilogMergerFile     = open(subSubEpilogMergerFileName,"w+")
+        subSubEpilogMergerFile.write("physics.producers."+trigInfoMergerName+" : { module_type : MergeTriggerInfo }");
+        subSubEpilogMergerFile.close();
 
-    relSubSubEpilogFileName    = relSubEpilogDirName + "/main_"+ trigInfoMergerName + '.fcl' 
-    epilog=("\n#include \""+relSubSubEpilogFileName +"\"")
+        relSubSubEpilogFileName    = relSubEpilogDirName + "/main_"+ trigInfoMergerName + '.fcl' 
+        epilog=("\n#include \""+relSubSubEpilogFileName +"\"")
 
-    if doWrite :
         subEpilogFile.write(epilog)
         subEpilogFile.close()
 

--- a/Trigger/python/genTriggerFcl.py
+++ b/Trigger/python/genTriggerFcl.py
@@ -29,7 +29,7 @@ def appendEpilog(trig_path, relProjectDir, outDir, srcDir, verbose, doWrite, sou
     helix_filters    = ['EventPrescale','SDCountFilter','TCFilter', 'HSFilter']
     tc_filters       = ['EventPrescale','SDCountFilter','TCFilter']
     calo_filters     = ['EventPrescale','CDCountFilter','Filter'  ]
-    unbiased_filters = ['Prescale']
+    unbiased_filters = ['EventPrescale']
     minbias_filters  = ['EventPrescale','Filter'       ]
     cst_filters      = ['EventPrescale','SDCountFilter','TCFilter', 'TSFilter']
     
@@ -79,8 +79,8 @@ def appendEpilog(trig_path, relProjectDir, outDir, srcDir, verbose, doWrite, sou
 
         subSubEpilogInputFileName = srcDir+"Trigger/data/" + trig_path + "/main_"+ filterName + '.fcl' 
         sourceFiles.append(subSubEpilogInputFileName)
-        subSubEpilogFileName = subEpilogDirName + "/main_"+ filterName + '.fcl' 
-        relSubSubEpilogFileName = relSubEpilogDirName + "/main_"+ filterName + '.fcl' 
+        subSubEpilogFileName      = subEpilogDirName + "/main_"+ filterName + '.fcl' 
+        relSubSubEpilogFileName   = relSubEpilogDirName + "/main_"+ filterName + '.fcl' 
         targetFiles.append(subSubEpilogFileName)
         if verbose:
             print("Creating {}".format(subSubEpilogFileName))
@@ -102,7 +102,20 @@ def appendEpilog(trig_path, relProjectDir, outDir, srcDir, verbose, doWrite, sou
         if doWrite :
             subEpilogFile.write(epilog)
 
-    if doWrite:
+    #now create the instance for the TriggerInfo Merger
+    trigInfoMergerName         = trig_path + "TriggerInfoMerger"
+    subSubEpilogMergerFileName = subEpilogDirName + "/main_" + trigInfoMergerName + '.fcl'
+    if verbose:
+        print("Creating {}".format(subSubEpilogMergerFileName))
+    subSubEpilogMergerFile     = open(subSubEpilogMergerFileName,"w")
+    subSubEpilogMergerFile.write("physics.producers."+trigInfoMergerName+" : { module_type : MergeTriggerInfo }");
+    subSubEpilogMergerFile.close();
+
+    relSubSubEpilogFileName    = relSubEpilogDirName + "/main_"+ trigInfoMergerName + '.fcl' 
+    epilog=("\n#include \""+relSubSubEpilogFileName +"\"")
+
+    if doWrite :
+        subEpilogFile.write(epilog)
         subEpilogFile.close()
 
     # return a line to be added to the main epilog file

--- a/Trigger/src/MergeTriggerInfo_module.cc
+++ b/Trigger/src/MergeTriggerInfo_module.cc
@@ -1,0 +1,70 @@
+//
+//  Merge the TriggerInfo objects generated within the trigger-path
+//  author: G. Pezzullo
+//
+#include "fhiclcpp/types/Atom.h"
+#include "canvas/Utilities/InputTag.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Selector.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+// mu2e data products
+#include "RecoDataProducts/inc/TriggerInfo.hh"
+// C++
+#include <vector>
+#include <memory>
+#include <iostream>
+#include <forward_list>
+#include <string>
+
+
+namespace mu2e {
+  class MergeTriggerInfo : public art::EDProducer {
+  public:
+    using  Name    = fhicl::Name;
+    using  Comment = fhicl::Comment;
+    struct Config {
+      fhicl::Atom<int> debug{ Name("debugLevel"),
+	  Comment("Debug Level"), 0};
+    };
+
+    using        Parameters = art::EDProducer::Table<Config>;
+    explicit     MergeTriggerInfo(const Parameters& conf);
+    void         produce(art::Event& evt) override;
+  private:
+    int          _debug;
+  };
+
+  MergeTriggerInfo::MergeTriggerInfo(const Parameters& config) : 
+    art::EDProducer{config},
+    _debug   (config().debug())
+  {
+    produces<TriggerInfoCollection>    ();
+  }
+
+  void MergeTriggerInfo::produce(art::Event& event) {
+    std::unique_ptr<TriggerInfoCollection> tiCol(new TriggerInfoCollection);
+
+    // create the selector
+    art::Selector selector(art::ProductInstanceNameSelector("") &&
+			   art::ProcessNameSelector("*")); 
+    //			   art::ModuleLabelSelector(""));// && 
+    //                           art::ProcessNameSelector("*"));
+    std::vector<art::Handle<TriggerInfo> > list_of_triggerInfo; 
+    event.getMany(selector, list_of_triggerInfo);
+
+    if(_debug > 0){
+      std::cout << "["<<moduleDescription().moduleLabel() << "] number of TriggerInfo found in the is: "<< list_of_triggerInfo.size() << std::endl;
+    }
+    
+    for (auto trigInfoH: list_of_triggerInfo){
+      TriggerInfo trigInfo(*trigInfoH.product());
+      tiCol->push_back(trigInfo);
+    }
+    
+    event.put(std::move(tiCol));
+  }
+}
+DEFINE_ART_MODULE(mu2e::MergeTriggerInfo)

--- a/TrkFilters/fcl/prolog_trigger.fcl
+++ b/TrkFilters/fcl/prolog_trigger.fcl
@@ -1673,100 +1673,100 @@ TrkFilters : {
 
 	tprSeedDeM           : [ tprSeedDeMEventPrescale, tprSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprSeedDeMHSFilter, TTKSFDeM, tprSeedDeMTSFilter ]
+				 TTtimeClusterFinder, tprSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprSeedDeMHSFilter, TTKSFDeM, tprSeedDeMTSFilter, tprSeedDeMTriggerInfoMerger ]
 	tprSeedDeP           : [ tprSeedDePEventPrescale, tprSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprSeedDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprSeedDePHSFilter, TTKSFDeP, tprSeedDePTSFilter ]
+				 TTtimeClusterFinder, tprSeedDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprSeedDePHSFilter, TTKSFDeP, tprSeedDePTSFilter, tprSeedDePTriggerInfoMerger  ]
 
 	tprLowPSeedDeM       : [ tprLowPSeedDeMEventPrescale, tprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprLowPSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprLowPSeedDeMHSFilter, TTKSFDeM, tprLowPSeedDeMTSFilter ]
+				 TTtimeClusterFinder, tprLowPSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprLowPSeedDeMHSFilter, TTKSFDeM, tprLowPSeedDeMTSFilter, tprLowPSeedDeMTriggerInfoMerger ]
 	tprLowPSeedDeP       : [ tprLowPSeedDePEventPrescale, tprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprLowPSeedDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprLowPSeedDePHSFilter, TTKSFDeP, tprLowPSeedDePTSFilter ]
+				 TTtimeClusterFinder, tprLowPSeedDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprLowPSeedDePHSFilter, TTKSFDeP, tprLowPSeedDePTSFilter, tprLowPSeedDePTriggerInfoMerger ]
 
 	tprCosmicSeedDeM     : [ tprCosmicSeedDeMEventPrescale, tprCosmicSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprCosmicSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprCosmicSeedDeMHSFilter, TTKSFDeM, tprCosmicSeedDeMTSFilter ]
+				 TTtimeClusterFinder, tprCosmicSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprCosmicSeedDeMHSFilter, TTKSFDeM, tprCosmicSeedDeMTSFilter, tprCosmicSeedDeMTriggerInfoMerger ]
 	tprCosmicSeedDeP     : [ tprCosmicSeedDePEventPrescale, tprCosmicSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprCosmicSeedDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprCosmicSeedDePHSFilter, TTKSFDeP, tprCosmicSeedDePTSFilter ]
+				 TTtimeClusterFinder, tprCosmicSeedDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprCosmicSeedDePHSFilter, TTKSFDeP, tprCosmicSeedDePTSFilter, tprCosmicSeedDePTriggerInfoMerger ]
 
 	tprCosmicHelixDeM     : [ tprCosmicHelixDeMEventPrescale, tprCosmicHelixDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprCosmicHelixDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprCosmicHelixDeMHSFilter ]
+				 TTtimeClusterFinder, tprCosmicHelixDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprCosmicHelixDeMHSFilter, tprCosmicHelixDeMTriggerInfoMerger ]
 	tprCosmicHelixDeP     : [ tprCosmicHelixDePEventPrescale, tprCosmicHelixDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprCosmicHelixDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprCosmicHelixDePHSFilter ]
+				 TTtimeClusterFinder, tprCosmicHelixDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprCosmicHelixDePHSFilter, tprCosmicHelixDePTriggerInfoMerger ]
 
 	tprCosmicHelixUeM     : [ tprCosmicHelixUeMEventPrescale, tprCosmicHelixUeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprCosmicHelixUeMTCFilter, TThelixFinder, TTHelixMergerUeM, tprCosmicHelixUeMHSFilter ]
+				 TTtimeClusterFinder, tprCosmicHelixUeMTCFilter, TThelixFinder, TTHelixMergerUeM, tprCosmicHelixUeMHSFilter, tprCosmicHelixUeMTriggerInfoMerger ]
 	tprCosmicHelixUeP     : [ tprCosmicHelixUePEventPrescale, tprCosmicHelixUePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprCosmicHelixUePTCFilter, TThelixFinder,TTHelixMergerUeP,  tprCosmicHelixUePHSFilter ]
+				 TTtimeClusterFinder, tprCosmicHelixUePTCFilter, TThelixFinder,TTHelixMergerUeP,  tprCosmicHelixUePHSFilter, tprCosmicHelixUePTriggerInfoMerger ]
 
 
 	# sequences that use a collection of combohits filtered using the calorimeter cluster info 
 	tprSeedUCCDeM        : [ tprSeedUCCDeMEventPrescale, tprSeedUCCDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHitsUCC, 
-				 TTtimeClusterFinderUCC, tprSeedUCCDeMTCFilter, TThelixFinderUCC, TTHelixUCCMergerDeM, tprSeedUCCDeMHSFilter, TTKSFUCCDeM, tprSeedUCCDeMTSFilter ]
+				 TTtimeClusterFinderUCC, tprSeedUCCDeMTCFilter, TThelixFinderUCC, TTHelixUCCMergerDeM, tprSeedUCCDeMHSFilter, TTKSFUCCDeM, tprSeedUCCDeMTSFilter, tprSeedUCCDeMTriggerInfoMerger ]
 	tprSeedUCCDeP        : [ tprSeedUCCDePEventPrescale, tprSeedUCCDePSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHitsUCC, 
-				 TTtimeClusterFinderUCC, tprSeedUCCDePTCFilter, TThelixFinderUCC, TTHelixUCCMergerDeP, tprSeedUCCDePHSFilter, TTKSFUCCDeP, tprSeedUCCDePTSFilter ]
+				 TTtimeClusterFinderUCC, tprSeedUCCDePTCFilter, TThelixFinderUCC, TTHelixUCCMergerDeP, tprSeedUCCDePHSFilter, TTKSFUCCDeP, tprSeedUCCDePTSFilter, tprSeedUCCDeMTriggerInfoMerger ]
 
 	#   calibration with DIO-Michel form Inner Proton Absorber
 	tprHelixCalibIPADeM  : [ tprHelixCalibIPADeMEventPrescale, tprHelixCalibIPADeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprHelixCalibIPADeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprHelixCalibIPADeMHSFilter  ]
+				 TTtimeClusterFinder, tprHelixCalibIPADeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprHelixCalibIPADeMHSFilter, tprHelixCalibIPADeMTriggerInfoMerger  ]
 
 	#    beam monitoring using the e- from the DIO in the IPA
 	tprHelixIPADeM       : [ tprHelixIPADeMEventPrescale, tprHelixIPADeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprHelixIPADeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprHelixIPADeMHSFilter  ]
+				 TTtimeClusterFinder, tprHelixIPADeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprHelixIPADeMHSFilter, tprHelixIPADeMTriggerInfoMerger  ]
 	
 	#calo-seeded tracking
 	cprSeedDeM           : [ cprSeedDeMEventPrescale, cprSeedDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				 TTCalTimePeakFinder, cprSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprSeedDeMHSFilter,
-				 TTCalSeedFitDem, cprSeedDeMTSFilter ]
+				 TTCalSeedFitDem, cprSeedDeMTSFilter, cprSeedDeMTriggerInfoMerger ]
 	cprSeedDeP           : [ cprSeedDePEventPrescale, cprSeedDePSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTCalTimePeakFinder, cprSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprSeedDePHSFilter, 
-				 TTCalSeedFitDep, cprSeedDePTSFilter ]
+				 TTCalSeedFitDep, cprSeedDePTSFilter, cprSeedDePTriggerInfoMerger ]
 
 	cprLowPSeedDeM       : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				 TTCalTimePeakFinder, cprLowPSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprLowPSeedDeMHSFilter,
-				 TTCalSeedFitDem, cprLowPSeedDeMTSFilter ]
+				 TTCalSeedFitDem, cprLowPSeedDeMTSFilter, cprLowPSeedDeMTriggerInfoMerger ]
 	cprLowPSeedDeP       : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTCalTimePeakFinder, cprLowPSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprLowPSeedDePHSFilter, 
-				 TTCalSeedFitDep, cprLowPSeedDePTSFilter ]
+				 TTCalSeedFitDep, cprLowPSeedDePTSFilter, cprLowPSeedDePTriggerInfoMerger ]
 
 	cprCosmicSeedDeM     : [ cprCosmicSeedDeMEventPrescale, cprCosmicSeedDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				 TTCalTimePeakFinder, cprCosmicSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprCosmicSeedDeMHSFilter,
-				 TTCalSeedFitDem, cprCosmicSeedDeMTSFilter ]
+				 TTCalSeedFitDem, cprCosmicSeedDeMTSFilter, cprCosmicSeedDeMTriggerInfoMerger ]
 	cprCosmicSeedDeP     : [ cprCosmicSeedDePEventPrescale, cprCosmicSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTCalTimePeakFinder, cprCosmicSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprCosmicSeedDePHSFilter, 
-				 TTCalSeedFitDep, cprCosmicSeedDePTSFilter ]
+				 TTCalSeedFitDep, cprCosmicSeedDePTSFilter, cprCosmicSeedDePTriggerInfoMerger ]
 	cprCosmicHelixDeM     : [ cprCosmicHelixDeMEventPrescale, cprCosmicHelixDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
-				 TTCalTimePeakFinder, cprCosmicHelixDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprCosmicHelixDeMHSFilter ]
+				 TTCalTimePeakFinder, cprCosmicHelixDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprCosmicHelixDeMHSFilter, cprCosmicHelixDeMTriggerInfoMerger ]
 	cprCosmicHelixDeP     : [ cprCosmicHelixDePEventPrescale, cprCosmicHelixDePSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTCalTimePeakFinder, cprCosmicHelixDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprCosmicHelixDePHSFilter ]
+				 TTCalTimePeakFinder, cprCosmicHelixDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprCosmicHelixDePHSFilter, cprCosmicHelixDePTriggerInfoMerger ]
 
 	cprSeedUCCDeM        : [ cprSeedUCCDeMEventPrescale, cprSeedUCCDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHitsUCC,
 				 TTCalTimePeakFinderUCC, cprSeedUCCDeMTCFilter, TTCalHelixFinderUCCDe, TTCalHelixUCCMergerDeM, cprSeedUCCDeMHSFilter,
-				 TTCalSeedFitUCCDem, cprSeedUCCDeMTSFilter ]
+				 TTCalSeedFitUCCDem, cprSeedUCCDeMTSFilter, cprSeedUCCDeMTriggerInfoMerger ]
 	cprSeedUCCDeP        : [ cprSeedUCCDePEventPrescale, cprSeedUCCDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHitsUCC, 
 				 TTCalTimePeakFinderUCC, cprSeedUCCDePTCFilter, TTCalHelixFinderUCCDe, TTCalHelixUCCMergerDeP, cprSeedUCCDePHSFilter, 
-				 TTCalSeedFitUCCDep, cprSeedUCCDePTSFilter ]
+				 TTCalSeedFitUCCDep, cprSeedUCCDePTSFilter, cprSeedUCCDePTriggerInfoMerger ]
 	
 	#fast tracking sequences that uses the calorimeter-time selection to reduce the number of TimeClusters and also the number of hits processed by the Delta-ray 
 	#removal algorithm
@@ -1779,7 +1779,7 @@ TrkFilters : {
 	# sequences for doing timing tests
 	tprSeedDeMTiming0   : [ tprSeedDeMEventPrescale, tprSeedDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprSeedDeMHSFilter, TTKSFDeM ]
+				 TTtimeClusterFinder, tprSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprSeedDeMHSFilter, TTKSFDeM, tprSeedDeMTriggerInfoMerger ]
 	tprSeedDeMTiming1   : [ tprSeedDeMEventPrescale, tprSeedDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM ]
@@ -1789,7 +1789,7 @@ TrkFilters : {
 
 	tprSeedDePTiming0   : [ tprSeedDePEventPrescale, tprSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				 TTtimeClusterFinder, tprSeedDePTCFilter, TThelixFinder, TTHelixMergerDeP, tprSeedDePHSFilter, TTKSFDeP ]
+				 TTtimeClusterFinder, tprSeedDePTCFilter, TThelixFinder, TTHelixMergerDeP, tprSeedDePHSFilter, TTKSFDeP, tprSeedDePTriggerInfoMerger ]
 	tprSeedDePTiming1   : [ tprSeedDePEventPrescale, tprSeedDePSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprSeedDePTCFilter, TThelixFinder, TTHelixMergerDeP ]
@@ -1800,7 +1800,7 @@ TrkFilters : {
 	cprSeedDeMTiming0   : [ cprSeedDeMEventPrescale, cprSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				@sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				TTCalTimePeakFinder, cprSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprSeedDeMHSFilter,
-				TTCalSeedFitDem ]
+				TTCalSeedFitDem, cprSeedDeMTriggerInfoMerger ]
 	cprSeedDeMTiming1   : [ cprSeedDeMEventPrescale, cprSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				@sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				TTCalTimePeakFinder, cprSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM ]
@@ -1811,7 +1811,7 @@ TrkFilters : {
 	cprSeedDePTiming0   : [ cprSeedDePEventPrescale, cprSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				@sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				TTCalTimePeakFinder, cprSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprSeedDePHSFilter, 
-				TTCalSeedFitDep ]
+				TTCalSeedFitDep, cprSeedDePTriggerInfoMerger ]
 	cprSeedDePTiming1   : [ cprSeedDePEventPrescale, cprSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				@sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				TTCalTimePeakFinder, cprSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP ]
@@ -1824,7 +1824,7 @@ TrkFilters : {
 	tprLowPSeedDeMTiming0      : [ tprLowPSeedDeMEventPrescale, tprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTtimeClusterFinder, tprLowPSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprLowPSeedDeMHSFilter, 
-				       TTKSFDeM, tprLowPSeedDeMPrescale ]
+				       TTKSFDeM, tprLowPSeedDeMPrescale, tprLowPSeedDeMTriggerInfoMerger ]
 
 	tprLowPSeedDeMTiming1      : [ tprLowPSeedDeMEventPrescale, tprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
@@ -1838,7 +1838,7 @@ TrkFilters : {
 	tprLowPSeedDePTiming0      : [ tprLowPSeedDePEventPrescale, tprLowPSeedDePSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTtimeClusterFinder, tprLowPSeedDePTCFilter, TThelixFinder, TTHelixMergerDeP, tprLowPSeedDePHSFilter, 
-				       TTKSFDeP, tprLowPSeedDePPrescale ]
+				       TTKSFDeP, tprLowPSeedDePTriggerInfoMerger ]
 
 	tprLowPSeedDePTiming1      : [ tprLowPSeedDePEventPrescale, tprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
@@ -1852,29 +1852,29 @@ TrkFilters : {
 	cprLowPSeedDeMTiming0      : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				       TTCalTimePeakFinder, cprLowPSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprLowPSeedDeMHSFilter,
-				       TTCalSeedFitDem, cprLowPSeedDeMPrescale ]
+				       TTCalSeedFitDem, cprLowPSeedDeMTriggerInfoMerger ]
 
 	cprLowPSeedDeMTiming1      : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
-				       TTCalTimePeakFinder, cprLowPSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprLowPSeedDeMPrescale ]
+				       TTCalTimePeakFinder, cprLowPSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM]
 	
 	cprLowPSeedDeMTiming2      : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
-				       TTCalTimePeakFinder, cprLowPSeedDeMPrescale ]
+				       TTCalTimePeakFinder]
 
 
 	cprLowPSeedDePTiming0      : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTCalTimePeakFinder, cprLowPSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprLowPSeedDePHSFilter, 
-				       TTCalSeedFitDep, cprLowPSeedDePPrescale ]
+				       TTCalSeedFitDep, cprLowPSeedDePTriggerInfoMerger ]
 
 	cprLowPSeedDePTiming1      : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				       TTCalTimePeakFinder, cprLowPSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprLowPSeedDePPrescale ]
+				       TTCalTimePeakFinder, cprLowPSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP ]
 	
 	cprLowPSeedDePTiming2      : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
-				       TTCalTimePeakFinder, cprLowPSeedDePPrescale ]
+				       TTCalTimePeakFinder ]
 
 
 	#kalman filter included

--- a/TrkFilters/fcl/prolog_trigger.fcl
+++ b/TrkFilters/fcl/prolog_trigger.fcl
@@ -1658,10 +1658,11 @@ TrkFilters : {
     # sequences for different trigger paths.  Early triggers are prescaled
     sequences : {
 	# #trkpatrec tracking
-	tprTimeClusterDeM    : [ tprTimeClusterDeMEventPrescale, tprTimeClusterDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	tprTimeClusterDeM    : [ tprTimeClusterDeMEventPrescale, tprTimeClusterDeMSDCountFilter, 
+				 @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprTimeClusterDeMTCFilter ]
-	tprTimeClusterDeP    : [ tprTimeClusterDePEventPrescale, tprTimeClusterDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	tprTimeClusterDeP    : [ tprTimeClusterDePEventPrescale, tprTimeClusterDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprTimeClusterDePTCFilter ]
 
@@ -1670,99 +1671,99 @@ TrkFilters : {
 	# tprHelixDeP          : [ tprDePHelixEventPrescale, tprDePHelixSDCountFilter, @sequence::CaloClusterTrigger.Reco, @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 	# 			 TTtimeClusterFinder, tprHelixDePTCFilter, TThelixFinder, TTHelixMergerDeP, tprHelixDePHSFilter  ]
 
-	tprSeedDeM           : [ tprSeedDeMEventPrescale, tprSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprSeedDeM           : [ tprSeedDeMEventPrescale, tprSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprSeedDeMHSFilter, TTKSFDeM, tprSeedDeMTSFilter ]
-	tprSeedDeP           : [ tprSeedDePEventPrescale, tprSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprSeedDeP           : [ tprSeedDePEventPrescale, tprSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprSeedDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprSeedDePHSFilter, TTKSFDeP, tprSeedDePTSFilter ]
 
-	tprLowPSeedDeM       : [ tprLowPSeedDeMEventPrescale, tprLowPSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprLowPSeedDeM       : [ tprLowPSeedDeMEventPrescale, tprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprLowPSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprLowPSeedDeMHSFilter, TTKSFDeM, tprLowPSeedDeMTSFilter ]
-	tprLowPSeedDeP       : [ tprLowPSeedDePEventPrescale, tprLowPSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprLowPSeedDeP       : [ tprLowPSeedDePEventPrescale, tprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprLowPSeedDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprLowPSeedDePHSFilter, TTKSFDeP, tprLowPSeedDePTSFilter ]
 
-	tprCosmicSeedDeM     : [ tprCosmicSeedDeMEventPrescale, tprCosmicSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprCosmicSeedDeM     : [ tprCosmicSeedDeMEventPrescale, tprCosmicSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprCosmicSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprCosmicSeedDeMHSFilter, TTKSFDeM, tprCosmicSeedDeMTSFilter ]
 	tprCosmicSeedDeP     : [ tprCosmicSeedDePEventPrescale, tprCosmicSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprCosmicSeedDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprCosmicSeedDePHSFilter, TTKSFDeP, tprCosmicSeedDePTSFilter ]
 
-	tprCosmicHelixDeM     : [ tprCosmicHelixDeMEventPrescale, tprCosmicHelixDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprCosmicHelixDeM     : [ tprCosmicHelixDeMEventPrescale, tprCosmicHelixDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprCosmicHelixDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprCosmicHelixDeMHSFilter ]
 	tprCosmicHelixDeP     : [ tprCosmicHelixDePEventPrescale, tprCosmicHelixDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprCosmicHelixDePTCFilter, TThelixFinder,TTHelixMergerDeP,  tprCosmicHelixDePHSFilter ]
 
-	tprCosmicHelixUeM     : [ tprCosmicHelixUeMEventPrescale, tprCosmicHelixUeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprCosmicHelixUeM     : [ tprCosmicHelixUeMEventPrescale, tprCosmicHelixUeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprCosmicHelixUeMTCFilter, TThelixFinder, TTHelixMergerUeM, tprCosmicHelixUeMHSFilter ]
-	tprCosmicHelixUeP     : [ tprCosmicHelixUePEventPrescale, tprCosmicHelixUePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprCosmicHelixUeP     : [ tprCosmicHelixUePEventPrescale, tprCosmicHelixUePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprCosmicHelixUePTCFilter, TThelixFinder,TTHelixMergerUeP,  tprCosmicHelixUePHSFilter ]
 
 
 	# sequences that use a collection of combohits filtered using the calorimeter cluster info 
-	tprSeedUCCDeM        : [ tprSeedUCCDeMEventPrescale, tprSeedUCCDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprSeedUCCDeM        : [ tprSeedUCCDeMEventPrescale, tprSeedUCCDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHitsUCC, 
 				 TTtimeClusterFinderUCC, tprSeedUCCDeMTCFilter, TThelixFinderUCC, TTHelixUCCMergerDeM, tprSeedUCCDeMHSFilter, TTKSFUCCDeM, tprSeedUCCDeMTSFilter ]
-	tprSeedUCCDeP        : [ tprSeedUCCDePEventPrescale, tprSeedUCCDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprSeedUCCDeP        : [ tprSeedUCCDePEventPrescale, tprSeedUCCDePSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHitsUCC, 
 				 TTtimeClusterFinderUCC, tprSeedUCCDePTCFilter, TThelixFinderUCC, TTHelixUCCMergerDeP, tprSeedUCCDePHSFilter, TTKSFUCCDeP, tprSeedUCCDePTSFilter ]
 
 	#   calibration with DIO-Michel form Inner Proton Absorber
-	tprHelixCalibIPADeM  : [ tprHelixCalibIPADeMEventPrescale, tprHelixCalibIPADeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprHelixCalibIPADeM  : [ tprHelixCalibIPADeMEventPrescale, tprHelixCalibIPADeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprHelixCalibIPADeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprHelixCalibIPADeMHSFilter  ]
 
 	#    beam monitoring using the e- from the DIO in the IPA
-	tprHelixIPADeM       : [ tprHelixIPADeMEventPrescale, tprHelixIPADeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprHelixIPADeM       : [ tprHelixIPADeMEventPrescale, tprHelixIPADeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprHelixIPADeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprHelixIPADeMHSFilter  ]
 	
 	#calo-seeded tracking
-	cprSeedDeM           : [ cprSeedDeMEventPrescale, cprSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprSeedDeM           : [ cprSeedDeMEventPrescale, cprSeedDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				 TTCalTimePeakFinder, cprSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprSeedDeMHSFilter,
 				 TTCalSeedFitDem, cprSeedDeMTSFilter ]
-	cprSeedDeP           : [ cprSeedDePEventPrescale, cprSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprSeedDeP           : [ cprSeedDePEventPrescale, cprSeedDePSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTCalTimePeakFinder, cprSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprSeedDePHSFilter, 
 				 TTCalSeedFitDep, cprSeedDePTSFilter ]
 
-	cprLowPSeedDeM       : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprLowPSeedDeM       : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				 TTCalTimePeakFinder, cprLowPSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprLowPSeedDeMHSFilter,
 				 TTCalSeedFitDem, cprLowPSeedDeMTSFilter ]
-	cprLowPSeedDeP       : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprLowPSeedDeP       : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTCalTimePeakFinder, cprLowPSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprLowPSeedDePHSFilter, 
 				 TTCalSeedFitDep, cprLowPSeedDePTSFilter ]
 
-	cprCosmicSeedDeM     : [ cprCosmicSeedDeMEventPrescale, cprCosmicSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprCosmicSeedDeM     : [ cprCosmicSeedDeMEventPrescale, cprCosmicSeedDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				 TTCalTimePeakFinder, cprCosmicSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprCosmicSeedDeMHSFilter,
 				 TTCalSeedFitDem, cprCosmicSeedDeMTSFilter ]
-	cprCosmicSeedDeP     : [ cprCosmicSeedDePEventPrescale, cprCosmicSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprCosmicSeedDeP     : [ cprCosmicSeedDePEventPrescale, cprCosmicSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTCalTimePeakFinder, cprCosmicSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprCosmicSeedDePHSFilter, 
 				 TTCalSeedFitDep, cprCosmicSeedDePTSFilter ]
-	cprCosmicHelixDeM     : [ cprCosmicHelixDeMEventPrescale, cprCosmicHelixDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprCosmicHelixDeM     : [ cprCosmicHelixDeMEventPrescale, cprCosmicHelixDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				 TTCalTimePeakFinder, cprCosmicHelixDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprCosmicHelixDeMHSFilter ]
-	cprCosmicHelixDeP     : [ cprCosmicHelixDePEventPrescale, cprCosmicHelixDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprCosmicHelixDeP     : [ cprCosmicHelixDePEventPrescale, cprCosmicHelixDePSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTCalTimePeakFinder, cprCosmicHelixDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprCosmicHelixDePHSFilter ]
 
-	cprSeedUCCDeM        : [ cprSeedUCCDeMEventPrescale, cprSeedUCCDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprSeedUCCDeM        : [ cprSeedUCCDeMEventPrescale, cprSeedUCCDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHitsUCC,
 				 TTCalTimePeakFinderUCC, cprSeedUCCDeMTCFilter, TTCalHelixFinderUCCDe, TTCalHelixUCCMergerDeM, cprSeedUCCDeMHSFilter,
 				 TTCalSeedFitUCCDem, cprSeedUCCDeMTSFilter ]
-	cprSeedUCCDeP        : [ cprSeedUCCDePEventPrescale, cprSeedUCCDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprSeedUCCDeP        : [ cprSeedUCCDePEventPrescale, cprSeedUCCDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHitsUCC, 
 				 TTCalTimePeakFinderUCC, cprSeedUCCDePTCFilter, TTCalHelixFinderUCCDe, TTCalHelixUCCMergerDeP, cprSeedUCCDePHSFilter, 
 				 TTCalSeedFitUCCDep, cprSeedUCCDePTSFilter ]
@@ -1776,108 +1777,108 @@ TrkFilters : {
 
 
 	# sequences for doing timing tests
-	tprSeedDeMTiming0   : [ tprSeedDeMEventPrescale, tprSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprSeedDeMTiming0   : [ tprSeedDeMEventPrescale, tprSeedDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprSeedDeMHSFilter, TTKSFDeM ]
-	tprSeedDeMTiming1   : [ tprSeedDeMEventPrescale, tprSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprSeedDeMTiming1   : [ tprSeedDeMEventPrescale, tprSeedDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM ]
-	tprSeedDeMTiming2   : [ tprSeedDeMEventPrescale, tprSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprSeedDeMTiming2   : [ tprSeedDeMEventPrescale, tprSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder ]
 
-	tprSeedDePTiming0   : [ tprSeedDePEventPrescale, tprSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprSeedDePTiming0   : [ tprSeedDePEventPrescale, tprSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprSeedDePTCFilter, TThelixFinder, TTHelixMergerDeP, tprSeedDePHSFilter, TTKSFDeP ]
-	tprSeedDePTiming1   : [ tprSeedDePEventPrescale, tprSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprSeedDePTiming1   : [ tprSeedDePEventPrescale, tprSeedDePSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder, tprSeedDePTCFilter, TThelixFinder, TTHelixMergerDeP ]
 	tprSeedDePTiming2   : [ tprSeedDePEventPrescale, tprSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
 				 @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				 TTtimeClusterFinder ]
 
-	cprSeedDeMTiming0   : [ cprSeedDeMEventPrescale, cprSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprSeedDeMTiming0   : [ cprSeedDeMEventPrescale, cprSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				@sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				TTCalTimePeakFinder, cprSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprSeedDeMHSFilter,
 				TTCalSeedFitDem ]
-	cprSeedDeMTiming1   : [ cprSeedDeMEventPrescale, cprSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprSeedDeMTiming1   : [ cprSeedDeMEventPrescale, cprSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				@sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				TTCalTimePeakFinder, cprSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM ]
 	cprSeedDeMTiming2   : [ cprSeedDeMEventPrescale, cprSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
 				@sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				TTCalTimePeakFinder ]
 
-	cprSeedDePTiming0   : [ cprSeedDePEventPrescale, cprSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprSeedDePTiming0   : [ cprSeedDePEventPrescale, cprSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				@sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				TTCalTimePeakFinder, cprSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprSeedDePHSFilter, 
 				TTCalSeedFitDep ]
-	cprSeedDePTiming1   : [ cprSeedDePEventPrescale, cprSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprSeedDePTiming1   : [ cprSeedDePEventPrescale, cprSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				@sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				TTCalTimePeakFinder, cprSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP ]
-	cprSeedDePTiming2   : [ cprSeedDePEventPrescale, cprSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprSeedDePTiming2   : [ cprSeedDePEventPrescale, cprSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				@sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				TTCalTimePeakFinder ]
 
 
 
-	tprLowPSeedDeMTiming0      : [ tprLowPSeedDeMEventPrescale, tprLowPSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprLowPSeedDeMTiming0      : [ tprLowPSeedDeMEventPrescale, tprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTtimeClusterFinder, tprLowPSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprLowPSeedDeMHSFilter, 
 				       TTKSFDeM, tprLowPSeedDeMPrescale ]
 
-	tprLowPSeedDeMTiming1      : [ tprLowPSeedDeMEventPrescale, tprLowPSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprLowPSeedDeMTiming1      : [ tprLowPSeedDeMEventPrescale, tprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTtimeClusterFinder, tprLowPSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprLowPSeedDeMPrescale ]
 	
-	tprLowPSeedDeMTiming2      : [ tprLowPSeedDeMEventPrescale, tprLowPSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprLowPSeedDeMTiming2      : [ tprLowPSeedDeMEventPrescale, tprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTtimeClusterFinder, tprLowPSeedDeMPrescale ]
 
 
-	tprLowPSeedDePTiming0      : [ tprLowPSeedDePEventPrescale, tprLowPSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprLowPSeedDePTiming0      : [ tprLowPSeedDePEventPrescale, tprLowPSeedDePSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco, 
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTtimeClusterFinder, tprLowPSeedDePTCFilter, TThelixFinder, TTHelixMergerDeP, tprLowPSeedDePHSFilter, 
 				       TTKSFDeP, tprLowPSeedDePPrescale ]
 
-	tprLowPSeedDePTiming1      : [ tprLowPSeedDePEventPrescale, tprLowPSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprLowPSeedDePTiming1      : [ tprLowPSeedDePEventPrescale, tprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTtimeClusterFinder, tprLowPSeedDePTCFilter, TThelixFinder, TTHelixMergerDeP, tprLowPSeedDePPrescale ]
 	
-	tprLowPSeedDePTiming2      : [ tprLowPSeedDePEventPrescale, tprLowPSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco, 
+	tprLowPSeedDePTiming2      : [ tprLowPSeedDePEventPrescale, tprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco, 
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTtimeClusterFinder, tprLowPSeedDePPrescale ]
 
 
-	cprLowPSeedDeMTiming0      : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprLowPSeedDeMTiming0      : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				       TTCalTimePeakFinder, cprLowPSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprLowPSeedDeMHSFilter,
 				       TTCalSeedFitDem, cprLowPSeedDeMPrescale ]
 
-	cprLowPSeedDeMTiming1      : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprLowPSeedDeMTiming1      : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				       TTCalTimePeakFinder, cprLowPSeedDeMTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprLowPSeedDeMPrescale ]
 	
-	cprLowPSeedDeMTiming2      : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprLowPSeedDeMTiming2      : [ cprLowPSeedDeMEventPrescale, cprLowPSeedDeMSDCountFilter,  @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
 				       TTCalTimePeakFinder, cprLowPSeedDeMPrescale ]
 
 
-	cprLowPSeedDePTiming0      : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprLowPSeedDePTiming0      : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTCalTimePeakFinder, cprLowPSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprLowPSeedDePHSFilter, 
 				       TTCalSeedFitDep, cprLowPSeedDePPrescale ]
 
-	cprLowPSeedDePTiming1      : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprLowPSeedDePTiming1      : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTCalTimePeakFinder, cprLowPSeedDePTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeP, cprLowPSeedDePPrescale ]
 	
-	cprLowPSeedDePTiming2      : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloClusterTrigger.Reco,
+	cprLowPSeedDePTiming2      : [ cprLowPSeedDePEventPrescale, cprLowPSeedDePSDCountFilter, @sequence::CaloHitRecoTrigger.prepareHits,  @sequence::CaloClusterTrigger.Reco,
 				       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 				       TTCalTimePeakFinder, cprLowPSeedDePPrescale ]
 
 
 	#kalman filter included
-	tprKalDeM  : [ @sequence::CaloClusterTrigger.Reco,
+	tprKalDeM  : [ @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
 		       @sequence::TrkHitRecoTrigger.sequences.TTprepareHits, 
 		       TTtimeClusterFinder, tprSeedDeMTCFilter, TThelixFinder, TTHelixMergerDeM, tprSeedDeMHSFilter, 
 		       TTKSFDeM, tprSeedDeMTSFilter, TTKFFDeM, tprSeedDeMKFFilter ]


### PR DESCRIPTION
added a temporary fix for allowing to run the trigger sequences w/o errors. Another PR will be needed to implement in the proper way the algorithm we currently use in the Online recon sequence.