### PR TITLE
Used  AntiLeakRegistry for rotation matrices and nullptr for identity rotations

### DIFF
--- a/Mu2eG4/src/constructDS.cc
+++ b/Mu2eG4/src/constructDS.cc
@@ -188,28 +188,28 @@ namespace mu2e {
       G4ThreeVector dsFrontPosition( dsP.x(), dsP.y(), dsFrontZ0);
 
       nestTubs( "DSFront",
-		dsFrontParams,
-		dsCryoMaterial,
-		0,
-		dsFrontPosition-_hallOriginInMu2e,
-		parent,
-		0,
-		G4Color::Blue(),
-		"ds"
-		);
+                dsFrontParams,
+                dsCryoMaterial,
+                0,
+                dsFrontPosition-_hallOriginInMu2e,
+                parent,
+                0,
+                G4Color::Blue(),
+                "ds"
+                );
     } else {
       double interconnectRIn  = _config.getDouble("ds.interconnect.rIn");
       double interconnectROut = _config.getDouble("ds.interconnect.rOut");
       nestTubs( "TSDSInterConnect",
-		TubsParams(interconnectRIn, interconnectROut, interconnectHL-smallOffset),
-		dsCryoMaterial,
-		0,
-		dsP-_hallOriginInMu2e-CLHEP::Hep3Vector(0.,0.,ds->halfLength()+interconnectHL+smallOffset),
-		parent,
-		0,
-		G4Color::Blue(),
-		"ds"
-		);
+                TubsParams(interconnectRIn, interconnectROut, interconnectHL-smallOffset),
+                dsCryoMaterial,
+                0,
+                dsP-_hallOriginInMu2e-CLHEP::Hep3Vector(0.,0.,ds->halfLength()+interconnectHL+smallOffset),
+                parent,
+                0,
+                G4Color::Blue(),
+                "ds"
+                );
     }
 
     // DS thermal shield
@@ -585,19 +585,19 @@ namespace mu2e {
                       ( "NorthRailDS3", ds->lengthRail3()/2.0*CLHEP::mm,
                        uRailOutline, vRailOutline,
                        findMaterialOrThrow(ds->RailMaterial()),
- 		       nRailRotat, ds->n3RailCenter(),
- 		       dsShieldParent, 0, isDSVisible,
- 		       G4Colour::Blue(), isDSSolid,
- 		       forceAuxEdgeVisible, placePV, doSurfaceCheck );
+                       nRailRotat, ds->n3RailCenter(),
+                       dsShieldParent, 0, isDSVisible,
+                       G4Colour::Blue(), isDSSolid,
+                       forceAuxEdgeVisible, placePV, doSurfaceCheck );
 
      VolumeInfo RailS3 = nestExtrudedSolid
                       ( "SouthRailDS3", ds->lengthRail3()/2.0*CLHEP::mm,
- 		       uRailOutline, vRailOutline,
- 		       findMaterialOrThrow(ds->RailMaterial()),
- 		       sRailRotat, ds->s3RailCenter(),
- 		       dsShieldParent, 0, isDSVisible,
- 		       G4Colour::Blue(), isDSSolid,
- 		       forceAuxEdgeVisible, placePV, doSurfaceCheck );
+                       uRailOutline, vRailOutline,
+                       findMaterialOrThrow(ds->RailMaterial()),
+                       sRailRotat, ds->s3RailCenter(),
+                       dsShieldParent, 0, isDSVisible,
+                       G4Colour::Blue(), isDSSolid,
+                       forceAuxEdgeVisible, placePV, doSurfaceCheck );
 
      // Now put bearing blocks on rails
      // D. No. Brown, Jan 2016
@@ -622,36 +622,36 @@ namespace mu2e {
        std::stringstream sstm;
        sstm << "BearingBlock_DS2_" << iB2+1;
        VolumeInfo BBlock2 = nestExtrudedSolid
-	 ( sstm.str().c_str(), lenBB2,
-	   uBBlockOutline, vBBlockOutline,
-	   findMaterialOrThrow(ds->BBlockMaterial()),
-	   BBRotat, BBCenters2[iB2] - DS2Offset,
-	   ds2VacInfo.logical,
-	   0, isDSVisible,
-	   G4Colour::Blue(), isDSSolid,
-	   forceAuxEdgeVisible, placePV, doSurfaceCheck );
+         ( sstm.str().c_str(), lenBB2,
+           uBBlockOutline, vBBlockOutline,
+           findMaterialOrThrow(ds->BBlockMaterial()),
+           BBRotat, BBCenters2[iB2] - DS2Offset,
+           ds2VacInfo.logical,
+           0, isDSVisible,
+           G4Colour::Blue(), isDSSolid,
+           forceAuxEdgeVisible, placePV, doSurfaceCheck );
        // Now add Couplers
        if (iB2 < nB2 - 2 && (cScheme == 0 || (cScheme == 1 && BBCenters2[iB2].x() > 0.0) || (cScheme == 2 && BBCenters2[iB2].x() < 0) ) ) {
-	 coupleCounter++;
-	 std::stringstream couplerName;
-	 couplerName << "Coupler_DS2_" << coupleCounter;
-	 double lenCoupler = BBCenters2[iB2+2].z() - BBCenters2[iB2].z()
-	   - 2.*lenBB2 - 0.2; // The 0.2 is to avoid accidental overlaps.
-	 // The 2.* is because lenBB2 is actually halfLength
-	 CLHEP::Hep3Vector cenCoupler( (BBCenters2[iB2] + BBCenters2[iB2+2] )*0.5 + CLHEP::Hep3Vector(0.0,yCoupler,0.0));
-	 std::vector<double> halfDims = { widCoupler/2.0,
-					  hCoupler/2.0,
-					  lenCoupler/2.0 };
-	 nestBox( couplerName.str(),
-		  halfDims,
-		  findMaterialOrThrow(ds->BBlockMaterial()),
-		  BBRotat,
-		  cenCoupler - DS2Offset,
-		  ds2VacInfo.logical,
-		  0, isDSVisible,
-		  G4Colour::Blue(), isDSSolid,
-		  forceAuxEdgeVisible, placePV, doSurfaceCheck );
-		
+         coupleCounter++;
+         std::stringstream couplerName;
+         couplerName << "Coupler_DS2_" << coupleCounter;
+         double lenCoupler = BBCenters2[iB2+2].z() - BBCenters2[iB2].z()
+           - 2.*lenBB2 - 0.2; // The 0.2 is to avoid accidental overlaps.
+         // The 2.* is because lenBB2 is actually halfLength
+         CLHEP::Hep3Vector cenCoupler( (BBCenters2[iB2] + BBCenters2[iB2+2] )*0.5 + CLHEP::Hep3Vector(0.0,yCoupler,0.0));
+         std::vector<double> halfDims = { widCoupler/2.0,
+                                          hCoupler/2.0,
+                                          lenCoupler/2.0 };
+         nestBox( couplerName.str(),
+                  halfDims,
+                  findMaterialOrThrow(ds->BBlockMaterial()),
+                  BBRotat,
+                  cenCoupler - DS2Offset,
+                  ds2VacInfo.logical,
+                  0, isDSVisible,
+                  G4Colour::Blue(), isDSSolid,
+                  forceAuxEdgeVisible, placePV, doSurfaceCheck );
+
        } // end of if for adding coupler if not last bearing block
      }
 
@@ -663,35 +663,35 @@ namespace mu2e {
        sstm << "BearingBlock_DS3_" << iB3+1;
 
        VolumeInfo BBlock3 = nestExtrudedSolid
-	 ( sstm.str().c_str(), lenBB3,
-	   uBBlockOutline, vBBlockOutline,
-	   findMaterialOrThrow(ds->BBlockMaterial()),
-	   BBRotat, BBCenters3[iB3],
-	   dsShieldParent, 0, isDSVisible,
-	   G4Colour::Blue(), isDSSolid,
-	   forceAuxEdgeVisible, placePV, doSurfaceCheck );
+         ( sstm.str().c_str(), lenBB3,
+           uBBlockOutline, vBBlockOutline,
+           findMaterialOrThrow(ds->BBlockMaterial()),
+           BBRotat, BBCenters3[iB3],
+           dsShieldParent, 0, isDSVisible,
+           G4Colour::Blue(), isDSSolid,
+           forceAuxEdgeVisible, placePV, doSurfaceCheck );
        // Now add Couplers
        if (iB3 < nB3 - 2 && (cScheme == 0 || (cScheme == 1 && BBCenters3[iB3].x() > 0.0) || (cScheme == 2 && BBCenters3[iB3].x() < 0) ) ) {
-	 coupleCounter++;
-	 std::stringstream couplerName;
-	 couplerName << "Coupler_DS3_" << coupleCounter;
-	 double lenCoupler = BBCenters3[iB3+2].z() - BBCenters3[iB3].z()
-	   - 2.*lenBB3 - 0.2; // The 0.2 is to avoid accidental overlaps.
-	 // The 2.* is because lenBB3 is actually halfLength
-	 CLHEP::Hep3Vector cenCoupler( (BBCenters3[iB3] + BBCenters3[iB3+2] )*0.5 + CLHEP::Hep3Vector(0.0,yCoupler,0.0));
-	 std::vector<double> halfDims = { widCoupler/2.0,
-					  hCoupler/2.0,
-					  lenCoupler/2.0 };
-	 nestBox( couplerName.str(),
-		  halfDims,
-		  findMaterialOrThrow(ds->BBlockMaterial()),
-		  BBRotat,
-		  cenCoupler,
-		  dsShieldParent,
-		  0, isDSVisible,
-		  G4Colour::Blue(), isDSSolid,
-		  forceAuxEdgeVisible, placePV, doSurfaceCheck );
-		
+         coupleCounter++;
+         std::stringstream couplerName;
+         couplerName << "Coupler_DS3_" << coupleCounter;
+         double lenCoupler = BBCenters3[iB3+2].z() - BBCenters3[iB3].z()
+           - 2.*lenBB3 - 0.2; // The 0.2 is to avoid accidental overlaps.
+         // The 2.* is because lenBB3 is actually halfLength
+         CLHEP::Hep3Vector cenCoupler( (BBCenters3[iB3] + BBCenters3[iB3+2] )*0.5 + CLHEP::Hep3Vector(0.0,yCoupler,0.0));
+         std::vector<double> halfDims = { widCoupler/2.0,
+                                          hCoupler/2.0,
+                                          lenCoupler/2.0 };
+         nestBox( couplerName.str(),
+                  halfDims,
+                  findMaterialOrThrow(ds->BBlockMaterial()),
+                  BBRotat,
+                  cenCoupler,
+                  dsShieldParent,
+                  0, isDSVisible,
+                  G4Colour::Blue(), isDSSolid,
+                  forceAuxEdgeVisible, placePV, doSurfaceCheck );
+
        } // end of if for adding coupler if not last bearing block
 
 
@@ -704,13 +704,13 @@ namespace mu2e {
        std::vector<double> uOutlineMBSS = ds->uOutlineMBSS();
        std::vector<double> vOutlineMBSS = ds->vOutlineMBSS();
        VolumeInfo MBSS = nestExtrudedSolid
-	 ( "MBSSphericalSupport", ds->lengthMBSS()/2.0*CLHEP::mm,
-	   uOutlineMBSS, vOutlineMBSS,
-	   findMaterialOrThrow(ds->MBSSmaterial()),
-	   0, ds->MBSSlocation(),
-	   dsShieldParent, 0, isDSVisible,
-	   G4Colour::Blue(), isDSSolid,
-	   forceAuxEdgeVisible, placePV, doSurfaceCheck );
+         ( "MBSSphericalSupport", ds->lengthMBSS()/2.0*CLHEP::mm,
+           uOutlineMBSS, vOutlineMBSS,
+           findMaterialOrThrow(ds->MBSSmaterial()),
+           0, ds->MBSSlocation(),
+           dsShieldParent, 0, isDSVisible,
+           G4Colour::Blue(), isDSSolid,
+           forceAuxEdgeVisible, placePV, doSurfaceCheck );
      }  // end of if ( ds->hasMBSS() )
 
      // End of MBS spherical shielding, begin cable runs for Cal and Tracker
@@ -935,29 +935,29 @@ namespace mu2e {
          }
 
        } // end of if ( CableRunVersion > 1 )
-       
+
        //Add cabling outside IFB and add panels representing cables exiting IFB Seal
        if ( ds->cableRunVersion() > 2 ) {
-	 //Defining the outter circular arc for the calorimeter cabling
-	 TubsParams  calIFBCableRun1Params ( ds->calR1CableRunIFB(),
-					     ds->calR2CableRunIFB(),
-					     ds->zHLCableRunIFB(),
-					     ds->calPhi0CableRunIFB()*CLHEP::degree,
-					     ds->calDPhiCableRunIFB()*CLHEP::degree);
+         //Defining the outter circular arc for the calorimeter cabling
+         TubsParams  calIFBCableRun1Params ( ds->calR1CableRunIFB(),
+                                             ds->calR2CableRunIFB(),
+                                             ds->zHLCableRunIFB(),
+                                             ds->calPhi0CableRunIFB()*CLHEP::degree,
+                                             ds->calDPhiCableRunIFB()*CLHEP::degree);
 
-	 CLHEP::Hep3Vector calIFBCableRunLoc( 0.0, 0.0, ds->zCCableRunIFB() );
-	 
-	 VolumeInfo icrTmp1 = nestTubs( "CalIFBCableRun1",
-					calIFBCableRun1Params,
-					findMaterialOrThrow(ds->materialCalCableRunIFB()),
-					0,
-					calIFBCableRunLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-					// dsShieldParent,
-					parent, // hall air since outside detector
-					0,
-					G4Color::Magenta(),
-					"ds"
-					);
+         CLHEP::Hep3Vector calIFBCableRunLoc( 0.0, 0.0, ds->zCCableRunIFB() );
+
+         VolumeInfo icrTmp1 = nestTubs( "CalIFBCableRun1",
+                                        calIFBCableRun1Params,
+                                        findMaterialOrThrow(ds->materialCalCableRunIFB()),
+                                        0,
+                                        calIFBCableRunLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                        // dsShieldParent,
+                                        parent, // hall air since outside detector
+                                        0,
+                                        G4Color::Magenta(),
+                                        "ds"
+                                        );
          // "Fibre Core"
          placeTubeCore ( "CalIFBCableRunCore1",
                          ds->rCableRunCalCoreFract(),
@@ -968,30 +968,30 @@ namespace mu2e {
                          icrTmp1,
                          calIFBCableRun1Params,
                          // "ds",
-			 "ds",
+                         "ds",
                          _config,
-			 1
+                         1
                          );
-				       
-				       
-	 TubsParams  calIFBCableRun2Params ( ds->calR1CableRunIFB(),
-					     ds->calR2CableRunIFB(),
-					     ds->zHLCableRunIFB(),
-					     (180.0 - ds->calPhi0CableRunIFB()
-					      - ds->calDPhiCableRunIFB())*CLHEP::degree,
-					     ds->calDPhiCableRunIFB()*CLHEP::degree);
 
-	 VolumeInfo icrTmp2 = nestTubs( "CalIFBCableRun2",
-					calIFBCableRun2Params,
-					findMaterialOrThrow(ds->materialCalCableRunIFB()),
-					0,
-					calIFBCableRunLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-					// dsShieldParent,
-					parent,
-					0,
-					G4Color::Magenta(),
-					"ds"
-					);
+
+         TubsParams  calIFBCableRun2Params ( ds->calR1CableRunIFB(),
+                                             ds->calR2CableRunIFB(),
+                                             ds->zHLCableRunIFB(),
+                                             (180.0 - ds->calPhi0CableRunIFB()
+                                              - ds->calDPhiCableRunIFB())*CLHEP::degree,
+                                             ds->calDPhiCableRunIFB()*CLHEP::degree);
+
+         VolumeInfo icrTmp2 = nestTubs( "CalIFBCableRun2",
+                                        calIFBCableRun2Params,
+                                        findMaterialOrThrow(ds->materialCalCableRunIFB()),
+                                        0,
+                                        calIFBCableRunLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                        // dsShieldParent,
+                                        parent,
+                                        0,
+                                        G4Color::Magenta(),
+                                        "ds"
+                                        );
 
          // "Fibre Core"
          placeTubeCore ( "CalIFBCableRunCore2",
@@ -1003,149 +1003,149 @@ namespace mu2e {
                          icrTmp2,
                          calIFBCableRun2Params,
                          // "ds",
-			 "ds",
+                         "ds",
                          _config,
-			 1
+                         1
                          );
 
-	 //Add radial components of calorimeter outside cabling
-	 CLHEP::HepRotation * turn = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	 turn->rotateZ(-ds->calPhiECableRunIFB()*CLHEP::degree);
-	 //add a buffer so box doesn't go beyond the radius of the track cable ring
-	 double rend0  = ds->calR2CableRunIFB();
-	 double boxwidth = ds->calEndWCableRunIFB();
-	 double deltar = sqrt(rend0*rend0 - boxwidth*boxwidth/4.);
-	 double calIFBCableRunEnd[] = { (deltar - ds->calREndCableRunIFB())/2.,
-					boxwidth/2.,
-					ds->zHLCableRunIFB()};
-	 CLHEP::Hep3Vector calIFBCableRunEndLoc1( (deltar + ds->calREndCableRunIFB())/2.,
-						 0.0, ds->zCCableRunIFB() );
+         //Add radial components of calorimeter outside cabling
+         CLHEP::HepRotation * turn = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+         turn->rotateZ(-ds->calPhiECableRunIFB()*CLHEP::degree);
+         //add a buffer so box doesn't go beyond the radius of the track cable ring
+         double rend0  = ds->calR2CableRunIFB();
+         double boxwidth = ds->calEndWCableRunIFB();
+         double deltar = sqrt(rend0*rend0 - boxwidth*boxwidth/4.);
+         double calIFBCableRunEnd[] = { (deltar - ds->calREndCableRunIFB())/2.,
+                                        boxwidth/2.,
+                                        ds->zHLCableRunIFB()};
+         CLHEP::Hep3Vector calIFBCableRunEndLoc1( (deltar + ds->calREndCableRunIFB())/2.,
+                                                 0.0, ds->zCCableRunIFB() );
 
-	 calIFBCableRunEndLoc1.rotateZ(ds->calPhiECableRunIFB()*CLHEP::degree);
+         calIFBCableRunEndLoc1.rotateZ(ds->calPhiECableRunIFB()*CLHEP::degree);
 
-	 VolumeInfo iceTmp1 = nestBox( "CalIFBCableRunEnd1",
-				       calIFBCableRunEnd,
-				       findMaterialOrThrow(ds->materialCalCableRunIFB()),
-				       turn,
-				       calIFBCableRunEndLoc1+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-				       // dsShieldParent,
-				       parent,
-				       0,
-				       G4Color::Magenta(),
-				       // "ds"
-				       "ds"
-				       );
-	 double calIFBCableRunEndCore[] = { calIFBCableRunEnd[0],
-					    calIFBCableRunEnd[1]*ds->rdCableRunCalCoreFract(),
-					    calIFBCableRunEnd[2]*ds->dPhiCableRunCalCoreFract()};
+         VolumeInfo iceTmp1 = nestBox( "CalIFBCableRunEnd1",
+                                       calIFBCableRunEnd,
+                                       findMaterialOrThrow(ds->materialCalCableRunIFB()),
+                                       turn,
+                                       calIFBCableRunEndLoc1+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                       // dsShieldParent,
+                                       parent,
+                                       0,
+                                       G4Color::Magenta(),
+                                       // "ds"
+                                       "ds"
+                                       );
+         double calIFBCableRunEndCore[] = { calIFBCableRunEnd[0],
+                                            calIFBCableRunEnd[1]*ds->rdCableRunCalCoreFract(),
+                                            calIFBCableRunEnd[2]*ds->dPhiCableRunCalCoreFract()};
 
-	 VolumeInfo icecTmp1 = nestBox( "CalIFBCableRunEndCore1",
-					calIFBCableRunEndCore,
-					findMaterialOrThrow(ds->materialCableRunCalCore()),
-					nullptr,
-					CLHEP::Hep3Vector(),
-					iceTmp1,
-					0,
-					G4Color::Yellow(),
-					// "ds"
-					"ds"
-					);
+         VolumeInfo icecTmp1 = nestBox( "CalIFBCableRunEndCore1",
+                                        calIFBCableRunEndCore,
+                                        findMaterialOrThrow(ds->materialCableRunCalCore()),
+                                        nullptr,
+                                        CLHEP::Hep3Vector(),
+                                        iceTmp1,
+                                        0,
+                                        G4Color::Yellow(),
+                                        // "ds"
+                                        "ds"
+                                        );
 
-	 CLHEP::HepRotation * turn2 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	 turn2->rotateZ((ds->calPhiECableRunIFB()-180.)*CLHEP::degree);
+         CLHEP::HepRotation * turn2 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+         turn2->rotateZ((ds->calPhiECableRunIFB()-180.)*CLHEP::degree);
 
-	 CLHEP::Hep3Vector calIFBCableRunEndLoc2( (deltar + ds->calREndCableRunIFB())/2.,
-						 0.0, ds->zCCableRunIFB() );
+         CLHEP::Hep3Vector calIFBCableRunEndLoc2( (deltar + ds->calREndCableRunIFB())/2.,
+                                                 0.0, ds->zCCableRunIFB() );
 
-	 calIFBCableRunEndLoc2.rotateZ((180.-ds->calPhiECableRunIFB())*CLHEP::degree);
+         calIFBCableRunEndLoc2.rotateZ((180.-ds->calPhiECableRunIFB())*CLHEP::degree);
 
-	 VolumeInfo iceTmp2 = nestBox( "CalIFBCableRunEnd2",
-				       calIFBCableRunEnd,
-				       findMaterialOrThrow(ds->materialCalCableRunIFB()),
-				       turn2,
-				       calIFBCableRunEndLoc2+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-				       // dsShieldParent,
-				       parent,
-				       0,
-				       G4Color::Magenta(),
-				       // "ds"
-				       "ds"
-				       );
+         VolumeInfo iceTmp2 = nestBox( "CalIFBCableRunEnd2",
+                                       calIFBCableRunEnd,
+                                       findMaterialOrThrow(ds->materialCalCableRunIFB()),
+                                       turn2,
+                                       calIFBCableRunEndLoc2+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                       // dsShieldParent,
+                                       parent,
+                                       0,
+                                       G4Color::Magenta(),
+                                       // "ds"
+                                       "ds"
+                                       );
 
-	 VolumeInfo icecTmp2 = nestBox( "CalIFBCableRunEndCore2",
-					calIFBCableRunEndCore,
-					findMaterialOrThrow(ds->materialCableRunCalCore()),
-					nullptr,
-					CLHEP::Hep3Vector(),
-					iceTmp2,
-					0,
-					G4Color::Yellow(),
-					// "ds"
-					"ds"
-					);
+         VolumeInfo icecTmp2 = nestBox( "CalIFBCableRunEndCore2",
+                                        calIFBCableRunEndCore,
+                                        findMaterialOrThrow(ds->materialCableRunCalCore()),
+                                        nullptr,
+                                        CLHEP::Hep3Vector(),
+                                        iceTmp2,
+                                        0,
+                                        G4Color::Yellow(),
+                                        // "ds"
+                                        "ds"
+                                        );
 
-	 //Cabling at the bottom of the IFB cabling
-	 double r_bot_ifb     = ds->trkR2CableRunIFB() + 1.; //use bottom of tracker cabling + 1 mm
+         //Cabling at the bottom of the IFB cabling
+         double r_bot_ifb     = ds->trkR2CableRunIFB() + 1.; //use bottom of tracker cabling + 1 mm
 
-	 // double boxwidth = ds->calEndWCableRunIFB();
-	 double calIFBCableRunBot[] = { boxwidth/2., //use same box dimensions
-					ds->calBLCableRunIFB()/2., //length of the piece
-					ds->zHLCableRunIFB()}; //same width in z as the rest
-	 CLHEP::Hep3Vector calIFBCableRunBotLoc1( ds->calBCXCableRunIFB(), 
-						 -r_bot_ifb-calIFBCableRunBot[1], ds->zCCableRunIFB() );
-
-
-	 VolumeInfo icbTmp1 = nestBox( "CalIFBCableRunBottom1",
-				       calIFBCableRunBot,
-				       findMaterialOrThrow(ds->materialCalCableRunIFB()),
-				       nullptr,
-				       calIFBCableRunBotLoc1+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-				       parent,
-				       0,
-				       G4Color::Magenta(),
-				       "ds"
-				       );
-
-	 double calIFBCableRunBotCore[] = { calIFBCableRunBot[0]*ds->dPhiCableRunCalCoreFract(),
-					    calIFBCableRunBot[1],
-					    calIFBCableRunBot[2]*ds->rdCableRunCalCoreFract()};
-
-	 VolumeInfo icbcTmp1 = nestBox( "CalIFBCableRunBottomCore1",
-					calIFBCableRunBotCore,
-					findMaterialOrThrow(ds->materialCableRunCalCore()),
-					nullptr,
-					CLHEP::Hep3Vector(),
-					icbTmp1,
-					0,
-					G4Color::Yellow(),
-					"ds"
-					);
-
-	 CLHEP::Hep3Vector calIFBCableRunBotLoc2(-ds->calBCXCableRunIFB(), 
-						 -r_bot_ifb-calIFBCableRunBot[1], ds->zCCableRunIFB() );
+         // double boxwidth = ds->calEndWCableRunIFB();
+         double calIFBCableRunBot[] = { boxwidth/2., //use same box dimensions
+                                        ds->calBLCableRunIFB()/2., //length of the piece
+                                        ds->zHLCableRunIFB()}; //same width in z as the rest
+         CLHEP::Hep3Vector calIFBCableRunBotLoc1( ds->calBCXCableRunIFB(),
+                                                 -r_bot_ifb-calIFBCableRunBot[1], ds->zCCableRunIFB() );
 
 
-	 VolumeInfo icbTmp2 = nestBox( "CalIFBCableRunBottom2",
-				       calIFBCableRunBot,
-				       findMaterialOrThrow(ds->materialCalCableRunIFB()),
-				       nullptr,
-				       calIFBCableRunBotLoc2+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-				       parent,
-				       0,
-				       G4Color::Magenta(),
-				       "ds"
-				       );
+         VolumeInfo icbTmp1 = nestBox( "CalIFBCableRunBottom1",
+                                       calIFBCableRunBot,
+                                       findMaterialOrThrow(ds->materialCalCableRunIFB()),
+                                       nullptr,
+                                       calIFBCableRunBotLoc1+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                       parent,
+                                       0,
+                                       G4Color::Magenta(),
+                                       "ds"
+                                       );
 
-	 VolumeInfo icbcTmp2 = nestBox( "CalIFBCableRunBottomCore2",
-					calIFBCableRunBotCore,
-					findMaterialOrThrow(ds->materialCableRunCalCore()),
-					nullptr,
-					CLHEP::Hep3Vector(),
-					icbTmp2,
-					0,
-					G4Color::Yellow(),
-					"ds"
-					);
+         double calIFBCableRunBotCore[] = { calIFBCableRunBot[0]*ds->dPhiCableRunCalCoreFract(),
+                                            calIFBCableRunBot[1],
+                                            calIFBCableRunBot[2]*ds->rdCableRunCalCoreFract()};
+
+         VolumeInfo icbcTmp1 = nestBox( "CalIFBCableRunBottomCore1",
+                                        calIFBCableRunBotCore,
+                                        findMaterialOrThrow(ds->materialCableRunCalCore()),
+                                        nullptr,
+                                        CLHEP::Hep3Vector(),
+                                        icbTmp1,
+                                        0,
+                                        G4Color::Yellow(),
+                                        "ds"
+                                        );
+
+         CLHEP::Hep3Vector calIFBCableRunBotLoc2(-ds->calBCXCableRunIFB(),
+                                                 -r_bot_ifb-calIFBCableRunBot[1], ds->zCCableRunIFB() );
+
+
+         VolumeInfo icbTmp2 = nestBox( "CalIFBCableRunBottom2",
+                                       calIFBCableRunBot,
+                                       findMaterialOrThrow(ds->materialCalCableRunIFB()),
+                                       nullptr,
+                                       calIFBCableRunBotLoc2+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                       parent,
+                                       0,
+                                       G4Color::Magenta(),
+                                       "ds"
+                                       );
+
+         VolumeInfo icbcTmp2 = nestBox( "CalIFBCableRunBottomCore2",
+                                        calIFBCableRunBotCore,
+                                        findMaterialOrThrow(ds->materialCableRunCalCore()),
+                                        nullptr,
+                                        CLHEP::Hep3Vector(),
+                                        icbTmp2,
+                                        0,
+                                        G4Color::Yellow(),
+                                        "ds"
+                                        );
 
 
 
@@ -1187,19 +1187,19 @@ namespace mu2e {
                          calIFBCableExit1Params,
                          "ds",
                          _config,
-			 0
+                         0
                          );
 
-	 VolumeInfo icpTmp2 = nestTubs( "CalIFBCablePanelPOut1",
-					calIFBCableExit1Params,
-					findMaterialOrThrow(ds->calPMatCableRunIFB()),
-					0,
-					calIFBCablePOutLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-					parent,
-					0,
-					G4Color::Magenta(),
-					"ds"
-					);
+         VolumeInfo icpTmp2 = nestTubs( "CalIFBCablePanelPOut1",
+                                        calIFBCableExit1Params,
+                                        findMaterialOrThrow(ds->calPMatCableRunIFB()),
+                                        0,
+                                        calIFBCablePOutLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                        parent,
+                                        0,
+                                        G4Color::Magenta(),
+                                        "ds"
+                                        );
          // "Fibre Core"
          placeTubeCore ( "CalIFBCablePanelOutCore1",
                          ds->rCableRunCalCoreFract(),
@@ -1234,18 +1234,18 @@ namespace mu2e {
                          calIFBCableExit2Params,
                          "ds",
                          _config,
-			 0
+                         0
                          );
-	 VolumeInfo icpTmp4 = nestTubs( "CalIFBCablePanelPOut2",
-					calIFBCableExit2Params,
-					findMaterialOrThrow(ds->calPMatCableRunIFB()),
-					0,
-					calIFBCablePOutLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-					parent,
-					0,
-					G4Color::Magenta(),
-					"ds"
-					);
+         VolumeInfo icpTmp4 = nestTubs( "CalIFBCablePanelPOut2",
+                                        calIFBCableExit2Params,
+                                        findMaterialOrThrow(ds->calPMatCableRunIFB()),
+                                        0,
+                                        calIFBCablePOutLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                        parent,
+                                        0,
+                                        G4Color::Magenta(),
+                                        "ds"
+                                        );
          // "Fibre Core"
          placeTubeCore ( "CalIFBCablePanelOutCore2",
                          ds->rCableRunCalCoreFract(),
@@ -1257,27 +1257,27 @@ namespace mu2e {
                          calIFBCableExit2Params,
                          "ds",
                          _config,
-			 0
+                         0
                          );
 
-	 //Define circular arcs for Tracker cabling exiting DS
-	 TubsParams  trkIFBCableRun1Params ( ds->trkR1CableRunIFB(),
-					     ds->trkR2CableRunIFB(),
-					     ds->zHLCableRunIFB(),
-					     ds->trkPhi0CableRunIFB()*CLHEP::degree,
-					     ds->trkDPhiCableRunIFB()*CLHEP::degree);
+         //Define circular arcs for Tracker cabling exiting DS
+         TubsParams  trkIFBCableRun1Params ( ds->trkR1CableRunIFB(),
+                                             ds->trkR2CableRunIFB(),
+                                             ds->zHLCableRunIFB(),
+                                             ds->trkPhi0CableRunIFB()*CLHEP::degree,
+                                             ds->trkDPhiCableRunIFB()*CLHEP::degree);
 
-	 
-	 VolumeInfo icrTmp3 = nestTubs( "TrkIFBCableRun1",
-					trkIFBCableRun1Params,
-					findMaterialOrThrow(ds->materialTrkCableRunIFB()),
-					0,
-					calIFBCableRunLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-					parent,
-					0,
-					G4Color::Magenta(),
-					"ds"
-					);
+
+         VolumeInfo icrTmp3 = nestTubs( "TrkIFBCableRun1",
+                                        trkIFBCableRun1Params,
+                                        findMaterialOrThrow(ds->materialTrkCableRunIFB()),
+                                        0,
+                                        calIFBCableRunLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                        parent,
+                                        0,
+                                        G4Color::Magenta(),
+                                        "ds"
+                                        );
 
          // "Fibre Core"
          placeTubeCore ( "TrkIFBCableRunCore1",
@@ -1290,27 +1290,27 @@ namespace mu2e {
                          trkIFBCableRun1Params,
                          "ds",
                          _config,
-			 1
+                         1
                          );
 
-	 TubsParams  trkIFBCableRun2Params ( ds->trkR1CableRunIFB(),
-					     ds->trkR2CableRunIFB(),
-					     ds->zHLCableRunIFB(),
-					     (180.0 - ds->trkPhi0CableRunIFB()
-					      - ds->trkDPhiCableRunIFB())*CLHEP::degree,
-					     ds->trkDPhiCableRunIFB()*CLHEP::degree);
+         TubsParams  trkIFBCableRun2Params ( ds->trkR1CableRunIFB(),
+                                             ds->trkR2CableRunIFB(),
+                                             ds->zHLCableRunIFB(),
+                                             (180.0 - ds->trkPhi0CableRunIFB()
+                                              - ds->trkDPhiCableRunIFB())*CLHEP::degree,
+                                             ds->trkDPhiCableRunIFB()*CLHEP::degree);
 
-	 VolumeInfo icrTmp4 = nestTubs( "TrkIFBCableRun2",
-					trkIFBCableRun2Params,
-					findMaterialOrThrow(ds->materialTrkCableRunIFB()),
-					0,
-					calIFBCableRunLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-					parent,
-					0,
-					G4Color::Magenta(),
-					"ds"
-					);
-	 
+         VolumeInfo icrTmp4 = nestTubs( "TrkIFBCableRun2",
+                                        trkIFBCableRun2Params,
+                                        findMaterialOrThrow(ds->materialTrkCableRunIFB()),
+                                        0,
+                                        calIFBCableRunLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                        parent,
+                                        0,
+                                        G4Color::Magenta(),
+                                        "ds"
+                                        );
+
          // "Fibre Core"
          placeTubeCore ( "TrkIFBCableRunCore2",
                          ds->rCableRunTrkCoreFract(),
@@ -1322,136 +1322,136 @@ namespace mu2e {
                          trkIFBCableRun2Params,
                          "ds",
                          _config,
-			 1
+                         1
                          );
 
-	 //Define radial components of Tracker cabling exiting DS
-	 CLHEP::HepRotation * turn3 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	 turn3->rotateZ(-ds->trkPhiECableRunIFB()*CLHEP::degree);
+         //Define radial components of Tracker cabling exiting DS
+         CLHEP::HepRotation * turn3 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+         turn3->rotateZ(-ds->trkPhiECableRunIFB()*CLHEP::degree);
 
-	 double trkIFBCableRunEnd[] = { 0.,
-					ds->trkEndWCableRunIFB()/2.,
-					ds->zHLCableRunIFB()};
-	 //use width and radius of cable runs to find x length to not intesect
-	 trkIFBCableRunEnd[0] = sqrt(pow(ds->calR1CableRunIFB(),2)-pow(trkIFBCableRunEnd[1],2)) - 5.;
-	 //half length is half the distance between initial R and intersect point
-	 trkIFBCableRunEnd[0] =  (trkIFBCableRunEnd[0] - ds->trkREndCableRunIFB())/2.;
-	 if(trkIFBCableRunEnd[0] < 0.) 	 trkIFBCableRunEnd[0] = 0.;
+         double trkIFBCableRunEnd[] = { 0.,
+                                        ds->trkEndWCableRunIFB()/2.,
+                                        ds->zHLCableRunIFB()};
+         //use width and radius of cable runs to find x length to not intesect
+         trkIFBCableRunEnd[0] = sqrt(pow(ds->calR1CableRunIFB(),2)-pow(trkIFBCableRunEnd[1],2)) - 5.;
+         //half length is half the distance between initial R and intersect point
+         trkIFBCableRunEnd[0] =  (trkIFBCableRunEnd[0] - ds->trkREndCableRunIFB())/2.;
+         if(trkIFBCableRunEnd[0] < 0.)   trkIFBCableRunEnd[0] = 0.;
 
-	 CLHEP::Hep3Vector trkIFBCableRunEndLoc1( ds->trkREndCableRunIFB() + trkIFBCableRunEnd[0],
-						 0.0, ds->zCCableRunIFB() );
-	 trkIFBCableRunEndLoc1.rotateZ(ds->trkPhiECableRunIFB()*CLHEP::degree);
+         CLHEP::Hep3Vector trkIFBCableRunEndLoc1( ds->trkREndCableRunIFB() + trkIFBCableRunEnd[0],
+                                                 0.0, ds->zCCableRunIFB() );
+         trkIFBCableRunEndLoc1.rotateZ(ds->trkPhiECableRunIFB()*CLHEP::degree);
 
-	 VolumeInfo iceTmp3 = nestBox( "TrkIFBCableRunEnd1",
-				       trkIFBCableRunEnd,
-				       findMaterialOrThrow(ds->materialTrkCableRunIFB()),
-				       turn3,
-				       trkIFBCableRunEndLoc1+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-				       parent,
-				       0,
-				       G4Color::Magenta(),
-				       "ds"
-				       );
-	 double trkIFBCableRunEndCore[] = { trkIFBCableRunEnd[0],
-					    trkIFBCableRunEnd[1]*ds->rdCableRunTrkCoreFract(),
-					    trkIFBCableRunEnd[2]*ds->dPhiCableRunTrkCoreFract()};
+         VolumeInfo iceTmp3 = nestBox( "TrkIFBCableRunEnd1",
+                                       trkIFBCableRunEnd,
+                                       findMaterialOrThrow(ds->materialTrkCableRunIFB()),
+                                       turn3,
+                                       trkIFBCableRunEndLoc1+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                       parent,
+                                       0,
+                                       G4Color::Magenta(),
+                                       "ds"
+                                       );
+         double trkIFBCableRunEndCore[] = { trkIFBCableRunEnd[0],
+                                            trkIFBCableRunEnd[1]*ds->rdCableRunTrkCoreFract(),
+                                            trkIFBCableRunEnd[2]*ds->dPhiCableRunTrkCoreFract()};
 
-	 VolumeInfo icecTmp3 = nestBox( "TrkIFBCableRunEndCore1",
-					trkIFBCableRunEndCore,
-					findMaterialOrThrow(ds->materialCableRunTrkCore()),
-					nullptr,
-					CLHEP::Hep3Vector(),
-					iceTmp3,
-					0,
-					G4Color::Yellow(),
-					"ds"
-					);
+         VolumeInfo icecTmp3 = nestBox( "TrkIFBCableRunEndCore1",
+                                        trkIFBCableRunEndCore,
+                                        findMaterialOrThrow(ds->materialCableRunTrkCore()),
+                                        nullptr,
+                                        CLHEP::Hep3Vector(),
+                                        iceTmp3,
+                                        0,
+                                        G4Color::Yellow(),
+                                        "ds"
+                                        );
 
-	 CLHEP::HepRotation * turn4 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	 turn4->rotateZ((ds->trkPhiECableRunIFB()-180.)*CLHEP::degree);
+         CLHEP::HepRotation * turn4 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+         turn4->rotateZ((ds->trkPhiECableRunIFB()-180.)*CLHEP::degree);
 
-	 CLHEP::Hep3Vector trkIFBCableRunEndLoc2( ds->trkREndCableRunIFB() + trkIFBCableRunEnd[0],
-						 0.0, ds->zCCableRunIFB() );
-	 trkIFBCableRunEndLoc2.rotateZ((180.-ds->trkPhiECableRunIFB())*CLHEP::degree);
+         CLHEP::Hep3Vector trkIFBCableRunEndLoc2( ds->trkREndCableRunIFB() + trkIFBCableRunEnd[0],
+                                                 0.0, ds->zCCableRunIFB() );
+         trkIFBCableRunEndLoc2.rotateZ((180.-ds->trkPhiECableRunIFB())*CLHEP::degree);
 
-	 VolumeInfo iceTmp4 = nestBox( "TrkIFBCableRunEnd2",
-				       trkIFBCableRunEnd,
-				       findMaterialOrThrow(ds->materialTrkCableRunIFB()),
-				       turn4,
-				       trkIFBCableRunEndLoc2+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-				       parent,
-				       0,
-				       G4Color::Magenta(),
-				       "ds"
-				       );
-	 VolumeInfo icecTmp4 = nestBox( "TrkIFBCableRunEndCore2",
-					trkIFBCableRunEndCore,
-					findMaterialOrThrow(ds->materialCableRunTrkCore()),
-					nullptr,
-					CLHEP::Hep3Vector(),
-					iceTmp4,
-					0,
-					G4Color::Yellow(),
-					"ds"
-					);
+         VolumeInfo iceTmp4 = nestBox( "TrkIFBCableRunEnd2",
+                                       trkIFBCableRunEnd,
+                                       findMaterialOrThrow(ds->materialTrkCableRunIFB()),
+                                       turn4,
+                                       trkIFBCableRunEndLoc2+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                       parent,
+                                       0,
+                                       G4Color::Magenta(),
+                                       "ds"
+                                       );
+         VolumeInfo icecTmp4 = nestBox( "TrkIFBCableRunEndCore2",
+                                        trkIFBCableRunEndCore,
+                                        findMaterialOrThrow(ds->materialCableRunTrkCore()),
+                                        nullptr,
+                                        CLHEP::Hep3Vector(),
+                                        iceTmp4,
+                                        0,
+                                        G4Color::Yellow(),
+                                        "ds"
+                                        );
 
 
-	 //Cabling at the bottom of the IFB cabling
-	 double trkIFBCableRunBot[] = { ds->trkEndWCableRunIFB()/2., //use same box dimensions
-					ds->trkBLCableRunIFB()/2., //length of the piece
-					ds->zHLCableRunIFB()}; //same width in z as the rest
-	 CLHEP::Hep3Vector trkIFBCableRunBotLoc1( ds->trkBCXCableRunIFB(), 
-						 -r_bot_ifb-trkIFBCableRunBot[1], ds->zCCableRunIFB() );
-	 VolumeInfo icbTmp3 = nestBox( "TrkIFBCableRunBottom1",
-				       trkIFBCableRunBot,
-				       findMaterialOrThrow(ds->materialTrkCableRunIFB()),
-				       nullptr,
-				       trkIFBCableRunBotLoc1+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-				       parent,
-				       0,
-				       G4Color::Magenta(),
-				       "ds"
-				       );
+         //Cabling at the bottom of the IFB cabling
+         double trkIFBCableRunBot[] = { ds->trkEndWCableRunIFB()/2., //use same box dimensions
+                                        ds->trkBLCableRunIFB()/2., //length of the piece
+                                        ds->zHLCableRunIFB()}; //same width in z as the rest
+         CLHEP::Hep3Vector trkIFBCableRunBotLoc1( ds->trkBCXCableRunIFB(),
+                                                 -r_bot_ifb-trkIFBCableRunBot[1], ds->zCCableRunIFB() );
+         VolumeInfo icbTmp3 = nestBox( "TrkIFBCableRunBottom1",
+                                       trkIFBCableRunBot,
+                                       findMaterialOrThrow(ds->materialTrkCableRunIFB()),
+                                       nullptr,
+                                       trkIFBCableRunBotLoc1+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                       parent,
+                                       0,
+                                       G4Color::Magenta(),
+                                       "ds"
+                                       );
 
-	 double trkIFBCableRunBotCore[] = { trkIFBCableRunBot[0]*ds->dPhiCableRunTrkCoreFract(),
-					    trkIFBCableRunBot[1],
-					    trkIFBCableRunBot[2]*ds->rdCableRunTrkCoreFract()};
+         double trkIFBCableRunBotCore[] = { trkIFBCableRunBot[0]*ds->dPhiCableRunTrkCoreFract(),
+                                            trkIFBCableRunBot[1],
+                                            trkIFBCableRunBot[2]*ds->rdCableRunTrkCoreFract()};
 
-	 VolumeInfo icbcTmp3 = nestBox( "TrkIFBCableRunBottomCore1",
-					trkIFBCableRunBotCore,
-					findMaterialOrThrow(ds->materialCableRunTrkCore()),
-					nullptr,
-					CLHEP::Hep3Vector(),
-					icbTmp3,
-					0,
-					G4Color::Yellow(),
-					"ds"
-					);
+         VolumeInfo icbcTmp3 = nestBox( "TrkIFBCableRunBottomCore1",
+                                        trkIFBCableRunBotCore,
+                                        findMaterialOrThrow(ds->materialCableRunTrkCore()),
+                                        nullptr,
+                                        CLHEP::Hep3Vector(),
+                                        icbTmp3,
+                                        0,
+                                        G4Color::Yellow(),
+                                        "ds"
+                                        );
 
-	 CLHEP::Hep3Vector trkIFBCableRunBotLoc2(-ds->trkBCXCableRunIFB(), 
-						 -r_bot_ifb-trkIFBCableRunBot[1], ds->zCCableRunIFB() );
+         CLHEP::Hep3Vector trkIFBCableRunBotLoc2(-ds->trkBCXCableRunIFB(),
+                                                 -r_bot_ifb-trkIFBCableRunBot[1], ds->zCCableRunIFB() );
 
-	 VolumeInfo icbTmp4 = nestBox( "TrkIFBCableRunBottom2",
-				       trkIFBCableRunBot,
-				       findMaterialOrThrow(ds->materialTrkCableRunIFB()),
-				       nullptr,
-				       trkIFBCableRunBotLoc2+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-				       parent,
-				       0,
-				       G4Color::Magenta(),
-				       "ds"
-				       );
+         VolumeInfo icbTmp4 = nestBox( "TrkIFBCableRunBottom2",
+                                       trkIFBCableRunBot,
+                                       findMaterialOrThrow(ds->materialTrkCableRunIFB()),
+                                       nullptr,
+                                       trkIFBCableRunBotLoc2+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                       parent,
+                                       0,
+                                       G4Color::Magenta(),
+                                       "ds"
+                                       );
 
-	 VolumeInfo icbcTmp4 = nestBox( "TrkIFBCableRunBottomCore2",
-					trkIFBCableRunBotCore,
-					findMaterialOrThrow(ds->materialCableRunTrkCore()),
-					nullptr,
-					CLHEP::Hep3Vector(),
-					icbTmp4,
-					0,
-					G4Color::Yellow(),
-					"ds"
-					);
+         VolumeInfo icbcTmp4 = nestBox( "TrkIFBCableRunBottomCore2",
+                                        trkIFBCableRunBotCore,
+                                        findMaterialOrThrow(ds->materialCableRunTrkCore()),
+                                        nullptr,
+                                        CLHEP::Hep3Vector(),
+                                        icbTmp4,
+                                        0,
+                                        G4Color::Yellow(),
+                                        "ds"
+                                        );
 
 
          //Define panels on either side of exit of DS representing cables leaving for tracker
@@ -1492,19 +1492,19 @@ namespace mu2e {
                          trkIFBCableExit1Params,
                          "ds",
                          _config,
-			 0
+                         0
                          );
 
-	 VolumeInfo icpTmp6 = nestTubs( "TrkIFBCablePanelPOut1",
-					trkIFBCableExit1Params,
-					findMaterialOrThrow(ds->trkPMatCableRunIFB()),
-					0,
-					trkIFBCablePOutLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-					parent,
-					0,
-					G4Color::Magenta(),
-					"ds"
-					);
+         VolumeInfo icpTmp6 = nestTubs( "TrkIFBCablePanelPOut1",
+                                        trkIFBCableExit1Params,
+                                        findMaterialOrThrow(ds->trkPMatCableRunIFB()),
+                                        0,
+                                        trkIFBCablePOutLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                        parent,
+                                        0,
+                                        G4Color::Magenta(),
+                                        "ds"
+                                        );
 
          // "Fibre Core"
          placeTubeCore ( "TrkIFBCablePanelOutCore1",
@@ -1542,19 +1542,19 @@ namespace mu2e {
                          trkIFBCableExit2Params,
                          "ds",
                          _config,
-			 0
+                         0
                          );
 
-	 VolumeInfo icpTmp8 = nestTubs( "TrkIFBCablePanelPOut2",
-					trkIFBCableExit2Params,
-					findMaterialOrThrow(ds->trkPMatCableRunIFB()),
-					0,
-					trkIFBCablePOutLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
-					parent,
-					0,
-					G4Color::Magenta(),
-					"ds"
-					);
+         VolumeInfo icpTmp8 = nestTubs( "TrkIFBCablePanelPOut2",
+                                        trkIFBCableExit2Params,
+                                        findMaterialOrThrow(ds->trkPMatCableRunIFB()),
+                                        0,
+                                        trkIFBCablePOutLoc+dsShieldParent.centerInMu2e()-_hallOriginInMu2e,
+                                        parent,
+                                        0,
+                                        G4Color::Magenta(),
+                                        "ds"
+                                        );
 
          // "Fibre Core"
          placeTubeCore ( "TrkIFBCablePanelOutCore2",
@@ -1567,7 +1567,7 @@ namespace mu2e {
                          trkIFBCableExit2Params,
                          "ds",
                          _config,
-			 0
+                         0
                          );
 
 
@@ -1800,43 +1800,43 @@ namespace mu2e {
 
      if ( ds->hasServicePipes() ) {
        TubsParams pipeMomParms( 0.0,
-				ds->servicePipeROut(),
-				ds->servicePipeHalfLength());//default phi,dphi
+                                ds->servicePipeROut(),
+                                ds->servicePipeHalfLength());//default phi,dphi
        TubsParams pipeSelfParms(ds->servicePipeRIn(),
-				ds->servicePipeROut(),
-				ds->servicePipeHalfLength() );
+                                ds->servicePipeROut(),
+                                ds->servicePipeHalfLength() );
        std::vector<double>theXs = ds->servicePipeXCs();
        double theY = ds->servicePipeYC();
        double theZ = ds->servicePipeZC();
 
        for ( unsigned int iP = 0; iP < theXs.size(); iP++ ) {
-	 CLHEP::Hep3Vector pipeLoc(theXs[iP],theY, theZ);
-	 ostringstream pmName;
-	 pmName << "DSservicePipeMother" << iP+1;
-	 VolumeInfo DSPipeMother = nestTubs ( pmName.str(),
-					      pipeMomParms,
-					      findMaterialOrThrow(ds->servicePipeFillMat()),
-					      0,
-					      pipeLoc,
-					      dsShieldParent,
-					      0,
-					      G4Color::Magenta(),
-					      "ds"
-					      );
+         CLHEP::Hep3Vector pipeLoc(theXs[iP],theY, theZ);
+         ostringstream pmName;
+         pmName << "DSservicePipeMother" << iP+1;
+         VolumeInfo DSPipeMother = nestTubs ( pmName.str(),
+                                              pipeMomParms,
+                                              findMaterialOrThrow(ds->servicePipeFillMat()),
+                                              0,
+                                              pipeLoc,
+                                              dsShieldParent,
+                                              0,
+                                              G4Color::Magenta(),
+                                              "ds"
+                                              );
 
-	 // Now make it a real pipe
-	 ostringstream pName;
-	 pName << "DSservicePipe" << iP+1;
-	 nestTubs ( pName.str(),
-		    pipeSelfParms,
-		    findMaterialOrThrow(ds->servicePipeMaterial()),
-		    0,
-		    CLHEP::Hep3Vector(),
-		    DSPipeMother,
-		    0,
-		    G4Color::Magenta(),
-		    "ds"
-		    );
+         // Now make it a real pipe
+         ostringstream pName;
+         pName << "DSservicePipe" << iP+1;
+         nestTubs ( pName.str(),
+                    pipeSelfParms,
+                    findMaterialOrThrow(ds->servicePipeMaterial()),
+                    0,
+                    CLHEP::Hep3Vector(),
+                    DSPipeMother,
+                    0,
+                    G4Color::Magenta(),
+                    "ds"
+                    );
 
        } // End of loop over service pipes
      } // end of if ( ds->hasServicePipes() )
@@ -1855,7 +1855,7 @@ namespace mu2e {
                        const std::string &  lookupToken,
                        const SimpleConfig & config,
                        const int zNotPhi
-		       ) {
+                       ) {
 
     int const verbosityLevel = config.getInt("ds.verbosityLevel",0);
     TubsParams cableRunCoreParams =
@@ -1864,18 +1864,18 @@ namespace mu2e {
                               radiusDFract,
                               dPhiFraction,
                               verbosityLevel,
-			      zNotPhi);
+                              zNotPhi);
 
     VolumeInfo tempCore = nestTubs( name,
-				    cableRunCoreParams,
-				    findMaterialOrThrow(material),
-				    nullptr,
-				    CLHEP::Hep3Vector(),
-				    parent,
-				    0,
-				    color,
-				    lookupToken
-				    );
+                                    cableRunCoreParams,
+                                    findMaterialOrThrow(material),
+                                    nullptr,
+                                    CLHEP::Hep3Vector(),
+                                    parent,
+                                    0,
+                                    color,
+                                    lookupToken
+                                    );
     if (verbosityLevel > 0) {
       G4cout << __func__ << " parent params: " << parentParams << G4endl;
       G4cout << __func__ << " core   name:   " << name << G4endl;
@@ -1890,7 +1890,7 @@ namespace mu2e {
                                       double radiusDFract,
                                       double dPhiFraction,
                                       int verbosityLevel,
-				      const int zNotPhi) {
+                                      const int zNotPhi) {
 
 
     // calculating the core parameters based on the the parent tube
@@ -1931,38 +1931,38 @@ namespace mu2e {
 
       if ( corePhi0 < parentParams.phi0() ) {
 
-	throw cet::exception("GEOM") << __func__
-				     << " inconsitent cable core parameters: "
-				     << corePhi0
-				     << ", "
-				     << coreDeltaPhi
-				     << "\n";
+        throw cet::exception("GEOM") << __func__
+                                     << " inconsitent cable core parameters: "
+                                     << corePhi0
+                                     << ", "
+                                     << coreDeltaPhi
+                                     << "\n";
 
       }
       return TubsParams( coreInnerRadius,
-			 coreOuterRadius,
-			 parentParams.zHalfLength(),
-			 corePhi0,
-			 coreDeltaPhi );
+                         coreOuterRadius,
+                         parentParams.zHalfLength(),
+                         corePhi0,
+                         coreDeltaPhi );
 
     } else { //if an arc in a z plane, with dZ and dR fractions
       double coreZHalfExtent = parentParams.zHalfLength() * dPhiFraction;
 
       if ( dPhiFraction > 1. || dPhiFraction < 0. ) {
 
-	throw cet::exception("GEOM") << __func__
-				     << " inconsitent cable core parameters: "
-				     << coreZHalfExtent
-				     << ", "
-				     << dPhiFraction
-				     << "\n";
+        throw cet::exception("GEOM") << __func__
+                                     << " inconsitent cable core parameters: "
+                                     << coreZHalfExtent
+                                     << ", "
+                                     << dPhiFraction
+                                     << "\n";
 
       }
       return TubsParams( coreInnerRadius,
-			 coreOuterRadius,
-			 coreZHalfExtent,
-			 parentParams.phi0(),
-			 parentParams.phiTotal());
+                         coreOuterRadius,
+                         coreZHalfExtent,
+                         parentParams.phi0(),
+                         parentParams.phiTotal());
 
     }
   }

--- a/Mu2eG4/src/constructDS.cc
+++ b/Mu2eG4/src/constructDS.cc
@@ -72,6 +72,7 @@ namespace mu2e {
     const bool doSurfaceCheck      = geomOptions->doSurfaceCheck("ds");
     const bool placePV             = geomOptions->placePV("ds");
 
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
 
     // Fetch parent (hall) position
     G4ThreeVector _hallOriginInMu2e = parent.centerInMu2e();
@@ -556,8 +557,8 @@ namespace mu2e {
     std::vector<double> uRailOutline = ds->uOutlineRail();
     std::vector<double> vRailOutline = ds->vOutlineRail();
 
-    CLHEP::HepRotation* nRailRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
-    CLHEP::HepRotation* sRailRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+    CLHEP::HepRotation* nRailRotat = nullptr;
+    CLHEP::HepRotation* sRailRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
     sRailRotat->rotateY(180.0*CLHEP::degree);
 
     VolumeInfo RailN2 = nestExtrudedSolid
@@ -603,7 +604,7 @@ namespace mu2e {
      // First in DS2Vacuum region
      std::vector<double> uBBlockOutline = ds->uOutlineBBlock();
      std::vector<double> vBBlockOutline = ds->vOutlineBBlock();
-     CLHEP::HepRotation* BBRotat = new CLHEP::HepRotation( CLHEP::HepRotation::IDENTITY);
+     CLHEP::HepRotation* BBRotat = nullptr;
      double lenBB2 = ds->lengthBBlock2()/2.0*CLHEP::mm;
      double lenBB3 = ds->lengthBBlock3()/2.0*CLHEP::mm;
      std::vector<CLHEP::Hep3Vector> BBCenters2 = ds->BBlockCenters2();
@@ -1008,7 +1009,7 @@ namespace mu2e {
                          );
 
 	 //Add radial components of calorimeter outside cabling
-	 CLHEP::HepRotation * turn = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	 CLHEP::HepRotation * turn = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	 turn->rotateZ(-ds->calPhiECableRunIFB()*CLHEP::degree);
 	 //add a buffer so box doesn't go beyond the radius of the track cable ring
 	 double rend0  = ds->calR2CableRunIFB();
@@ -1050,7 +1051,7 @@ namespace mu2e {
 					"ds"
 					);
 
-	 CLHEP::HepRotation * turn2 = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	 CLHEP::HepRotation * turn2 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	 turn2->rotateZ((ds->calPhiECableRunIFB()-180.)*CLHEP::degree);
 
 	 CLHEP::Hep3Vector calIFBCableRunEndLoc2( (deltar + ds->calREndCableRunIFB())/2.,
@@ -1325,7 +1326,7 @@ namespace mu2e {
                          );
 
 	 //Define radial components of Tracker cabling exiting DS
-	 CLHEP::HepRotation * turn3 = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	 CLHEP::HepRotation * turn3 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	 turn3->rotateZ(-ds->trkPhiECableRunIFB()*CLHEP::degree);
 
 	 double trkIFBCableRunEnd[] = { 0.,
@@ -1366,7 +1367,7 @@ namespace mu2e {
 					"ds"
 					);
 
-	 CLHEP::HepRotation * turn4 = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	 CLHEP::HepRotation * turn4 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	 turn4->rotateZ((ds->trkPhiECableRunIFB()-180.)*CLHEP::degree);
 
 	 CLHEP::Hep3Vector trkIFBCableRunEndLoc2( ds->trkREndCableRunIFB() + trkIFBCableRunEnd[0],

--- a/Mu2eG4/src/constructExternalShielding.cc
+++ b/Mu2eG4/src/constructExternalShielding.cc
@@ -1,6 +1,6 @@
 // David Norvil Brown, University of Louisville, November 2014
 //
-// 
+//
 
 #include "Mu2eG4/inc/constructExternalShielding.hh"
 
@@ -68,15 +68,15 @@ namespace mu2e {
     geomOptions->loadEntry( config, "ExtShielUpstream",    "ExtShieldUpstream");
     geomOptions->loadEntry( config, "ExtShieldDownstream", "ExtShieldDownstream");
 
-    const bool isExtShieldUpstreamVisible   = geomOptions->isVisible("ExtShieldUpstream"); 
-    const bool isExtShieldUpstreamSolid     = geomOptions->isSolid("ExtShieldUpstream"); 
-    const bool isExtShieldDownstreamVisible = geomOptions->isVisible("ExtShieldDownstream"); 
-    const bool isExtShieldDownstreamSolid   = geomOptions->isSolid("ExtShieldDownstream"); 
-    const bool forceAuxEdgeVisible          = geomOptions->forceAuxEdgeVisible("ExtShield"); 
+    const bool isExtShieldUpstreamVisible   = geomOptions->isVisible("ExtShieldUpstream");
+    const bool isExtShieldUpstreamSolid     = geomOptions->isSolid("ExtShieldUpstream");
+    const bool isExtShieldDownstreamVisible = geomOptions->isVisible("ExtShieldDownstream");
+    const bool isExtShieldDownstreamSolid   = geomOptions->isSolid("ExtShieldDownstream");
+    const bool forceAuxEdgeVisible          = geomOptions->forceAuxEdgeVisible("ExtShield");
     const bool doSurfaceCheck               = geomOptions->doSurfaceCheck("ExtShield");
     const bool placePV                      = geomOptions->placePV("ExtShield");
 
-    
+
     //----------------------------------------------------------------
     // Upstream External Shielding Boxes <=====
     //----------------------------------------------------------------
@@ -93,34 +93,34 @@ namespace mu2e {
     for(int i = 0; i < nBox; i++)
     {
 
-	// combine the tolerances with the dimensions.
-	std::vector<double> lwhs  = dims[i];
-	std::vector<double> dlwhs = tols[i];
-	for ( unsigned int idim = 0; idim < lwhs.size(); idim++ ) {
-	  lwhs[idim] += dlwhs[idim]/2.0;
-	}
+        // combine the tolerances with the dimensions.
+        std::vector<double> lwhs  = dims[i];
+        std::vector<double> dlwhs = tols[i];
+        for ( unsigned int idim = 0; idim < lwhs.size(); idim++ ) {
+          lwhs[idim] += dlwhs[idim]/2.0;
+        }
 
-	//  Make the name of the box
-	std::ostringstream name;
-	name << "ExtShieldUpstreamBox_" << i+1 ;
+        //  Make the name of the box
+        std::ostringstream name;
+        name << "ExtShieldUpstreamBox_" << i+1 ;
 
-	// Make the needed rotation by parsing orientation
+        // Make the needed rotation by parsing orientation
         CLHEP::HepRotation* itsRotat= reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	std::string orientInit = orients[i];
+        std::string orientInit = orients[i];
 
-	OR->getRotationFromOrientation(*itsRotat, orientInit);
+        OR->getRotationFromOrientation(*itsRotat, orientInit);
 
-	// Build each box here
-	nestBox( name.str(), lwhs, findMaterialOrThrow(mats[i]),
-		 itsRotat, sites[i]-parent.centerInMu2e(),
-		 parent.logical,
-		 0,
-		 isExtShieldUpstreamVisible,
-		 G4Colour::Magenta(),
-		 isExtShieldUpstreamSolid,
-		 forceAuxEdgeVisible,
-		 placePV,
-		 doSurfaceCheck);
+        // Build each box here
+        nestBox( name.str(), lwhs, findMaterialOrThrow(mats[i]),
+                 itsRotat, sites[i]-parent.centerInMu2e(),
+                 parent.logical,
+                 0,
+                 isExtShieldUpstreamVisible,
+                 G4Colour::Magenta(),
+                 isExtShieldUpstreamSolid,
+                 forceAuxEdgeVisible,
+                 placePV,
+                 doSurfaceCheck);
     }
 
 
@@ -150,291 +150,291 @@ namespace mu2e {
 
     for(int i = 0; i < nBox; i++)
       {
-	// combine the tolerances with the outline dimensions.
-	std::vector<G4TwoVector> itsOutline;
-	std::vector<std::vector<double> > vertices = outlDS[i];
-	double du = tolsDS[i][0];
-	double dv = tolsDS[i][1];
-	double dw = tolsDS[i][2];
-	double hlen = lengDS[i];
-	double xCnt[vertices.size()];
-	double yCnt[vertices.size()];
-	double epsilon = 1.0e-4;
+        // combine the tolerances with the outline dimensions.
+        std::vector<G4TwoVector> itsOutline;
+        std::vector<std::vector<double> > vertices = outlDS[i];
+        double du = tolsDS[i][0];
+        double dv = tolsDS[i][1];
+        double dw = tolsDS[i][2];
+        double hlen = lengDS[i];
+        double xCnt[vertices.size()];
+        double yCnt[vertices.size()];
+        double epsilon = 1.0e-4;
 
-	for ( unsigned int idim = 0; idim < vertices.size(); idim++ ) {
-	  // Decide how to apply tolerances by looking where other vertices
-	  // lie relative to this vertex.
-	  xCnt[idim] = 0.0;
-	  yCnt[idim] = 0.0;
-	  bool Q1, Q2, Q3, Q4;  // The four quadrants on the Cartesian plane
-	  Q1 = Q2 = Q3 = Q4 = false;
-	  bool N, S, E, W;      // and the cardinal directions
-	  N = S = E = W = false;     
-	  for ( unsigned int j = 0; j < vertices.size(); j++ ) {
-	    if ( j != idim ) {
-	      // Here we figure out where other vertices are relative to
-	      // This vertex.
-	      double xDiff = vertices[j][0] - vertices[idim][0];
-	      double yDiff = vertices[j][1] - vertices[idim][1];
-	      if ( xDiff > epsilon ) { // Must be Q1 or Q4 or E
-		if ( yDiff > epsilon ) {
-		  Q1 = true;
-		} else if ( yDiff < -epsilon ) {
-		  Q4 = true;
-		} else { 
-		  E = true; 
-		}
-	      } else if ( xDiff < -epsilon ) { // Must be Q2 or Q3 or W
-		if ( yDiff > epsilon ) {
-		  Q2 = true;
-		} else if ( yDiff < -epsilon ) {
-		  Q3 = true;
-		} else { 
-		  W = true; 
-		}
-	      } else { // Must be North or South
-		if ( yDiff > epsilon ) {
-		  N = true;
-		} else if ( yDiff < epsilon ) {
-		  S = true;
-		} // There should never be an else case since I test for j!=idim	
-	      }
-	    } // endif j != idim
-	  } // end for loop over all other vertices
-	  // Now for idim, decide how to apply tols.
+        for ( unsigned int idim = 0; idim < vertices.size(); idim++ ) {
+          // Decide how to apply tolerances by looking where other vertices
+          // lie relative to this vertex.
+          xCnt[idim] = 0.0;
+          yCnt[idim] = 0.0;
+          bool Q1, Q2, Q3, Q4;  // The four quadrants on the Cartesian plane
+          Q1 = Q2 = Q3 = Q4 = false;
+          bool N, S, E, W;      // and the cardinal directions
+          N = S = E = W = false;
+          for ( unsigned int j = 0; j < vertices.size(); j++ ) {
+            if ( j != idim ) {
+              // Here we figure out where other vertices are relative to
+              // This vertex.
+              double xDiff = vertices[j][0] - vertices[idim][0];
+              double yDiff = vertices[j][1] - vertices[idim][1];
+              if ( xDiff > epsilon ) { // Must be Q1 or Q4 or E
+                if ( yDiff > epsilon ) {
+                  Q1 = true;
+                } else if ( yDiff < -epsilon ) {
+                  Q4 = true;
+                } else {
+                  E = true;
+                }
+              } else if ( xDiff < -epsilon ) { // Must be Q2 or Q3 or W
+                if ( yDiff > epsilon ) {
+                  Q2 = true;
+                } else if ( yDiff < -epsilon ) {
+                  Q3 = true;
+                } else {
+                  W = true;
+                }
+              } else { // Must be North or South
+                if ( yDiff > epsilon ) {
+                  N = true;
+                } else if ( yDiff < epsilon ) {
+                  S = true;
+                } // There should never be an else case since I test for j!=idim
+              }
+            } // endif j != idim
+          } // end for loop over all other vertices
+          // Now for idim, decide how to apply tols.
 
-	  if ( ( !Q1 && !Q4 && !E ) || ( Q2 && Q3 && W && !(Q1 && Q4 && E)) 
-	       || ( W && !E ) || ( N && E && !Q1 ) || (S && E && !Q4) ) {
-	    xCnt[idim] = 1.0;
-	  } else if ( ( !Q2 && !Q3 && !W ) 
-		      || ( Q1 && Q4 && E && !(Q2 && Q3 && W)) || ( E && !W )
-		      || ( N && W && !Q2 ) || ( S && W && !Q3 ) ) {
-	    xCnt[idim] = -1.0;
-	  }
-	  if ( ( !Q1 && !Q2 && !N ) || ( ((S && W) || (N && E)) && Q3 && !Q1 ) 
-	       || ( ((S && E) || (N && W)) && Q4 && !Q2) || ( S && !N ) ) {
-	    yCnt[idim] = 1.0;
-	  } else if ( ( !Q3 && !Q4 && !S ) // Along bottom edge 
-		      || ( ((S && W) || (N && E)) && Q1 && !Q3 ) // mid corner
-		      || ( ((S && E) || (N && W)) && Q2 && !Q4 ) // int corner
-		      || ( N && !S )) {
-	    yCnt[idim] = -1.0;
-	  }
-	  if ( fabs(xCnt[idim]) < epsilon ) { // Special vertex - check
-	    unsigned int neighbor1 = idim + 1;
-	    if ( idim == vertices.size() ) neighbor1 = 0;
-	    unsigned int neighbor2 = idim - 1;
-	    if ( idim == 0 ) neighbor2 = vertices.size() - 1;
-	    double xC = (vertices[neighbor1][0] + vertices[neighbor2][0])/2.0;
-	    if ( xC < vertices[idim][0] ) {
-	      xCnt[idim] = 1.0;
-	    } else if ( xC > vertices[idim][0] ) {
-	      xCnt[idim] = -1.0;
-	    }
-	  }
-	  if ( fabs(yCnt[idim]) < epsilon ) { // Special vertex - check
-	    unsigned int neighbor1 = idim + 1;
-	    if ( idim == vertices.size() ) neighbor1 = 0;
-	    unsigned int neighbor2 = idim - 1;
-	    if ( idim == 0 ) neighbor2 = vertices.size();
-	    double yC = (vertices[neighbor1][1] + vertices[neighbor2][1])/2.0;
-	    if ( yC < vertices[idim][1] ) {
-	      yCnt[idim] = 1.0;
-	    } else if ( yC > vertices[idim][1] ) {
-	      yCnt[idim] = -1.0;
-	    }
-	  }
+          if ( ( !Q1 && !Q4 && !E ) || ( Q2 && Q3 && W && !(Q1 && Q4 && E))
+               || ( W && !E ) || ( N && E && !Q1 ) || (S && E && !Q4) ) {
+            xCnt[idim] = 1.0;
+          } else if ( ( !Q2 && !Q3 && !W )
+                      || ( Q1 && Q4 && E && !(Q2 && Q3 && W)) || ( E && !W )
+                      || ( N && W && !Q2 ) || ( S && W && !Q3 ) ) {
+            xCnt[idim] = -1.0;
+          }
+          if ( ( !Q1 && !Q2 && !N ) || ( ((S && W) || (N && E)) && Q3 && !Q1 )
+               || ( ((S && E) || (N && W)) && Q4 && !Q2) || ( S && !N ) ) {
+            yCnt[idim] = 1.0;
+          } else if ( ( !Q3 && !Q4 && !S ) // Along bottom edge
+                      || ( ((S && W) || (N && E)) && Q1 && !Q3 ) // mid corner
+                      || ( ((S && E) || (N && W)) && Q2 && !Q4 ) // int corner
+                      || ( N && !S )) {
+            yCnt[idim] = -1.0;
+          }
+          if ( fabs(xCnt[idim]) < epsilon ) { // Special vertex - check
+            unsigned int neighbor1 = idim + 1;
+            if ( idim == vertices.size() ) neighbor1 = 0;
+            unsigned int neighbor2 = idim - 1;
+            if ( idim == 0 ) neighbor2 = vertices.size() - 1;
+            double xC = (vertices[neighbor1][0] + vertices[neighbor2][0])/2.0;
+            if ( xC < vertices[idim][0] ) {
+              xCnt[idim] = 1.0;
+            } else if ( xC > vertices[idim][0] ) {
+              xCnt[idim] = -1.0;
+            }
+          }
+          if ( fabs(yCnt[idim]) < epsilon ) { // Special vertex - check
+            unsigned int neighbor1 = idim + 1;
+            if ( idim == vertices.size() ) neighbor1 = 0;
+            unsigned int neighbor2 = idim - 1;
+            if ( idim == 0 ) neighbor2 = vertices.size();
+            double yC = (vertices[neighbor1][1] + vertices[neighbor2][1])/2.0;
+            if ( yC < vertices[idim][1] ) {
+              yCnt[idim] = 1.0;
+            } else if ( yC > vertices[idim][1] ) {
+              yCnt[idim] = -1.0;
+            }
+          }
 
-	} // loop over all vertices to find xCnt and yCnt
+        } // loop over all vertices to find xCnt and yCnt
 
-	for ( unsigned int idim = 0; idim < vertices.size(); idim++ ) {
-	  vertices[idim][0] += xCnt[idim] * du;
-	  vertices[idim][1] += yCnt[idim] * dv;
+        for ( unsigned int idim = 0; idim < vertices.size(); idim++ ) {
+          vertices[idim][0] += xCnt[idim] * du;
+          vertices[idim][1] += yCnt[idim] * dv;
 
-	  G4TwoVector vertex( vertices[idim][0], vertices[idim][1] );
-	  itsOutline.push_back(vertex);
-	} // modified all the vertices appropriately
-	hlen += dw;
+          G4TwoVector vertex( vertices[idim][0], vertices[idim][1] );
+          itsOutline.push_back(vertex);
+        } // modified all the vertices appropriately
+        hlen += dw;
 
-	//  Make the name of the box
-	std::ostringstream name;
-	name << "ExtShieldDownstreamBox_" << i+1 ;
+        //  Make the name of the box
+        std::ostringstream name;
+        name << "ExtShieldDownstreamBox_" << i+1 ;
 
-	// Make the needed rotation by parsing orientation
-	std::string orientDSInit = orientsDS[i];
+        // Make the needed rotation by parsing orientation
+        std::string orientDSInit = orientsDS[i];
 
-	CLHEP::HepRotation* itsDSRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	OR->getRotationFromOrientation( *itsDSRotat, orientDSInit );
+        CLHEP::HepRotation* itsDSRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+        OR->getRotationFromOrientation( *itsDSRotat, orientDSInit );
 
-	// ****************************************
-	// Now add holes and notches
-	// ***************************************
-	if ( nHolesDS[i] + nNotchesDS[i] > 0 ) {
+        // ****************************************
+        // Now add holes and notches
+        // ***************************************
+        if ( nHolesDS[i] + nNotchesDS[i] > 0 ) {
 
- 	  // This box has at least one window or notch.  
-	  // Each is implemented as a
-	  // G4SubtractionSolid to allow for another volume placement
-	  // through it.  First go ahead and make the extrusion for the block.
-	  std::ostringstream name1;
-	  name1 << "ExtShieldDownstreamBox_sub_" << i+1;
+          // This box has at least one window or notch.
+          // Each is implemented as a
+          // G4SubtractionSolid to allow for another volume placement
+          // through it.  First go ahead and make the extrusion for the block.
+          std::ostringstream name1;
+          name1 << "ExtShieldDownstreamBox_sub_" << i+1;
 
-	  G4ExtrudedSolid* block = new G4ExtrudedSolid( name1.str(),
-							itsOutline,
-							hlen,
-							G4TwoVector(0,0), 1.,
-							G4TwoVector(0,0), 1.);
-	  
-	  // Now create the volume for the block
-	  VolumeInfo extShieldVol(name.str(),
-				  sitesDS[i]-parent.centerInMu2e(),
-				  parent.centerInWorld);
+          G4ExtrudedSolid* block = new G4ExtrudedSolid( name1.str(),
+                                                        itsOutline,
+                                                        hlen,
+                                                        G4TwoVector(0,0), 1.,
+                                                        G4TwoVector(0,0), 1.);
 
-
-	  // Create a subtraction solid that will become the solid for the 
-	  // volume.
-
-	  G4SubtractionSolid* aSolid = 0;
-
-	  // Find the index of the first hole, for accessing info lists...
-	  int hID = holeIDDS[i];
-
-	  // Now loop over the holes and make them.
-	  for ( int jHole = 0; jHole < nHolesDS[i]; jHole++ ) {
-	    // Now make the window (AKA "Hole")
-	    name << "h" << jHole+1;
-	    //	    std::cout << __func__ << " making " << name.str() << std::endl;
-
-	    int thisHID = hID + jHole; // get pointer for right hole
-
-	    const TubsParams windparams(0.0,  //inner radius
-					holeRadDS[thisHID], // outer
-					holeLenDS[thisHID]  //obvious?
-					);
-
-	    std::ostringstream name2;
-	    name2 << "ExtShieldDownstreamBox" << i+1 << "hole" << jHole+1;
-
-	    G4Tubs* aWindTub = new G4Tubs( name2.str(), 
-					   windparams.data()[0], 
-					   windparams.data()[1], 
-					   windparams.data()[2]+2.,// to satisfy a G4SubtractionSolid feature
-					   windparams.data()[3], 
-					   windparams.data()[4]);
-	    
-	    CLHEP::HepRotation* windRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	    OR->getRotationFromOrientation( *windRotat, holeOrientsDS[hID] );
+          // Now create the volume for the block
+          VolumeInfo extShieldVol(name.str(),
+                                  sitesDS[i]-parent.centerInMu2e(),
+                                  parent.centerInWorld);
 
 
-	    if ( 0 == aSolid ) { 
-	      aSolid = new G4SubtractionSolid( extShieldVol.name,
-					       block,
-					       aWindTub,
-					       windRotat,
-					       holeLocDS[thisHID]);
-	    } else {
-	      G4SubtractionSolid * bSolid = new G4SubtractionSolid 
-		( extShieldVol.name,
-		  aSolid,
-		  aWindTub,
-		  windRotat,
-		  holeLocDS[thisHID]);
-	      aSolid = bSolid;
-	    }
-	  } // End of loop over holes. Now loop over notches.
+          // Create a subtraction solid that will become the solid for the
+          // volume.
+
+          G4SubtractionSolid* aSolid = 0;
+
+          // Find the index of the first hole, for accessing info lists...
+          int hID = holeIDDS[i];
+
+          // Now loop over the holes and make them.
+          for ( int jHole = 0; jHole < nHolesDS[i]; jHole++ ) {
+            // Now make the window (AKA "Hole")
+            name << "h" << jHole+1;
+            //      std::cout << __func__ << " making " << name.str() << std::endl;
+
+            int thisHID = hID + jHole; // get pointer for right hole
+
+            const TubsParams windparams(0.0,  //inner radius
+                                        holeRadDS[thisHID], // outer
+                                        holeLenDS[thisHID]  //obvious?
+                                        );
+
+            std::ostringstream name2;
+            name2 << "ExtShieldDownstreamBox" << i+1 << "hole" << jHole+1;
+
+            G4Tubs* aWindTub = new G4Tubs( name2.str(),
+                                           windparams.data()[0],
+                                           windparams.data()[1],
+                                           windparams.data()[2]+2.,// to satisfy a G4SubtractionSolid feature
+                                           windparams.data()[3],
+                                           windparams.data()[4]);
+
+            CLHEP::HepRotation* windRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+            OR->getRotationFromOrientation( *windRotat, holeOrientsDS[hID] );
 
 
-  	  // Find the index of the first notch, for accessing info lists...
-  	  int notchID = notchIDDS[i];
-
-	  for ( int jNotch = 0; jNotch < nNotchesDS[i]; jNotch++ ) {
-	    int thisNID = notchID + jNotch; //index for this notch
-
-	    // Put notch(es) into box now
-
-	    // Each notch is implemented as a
-	    // G4SubtractionSolid to allow for another volume placement
-	    // through it
-
-	    // Now make the notch 
-	    name << "n" << jNotch+1;
-
-	    ///	    std::cout << __func__ << " making " << name.str() << std::endl;
-
-
-	    // Get dimensions of this box
-	    std::vector<double>tempDims = notchDimDS[thisNID];
-
-	    std::ostringstream name2;
-	    name2 << "ExtShieldDownstreamBox" << i+1 << "Notch" << jNotch+1;
-
-	    G4Box* aNotchBox = new G4Box(  name2.str(), 
-					   tempDims[0],
-					   tempDims[1],
-					   tempDims[2]);
-
-	    CLHEP::HepRotation* notchRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+            if ( 0 == aSolid ) {
+              aSolid = new G4SubtractionSolid( extShieldVol.name,
+                                               block,
+                                               aWindTub,
+                                               windRotat,
+                                               holeLocDS[thisHID]);
+            } else {
+              G4SubtractionSolid * bSolid = new G4SubtractionSolid
+                ( extShieldVol.name,
+                  aSolid,
+                  aWindTub,
+                  windRotat,
+                  holeLocDS[thisHID]);
+              aSolid = bSolid;
+            }
+          } // End of loop over holes. Now loop over notches.
 
 
-	    if ( 0 == aSolid ) { 
-	      aSolid = new G4SubtractionSolid( extShieldVol.name,
-					       block,
-					       aNotchBox,
-					       notchRotat,
-					       notchLocDS[thisNID]);
-	    } else {
-	      G4SubtractionSolid * bSolid = new G4SubtractionSolid 
-		( extShieldVol.name,
-		  aSolid,
-		  aNotchBox,
-		  notchRotat,
-		  notchLocDS[thisNID]);
-	      aSolid = bSolid;
-	    }
-	  } // End of loop over notches
+          // Find the index of the first notch, for accessing info lists...
+          int notchID = notchIDDS[i];
 
-	  extShieldVol.solid = aSolid;
+          for ( int jNotch = 0; jNotch < nNotchesDS[i]; jNotch++ ) {
+            int thisNID = notchID + jNotch; //index for this notch
 
-	  finishNesting(extShieldVol,
-			findMaterialOrThrow(matsDS[i]),
-			itsDSRotat,
-			extShieldVol.centerInParent,
-			parent.logical,
-			0,
-			isExtShieldDownstreamVisible,
-			G4Colour::Magenta(),
-			isExtShieldDownstreamSolid,
-			forceAuxEdgeVisible,
-			placePV,
-			doSurfaceCheck);
-	} else {
+            // Put notch(es) into box now
 
-	  // Build each normal box here.  Normal means no holes or notches.
+            // Each notch is implemented as a
+            // G4SubtractionSolid to allow for another volume placement
+            // through it
 
-	  VolumeInfo extShieldVol(name.str(),
-				  sitesDS[i]-parent.centerInMu2e(),
-				  parent.centerInWorld);
+            // Now make the notch
+            name << "n" << jNotch+1;
 
-	  extShieldVol.solid = new G4ExtrudedSolid( extShieldVol.name,
-						    itsOutline,
-						    hlen,
-						    G4TwoVector(0,0), 1.,
-						    G4TwoVector(0,0), 1.);
+            ///     std::cout << __func__ << " making " << name.str() << std::endl;
 
 
-	  finishNesting(extShieldVol,
-			findMaterialOrThrow(matsDS[i]),
-			itsDSRotat,
-			extShieldVol.centerInParent,
-			parent.logical,
-			0,
-			isExtShieldDownstreamVisible,
-			G4Colour::Magenta(),
-			isExtShieldDownstreamSolid,
-			forceAuxEdgeVisible,
-			placePV,
-			doSurfaceCheck);
-	  
-	} // end of if...else...
+            // Get dimensions of this box
+            std::vector<double>tempDims = notchDimDS[thisNID];
+
+            std::ostringstream name2;
+            name2 << "ExtShieldDownstreamBox" << i+1 << "Notch" << jNotch+1;
+
+            G4Box* aNotchBox = new G4Box(  name2.str(),
+                                           tempDims[0],
+                                           tempDims[1],
+                                           tempDims[2]);
+
+            CLHEP::HepRotation* notchRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+
+
+            if ( 0 == aSolid ) {
+              aSolid = new G4SubtractionSolid( extShieldVol.name,
+                                               block,
+                                               aNotchBox,
+                                               notchRotat,
+                                               notchLocDS[thisNID]);
+            } else {
+              G4SubtractionSolid * bSolid = new G4SubtractionSolid
+                ( extShieldVol.name,
+                  aSolid,
+                  aNotchBox,
+                  notchRotat,
+                  notchLocDS[thisNID]);
+              aSolid = bSolid;
+            }
+          } // End of loop over notches
+
+          extShieldVol.solid = aSolid;
+
+          finishNesting(extShieldVol,
+                        findMaterialOrThrow(matsDS[i]),
+                        itsDSRotat,
+                        extShieldVol.centerInParent,
+                        parent.logical,
+                        0,
+                        isExtShieldDownstreamVisible,
+                        G4Colour::Magenta(),
+                        isExtShieldDownstreamSolid,
+                        forceAuxEdgeVisible,
+                        placePV,
+                        doSurfaceCheck);
+        } else {
+
+          // Build each normal box here.  Normal means no holes or notches.
+
+          VolumeInfo extShieldVol(name.str(),
+                                  sitesDS[i]-parent.centerInMu2e(),
+                                  parent.centerInWorld);
+
+          extShieldVol.solid = new G4ExtrudedSolid( extShieldVol.name,
+                                                    itsOutline,
+                                                    hlen,
+                                                    G4TwoVector(0,0), 1.,
+                                                    G4TwoVector(0,0), 1.);
+
+
+          finishNesting(extShieldVol,
+                        findMaterialOrThrow(matsDS[i]),
+                        itsDSRotat,
+                        extShieldVol.centerInParent,
+                        parent.logical,
+                        0,
+                        isExtShieldDownstreamVisible,
+                        G4Colour::Magenta(),
+                        isExtShieldDownstreamSolid,
+                        forceAuxEdgeVisible,
+                        placePV,
+                        doSurfaceCheck);
+
+        } // end of if...else...
 
       } // end of for loop over boxes
     // Do a bit of cleanup
@@ -445,4 +445,3 @@ namespace mu2e {
   } // end of constructExternalShielding fn
 
 } // namespace mu2e
-

--- a/Mu2eG4/src/constructExternalShielding.cc
+++ b/Mu2eG4/src/constructExternalShielding.cc
@@ -21,6 +21,7 @@
 #include "GeometryService/inc/WorldG4.hh"
 #include "Mu2eG4/inc/findMaterialOrThrow.hh"
 #include "Mu2eG4Helper/inc/VolumeInfo.hh"
+#include "Mu2eG4Helper/inc/Mu2eG4Helper.hh"
 #include "GeomPrimitives/inc/Tube.hh"
 #include "GeomPrimitives/inc/TubsParams.hh"
 #include "ConfigTools/inc/SimpleConfig.hh"
@@ -57,6 +58,7 @@ namespace mu2e {
     GeomHandle<ExtShieldUpstream> extshldUp;
     GeomHandle<ExtShieldDownstream> extshldDn;
 
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
     // Utility for converting orientations to rotations
     OrientationResolver* OR = new OrientationResolver();
 
@@ -103,7 +105,7 @@ namespace mu2e {
 	name << "ExtShieldUpstreamBox_" << i+1 ;
 
 	// Make the needed rotation by parsing orientation
-        CLHEP::HepRotation* itsRotat= new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+        CLHEP::HepRotation* itsRotat= reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	std::string orientInit = orients[i];
 
 	OR->getRotationFromOrientation(*itsRotat, orientInit);
@@ -261,7 +263,7 @@ namespace mu2e {
 	// Make the needed rotation by parsing orientation
 	std::string orientDSInit = orientsDS[i];
 
-	CLHEP::HepRotation* itsDSRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	CLHEP::HepRotation* itsDSRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	OR->getRotationFromOrientation( *itsDSRotat, orientDSInit );
 
 	// ****************************************
@@ -319,7 +321,7 @@ namespace mu2e {
 					   windparams.data()[3], 
 					   windparams.data()[4]);
 	    
-	    CLHEP::HepRotation* windRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	    CLHEP::HepRotation* windRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	    OR->getRotationFromOrientation( *windRotat, holeOrientsDS[hID] );
 
 
@@ -370,7 +372,7 @@ namespace mu2e {
 					   tempDims[1],
 					   tempDims[2]);
 
-	    CLHEP::HepRotation* notchRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	    CLHEP::HepRotation* notchRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 
 
 	    if ( 0 == aSolid ) { 

--- a/Mu2eG4/src/constructHall.cc
+++ b/Mu2eG4/src/constructHall.cc
@@ -17,6 +17,7 @@
 #include "Mu2eHallGeom/inc/Mu2eHall.hh"
 #include "Mu2eG4/inc/constructHall.hh"
 #include "Mu2eG4/inc/MaterialFinder.hh"
+#include "Mu2eG4Helper/inc/Mu2eG4Helper.hh"
 #include "Mu2eG4/inc/findMaterialOrThrow.hh"
 #include "Mu2eG4/inc/finishNesting.hh"
 #include "Mu2eG4/inc/nestBox.hh"
@@ -109,6 +110,8 @@ namespace mu2e {
     const bool forceAuxEdgeVisible = geoOptions->forceAuxEdgeVisible("HallAir");
     const bool placePV             = geoOptions->placePV("HallAir");
 
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
+
     OrientationResolver* OR = new OrientationResolver();
 
     // Loop over all volumes in the map
@@ -146,7 +149,7 @@ namespace mu2e {
           G4Box* notchBox = new G4Box( notchName.str(),
                                        halfDims[0],halfDims[1],halfDims[2]);
 
-          CLHEP::HepRotation* notchRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+          CLHEP::HepRotation* notchRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
           OR->getRotationFromOrientation( *notchRotat, tmpNotch.getOrient());
 
           if ( 0 == aSolid ) {
@@ -234,6 +237,8 @@ namespace mu2e {
     const bool forceAuxEdgeVisible = geoOptions->forceAuxEdgeVisible("HallAir");
     const bool placePV             = geoOptions->placePV("HallAir");
 
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
+
     OrientationResolver* OR = new OrientationResolver();
 
     // Loop over all volumes in the map
@@ -244,7 +249,7 @@ namespace mu2e {
 
       geoOptions->loadEntry( config, volume.getName(), volume.getName() );
       const CLHEP::HepRotation vRot = rot*volume.getRotation();
-      const G4RotationMatrix* vRotG4 = new G4RotationMatrix(vRot);
+      const G4RotationMatrix* vRotG4 = reg.add(G4RotationMatrix(vRot));
 
       if ( notchMgr.hasNotches( volName ) ) {
         // First do volumes with notches
@@ -273,7 +278,7 @@ namespace mu2e {
           G4Box* notchBox = new G4Box( notchName.str(),
                                        halfDims[0],halfDims[1],halfDims[2]);
 
-          CLHEP::HepRotation* notchRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+          CLHEP::HepRotation* notchRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
           OR->getRotationFromOrientation( *notchRotat, tmpNotch.getOrient());
 
           if ( 0 == aSolid ) {

--- a/Mu2eG4/src/constructHaymanRings.cc
+++ b/Mu2eG4/src/constructHaymanRings.cc
@@ -143,7 +143,7 @@ namespace mu2e {
 
     //
     // this extra Core word because in making a sensitive detector, the code sees "ProductionTarget" in
-    // "ProductionTarget*" and screws up.  Need something unique.  easier than fixing LV.name function 
+    // "ProductionTarget*" and screws up.  Need something unique.  easier than fixing LV.name function
     VolumeInfo prodTargetInfo   = nestTubs( "ProductionTargetCore",
                                             prodTargetParams,
                                             prodTargetMaterial,
@@ -174,24 +174,24 @@ namespace mu2e {
     CLHEP::Hep3Vector SupportRingFarTSOffset (+0., 0., +0.);
     CLHEP::Hep3Vector SupportRingNearTSOffset(+0., 0., +0.);
     VolumeInfo supportRingsFarTSInfo = nestTubs("SupportRingsFarTS",
-						supportRingsParams,
-						supportRingsMaterial,
-						&tgt->productionTargetRotation(),
-						_loclCenter+SupportRingFarTSOffset,
-						prodTargetMotherInfo,
-						0,
-						G4Colour::Yellow()
-						);
+                                                supportRingsParams,
+                                                supportRingsMaterial,
+                                                &tgt->productionTargetRotation(),
+                                                _loclCenter+SupportRingFarTSOffset,
+                                                prodTargetMotherInfo,
+                                                0,
+                                                G4Colour::Yellow()
+                                                );
 
     VolumeInfo supportRingsNearTSInfo = nestTubs("SupportRingsNearTS",
-						 supportRingsParams,
-						 supportRingsMaterial,
-						 &tgt->productionTargetRotation(),
-						 _loclCenter+SupportRingNearTSOffset,
-						 prodTargetMotherInfo,
-						 0,
-						 G4Colour::Yellow()
-						 );
+                                                 supportRingsParams,
+                                                 supportRingsMaterial,
+                                                 &tgt->productionTargetRotation(),
+                                                 _loclCenter+SupportRingNearTSOffset,
+                                                 prodTargetMotherInfo,
+                                                 0,
+                                                 G4Colour::Yellow()
+                                                 );
     std::cout << "local center = " << _loclCenter << std::endl;
    std::cout << "local center far = " << SupportRingFarTSOffset << std::endl;
    std::cout << "local center near = " << SupportRingNearTSOffset << std::endl;
@@ -203,23 +203,23 @@ namespace mu2e {
       double finHalfLength = tgt->halfLength();
       //
       // in hayman, there are no hubs and in space no one can hear you scream.  Leave the code in for hooks later
-      
+
       G4Trd * myTrd = new G4Trd("FinTrapezoid",
-				//				finHalfLength, finHalfLengthOut,
-				tgt->finThickness()/2.0, tgt->finThickness()/2.0,
-				tgt->finHeight()/2.0,tgt->finHeight()/2.0,
-				finHalfLength);
+                                //                              finHalfLength, finHalfLengthOut,
+                                tgt->finThickness()/2.0, tgt->finThickness()/2.0,
+                                tgt->finHeight()/2.0,tgt->finHeight()/2.0,
+                                finHalfLength);
 
 
       G4Tubs* targetEndRingNearTS = new G4Tubs("targetEndRingFarTS",
-					    innerRadiusRing,outerRadiusRing,halfLengthRing,0.,2.*M_PI);
+                                            innerRadiusRing,outerRadiusRing,halfLengthRing,0.,2.*M_PI);
       G4Tubs* targetEndRingFarTS = new G4Tubs("targetEndRingNearTS",
-					    innerRadiusRing,outerRadiusRing,halfLengthRing,0.,2.*M_PI);
+                                            innerRadiusRing,outerRadiusRing,halfLengthRing,0.,2.*M_PI);
 
       VolumeInfo targetEndRingNearTSVol("targetEndRingNearTS",
-					   _loclCenter,prodTargetMotherInfo.centerInWorld);
-      VolumeInfo targetEndRingFarTSVol("targetEndRingFarTS", 
-					   _loclCenter,prodTargetMotherInfo.centerInWorld);
+                                           _loclCenter,prodTargetMotherInfo.centerInWorld);
+      VolumeInfo targetEndRingFarTSVol("targetEndRingFarTS",
+                                           _loclCenter,prodTargetMotherInfo.centerInWorld);
       G4Material* endRingsMaterial = findMaterialOrThrow("G4_W");
 
 
@@ -230,10 +230,10 @@ namespace mu2e {
       // std::vector<double> finDims = {tgt->finThickness()/2.0,tgt->finHeight()/2.0,finHalfLength};
       double rToFin = tgt->rOut()+tgt->finHeight()/2.0;
       std::cout << "r variables " << rToFin << " " << tgt->rOut() << " " << tgt->finHeight()/2. << std::endl;
-  
- 
+
+
       CLHEP::HepRotation* rotFinBase = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
- 
+
       std::cout << "rotfinbase = " << *rotFinBase << std::endl;
       CLHEP::HepRotation* rotFin1 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
       CLHEP::HepRotation* rotFin2 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
@@ -250,14 +250,14 @@ namespace mu2e {
       CLHEP::Hep3Vector finOffset2(-rToFin/sqrt(2.),-rToFin/sqrt(2.),0.);
       CLHEP::Hep3Vector finOffset3(rToFin/sqrt(2.),rToFin/sqrt(2.),0.);
       CLHEP::Hep3Vector finOffset4(-rToFin/sqrt(2.),rToFin/sqrt(2.),0.);
- 
+
       // These are shifts in the unrotated frame in x and y.  But then when I apply
       // the rotation, since the fins are not centered on the z-axis, they pick up a z-shift that I must
       // take out.  rather than calculate it for the special case I'll do the matrix. If life gets more complicated
       // in the future (target rotated along and y) it's straightforward if tedious.
       //
-      // it's complicated because the "finishNesting", rotates then shifts by what you give it; the above is wrong once the frame is 
-      // rotated... 
+      // it's complicated because the "finishNesting", rotates then shifts by what you give it; the above is wrong once the frame is
+      // rotated...
       CLHEP::Hep3Vector fin1Shift(rToFin/sqrt(2.),-rToFin/sqrt(2.),0.);
       CLHEP::Hep3Vector fin2Shift(-rToFin/sqrt(2.),-rToFin/sqrt(2.),0.);
       CLHEP::Hep3Vector fin3Shift(rToFin/sqrt(2.),rToFin/sqrt(2.),0.);
@@ -283,20 +283,20 @@ namespace mu2e {
       finOffset4 += CLHEP::Hep3Vector(0.,0.,-fin4Shift.z());
 
       VolumeInfo fin1Vol("ProductionTargetFin1",
-			 _loclCenter,
-			 prodTargetMotherInfo.centerInWorld);
+                         _loclCenter,
+                         prodTargetMotherInfo.centerInWorld);
 
       VolumeInfo fin2Vol("ProductionTargetFin2",
-			 _loclCenter,
-			 prodTargetMotherInfo.centerInWorld);
+                         _loclCenter,
+                         prodTargetMotherInfo.centerInWorld);
 
       VolumeInfo fin3Vol("ProductionTargetFin3",
-			 _loclCenter,
-			 prodTargetMotherInfo.centerInWorld);
+                         _loclCenter,
+                         prodTargetMotherInfo.centerInWorld);
 
       VolumeInfo fin4Vol("ProductionTargetFin4",
-			 _loclCenter,
-			 prodTargetMotherInfo.centerInWorld);
+                         _loclCenter,
+                         prodTargetMotherInfo.centerInWorld);
 
       fin1Vol.solid = myTrd;
       fin2Vol.solid = myTrd;
@@ -304,46 +304,46 @@ namespace mu2e {
       fin4Vol.solid = myTrd;
 
       finishNesting( fin1Vol,
-		     prodTargetMaterial,
-		     rotFin1,
-		     finOffset1,
-		     prodTargetMotherInfo.logical,
-		     0,
-		     G4Colour::Magenta(),
-		     "PS"
-		     );
+                     prodTargetMaterial,
+                     rotFin1,
+                     finOffset1,
+                     prodTargetMotherInfo.logical,
+                     0,
+                     G4Colour::Magenta(),
+                     "PS"
+                     );
 
       finishNesting( fin2Vol,
-		     prodTargetMaterial,
-		     rotFin2,
-		     finOffset2,
-		     prodTargetMotherInfo.logical,
-		     0,
-		     G4Colour::Magenta(),
-		     "PS"
-		     );
+                     prodTargetMaterial,
+                     rotFin2,
+                     finOffset2,
+                     prodTargetMotherInfo.logical,
+                     0,
+                     G4Colour::Magenta(),
+                     "PS"
+                     );
 
       finishNesting( fin3Vol,
-		     prodTargetMaterial,
-		     rotFin3,
-		     finOffset3,
-		     prodTargetMotherInfo.logical,
-		     0,
-		     G4Colour::Magenta(),
-		     "PS"
-		     );
-		    
+                     prodTargetMaterial,
+                     rotFin3,
+                     finOffset3,
+                     prodTargetMotherInfo.logical,
+                     0,
+                     G4Colour::Magenta(),
+                     "PS"
+                     );
+
 
       finishNesting( fin4Vol,
-		     prodTargetMaterial,
-		     rotFin4,
-		     finOffset4,
-		     prodTargetMotherInfo.logical,
-		     0,
-		     G4Colour::Magenta(),
-		     "PS"
-		     );
- 
+                     prodTargetMaterial,
+                     rotFin4,
+                     finOffset4,
+                     prodTargetMotherInfo.logical,
+                     0,
+                     G4Colour::Magenta(),
+                     "PS"
+                     );
+
 
       targetEndRingNearTSVol.solid = targetEndRingNearTS;
       targetEndRingFarTSVol.solid = targetEndRingFarTS;
@@ -352,7 +352,7 @@ namespace mu2e {
       // put these just past edge of target in z, and shift them in x because target rotated about y axis.
       // rotation is about y, and xprime  = x cos - z sin, zprime = z cos + x sin.  x is zero, z is L/2 + whatever I need to push past core
       //but also recall 14deg from z-axis, not from x-axis...
-      double lengthToEnd = tgt->halfLength()+(4.); //4. being half length of ring.  
+      double lengthToEnd = tgt->halfLength()+(4.); //4. being half length of ring.
       double deltaXRing =  sin(tgt->productionTargetRotation().getTheta());
       double deltaZRing =  cos(tgt->productionTargetRotation().getTheta());
       //
@@ -363,27 +363,27 @@ namespace mu2e {
       //std::cout << "length to end = " << lengthToEnd << std::endl;
       //std::cout << "ring offsets x,z = " << deltaXRing << " \n " << deltaZRing << std::endl;
      finishNesting(targetEndRingFarTSVol,
-		    endRingsMaterial,
-		    rotRing,
-		    farTSRingOffset,
-		    prodTargetMotherInfo.logical,
-		    0,
-		    G4Colour::Magenta(),
-		    "PS"
-		    );
+                    endRingsMaterial,
+                    rotRing,
+                    farTSRingOffset,
+                    prodTargetMotherInfo.logical,
+                    0,
+                    G4Colour::Magenta(),
+                    "PS"
+                    );
 
       finishNesting(targetEndRingNearTSVol,
-		    endRingsMaterial,
-		    rotRing,
-		    nearTSRingOffset,
-		    prodTargetMotherInfo.logical,
-		    0,
-		    G4Colour::Magenta(),
-		    "PS"
-		    );
+                    endRingsMaterial,
+                    rotRing,
+                    nearTSRingOffset,
+                    prodTargetMotherInfo.logical,
+                    0,
+                    G4Colour::Magenta(),
+                    "PS"
+                    );
 
 
-		    
+
     }
 
 
@@ -391,9 +391,9 @@ namespace mu2e {
     // Using the old terms "right" and "left" to mean "downstream" (DS)
     // and "upstream" (US), respectively.
 
-    // 
-    //hayman has no hubs.  In this approximation the spokes will hang in space.  
-    
+    //
+    //hayman has no hubs.  In this approximation the spokes will hang in space.
+
     /*
     Polycone const & pHubRgtParams = *tgt->getHubsRgtPtr();
     VolumeInfo prodTargetHubRgtInfo  = nestPolycone("ProductionTargetHubRgt",
@@ -418,7 +418,7 @@ namespace mu2e {
                                                     G4Colour::Magenta(),
                                                     "ProductionTarget"
                                                     );
-    
+
     */
     CLHEP::Hep3Vector zax(0,0,1);
     double spokeRad = 0.5*_config.getDouble("targetPS_Spoke_diameter");
@@ -466,7 +466,7 @@ namespace mu2e {
       iSpokeName<<"ProductionTargetSpokeRgt_"<<iSpk;
 
 
-       
+
       VolumeInfo iSpokeInfo   = nestTubs( iSpokeName.str(),
                                           iSpokeParams,
                                           spokeMaterial,
@@ -481,7 +481,7 @@ namespace mu2e {
                                           placePV,
                                           doSurfaceCheck
                                           );
-      
+
       ++iSpk;
     }
 
@@ -513,7 +513,7 @@ namespace mu2e {
       TubsParams iSpokeParams( 0.0, spokeRad, 0.5*tmpSpokeLength);
       std::stringstream iSpokeName;
       iSpokeName<<"ProductionTargetSpokeLft_"<<iSpk;
-      
+
       VolumeInfo iSpokeInfo   = nestTubs( iSpokeName.str(),
                                           iSpokeParams,
                                           spokeMaterial,
@@ -528,7 +528,7 @@ namespace mu2e {
                                           placePV,
                                           doSurfaceCheck
                                           );
-      
+
       ++iSpk;
     }
 

--- a/Mu2eG4/src/constructHaymanRings.cc
+++ b/Mu2eG4/src/constructHaymanRings.cc
@@ -1,11 +1,6 @@
 //
-// Free function to create  Production Solenoid and Production Target.
+// Free function to create Production Target.
 //
-//
-// Original author KLG based on Mu2eWorld constructPS
-//
-// Notes:
-// Construct the PS. Parent volume is the air inside of the hall.
 
 // C++ includes
 #include <iostream>
@@ -18,6 +13,7 @@
 #include "GeomPrimitives/inc/Tube.hh"
 #include "GeomPrimitives/inc/Polycone.hh"
 #include "Mu2eG4Helper/inc/VolumeInfo.hh"
+#include "Mu2eG4Helper/inc/Mu2eG4Helper.hh"
 #include "GeometryService/inc/G4GeometryOptions.hh"
 #include "GeometryService/inc/GeometryService.hh"
 #include "GeometryService/inc/GeomHandle.hh"
@@ -58,6 +54,7 @@ namespace mu2e {
 
     G4ThreeVector _hallOriginInMu2e = parent.centerInMu2e();
 
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
 
     // Build the production target.
     GeomHandle<ProductionTarget> tgt;
@@ -226,22 +223,22 @@ namespace mu2e {
       G4Material* endRingsMaterial = findMaterialOrThrow("G4_W");
 
 
-     CLHEP::HepRotation* rotRingBase = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+      CLHEP::HepRotation* rotRingBase = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 
-      CLHEP::HepRotation* rotRing = new CLHEP::HepRotation((*rotRingBase)*tgt->productionTargetRotation());
+      CLHEP::HepRotation* rotRing = reg.add(CLHEP::HepRotation((*rotRingBase)*tgt->productionTargetRotation()));
 
       // std::vector<double> finDims = {tgt->finThickness()/2.0,tgt->finHeight()/2.0,finHalfLength};
       double rToFin = tgt->rOut()+tgt->finHeight()/2.0;
       std::cout << "r variables " << rToFin << " " << tgt->rOut() << " " << tgt->finHeight()/2. << std::endl;
   
  
-      CLHEP::HepRotation* rotFinBase = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+      CLHEP::HepRotation* rotFinBase = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
  
       std::cout << "rotfinbase = " << *rotFinBase << std::endl;
-      CLHEP::HepRotation* rotFin1 = new CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation());
-      CLHEP::HepRotation* rotFin2 = new CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation());
-      CLHEP::HepRotation* rotFin3 = new CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation());
-      CLHEP::HepRotation* rotFin4 = new CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation());
+      CLHEP::HepRotation* rotFin1 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
+      CLHEP::HepRotation* rotFin2 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
+      CLHEP::HepRotation* rotFin3 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
+      CLHEP::HepRotation* rotFin4 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
 
 
       rotFin1->rotateZ(-M_PI/4.);
@@ -473,7 +470,7 @@ namespace mu2e {
       VolumeInfo iSpokeInfo   = nestTubs( iSpokeName.str(),
                                           iSpokeParams,
                                           spokeMaterial,
-                                          new CLHEP::HepRotation(tmpRotAxis,rotAngle),
+                                          reg.add(CLHEP::HepRotation(tmpRotAxis,rotAngle)),
                                           tmpMidPnt,
                                           prodTargetMotherInfo,
                                           0,
@@ -506,7 +503,7 @@ namespace mu2e {
       normalaxHub.rotateZ(tmpAngle);
       normalaxHub.transform(invTrgtRot);
       double deepAngleHub = tmpDirVec.angle(normalaxHub);
-      //CLHEP::HepRotation *tmpSpokeRot = new CLHEP::HepRotation(tmpRotAxis,rotAngle);
+      //CLHEP::HepRotation *tmpSpokeRot = reg.add(CLHEP::HepRotation(tmpRotAxis,rotAngle));
 
       double fixOverlapWheel = spokeRad*tan(deepAngleWheel);
       double fixOverlapHub = spokeRad*tan(deepAngleHub);
@@ -520,7 +517,7 @@ namespace mu2e {
       VolumeInfo iSpokeInfo   = nestTubs( iSpokeName.str(),
                                           iSpokeParams,
                                           spokeMaterial,
-                                          new CLHEP::HepRotation(tmpRotAxis,rotAngle),
+                                          reg.add(CLHEP::HepRotation(tmpRotAxis,rotAngle)),
                                           tmpMidPnt,
                                           prodTargetMotherInfo,
                                           0,

--- a/Mu2eG4/src/constructPSShield.cc
+++ b/Mu2eG4/src/constructPSShield.cc
@@ -54,13 +54,14 @@ namespace mu2e {
 
     const int version              = hrs->version();
 
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
     // -----------------------------
     // Put in beam pipe inlet.  David Norvil Brown, Louisville, March 2015
 
     Tube const & pssInletParams = hrs->beamInlet();
     //    G4Material* beampipeMaterial = findMaterialOrThrow(pssInletParams.materialName());
     CLHEP::Hep3Vector place = hrs->getBeamInletCenter();
-    CLHEP::HepRotation * turn = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+    CLHEP::HepRotation * turn = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
     turn->rotateY(hrs->getBeamAngleY());
     turn->rotateX(hrs->getBeamAngleX());
 

--- a/Mu2eG4/src/constructPSShield.cc
+++ b/Mu2eG4/src/constructPSShield.cc
@@ -132,54 +132,54 @@ namespace mu2e {
     // Treat the extra water and stainless sheath as end rings.
     if ( version > 1 ) {
       for(unsigned iER=0; iER < hrs->endRings().size(); ++iER) {
-	std::ostringstream osnum;
-	osnum << iER + 1;
+        std::ostringstream osnum;
+        osnum << iER + 1;
 
-	const Polycone& eRing = hrs->endRings()[iER];
-	G4VSolid *psersolid = new G4Polycone("PSShieldEndRing"+osnum.str(),
-					    0, 2*M_PI,
-					    eRing.numZPlanes(),
-					    &eRing.zPlanes()[0],
-					    &eRing.rInner()[0],
-					    &eRing.rOuter()[0]
-					    );
+        const Polycone& eRing = hrs->endRings()[iER];
+        G4VSolid *psersolid = new G4Polycone("PSShieldEndRing"+osnum.str(),
+                                            0, 2*M_PI,
+                                            eRing.numZPlanes(),
+                                            &eRing.zPlanes()[0],
+                                            &eRing.rInner()[0],
+                                            &eRing.rOuter()[0]
+                                            );
 
-	VolumeInfo pser("PSShieldEndRing"+osnum.str(),
-		       eRing.originInMu2e() - parent.centerInMu2e(),
-		       parent.centerInWorld);
-	//	std::cout << "endring = " << eRing.originInMu2e() << " " << parent.centerInMu2e() << std::endl;
-	G4VSolid *aSolid = 0;
-	if ( 1 == iER ) {
-	  // downstream - beam inlet tube penetrates
-	  aSolid = new G4SubtractionSolid ( pser.name,
-					    psersolid,
-					    beamPassTub,
-					    turn,
-					    place-eRing.originInMu2e());
-	} else {
-	  // upstream - beam inlet tube does not penetrate
-	  // Same for extra water and stainless sheath.
-	  aSolid = psersolid;
-	}
+        VolumeInfo pser("PSShieldEndRing"+osnum.str(),
+                       eRing.originInMu2e() - parent.centerInMu2e(),
+                       parent.centerInWorld);
+        //      std::cout << "endring = " << eRing.originInMu2e() << " " << parent.centerInMu2e() << std::endl;
+        G4VSolid *aSolid = 0;
+        if ( 1 == iER ) {
+          // downstream - beam inlet tube penetrates
+          aSolid = new G4SubtractionSolid ( pser.name,
+                                            psersolid,
+                                            beamPassTub,
+                                            turn,
+                                            place-eRing.originInMu2e());
+        } else {
+          // upstream - beam inlet tube does not penetrate
+          // Same for extra water and stainless sheath.
+          aSolid = psersolid;
+        }
 
-	pser.solid = aSolid;
-	pser.solid->SetName(pser.name);
+        pser.solid = aSolid;
+        pser.solid->SetName(pser.name);
 
-	finishNesting(pser,
-		      findMaterialOrThrow(eRing.materialName()),
-		      0,
-		      pser.centerInParent,
-		      parent.logical,
-		      0,
-		      isVisible,
-		      G4Colour(config.getHep3Vector("PSShield.endRing.color")),
-		      isSolid,
-		      forceAuxEdgeVisible,
-		      placePV,
-		      doSurfaceCheck
-		      );
+        finishNesting(pser,
+                      findMaterialOrThrow(eRing.materialName()),
+                      0,
+                      pser.centerInParent,
+                      parent.logical,
+                      0,
+                      isVisible,
+                      G4Colour(config.getHep3Vector("PSShield.endRing.color")),
+                      isSolid,
+                      forceAuxEdgeVisible,
+                      placePV,
+                      doSurfaceCheck
+                      );
       }
-	    
+
     } // end if ( version > 1)...  (putting in endRings)
 
 

--- a/Mu2eG4/src/constructProtonAbsorber.cc
+++ b/Mu2eG4/src/constructProtonAbsorber.cc
@@ -67,6 +67,7 @@ namespace mu2e {
 
     // Access to the Mu2eG4HelperService.
     Mu2eG4Helper* _helper = &(*(art::ServiceHandle<Mu2eG4Helper>()));
+    AntiLeakRegistry & reg = _helper->antiLeakRegistry();
 
     const bool inGaragePosition = _config.getBool("inGaragePosition",false); //offset detector train elements for extracted position
     const bool OPA_IPA_ST_Extracted = (inGaragePosition) ? _config.getBool("garage.extractOPA_IPA_ST") : false;
@@ -139,7 +140,6 @@ namespace mu2e {
       }
 
       if ( _config.getBool("protonabsorber.visible",true) ) {
-        AntiLeakRegistry & reg = _helper->antiLeakRegistry();
         hpabs->SetVisibility( _config.getBool("protonabsorber.solid",true),
                               forceAuxEdgeVisible,
                               G4Color::Green(), reg);
@@ -522,7 +522,7 @@ namespace mu2e {
                                     pabs3SlotWidth/2.0,
                                     400*CLHEP::mm, pabs3SlotLength/2.0 );
 
-          CLHEP::HepRotation* slot1Rotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+          CLHEP::HepRotation* slot1Rotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
           slot1Rotat->rotateZ(120.0*CLHEP::degree);
 
           CLHEP::Hep3Vector slot1spot(300.0*CLHEP::mm*sin(120.0*CLHEP::degree),
@@ -535,7 +535,7 @@ namespace mu2e {
                                                                slot1Rotat,
                                                                slot1spot );
 
-          CLHEP::HepRotation* slot2Rotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+          CLHEP::HepRotation* slot2Rotat (nullptr);
 
           CLHEP::Hep3Vector slot2spot(0., 300.0*CLHEP::mm, pabs3SlotOffset*CLHEP::mm );
 
@@ -545,7 +545,7 @@ namespace mu2e {
                                                                slot2Rotat,
                                                                slot2spot );
 
-          CLHEP::HepRotation* slot3Rotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+          CLHEP::HepRotation* slot3Rotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
           slot3Rotat->rotateZ(240.0*CLHEP::degree);
 
           CLHEP::Hep3Vector slot3spot(300.0*CLHEP::mm*sin(240.0*CLHEP::degree),
@@ -743,7 +743,7 @@ namespace mu2e {
             G4Box* notch = new G4Box("notch", notchWidth/2.*CLHEP::mm,
                                      (notchHeight+notchExtension)/2.*CLHEP::mm, hl*1.1 );
 
-            CLHEP::HepRotation* notch1Rotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+            CLHEP::HepRotation* notch1Rotat (nullptr);
             double notchOffset = notchHeight/2.;
             notchOffset -= notchExtension/2.; //so the extension is only on the bottom
             if(opaVersion < 3) notchOffset = 22.; //adding for backwards compatibility
@@ -755,7 +755,7 @@ namespace mu2e {
                                                                 notch1Rotat,
                                                                 notch1Locat);
 
-            CLHEP::HepRotation* notch2Rotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+            CLHEP::HepRotation* notch2Rotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
             notch2Rotat->rotateZ(120.0*CLHEP::degree);
 
             CLHEP::Hep3Vector notch2Locat((rin+notchOffset)*CLHEP::mm*sin(120.0*CLHEP::degree),
@@ -768,7 +768,7 @@ namespace mu2e {
                                                                 notch2Rotat,
                                                                 notch2Locat);
 
-            CLHEP::HepRotation* notch3Rotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+            CLHEP::HepRotation* notch3Rotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
             notch3Rotat->rotateZ(240.0*CLHEP::degree);
 
             CLHEP::Hep3Vector notch3Locat((rin+notchOffset)*CLHEP::mm*sin(240.0*CLHEP::degree),
@@ -852,7 +852,7 @@ namespace mu2e {
                     cout << " iSlat = " << iSlat << endl;
                   const double slatAngle = pabs->slatAngles().at(iSlat)*CLHEP::degree; //taken in as degrees
 
-                  CLHEP::HepRotation* slatRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+                  CLHEP::HepRotation* slatRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
                   slatRotat->rotateZ(slatAngle);
                   const int slatIndex = pabs->slatTypes().at(iSlat); //get the type of slat
                   const double sHigh = pabs->slatHeights().at(slatIndex);
@@ -1214,7 +1214,7 @@ namespace mu2e {
             const double xMother = radius*sin(phi*CLHEP::degree) + parent1Info.centerInMu2e().x();
             const double yMother = radius*cos(phi*CLHEP::degree) + parent1Info.centerInMu2e().y();
             CLHEP::Hep3Vector motherBoxLoc(xMother,yMother,zMother);
-            CLHEP::HepRotation* motherBoxRot = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+            CLHEP::HepRotation* motherBoxRot = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
             motherBoxRot->rotateZ(phi*CLHEP::degree);
             ostringstream motherBoxName;
             motherBoxName << "OPA_CrossSupportMother_" << iCross+1;
@@ -1311,9 +1311,9 @@ namespace mu2e {
             crossBarLength -= 1.; //remove mm to ensure no overlaps of corners
             CLHEP::Hep3Vector crossBar1Loc(0., 0., 0.);
             CLHEP::Hep3Vector crossBar2Loc(0., 0., 0.); //wrt bar 1
-            CLHEP::HepRotation* crossBar1Rot = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+            CLHEP::HepRotation* crossBar1Rot = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
             crossBar1Rot->rotateY(crossBarAngle);
-            CLHEP::HepRotation* crossBar2Rot = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+            CLHEP::HepRotation* crossBar2Rot = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
             crossBar2Rot->rotateY(-2.*crossBarAngle); //double to account for rotation wrt bar 1
             ostringstream crossBarName;
             crossBarName << "OPA_CrossSupport_" << iCross+1 << "_CrossBar";
@@ -1350,7 +1350,7 @@ namespace mu2e {
       //***************************
 
       if ( pabs->degraderBuild() ) {
-        CLHEP::HepRotation* degraderRot = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+        CLHEP::HepRotation* degraderRot = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
         degraderRot->rotateZ(pabs->degraderRotation()*CLHEP::degree);
 
         // Make Frame
@@ -1464,7 +1464,7 @@ namespace mu2e {
 
 
         // Now put counterweight in DS2Vacuum
-        CLHEP::HepRotation* cwtRot = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+        CLHEP::HepRotation* cwtRot = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
         cwtRot->rotateY(90.0*CLHEP::degree);
         cwtRot->rotateX(pabs->degraderRotation()*CLHEP::degree);
 

--- a/Mu2eG4/src/constructSTM.cc
+++ b/Mu2eG4/src/constructSTM.cc
@@ -71,18 +71,18 @@ namespace mu2e {
     SupportTable    const & pSTMDetectorSupportTableParams = *stmgh.getSTMDetectorSupportTablePtr();
     GeDetector      const & pSTMDetector1Params            = *stmgh.getSTMDetector1Ptr();
     GeDetector      const & pSTMDetector2Params            = *stmgh.getSTMDetector2Ptr();
-    ShieldPipe      const & pSTMShieldPipeParams           = *stmgh.getSTMShieldPipePtr(); 
-    
+    ShieldPipe      const & pSTMShieldPipeParams           = *stmgh.getSTMShieldPipePtr();
+
     const auto geomOptions = art::ServiceHandle<GeometryService>()->geomOptions();
     geomOptions->loadEntry( _config, "stm", "stm");
 
-    const bool STMisVisible        = geomOptions->isVisible("stm"); 
-    const bool STMisSolid          = geomOptions->isSolid("stm"); 
-    const bool forceAuxEdgeVisible = geomOptions->forceAuxEdgeVisible("stm"); 
-    const bool doSurfaceCheck      = geomOptions->doSurfaceCheck("stm"); 
-    const bool placePV             = geomOptions->placePV("stm"); 
+    const bool STMisVisible        = geomOptions->isVisible("stm");
+    const bool STMisSolid          = geomOptions->isSolid("stm");
+    const bool forceAuxEdgeVisible = geomOptions->forceAuxEdgeVisible("stm");
+    const bool doSurfaceCheck      = geomOptions->doSurfaceCheck("stm");
+    const bool placePV             = geomOptions->placePV("stm");
     int  const verbosityLevel      = _config.getInt("stm.verbosityLevel", 0);
-    
+
     const G4ThreeVector zeroVector(0.,0.,0.);
 
     if ( verbosityLevel > 0) {
@@ -93,44 +93,44 @@ namespace mu2e {
     // Access to the Mu2eG4HelperService.
     Mu2eG4Helper* _helper = &(*(art::ServiceHandle<Mu2eG4Helper>()));
 
-    //For now just make the mother HallAir because the STM transpport pipe goes 
+    //For now just make the mother HallAir because the STM transpport pipe goes
     //into the End Cap Shielding mother
     //TODO: create STM Mother volume and make that the parent instead of HallAir
     VolumeInfo const & parentInfo = _helper->locateVolInfo("HallAir");
     G4ThreeVector parentCenterInMu2e = parentInfo.centerInMu2e();
-    
+
     // Fetch DS geom. object
     GeomHandle<DetectorSolenoid> ds;
-    const CLHEP::Hep3Vector &dsP( ds->position() );    
+    const CLHEP::Hep3Vector &dsP( ds->position() );
 
     GeomHandle<CosmicRayShield> CRS;
     std::vector<double> crvd_halflengths = CRS->getSectorHalfLengths("D");
     CLHEP::Hep3Vector   crvd_position    = CRS->getSectorPosition("D");
     const double z_crv_max = crvd_position.z() + crvd_halflengths[2];
-    
+
     // Create a reference position (most things in the STM geometry will be defined w.r.t. this position)
     // Our reference z is the downstream edge of the CRV
-    const G4ThreeVector stmReferencePositionInMu2e(dsP.x(), 
-                                                    0.0, 
+    const G4ThreeVector stmReferencePositionInMu2e(dsP.x(),
+                                                    0.0,
                                                     z_crv_max );
     const G4ThreeVector stmReferencePositionInParent = stmReferencePositionInMu2e - parentCenterInMu2e;
-    
-    
+
+
     //===================== Sweeper Magnet ==========================
-    
+
     G4ThreeVector stmMagnetPositionInMu2e   = pSTMMagnetParams.originInMu2e();
     G4ThreeVector stmMagnetPositionInParent = pSTMMagnetParams.originInMu2e() - parentCenterInMu2e;
-    
+
     // Make the magnet
     G4Box* boxMagnet     = new G4Box("boxMagnet",     pSTMMagnetParams.xHalfLength(),     pSTMMagnetParams.yHalfLength(),     pSTMMagnetParams.zHalfLength());
-    
+
     // Make the rectangular window (make the box that gets subtracted just a bit longer to be sure there are no edge effects)
-    const double stmMagnetHoleHalfLengths[3] = {pSTMMagnetParams.xHoleHalfLength(), 
-                                                pSTMMagnetParams.yHoleHalfLength(), 
+    const double stmMagnetHoleHalfLengths[3] = {pSTMMagnetParams.xHoleHalfLength(),
+                                                pSTMMagnetParams.yHoleHalfLength(),
                                                 pSTMMagnetParams.zHalfLength()     };
     G4Box* boxMagnetHole = new G4Box("boxMagnetHole", stmMagnetHoleHalfLengths[0]+pSTMShieldPipeParams.linerWidth(), stmMagnetHoleHalfLengths[1]+pSTMShieldPipeParams.linerWidth(), stmMagnetHoleHalfLengths[2]+1.0);
     VolumeInfo stmMagnet;
-    stmMagnet.name = "stmMagnet";    
+    stmMagnet.name = "stmMagnet";
     stmMagnet.solid = new G4SubtractionSolid(stmMagnet.name,boxMagnet,boxMagnetHole,0,zeroVector);
 
     // Make the poly-liner
@@ -138,16 +138,16 @@ namespace mu2e {
     G4Box* boxPolyHole = new G4Box("boxPolyHole", stmMagnetHoleHalfLengths[0], stmMagnetHoleHalfLengths[1], stmMagnetHoleHalfLengths[2]+1.0);
 
     VolumeInfo stmMagnetPLine;
-    stmMagnetPLine.name = "stmMagnetPLine";    
+    stmMagnetPLine.name = "stmMagnetPLine";
     stmMagnetPLine.solid = new G4SubtractionSolid(stmMagnetPLine.name,boxMagnetPLine,boxPolyHole,0,zeroVector);
 
 
-    
+
     if (pSTMMagnetParams.build()){
       finishNesting(stmMagnet,
                     findMaterialOrThrow(pSTMMagnetParams.materialName()),
                     0,
-                    stmMagnetPositionInParent, //mstmMagnetPositionInMother, 
+                    stmMagnetPositionInParent, //mstmMagnetPositionInMother,
                     parentInfo.logical, //parentInfo.logical, //mstmMotherInfo.logical,
                     0,
                     STMisVisible,
@@ -160,7 +160,7 @@ namespace mu2e {
       finishNesting(stmMagnetPLine,
                     findMaterialOrThrow(pSTMShieldPipeParams.materialLiner()),
                     0,
-                    stmMagnetPositionInParent, //mstmMagnetPositionInMother, 
+                    stmMagnetPositionInParent, //mstmMagnetPositionInMother,
                     parentInfo.logical, //parentInfo.logical, //mstmMotherInfo.logical,
                     0,
                     STMisVisible,
@@ -174,26 +174,26 @@ namespace mu2e {
     }
 
     if ( verbosityLevel > 0) {
-       cout << __func__ << " Sweeper magnet extent in z   : " 
+       cout << __func__ << " Sweeper magnet extent in z   : "
             << pSTMMagnetParams.zBegin() <<","<< pSTMMagnetParams.zEnd() << endl;
        cout << __func__ << " Sweeper magnet hole opening xHalfLength : "<< stmMagnetHoleHalfLengths[0] << endl;
        cout << __func__ << " Sweeper magnet hole opening yHalfLength : "<< stmMagnetHoleHalfLengths[1] << endl;
     }
-    
-    
+
+
     //===================== Transport Pipe ==========================
-    
+
     //create a disk so we can subtract a space for the existing VD to fit inside (avoid overlaps)
     GeomHandle<VirtualDetector> vdg;
     const double vdHL = CLHEP::mm * vdg->getHalfLength();
     const double vdR  = _config.getDouble("vd.DSNeutronShieldExit.r");
-    G4Tubs* aDiskVDDSNeutronShieldExitTub = new G4Tubs( "subtSpaceForVDDSNeutronShieldExit", 
-                                       0.0, 
-                                       vdR+0.01, 
+    G4Tubs* aDiskVDDSNeutronShieldExitTub = new G4Tubs( "subtSpaceForVDDSNeutronShieldExit",
+                                       0.0,
+                                       vdR+0.01,
                                        vdHL+0.01,// a bit larger to avoid overlap with VD
-                                       0.0, 
+                                       0.0,
                                        CLHEP::twopi);
-    CLHEP::Hep3Vector vdDSNeutronShieldExitPositionInMu2e = vdg->getGlobal(VirtualDetectorId::DSNeutronShieldExit);    
+    CLHEP::Hep3Vector vdDSNeutronShieldExitPositionInMu2e = vdg->getGlobal(VirtualDetectorId::DSNeutronShieldExit);
     CLHEP::Hep3Vector vdDSNeutronShieldExitPositionInParent = vdDSNeutronShieldExitPositionInMu2e - parentCenterInMu2e;
     if (verbosityLevel>0){
       std::cout << __func__ << " vdDSNeutronShieldExitPositionInMu2e = "<<vdDSNeutronShieldExitPositionInMu2e<<std::endl;
@@ -201,52 +201,52 @@ namespace mu2e {
 
 
     //create a disk so we can subtract a space for the existing VD to fit inside (avoid overlaps)
-    G4Tubs* aDiskVDSTM_UpStrTub = new G4Tubs( "subtSpaceForVDSTM_UpStr", 
-                                       0.0, 
-                                       1000.0, //make is very large to be sure we subtract enough  
+    G4Tubs* aDiskVDSTM_UpStrTub = new G4Tubs( "subtSpaceForVDSTM_UpStr",
+                                       0.0,
+                                       1000.0, //make is very large to be sure we subtract enough
                                        vdHL+0.01,// a bit larger to avoid overlap with VD
-                                       0.0, 
+                                       0.0,
                                        CLHEP::twopi);
-    CLHEP::Hep3Vector vdSTM_UpStrPositionInMu2e = vdg->getGlobal(VirtualDetectorId::STM_UpStr);    
+    CLHEP::Hep3Vector vdSTM_UpStrPositionInMu2e = vdg->getGlobal(VirtualDetectorId::STM_UpStr);
     CLHEP::Hep3Vector vdSTM_UpStrPositionInParent = vdSTM_UpStrPositionInMu2e - parentCenterInMu2e;
     if (verbosityLevel>0){
-      std::cout << __func__ << " vdSTM_UpStrPositionInMu2e = "<<vdSTM_UpStrPositionInMu2e<<std::endl;    
+      std::cout << __func__ << " vdSTM_UpStrPositionInMu2e = "<<vdSTM_UpStrPositionInMu2e<<std::endl;
     }
-    
+
     //create a disk so we can subtract a space for the existing VD to fit inside (avoid overlaps)
-//     G4Tubs* aDiskVDSTM_CRVShieldDnStrTub = new G4Tubs( "subtSpaceForVDSTM_CRVShieldDnStr", 
-//                                        0.0, 
-//                                        1000.0, //make is very large to be sure we subtract enough  
+//     G4Tubs* aDiskVDSTM_CRVShieldDnStrTub = new G4Tubs( "subtSpaceForVDSTM_CRVShieldDnStr",
+//                                        0.0,
+//                                        1000.0, //make is very large to be sure we subtract enough
 //                                        vdHL+0.01,// a bit larger to avoid overlap with VD
-//                                        0.0, 
+//                                        0.0,
 //                                        CLHEP::twopi);
-//     CLHEP::Hep3Vector vdSTM_CRVShieldDnStrPositionInMu2e   = vdg->getGlobal(VirtualDetectorId::STM_CRVShieldDnStr);    
+//     CLHEP::Hep3Vector vdSTM_CRVShieldDnStrPositionInMu2e   = vdg->getGlobal(VirtualDetectorId::STM_CRVShieldDnStr);
 //     CLHEP::Hep3Vector vdSTM_CRVShieldDnStrPositionInParent = vdSTM_CRVShieldDnStrPositionInMu2e - parentCenterInMu2e;
 //     if (verbosityLevel>0){
-//       std::cout<<"vdSTM_CRVShieldDnStrPositionInMu2e = "<<vdSTM_CRVShieldDnStrPositionInMu2e<<std::endl;  
+//       std::cout<<"vdSTM_CRVShieldDnStrPositionInMu2e = "<<vdSTM_CRVShieldDnStrPositionInMu2e<<std::endl;
 //     }
-   
-    
-    //---             
-    
-    
+
+
+    //---
+
+
     const double flangeHalfLength      =     pSTMTransportPipeParams.flangeHalfLength();
     const double flangeFullLength      = 2.0*pSTMTransportPipeParams.flangeHalfLength();
 
     //make the region of pipe that will contain the magnetic field
-    G4Tubs* aPipeCenterTub = new G4Tubs("aPipeCenterTub", 
-					pSTMTransportPipeParams.radiusIn(),  //inner radius
-					pSTMTransportPipeParams.radiusOut(), //outer radius
-					stmMagnetHoleHalfLengths[2],
-					0.0,
-					CLHEP::twopi);
+    G4Tubs* aPipeCenterTub = new G4Tubs("aPipeCenterTub",
+                                        pSTMTransportPipeParams.radiusIn(),  //inner radius
+                                        pSTMTransportPipeParams.radiusOut(), //outer radius
+                                        stmMagnetHoleHalfLengths[2],
+                                        0.0,
+                                        CLHEP::twopi);
 
     VolumeInfo pipeCenterTubInfo;
     pipeCenterTubInfo.name = "pipeCenterTub";
     pipeCenterTubInfo.solid = aPipeCenterTub;
 
     //make the gas that goes inside the region of pipe that contains the magnetic field
-    G4Tubs* aPipeCenterGasTub = new G4Tubs("aPipeCenterGasTub", 
+    G4Tubs* aPipeCenterGasTub = new G4Tubs("aPipeCenterGasTub",
                                            0.0, //inner radius of gas
                                            pSTMTransportPipeParams.radiusIn(), //outer radius of gas
                                            stmMagnetHoleHalfLengths[2],
@@ -257,13 +257,13 @@ namespace mu2e {
     pipeCenterGasTubInfo.solid = aPipeCenterGasTub;
 
     //make the region of pipe that goes downstream of the magnetic field, with a flange
-    G4Tubs* aPipeDnStrTub = new G4Tubs("aPipeDnStrTub", 
+    G4Tubs* aPipeDnStrTub = new G4Tubs("aPipeDnStrTub",
                                        pSTMTransportPipeParams.radiusIn(),  //inner radius
                                        pSTMTransportPipeParams.radiusOut()+pSTMTransportPipeParams.flangeOverhangR(), //outer radius
-                                       pSTMTransportPipeParams.dnStrHalflength(), 
+                                       pSTMTransportPipeParams.dnStrHalflength(),
                                        0.0,
                                        CLHEP::twopi);
-    G4Tubs* aPipeDnStrSubtTub = new G4Tubs("aPipeDnStrSubtTub", 
+    G4Tubs* aPipeDnStrSubtTub = new G4Tubs("aPipeDnStrSubtTub",
                                            pSTMTransportPipeParams.radiusOut(), //inner radius to subtract
                                            pSTMTransportPipeParams.radiusOut()+2.0*pSTMTransportPipeParams.flangeOverhangR(), //outer radius, make sure to subtract enough
                                            pSTMTransportPipeParams.dnStrHalflength(),
@@ -274,9 +274,9 @@ namespace mu2e {
     pipeDnStrTubInfo.name = "pipeDnStrTub";
     pipeDnStrTubInfo.solid = new G4SubtractionSolid(pipeDnStrTubInfo.name,aPipeDnStrTub, aPipeDnStrSubtTub, 0, flangeOffset);
     CLHEP::Hep3Vector pipeDnStrOffset(0.0, 0.0, stmMagnetHoleHalfLengths[2]+pSTMTransportPipeParams.dnStrHalflength());
-    
-    //make a downstream window to hold the helium or vacuum inside the pipe    
-    G4Tubs* aPipeDnStrWindowTub = new G4Tubs( "aPipeDnStrWindowTub", 
+
+    //make a downstream window to hold the helium or vacuum inside the pipe
+    G4Tubs* aPipeDnStrWindowTub = new G4Tubs( "aPipeDnStrWindowTub",
                                               0.0, // inner radius of window
                                               pSTMTransportPipeParams.radiusIn(), //outer radius of window
                                               pSTMTransportPipeParams.dnStrWindowHalflength(),
@@ -284,12 +284,12 @@ namespace mu2e {
                                               CLHEP::twopi);
     VolumeInfo pipeDnStrWindowTubInfo;
     pipeDnStrWindowTubInfo.name = "pipeDnStrWindowTub";
-    pipeDnStrWindowTubInfo.solid = aPipeDnStrWindowTub;       
+    pipeDnStrWindowTubInfo.solid = aPipeDnStrWindowTub;
     CLHEP::Hep3Vector pipeDnStrWindowOffset(0.0, 0.0, stmMagnetHoleHalfLengths[2]+2.0*pSTMTransportPipeParams.dnStrHalflength()-flangeHalfLength);
 
     //put gas/vacuum inside the downstream portion of the pipe
     const double gasDnStrHalfLength = 0.5*(2.0*pSTMTransportPipeParams.dnStrHalflength() - flangeHalfLength - pSTMTransportPipeParams.dnStrWindowHalflength() );
-    G4Tubs* aPipeGasDnStrTub = new G4Tubs( "aPipeGasDnStrTub", 
+    G4Tubs* aPipeGasDnStrTub = new G4Tubs( "aPipeGasDnStrTub",
                                             0.0, //inner radius
                                             pSTMTransportPipeParams.radiusIn(), //outer radius of gas
                                             gasDnStrHalfLength,
@@ -304,19 +304,19 @@ namespace mu2e {
     const double IFB_endplug_z_center     = ds->cryoZMax() + _config.getDouble("ifb.endplug.z");
     const double IFB_endplug_z_halflength = _config.getDouble("ifb.endplug.halfLength");
     const double pipeUpStrHalfLength = 0.5*((stmMagnetPositionInMu2e.z()-stmMagnetHoleHalfLengths[2]) - (IFB_endplug_z_center+IFB_endplug_z_halflength)) - pSTMTransportPipeParams.upStrSpace();//leave a space between pipe and IFB
-    
-    G4Tubs* aPipeUpStrTub     = new G4Tubs("aPipeUpStrTub", 
+
+    G4Tubs* aPipeUpStrTub     = new G4Tubs("aPipeUpStrTub",
                                            pSTMTransportPipeParams.radiusIn(), //inner radius
                                            pSTMTransportPipeParams.radiusOut()+pSTMTransportPipeParams.flangeOverhangR(), //outer radius
-                                           pipeUpStrHalfLength,// 
+                                           pipeUpStrHalfLength,//
                                            0.0,//
                                            CLHEP::twopi);
-    G4Tubs* aPipeUpStrSubtTub = new G4Tubs("aPipeUpStrSubtTub", 
+    G4Tubs* aPipeUpStrSubtTub = new G4Tubs("aPipeUpStrSubtTub",
                                            pSTMTransportPipeParams.radiusOut(), //inner radius
                                            pSTMTransportPipeParams.radiusOut()+2.0*pSTMTransportPipeParams.flangeOverhangR(), //outer radius, make sure to subtract enough
-                                           pipeUpStrHalfLength,// 
+                                           pipeUpStrHalfLength,//
                                            0.0,//
-                                           CLHEP::twopi);        
+                                           CLHEP::twopi);
     CLHEP::Hep3Vector pipeUpStrOffset(0.0, 0.0, -stmMagnetHoleHalfLengths[2]-pipeUpStrHalfLength);
     //first make the subtraction so it has a flange
     G4SubtractionSolid *pipeUpStrTubTemp1 = new G4SubtractionSolid("pipeUpStrTubTemp1",aPipeUpStrTub, aPipeUpStrSubtTub, 0, -flangeOffset);
@@ -324,37 +324,37 @@ namespace mu2e {
     //subtract a slice so VDDSNeutronShieldExit can fit through the pipe without overlap
     CLHEP::Hep3Vector vdDSNeutronShieldExitPositionWRTpipeUpStr = vdDSNeutronShieldExitPositionInMu2e - (stmMagnetPositionInMu2e+pipeUpStrOffset);
     CLHEP::Hep3Vector vdSTM_UpStrPositionWRTpipeUpStr = vdSTM_UpStrPositionInMu2e - (stmMagnetPositionInMu2e+pipeUpStrOffset);
-    //std::cout<<"vdDSNeutronShieldExitPositionWRTpipe = "<<vdDSNeutronShieldExitPositionWRTpipeUpStr<<std::endl;     
-    //std::cout<<"vdSTM_UpStrPositionWRTpipe = "<<vdDSNeutronShieldExitPositionWRTpipeUpStr<<std::endl;     
+    //std::cout<<"vdDSNeutronShieldExitPositionWRTpipe = "<<vdDSNeutronShieldExitPositionWRTpipeUpStr<<std::endl;
+    //std::cout<<"vdSTM_UpStrPositionWRTpipe = "<<vdDSNeutronShieldExitPositionWRTpipeUpStr<<std::endl;
     G4SubtractionSolid *pipeUpStrTubTemp2 = new G4SubtractionSolid("pipeUpStrTubTemp2",pipeUpStrTubTemp1, aDiskVDDSNeutronShieldExitTub,      0, vdDSNeutronShieldExitPositionWRTpipeUpStr);
-    G4SubtractionSolid *pipeUpStrTubTemp3 = new G4SubtractionSolid("pipeUpStrTubTemp3",pipeUpStrTubTemp2, aDiskVDSTM_UpStrTub,      0, vdSTM_UpStrPositionWRTpipeUpStr); 
+    G4SubtractionSolid *pipeUpStrTubTemp3 = new G4SubtractionSolid("pipeUpStrTubTemp3",pipeUpStrTubTemp2, aDiskVDSTM_UpStrTub,      0, vdSTM_UpStrPositionWRTpipeUpStr);
     VolumeInfo pipeUpStrTubInfo;
-    pipeUpStrTubInfo.name = "pipeUpStrTub";        
+    pipeUpStrTubInfo.name = "pipeUpStrTub";
     pipeUpStrTubInfo.solid = pipeUpStrTubTemp3;
 
-    
+
     //put gas inside the upstream portion of the pipe
     const double pipeGasUpStrHalfLength = 0.5*(2.0*pipeUpStrHalfLength - flangeHalfLength - pSTMTransportPipeParams.upStrWindowHalflength());
-    G4Tubs* aPipeGasUpStrTub = new G4Tubs( "aPipeGasUpStrTub", 
+    G4Tubs* aPipeGasUpStrTub = new G4Tubs( "aPipeGasUpStrTub",
                                             0.0, //inner radius
                                             pSTMTransportPipeParams.radiusIn(), //outer radius
-                                            pipeGasUpStrHalfLength,// 
+                                            pipeGasUpStrHalfLength,//
                                             0.0,//
                                             CLHEP::twopi);
     CLHEP::Hep3Vector pipeGasUpStrOffset(0.0, 0.0, -stmMagnetHoleHalfLengths[2]-pipeGasUpStrHalfLength);
     //subtract a slice so VDDSNeutronShieldExit can fit through the pipe without overlap
     CLHEP::Hep3Vector vdDSNeutronShieldExitPositionWRTpipeGasUpStr = vdDSNeutronShieldExitPositionInMu2e - (stmMagnetPositionInMu2e+pipeGasUpStrOffset);
     CLHEP::Hep3Vector vdSTM_UpStrPositionWRTpipeGasUpStr = vdSTM_UpStrPositionInMu2e - (stmMagnetPositionInMu2e+pipeGasUpStrOffset);
-    //std::cout<<"vdDSNeutronShieldExitPositionWRTtube = "<<vdDSNeutronShieldExitPositionWRTpipeGasUpStr<<std::endl; 
-    //std::cout<<"vdSTM_UpStrPositionWRTtube = "<<vdSTM_UpStrPositionWRTpipeGasUpStr<<std::endl; 
+    //std::cout<<"vdDSNeutronShieldExitPositionWRTtube = "<<vdDSNeutronShieldExitPositionWRTpipeGasUpStr<<std::endl;
+    //std::cout<<"vdSTM_UpStrPositionWRTtube = "<<vdSTM_UpStrPositionWRTpipeGasUpStr<<std::endl;
     G4SubtractionSolid *pipeGasUpStrTubTemp1 = new G4SubtractionSolid("pipeGasUpStrTubTemp1",aPipeGasUpStrTub,     aDiskVDDSNeutronShieldExitTub, 0, vdDSNeutronShieldExitPositionWRTpipeGasUpStr);
-    G4SubtractionSolid *pipeGasUpStrTubTemp2 = new G4SubtractionSolid("pipeGasUpStrTubTemp2",pipeGasUpStrTubTemp1, aDiskVDSTM_UpStrTub, 0, vdSTM_UpStrPositionWRTpipeGasUpStr);    
+    G4SubtractionSolid *pipeGasUpStrTubTemp2 = new G4SubtractionSolid("pipeGasUpStrTubTemp2",pipeGasUpStrTubTemp1, aDiskVDSTM_UpStrTub, 0, vdSTM_UpStrPositionWRTpipeGasUpStr);
     VolumeInfo pipeGasUpStrTubInfo;
-    pipeGasUpStrTubInfo.name = "pipeGasUpStrTub";    
+    pipeGasUpStrTubInfo.name = "pipeGasUpStrTub";
     pipeGasUpStrTubInfo.solid = pipeGasUpStrTubTemp2;
-    
+
     //make an upstream window to hold the gas/vacuum in the pipe
-    G4Tubs* aPipeUpStrWindowTub = new G4Tubs( "aPipeUpStrWindowTub", 
+    G4Tubs* aPipeUpStrWindowTub = new G4Tubs( "aPipeUpStrWindowTub",
                                             0.0, // inner radius
                                             pSTMTransportPipeParams.radiusIn(), //outer radius of window
                                             pSTMTransportPipeParams.upStrWindowHalflength(),
@@ -362,10 +362,10 @@ namespace mu2e {
                                             CLHEP::twopi);
     VolumeInfo pipeUpStrWindowTubInfo;
     pipeUpStrWindowTubInfo.name = "pipeUpStrWindowTub";
-    pipeUpStrWindowTubInfo.solid = aPipeUpStrWindowTub;       
+    pipeUpStrWindowTubInfo.solid = aPipeUpStrWindowTub;
     CLHEP::Hep3Vector pipeUpStrWindowOffset(0.0, 0.0, -stmMagnetHoleHalfLengths[2]-2.0*pipeUpStrHalfLength+flangeHalfLength);
 
-    
+
     if (pSTMTransportPipeParams.build()){
       if (verbosityLevel>0){
         const double pipeTotalHalfLength = pipeUpStrHalfLength+stmMagnetHoleHalfLengths[2]+pSTMTransportPipeParams.dnStrHalflength();
@@ -399,7 +399,7 @@ namespace mu2e {
                 forceAuxEdgeVisible,
                 placePV,
                 doSurfaceCheck
-                );  
+                );
       finishNesting(pipeDnStrTubInfo,
                 findMaterialOrThrow(pSTMTransportPipeParams.material()),
                 0x0,
@@ -425,7 +425,7 @@ namespace mu2e {
                 forceAuxEdgeVisible,
                 placePV,
                 doSurfaceCheck
-                );            
+                );
       finishNesting(pipeGasDnStrTubInfo,
                 findMaterialOrThrow(pSTMTransportPipeParams.gasMaterial()),
                 0x0,
@@ -438,7 +438,7 @@ namespace mu2e {
                 forceAuxEdgeVisible,
                 placePV,
                 doSurfaceCheck
-                );  
+                );
       finishNesting(pipeUpStrTubInfo,
                 findMaterialOrThrow(pSTMTransportPipeParams.material()),
                 0x0,
@@ -451,7 +451,7 @@ namespace mu2e {
                 forceAuxEdgeVisible,
                 placePV,
                 doSurfaceCheck
-                );            
+                );
       finishNesting(pipeGasUpStrTubInfo,
                 findMaterialOrThrow(pSTMTransportPipeParams.gasMaterial()),
                 0x0,
@@ -464,7 +464,7 @@ namespace mu2e {
                 forceAuxEdgeVisible,
                 placePV,
                 doSurfaceCheck
-                ); 
+                );
       finishNesting(pipeUpStrWindowTubInfo,
                 findMaterialOrThrow(pSTMTransportPipeParams.upStrWindowMaterial()),
                 0x0,
@@ -477,38 +477,38 @@ namespace mu2e {
                 forceAuxEdgeVisible,
                 placePV,
                 doSurfaceCheck
-                );             
+                );
     }
-    
 
-    
+
+
     // ----- Magnetic Field -----------------------------------------------------
     //Create a magnetic field inside the window (hole) of the magnet box
     //and in the pipe, and pipe gas, that goes through the magnet
     //Note the local values for the stepper etc...
     //Geant4 should take ownership of the objects created here
 
-    const double stmMagnetFieldHalfLengths[3] = {pSTMMagnetParams.xHoleHalfLength(), 
+    const double stmMagnetFieldHalfLengths[3] = {pSTMMagnetParams.xHoleHalfLength(),
                                                 pSTMMagnetParams.yHoleHalfLength(),
                                                 pSTMMagnetParams.zHalfLength()-pSTMShieldPipeParams.linerWidth()};
 
     VolumeInfo stmMagneticFieldBoxInfo;
     stmMagneticFieldBoxInfo.name = "stmMagneticField";
-    
+
     // Make another rectangular volume for the magnetic field
     G4Box* boxField  = new G4Box("boxField",stmMagnetFieldHalfLengths[0],stmMagnetFieldHalfLengths[1],stmMagnetFieldHalfLengths[2]);
 
-    G4Tubs* aPipeCenterTubSubt = new G4Tubs( "aPipeCenterTubSubt", 
+    G4Tubs* aPipeCenterTubSubt = new G4Tubs( "aPipeCenterTubSubt",
                                  0.0, //inner radius 0.0 to subtract also the gas region
                                  pSTMTransportPipeParams.radiusOut()+0.01, //outer radius
                                  stmMagnetFieldHalfLengths[2]+1.0,// make the subtraction slightly larger to avoid edge effects
                                  0.0,
-                                 CLHEP::twopi);    
-    
+                                 CLHEP::twopi);
+
     if (pSTMMagnetParams.build()){
       if  (pSTMTransportPipeParams.build()){
 
-          stmMagneticFieldBoxInfo.solid = new G4SubtractionSolid(stmMagneticFieldBoxInfo.name,boxField,aPipeCenterTubSubt,0,zeroVector);                  
+          stmMagneticFieldBoxInfo.solid = new G4SubtractionSolid(stmMagneticFieldBoxInfo.name,boxField,aPipeCenterTubSubt,0,zeroVector);
           finishNesting(stmMagneticFieldBoxInfo,
                         findMaterialOrThrow(_config.getString("hall.insideMaterialName")),
                         0x0,
@@ -517,12 +517,12 @@ namespace mu2e {
                         0,
                         pSTMMagnetParams.fieldVisible(),   //magnetic field itself visible
                         G4Color::Blue(),
-                        false,           
+                        false,
                         forceAuxEdgeVisible,
-                        placePV,         
+                        placePV,
                         doSurfaceCheck
                        );
-          
+
       } else {
           stmMagneticFieldBoxInfo = nestBox("stmMagneticField",
                                             stmMagnetFieldHalfLengths,
@@ -533,19 +533,19 @@ namespace mu2e {
                                             0,
                                             pSTMMagnetParams.fieldVisible(),
                                             G4Color::Blue(),
-                                            false,           
+                                            false,
                                             forceAuxEdgeVisible,
-                                            placePV,         
+                                            placePV,
                                             doSurfaceCheck
-                                           );  
+                                           );
       }
-  
+
       G4MagneticField        *localMagField        = new G4UniformMagField(G4ThreeVector(pSTMMagnetParams.field()*CLHEP::tesla,0.0,0.0));//This makes negatively charged particles go towards the floor
       G4Mag_EqRhs            *MagRHS               = new G4Mag_UsualEqRhs(localMagField);
       G4MagIntegratorStepper *localMagStepper      = new G4ExactHelixStepper(MagRHS); // we use a specialized stepper
       G4ChordFinder          *localMagChordFinder  = new G4ChordFinder(localMagField,1.0e-2*CLHEP::mm,localMagStepper);
       G4FieldManager         *localMagFieldManager = new G4FieldManager(localMagField,localMagChordFinder,false);// pure magnetic filed does not change energy
-  
+
       stmMagneticFieldBoxInfo.logical->SetFieldManager(localMagFieldManager, true); // last "true" arg propagates field to all volumes it contains
       if (pSTMTransportPipeParams.build()){
         pipeCenterTubInfo.logical->SetFieldManager(localMagFieldManager, true); // last "true" arg propagates field to all volumes it contains
@@ -558,11 +558,11 @@ namespace mu2e {
         pipeCenterGasTubInfo.logical->SetUserLimits(mstmMagStepLimit);
       }
 
-    }    
-    
+    }
+
 
     //===================== Field-of-View (FOV) Collimator ==========================
-    
+
     const double stmFOVCollHalfLength1 = pSTMFOVCollimatorParams.halfLength();
     const double stmFOVCollHalfWidth1  = pSTMFOVCollimatorParams.halfWidth();
     const double stmFOVCollHalfHeight1 = pSTMFOVCollimatorParams.halfHeight();
@@ -582,8 +582,8 @@ namespace mu2e {
     // Combine into the collimator with the liner cutout and collimation hole
     VolumeInfo collimatorFOV;
     collimatorFOV.name = "collimatorFOV";
-    collimatorFOV.solid = new G4SubtractionSolid(collimatorFOV.name,boxFOVColl,         tubFOVColl1,0,G4ThreeVector(0.0,0.0,0.0));    
-    collimatorFOV.solid = new G4SubtractionSolid(collimatorFOV.name,collimatorFOV.solid,boxFOVCollLinerToSubt,0,G4ThreeVector(0.0,0.0,-1.0*(stmFOVCollHalfLength1-pSTMFOVCollimatorParams.linerCutOutHalfLength() )));    
+    collimatorFOV.solid = new G4SubtractionSolid(collimatorFOV.name,boxFOVColl,         tubFOVColl1,0,G4ThreeVector(0.0,0.0,0.0));
+    collimatorFOV.solid = new G4SubtractionSolid(collimatorFOV.name,collimatorFOV.solid,boxFOVCollLinerToSubt,0,G4ThreeVector(0.0,0.0,-1.0*(stmFOVCollHalfLength1-pSTMFOVCollimatorParams.linerCutOutHalfLength() )));
 
     //position of liner
     G4ThreeVector stmFOVCollPositionInMu2e2   = stmFOVCollPositionInMu2e1   + G4ThreeVector(0.0,0.0, -stmFOVCollHalfLength1+2.0*pSTMFOVCollimatorParams.linerCutOutHalfLength()-stmFOVCollHalfLength2);
@@ -595,7 +595,7 @@ namespace mu2e {
     // Combine into the liner with hole
     VolumeInfo collimatorFOVliner;
     collimatorFOVliner.name = "collimatorFOVliner";
-    collimatorFOVliner.solid = new G4SubtractionSolid(collimatorFOVliner.name,boxFOVCollLiner,tubFOVCollLiner1,0,G4ThreeVector(0.0,0.0,0.0));    
+    collimatorFOVliner.solid = new G4SubtractionSolid(collimatorFOVliner.name,boxFOVCollLiner,tubFOVCollLiner1,0,G4ThreeVector(0.0,0.0,0.0));
 
     // Liner sheets to cover the upstream corner of FOV collimator
     VolumeInfo FOVlinerH;
@@ -660,8 +660,8 @@ namespace mu2e {
                     placePV,
                     doSurfaceCheck);
 
-    } 
-    
+    }
+
     G4Tubs *tubFOVCollAbsorber = new G4Tubs("tubFOVCollAbsorber", 0.0, pSTMFOVCollimatorParams.hole1RadiusUpStr()-0.01, _config.getDouble("stm.FOVcollimator.absorber.halfLength"), 0.0, CLHEP::twopi );
     VolumeInfo collimatorFOVAbsorber;
     collimatorFOVAbsorber.name = "collimatorFOVAbsorber";
@@ -681,35 +681,35 @@ namespace mu2e {
                     placePV,
                     doSurfaceCheck);
     }
-    
+
     if (verbosityLevel>0){
       std::cout<<__func__<<" STM FOV Coll (lead) z_center     = "<< stmFOVCollPositionInMu2e1.z() <<std::endl;
       std::cout<<__func__<<" STM FOV Coll (lead) z_halflength = "<< stmFOVCollHalfLength1 <<std::endl;
       std::cout<<__func__<<" STM FOV Coll (lead) z_min        = "<< stmFOVCollPositionInMu2e1.z()-stmFOVCollHalfLength1 <<std::endl;
       std::cout<<__func__<<" STM FOV Coll (lead) z_max        = "<< stmFOVCollPositionInMu2e1.z()+stmFOVCollHalfLength1 <<std::endl;
       std::cout<<__func__<<" STM FOV Coll (poly) z_center     = "<< stmFOVCollPositionInMu2e2.z() <<std::endl;
-      std::cout<<__func__<<" STM FOV Coll (poly) z_halflength = "<< stmFOVCollHalfLength2 <<std::endl;    
-      std::cout<<__func__<<" STM FOV Coll (poly) z_min        = "<< stmFOVCollPositionInMu2e2.z()-stmFOVCollHalfLength2 <<std::endl;    
+      std::cout<<__func__<<" STM FOV Coll (poly) z_halflength = "<< stmFOVCollHalfLength2 <<std::endl;
+      std::cout<<__func__<<" STM FOV Coll (poly) z_min        = "<< stmFOVCollPositionInMu2e2.z()-stmFOVCollHalfLength2 <<std::endl;
       std::cout<<__func__<<" STM FOV Coll (poly) z_max        = "<< stmFOVCollPositionInMu2e2.z()+stmFOVCollHalfLength2 <<std::endl;
-      std::cout<<__func__<<" STM FOV Coll (poly) r_UpStr      = "<< pSTMFOVCollimatorParams.hole1RadiusUpStr() <<std::endl;    
+      std::cout<<__func__<<" STM FOV Coll (poly) r_UpStr      = "<< pSTMFOVCollimatorParams.hole1RadiusUpStr() <<std::endl;
     }
-    
-    
+
+
     //===================== Magnet and FOV Collimator Support Table ==========================
-    
+
     //Just use a block of material for now (maybe stainless steel?, specified in configuration)
     G4Material*  stmMagnetSupportTableMaterial   = findMaterialOrThrow(pSTMMagnetSupportTableParams.materialName());
     const double stmMagnetSupportTableHalfLengths[3] = {pSTMMagnetSupportTableParams.tabletopHalfWidth(),
                                                  pSTMMagnetSupportTableParams.tabletopHalfHeight(),
                                                  pSTMMagnetSupportTableParams.tabletopHalfLength()};
-    
+
     const double mstmMagnetStandLegRadius  = pSTMMagnetSupportTableParams.legRadius();
 
     //G4ThreeVector stmMagnetStandPositionInMu2e   = mstmMagnetPositionInMu2e   + G4ThreeVector(0.0, -(pSTMMagnetParams.zHalfLength()+stmMagnetSupportTableHalfLengths[1]), pipeDnStrExtentHalflength + 0.5*stmFOVCollUpStrSpace + stmFOVCollHalfLength1);
     //G4ThreeVector stmMagnetStandPositionInParent = mstmMagnetPositionInParent + G4ThreeVector(0.0, -(pSTMMagnetParams.zHalfLength()+stmMagnetSupportTableHalfLengths[1]), pipeDnStrExtentHalflength + 0.5*stmFOVCollUpStrSpace + stmFOVCollHalfLength1);
     G4ThreeVector stmMagnetSupportTablePositionInMu2e   = pSTMMagnetSupportTableParams.originInMu2e();
     G4ThreeVector stmMagnetSupportTablePositionInParent = pSTMMagnetSupportTableParams.originInMu2e() - parentCenterInMu2e;
-    
+
     const double yExtentLow = std::abs(_config.getDouble("yOfFloorSurface.below.mu2eOrigin") );
     const double mstmMagnetStandLegHalfHeight = (yExtentLow-pSTMMagnetParams.zHalfLength()-2.0*stmMagnetSupportTableHalfLengths[1])/2.0;
     const TubsParams mstmMagnetStandLegParams(0.0, mstmMagnetStandLegRadius, mstmMagnetStandLegHalfHeight , 0.0, CLHEP::twopi);
@@ -722,9 +722,9 @@ namespace mu2e {
     if (pSTMMagnetSupportTableParams.build()){
       VolumeInfo mstmMagnetStandInfo = nestBox("mstmMagnetStandPlatform",
                                           stmMagnetSupportTableHalfLengths,
-                                          stmMagnetSupportTableMaterial, 
+                                          stmMagnetSupportTableMaterial,
                                           0x0,
-                                          stmMagnetSupportTablePositionInParent, //mstmMagnetStandPositionInMother, 
+                                          stmMagnetSupportTablePositionInParent, //mstmMagnetStandPositionInMother,
                                           parentInfo.logical,
                                           0,
                                           STMisVisible,
@@ -748,7 +748,7 @@ namespace mu2e {
                                               forceAuxEdgeVisible,
                                               placePV,
                                               doSurfaceCheck
-                                              ); 
+                                              );
 
       VolumeInfo mstmMagnetStandLeg2Info = nestTubs( "mstmMagnetStandLeg2",
                                               mstmMagnetStandLegParams,
@@ -763,7 +763,7 @@ namespace mu2e {
                                               forceAuxEdgeVisible,
                                               placePV,
                                               doSurfaceCheck
-                                              ); 
+                                              );
 
       VolumeInfo mstmMagnetStandLeg3Info = nestTubs( "mstmMagnetStandLeg3",
                                               mstmMagnetStandLegParams,
@@ -778,7 +778,7 @@ namespace mu2e {
                                               forceAuxEdgeVisible,
                                               placePV,
                                               doSurfaceCheck
-                                              ); 
+                                              );
 
       VolumeInfo mstmMagnetStandLeg4Info = nestTubs( "mstmMagnetStandLeg4",
                                               mstmMagnetStandLegParams,
@@ -793,14 +793,14 @@ namespace mu2e {
                                               forceAuxEdgeVisible,
                                               placePV,
                                               doSurfaceCheck
-                                              ); 
+                                              );
 
     }
-    
-    
-    
+
+
+
     //===================== Spot-Size (SS) Collimator ==========================
-    
+
     const double stmSSCollHalfLength1 = pSTMSSCollimatorParams.halfLength();
     const double stmSSCollHalfWidth1  = pSTMSSCollimatorParams.halfWidth();
     const double stmSSCollHalfHeight1 = pSTMSSCollimatorParams.halfHeight();
@@ -817,13 +817,13 @@ namespace mu2e {
 /*    //Make the tube(s) for the hole(s)
     G4Tubs *tubSSColl1 = new G4Tubs("tubSSColl1", 0.0, pSTMSSCollimatorParams.hole1RadiusUpStr(), stmSSCollHalfLength1+1.0, 0.0, CLHEP::twopi );
     G4Tubs *tubSSColl2 = new G4Tubs("tubSSColl2", 0.0, pSTMSSCollimatorParams.hole2RadiusUpStr(), stmSSCollHalfLength1+1.0, 0.0, CLHEP::twopi );
-    G4SubtractionSolid *collimatorSStemp1 = new G4SubtractionSolid("collimatorSStemp1",boxSSColl,         tubSSColl1,0,G4ThreeVector(pSTMSSCollimatorParams.hole1xOffset(),0.0,0.0));        
+    G4SubtractionSolid *collimatorSStemp1 = new G4SubtractionSolid("collimatorSStemp1",boxSSColl,         tubSSColl1,0,G4ThreeVector(pSTMSSCollimatorParams.hole1xOffset(),0.0,0.0));
     G4SubtractionSolid *collimatorSStemp2 = 0;
     if (pSTMSSCollimatorParams.hole2Build()){
-      collimatorSStemp2 = new G4SubtractionSolid("collimatorSStemp2",collimatorSStemp1, tubSSColl2,0,G4ThreeVector(pSTMSSCollimatorParams.hole2xOffset(),0.0,0.0));    
+      collimatorSStemp2 = new G4SubtractionSolid("collimatorSStemp2",collimatorSStemp1, tubSSColl2,0,G4ThreeVector(pSTMSSCollimatorParams.hole2xOffset(),0.0,0.0));
     } else {
       collimatorSStemp2 = collimatorSStemp1;
-    } */   
+    } */
     //---
 
     GeomHandle<StoppingTarget> stoppingTarget;
@@ -833,88 +833,88 @@ namespace mu2e {
     const double z_distance_tgt_coll = (z_collimator_downstream-z_tgtfoil_downstream);
 
     //Make the conical.disk for the first hole as wide as the StoppingTarget+extra on one end
-    //and as narrow as the desired collimation on the other end    
-    G4Cons* collWindow1 = new G4Cons( "collWindow1", 
+    //and as narrow as the desired collimation on the other end
+    G4Cons* collWindow1 = new G4Cons( "collWindow1",
                                       0.0,                          // rMin cone upstream
                                       foil_downstream.rOut()+150.0, // rMax cone upStream
                                       0.0,                          // rMin cone downstream
                                       pSTMSSCollimatorParams.hole1RadiusDnStr(), // rMax cone downstream
                                       z_distance_tgt_coll/2.0,      //halflength
                                       0.0,                          //start angle
-                                      CLHEP::twopi                  //end angle  
-                                    );    
+                                      CLHEP::twopi                  //end angle
+                                    );
     //Make the conical.disk for the second hole as wide as the StoppingTarget+extra on one end
     //and as narrow as the desired collimation on the other end
-    G4Cons* collWindow2 = new G4Cons( "collWindow2", 
+    G4Cons* collWindow2 = new G4Cons( "collWindow2",
                                       0.0,                          // rMin cone upstream
                                       foil_downstream.rOut()+150.0, // rMax cone upStream
                                       0.0,                          // rMin cone downstream
                                       pSTMSSCollimatorParams.hole2RadiusDnStr(), // rMax cone downstream
                                       z_distance_tgt_coll/2.0,      //halflength
                                       0.0,                          //start angle
-                                      CLHEP::twopi                  //end angle  
+                                      CLHEP::twopi                  //end angle
                                     );
 
-    
+
     const double xoffset_hole1 = pSTMSSCollimatorParams.hole1xOffset();
     const double angleY1 = -1.0*std::atan( (xoffset_hole1/2.0)/(z_distance_tgt_coll/2.0) );
     CLHEP::HepRotationY RYForCone1(angleY1);
     G4RotationMatrix *rotMatrixYforCone1 = reg.add(G4RotationMatrix(RYForCone1));
     const double z_shift1 = z_distance_tgt_coll/2.0*std::sin(std::abs(angleY1)) + pSTMSSCollimatorParams.hole1RadiusDnStr()*std::sin(std::abs(angleY1));
- 
+
     const double xoffset_hole2 = pSTMSSCollimatorParams.hole2xOffset();
     const double angleY2 = -1.0*std::atan( (xoffset_hole2/2.0)/(z_distance_tgt_coll/2.0) );
     CLHEP::HepRotationY RYForCone2(angleY2);
     G4RotationMatrix *rotMatrixYforCone2 = reg.add(G4RotationMatrix(RYForCone2));
     const double z_shift2 = z_distance_tgt_coll/2.0*std::sin(std::abs(angleY2)) + pSTMSSCollimatorParams.hole2RadiusDnStr()*std::sin(std::abs(angleY2));
-    
+
 //     const double z_FOVColl_downstream = stmFOVCollPositionInMu2e1.z() + stmFOVCollHalfLength1;
 //     const double z_SScollimator_downstream = stmSSCollPositionInMu2e1.z() + stmSSCollHalfLength1;
 //     const double z_distance_tgt_coll = (z_SScollimator_downstream-z_FOVColl_downstream);
-//     G4Cons* collWindow1 = new G4Cons( "collWindow1", 
+//     G4Cons* collWindow1 = new G4Cons( "collWindow1",
 //                                       0.0,                     // rMin upstream
 //                                       pSTMFOVCollimatorParams.hole1RadiusUpStr()+5.0,  // rMax upStream, 0.5cm larger than FOV coll opening
 //                                       0.0,                     // rMin downstream
 //                                       pSTMSSCollimatorParams.hole1RadiusDnStr(), // rMax downstream
 //                                       z_distance_tgt_coll/2.0, //halflength
 //                                       0.0,                     //start angle
-//                                       CLHEP::twopi             //end angle  
-//                                     );    
+//                                       CLHEP::twopi             //end angle
+//                                     );
 //     //Make the conical.disk for the first hole as wide as the Stopping Target on one end
 //     //and as narrow as the desired collimation on the other end
-//     G4Cons* collWindow2 = new G4Cons( "collWindow2", 
+//     G4Cons* collWindow2 = new G4Cons( "collWindow2",
 //                                       0.0,                     // rMin upstream
 //                                       pSTMFOVCollimatorParams.hole1RadiusUpStr()+5.0,  // rMax upStream, 0.5cm larger than FOV coll opening
 //                                       0.0,                     // rMin downstream
 //                                       pSTMSSCollimatorParams.hole2RadiusUpStr(), // rMax downstream
 //                                       z_distance_tgt_coll/2.0, //halflength
 //                                       0.0,                     //start angle
-//                                       CLHEP::twopi             //end angle  
-//                                     );    
-    
+//                                       CLHEP::twopi             //end angle
+//                                     );
+
     // Combine into the Wall with the Hole
-    // Use a G4SubtractionSolid to allow for another volume placement through it    
-    G4SubtractionSolid *collimatorSStemp1 = new G4SubtractionSolid("collimatorSStemp1",boxSSColl,collWindow1,rotMatrixYforCone1,G4ThreeVector(xoffset_hole1/2.0,0.0,-1.0*z_distance_tgt_coll/2.0+stmSSCollHalfLength1+z_shift1 ));    
+    // Use a G4SubtractionSolid to allow for another volume placement through it
+    G4SubtractionSolid *collimatorSStemp1 = new G4SubtractionSolid("collimatorSStemp1",boxSSColl,collWindow1,rotMatrixYforCone1,G4ThreeVector(xoffset_hole1/2.0,0.0,-1.0*z_distance_tgt_coll/2.0+stmSSCollHalfLength1+z_shift1 ));
     G4SubtractionSolid *collimatorSStemp2 = 0;
     if (pSTMSSCollimatorParams.hole2Build()){
-      collimatorSStemp2 = new G4SubtractionSolid("collimatorSStemp2",collimatorSStemp1,collWindow2,rotMatrixYforCone2,G4ThreeVector(xoffset_hole2/2.0,0.0,-1.0*z_distance_tgt_coll/2.0+stmSSCollHalfLength1+z_shift2 ));    
+      collimatorSStemp2 = new G4SubtractionSolid("collimatorSStemp2",collimatorSStemp1,collWindow2,rotMatrixYforCone2,G4ThreeVector(xoffset_hole2/2.0,0.0,-1.0*z_distance_tgt_coll/2.0+stmSSCollHalfLength1+z_shift2 ));
     } else {
       collimatorSStemp2 = collimatorSStemp1;
-    }    
+    }
 
     //---
-    
+
     //Make a box to subtract so liner can fit inside
     G4Box* boxSSCollLinerToSubt = new G4Box("boxSSCollLinerToSubt",stmSSCollHalfWidth2+0.001,stmSSCollHalfHeight2+0.001,stmSSCollHalfLength2+0.001);
     // Combine into the collimator with the liner cut-out and collimation hole
     VolumeInfo collimatorSS;
     collimatorSS.name = "collimatorSS";
     if (pSTMSSCollimatorParams.linerBuild()){
-       collimatorSS.solid = new G4SubtractionSolid(collimatorSS.name,collimatorSStemp2,boxSSCollLinerToSubt,0,G4ThreeVector(0.0,0.0,-stmSSCollHalfLength1+stmSSCollHalfLength2));    
+       collimatorSS.solid = new G4SubtractionSolid(collimatorSS.name,collimatorSStemp2,boxSSCollLinerToSubt,0,G4ThreeVector(0.0,0.0,-stmSSCollHalfLength1+stmSSCollHalfLength2));
     } else {
        collimatorSS.solid = collimatorSStemp2;
     }
- 
+
     //position of liner
     G4ThreeVector stmSSCollPositionInMu2e2   = stmSSCollPositionInMu2e1   + G4ThreeVector(0.0,0.0, -stmSSCollHalfLength1+stmSSCollHalfLength2);
     G4ThreeVector stmSSCollPositionInParent2 = stmSSCollPositionInParent1 + G4ThreeVector(0.0,0.0, -stmSSCollHalfLength1+stmSSCollHalfLength2);
@@ -923,19 +923,19 @@ namespace mu2e {
     G4SubtractionSolid *collimatorSSLinerTemp1 = 0;
     if (pSTMSSCollimatorParams.linerBuild()){
       boxSSCollLiner = new G4Box("boxSSCollLiner",stmSSCollHalfWidth2,stmSSCollHalfHeight2,stmSSCollHalfLength2);
-      collimatorSSLinerTemp1 = new G4SubtractionSolid("collimatorSSLinerTemp1",boxSSCollLiner,collWindow1,rotMatrixYforCone1,G4ThreeVector(xoffset_hole1/2.0,0.0,-1.0*z_distance_tgt_coll/2.0+stmSSCollHalfLength1+z_shift1 ));    
+      collimatorSSLinerTemp1 = new G4SubtractionSolid("collimatorSSLinerTemp1",boxSSCollLiner,collWindow1,rotMatrixYforCone1,G4ThreeVector(xoffset_hole1/2.0,0.0,-1.0*z_distance_tgt_coll/2.0+stmSSCollHalfLength1+z_shift1 ));
     } else {
       collimatorSSLinerTemp1 = 0;
     }
-    // tubSSColl1,0,(stmSSCollPositionInMu2e1-stmSSCollPositionInMu2e1)+G4ThreeVector(pSTMSSCollimatorParams.hole1xOffset(),0.0,0.0));    
+    // tubSSColl1,0,(stmSSCollPositionInMu2e1-stmSSCollPositionInMu2e1)+G4ThreeVector(pSTMSSCollimatorParams.hole1xOffset(),0.0,0.0));
     G4SubtractionSolid *collimatorSSLinerTemp2 = 0;
     if (pSTMSSCollimatorParams.hole2Build()){
-      collimatorSSLinerTemp2 = new G4SubtractionSolid("collimatorSSLinerTemp2",collimatorSSLinerTemp1,collWindow2,rotMatrixYforCone2,G4ThreeVector(xoffset_hole2/2.0,0.0,-1.0*z_distance_tgt_coll/2.0+stmSSCollHalfLength1+z_shift2 ));    
-      //tubSSColl2,0,(stmSSCollPositionInMu2e1-stmSSCollPositionInMu2e1)+G4ThreeVector(pSTMSSCollimatorParams.hole2xOffset(),0.0,0.0));    
+      collimatorSSLinerTemp2 = new G4SubtractionSolid("collimatorSSLinerTemp2",collimatorSSLinerTemp1,collWindow2,rotMatrixYforCone2,G4ThreeVector(xoffset_hole2/2.0,0.0,-1.0*z_distance_tgt_coll/2.0+stmSSCollHalfLength1+z_shift2 ));
+      //tubSSColl2,0,(stmSSCollPositionInMu2e1-stmSSCollPositionInMu2e1)+G4ThreeVector(pSTMSSCollimatorParams.hole2xOffset(),0.0,0.0));
     } else {
       collimatorSSLinerTemp2 = collimatorSSLinerTemp1;
     }
-    
+
     VolumeInfo collimatorSSliner;
     collimatorSSliner.name = "collimatorSSliner";
     collimatorSSliner.solid = collimatorSSLinerTemp2;
@@ -967,33 +967,33 @@ namespace mu2e {
                       placePV,
                       doSurfaceCheck);
       }
-    } 
-    
+    }
+
     if (verbosityLevel>0){
       std::cout<<__func__<<" STM SS Coll (lead)   z_center     = "<< stmSSCollPositionInMu2e1.z() <<std::endl;
       std::cout<<__func__<<" STM SS Coll (lead)   z_halflength = "<< stmSSCollHalfLength1 <<std::endl;
       std::cout<<__func__<<" STM SS Coll (lead)   z_max        = "<< stmSSCollPositionInMu2e1.z()+stmSSCollHalfLength1 <<std::endl;
       std::cout<<__func__<<" STM SS Coll (lead)   r_DnStr      = "<< pSTMSSCollimatorParams.hole1RadiusDnStr() <<std::endl;
       std::cout<<__func__<<" STM SS Coll (cutout) z_center     = "<< stmSSCollPositionInMu2e2.z() <<std::endl;
-      std::cout<<__func__<<" STM SS Coll (cutout) z_halflength = "<< stmSSCollHalfLength2 <<std::endl;    
-      std::cout<<__func__<<" STM SS Coll (cutout) z_min        = "<< stmSSCollPositionInMu2e2.z()-stmSSCollHalfLength2 <<std::endl;    
+      std::cout<<__func__<<" STM SS Coll (cutout) z_halflength = "<< stmSSCollHalfLength2 <<std::endl;
+      std::cout<<__func__<<" STM SS Coll (cutout) z_min        = "<< stmSSCollPositionInMu2e2.z()-stmSSCollHalfLength2 <<std::endl;
     }
-    
-    
-    
+
+
+
     //===================== STM Detector Support Table ==========================
-    
+
     //Just use a block of material for now (maybe stainless steel?, specified in configuration)
     G4Material*  stmDetectorSupportTableMaterial   = findMaterialOrThrow(pSTMDetectorSupportTableParams.materialName());
     const double stmDetectorSupportTableHalfLengths[3] = {pSTMDetectorSupportTableParams.tabletopHalfWidth(),
                                                  pSTMDetectorSupportTableParams.tabletopHalfHeight(),
                                                  pSTMDetectorSupportTableParams.tabletopHalfLength()};
-    
+
     const double mstmDetectorStandLegRadius  = pSTMDetectorSupportTableParams.legRadius();
 
     G4ThreeVector stmDetectorSupportTablePositionInMu2e   = pSTMDetectorSupportTableParams.originInMu2e();
     G4ThreeVector stmDetectorSupportTablePositionInParent = pSTMDetectorSupportTableParams.originInMu2e() - parentCenterInMu2e;
-    
+
     //const double yExtentLow = std::abs(_config.getDouble("yOfFloorSurface.below.mu2eOrigin") );
     const double mstmDetectorStandLegHalfHeight = (yExtentLow-pSTMSSCollimatorParams.halfHeight()-2.0*stmDetectorSupportTableHalfLengths[1])/2.0;
     const TubsParams mstmDetectorStandLegParams(0.0, mstmDetectorStandLegRadius, mstmDetectorStandLegHalfHeight , 0.0, CLHEP::twopi);
@@ -1006,9 +1006,9 @@ namespace mu2e {
     if (pSTMDetectorSupportTableParams.build()){
       VolumeInfo mstmDetectorStandInfo = nestBox("mstmDetectorStandPlatform",
                                           stmDetectorSupportTableHalfLengths,
-                                          stmDetectorSupportTableMaterial, 
+                                          stmDetectorSupportTableMaterial,
                                           0x0,
-                                          stmDetectorSupportTablePositionInParent, //mstmDetectorStandPositionInMother, 
+                                          stmDetectorSupportTablePositionInParent, //mstmDetectorStandPositionInMother,
                                           parentInfo.logical,
                                           0,
                                           STMisVisible,
@@ -1032,7 +1032,7 @@ namespace mu2e {
                                               forceAuxEdgeVisible,
                                               placePV,
                                               doSurfaceCheck
-                                              ); 
+                                              );
 
       VolumeInfo mstmDetectorStandLeg2Info = nestTubs( "mstmDetectorStandLeg2",
                                               mstmDetectorStandLegParams,
@@ -1047,7 +1047,7 @@ namespace mu2e {
                                               forceAuxEdgeVisible,
                                               placePV,
                                               doSurfaceCheck
-                                              ); 
+                                              );
 
       VolumeInfo mstmDetectorStandLeg3Info = nestTubs( "mstmDetectorStandLeg3",
                                               mstmDetectorStandLegParams,
@@ -1062,7 +1062,7 @@ namespace mu2e {
                                               forceAuxEdgeVisible,
                                               placePV,
                                               doSurfaceCheck
-                                              ); 
+                                              );
 
       VolumeInfo mstmDetectorStandLeg4Info = nestTubs( "mstmDetectorStandLeg4",
                                               mstmDetectorStandLegParams,
@@ -1077,13 +1077,13 @@ namespace mu2e {
                                               forceAuxEdgeVisible,
                                               placePV,
                                               doSurfaceCheck
-                                              ); 
+                                              );
 
-    }    
-    
-    
+    }
+
+
     //===================== STM Detector 1 ==========================
-    
+
     G4Material*  stmDet1Material                 =  findMaterialOrThrow(pSTMDetector1Params.crystalMaterial());
     const double stmDet1ROut                     =  pSTMDetector1Params.crystalRadiusOut();
     const double stmDet1HalfLength               =  pSTMDetector1Params.crystalHalfLength();
@@ -1102,14 +1102,14 @@ namespace mu2e {
     if ( stmDet1HalfLength > stmDet1CanHalfLength-stmDet1CanDnStrWindowHalfLength-stmDet1CanUpStrWindowHalfLength ){
       throw cet::exception("GEOM")<< " STM: det1 crystal length is larger than the inner length of the can. \n" ;
     }
-    
+
     const TubsParams stmDet1Params(0., stmDet1ROut, stmDet1HalfLength);
     const TubsParams stmDet1CanParams(stmDet1CanRIn, stmDet1CanROut, stmDet1CanHalfLength);
     const TubsParams stmDet1CanGasParams(0.,  stmDet1CanRIn, stmDet1CanHalfLength - stmDet1CanUpStrWindowHalfLength - stmDet1CanDnStrWindowHalfLength);
     const TubsParams stmDet1CanUpStrWindowParams(0., stmDet1CanRIn, stmDet1CanUpStrWindowHalfLength);
     const TubsParams stmDet1CanDnStrWindowParams(0., stmDet1CanRIn, stmDet1CanDnStrWindowHalfLength);
-    
-    G4ThreeVector stmDet1CanPositionInMu2e   = pSTMDetector1Params.originInMu2e();   
+
+    G4ThreeVector stmDet1CanPositionInMu2e   = pSTMDetector1Params.originInMu2e();
     G4ThreeVector stmDet1CanPositionInParent = pSTMDetector1Params.originInMu2e() - parentCenterInMu2e;
     G4ThreeVector stmDet1PositionInMu2e      = stmDet1CanPositionInMu2e;
     G4ThreeVector stmDet1PositionInParent    = stmDet1CanPositionInParent;
@@ -1158,7 +1158,7 @@ namespace mu2e {
                                             placePV,
                                             doSurfaceCheck
                                             );
-    
+
     VolumeInfo stmDet1CanDnStrWindowInfo = nestTubs( "stmDet1CanDnStrWindow",
                                             stmDet1CanDnStrWindowParams,
                                             stmDet1CanDnStrWindowMaterial,
@@ -1175,11 +1175,11 @@ namespace mu2e {
                                             );
 
     if (verbosityLevel>0){
-      std::cout << __func__ << " Warning: Gas not implemented inside STM detector1 can! (so that VD inside can does not overlap with can gas)" << std::endl; 
+      std::cout << __func__ << " Warning: Gas not implemented inside STM detector1 can! (so that VD inside can does not overlap with can gas)" << std::endl;
     }
-    
+
     //===================== STM Detector 2 ==========================
-    
+
     G4Material*  stmDet2Material                 =  findMaterialOrThrow(pSTMDetector2Params.crystalMaterial());
     const double stmDet2ROut                     =  pSTMDetector2Params.crystalRadiusOut();
     const double stmDet2HalfLength               =  pSTMDetector2Params.crystalHalfLength();
@@ -1198,14 +1198,14 @@ namespace mu2e {
     if ( stmDet2HalfLength > stmDet2CanHalfLength-stmDet2CanDnStrWindowHalfLength-stmDet2CanUpStrWindowHalfLength ){
       throw cet::exception("GEOM")<< " STM: det1 crystal length is larger than the inner length of the can. \n" ;
     }
-    
+
     const TubsParams stmDet2Params(0., stmDet2ROut, stmDet2HalfLength);
     const TubsParams stmDet2CanParams(stmDet2CanRIn, stmDet2CanROut, stmDet2CanHalfLength);
     const TubsParams stmDet2CanGasParams(0.,  stmDet2CanRIn, stmDet2CanHalfLength - stmDet2CanUpStrWindowHalfLength - stmDet2CanDnStrWindowHalfLength);
     const TubsParams stmDet2CanUpStrWindowParams(0., stmDet2CanRIn, stmDet2CanUpStrWindowHalfLength);
     const TubsParams stmDet2CanDnStrWindowParams(0., stmDet2CanRIn, stmDet2CanDnStrWindowHalfLength);
-    
-    G4ThreeVector stmDet2CanPositionInMu2e   = pSTMDetector2Params.originInMu2e();   
+
+    G4ThreeVector stmDet2CanPositionInMu2e   = pSTMDetector2Params.originInMu2e();
     G4ThreeVector stmDet2CanPositionInParent = pSTMDetector2Params.originInMu2e() - parentCenterInMu2e;
     G4ThreeVector stmDet2PositionInMu2e      = stmDet2CanPositionInMu2e;
     G4ThreeVector stmDet2PositionInParent    = stmDet2CanPositionInParent;
@@ -1254,7 +1254,7 @@ namespace mu2e {
                                             placePV,
                                             doSurfaceCheck
                                             );
-    
+
     VolumeInfo stmDet2CanDnStrWindowInfo = nestTubs( "stmDet2CanDnStrWindow",
                                             stmDet2CanDnStrWindowParams,
                                             stmDet2CanDnStrWindowMaterial,
@@ -1271,19 +1271,19 @@ namespace mu2e {
                                             );
 
     if (verbosityLevel>0){
-      std::cout << __func__ << " Warning: Gas not implemented inside STM detector1 can! (so that VD inside can does not overlap with can gas)" << std::endl; 
+      std::cout << __func__ << " Warning: Gas not implemented inside STM detector1 can! (so that VD inside can does not overlap with can gas)" << std::endl;
     }
-    
+
     //===================== Shield Pipe/Wall to prevent michel electrons from causing deadtime in the CRV  ==========================
 
     const double mstmCRVShieldDnStrSpace     =  pSTMShieldPipeParams.dnStrSpace();
     const double mstmCRVShieldHalfLength     =  pSTMShieldPipeParams.dnStrWallHalflength();
     const double mstmCRVShieldHalfWidth      =  pSTMMagnetParams.xHalfLength();
     const double mstmCRVShieldHalfHeight     =  pSTMMagnetParams.yHalfLength();
-    
+
     G4ThreeVector mstmCRVShieldPositionInMu2e   = stmMagnetPositionInMu2e + G4ThreeVector(0.0,0.0, -pSTMMagnetParams.zHalfLength()-mstmCRVShieldDnStrSpace-mstmCRVShieldHalfLength);
     G4ThreeVector mstmCRVShieldPositionInParent = mstmCRVShieldPositionInMu2e - parentCenterInMu2e;
-    
+
     // Make the box for the collimator wall
     G4Box* crvShieldBox = new G4Box("crvShieldBox",mstmCRVShieldHalfWidth,mstmCRVShieldHalfHeight,mstmCRVShieldHalfLength);
     //Make the tube for the hole
@@ -1292,21 +1292,21 @@ namespace mu2e {
     // create wall with hole
     VolumeInfo crvshield;
     crvshield.name = "crvshield";
-    crvshield.solid = new G4SubtractionSolid(crvshield.name,crvShieldBox,crvShieldHole,0,G4ThreeVector(0.0,0.0,0.0));    
+    crvshield.solid = new G4SubtractionSolid(crvshield.name,crvShieldBox,crvShieldHole,0,G4ThreeVector(0.0,0.0,0.0));
 
     //Make the tube to shield CRV
     const double crvShieldTubeHalfLength = pSTMShieldPipeParams.pipeHalfLength();
     G4Tubs *crvShieldTubeTemp = new G4Tubs( "crvShieldTubeTemp", pSTMShieldPipeParams.radiusIn(), pSTMShieldPipeParams.radiusIn()+pSTMShieldPipeParams.linerWidth(), crvShieldTubeHalfLength+mstmCRVShieldHalfLength, 0.0, CLHEP::twopi );
-    
+
     G4ThreeVector mstmCRVShieldTubePositionInMu2e      = mstmCRVShieldPositionInMu2e + G4ThreeVector(0.0,0.0,-mstmCRVShieldHalfLength-crvShieldTubeHalfLength-0.1);
     G4ThreeVector mstmCRVShieldTubeInPositionInParent  = mstmCRVShieldPositionInParent + G4ThreeVector(0.0,0.0,-crvShieldTubeHalfLength-0.1);
     G4ThreeVector mstmCRVShieldTubePositionInParent    = mstmCRVShieldPositionInParent + G4ThreeVector(0.0,0.0,-mstmCRVShieldHalfLength-crvShieldTubeHalfLength-0.1);
-    
+
     CLHEP::Hep3Vector vdSTM_UpStrPositionWRTcrvShieldTube           = vdSTM_UpStrPositionInMu2e           - mstmCRVShieldTubePositionInMu2e;
     CLHEP::Hep3Vector vdDSNeutronShieldExitPositionWRTcrvShieldTube = vdDSNeutronShieldExitPositionInMu2e - mstmCRVShieldTubePositionInMu2e;
-    
-    G4SubtractionSolid *crvShieldTubeTemp2 = new G4SubtractionSolid("crvShieldTubeTemp2",crvShieldTubeTemp, aDiskVDDSNeutronShieldExitTub, 0, vdDSNeutronShieldExitPositionWRTcrvShieldTube);    
-    
+
+    G4SubtractionSolid *crvShieldTubeTemp2 = new G4SubtractionSolid("crvShieldTubeTemp2",crvShieldTubeTemp, aDiskVDDSNeutronShieldExitTub, 0, vdDSNeutronShieldExitPositionWRTcrvShieldTube);
+
     VolumeInfo crvlinershieldtube;
     crvlinershieldtube.name = "crvlinershieldtube";
     crvlinershieldtube.solid = new G4SubtractionSolid(crvlinershieldtube.name,crvShieldTubeTemp2, aDiskVDSTM_UpStrTub, 0, vdSTM_UpStrPositionWRTcrvShieldTube);
@@ -1314,7 +1314,7 @@ namespace mu2e {
     VolumeInfo crvsteelshieldtube;
     crvsteelshieldtube.name = "crvsteelshieldtube";
     crvsteelshieldtube.solid = new G4Tubs(crvsteelshieldtube.name , pSTMShieldPipeParams.radiusIn()+pSTMShieldPipeParams.linerWidth(),  pSTMShieldPipeParams.radiusOut(), crvShieldTubeHalfLength, 0.0, CLHEP::twopi );
-    
+
     if (pSTMShieldPipeParams.build()){
       finishNesting(crvshield,
                     findMaterialOrThrow(pSTMShieldPipeParams.material()),
@@ -1339,22 +1339,20 @@ namespace mu2e {
                     STMisSolid,
                     forceAuxEdgeVisible,
                     placePV,
-                    doSurfaceCheck);   
+                    doSurfaceCheck);
       finishNesting(crvsteelshieldtube,
                     findMaterialOrThrow(pSTMShieldPipeParams.material()),
                     0,
-                    mstmCRVShieldTubePositionInParent, 
-                    parentInfo.logical, 
+                    mstmCRVShieldTubePositionInParent,
+                    parentInfo.logical,
                     0,
                     STMisVisible,
                     G4Colour::Magenta(),
                     STMisSolid,
                     forceAuxEdgeVisible,
                     placePV,
-                    doSurfaceCheck); 
+                    doSurfaceCheck);
     }
-    
-    
 
   } // end of constructSTM;
 

--- a/Mu2eG4/src/constructSTM.cc
+++ b/Mu2eG4/src/constructSTM.cc
@@ -89,7 +89,7 @@ namespace mu2e {
        cout << __func__ << " STM verbosityLevel    : " << verbosityLevel  << endl;
     }
 
-    
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
     // Access to the Mu2eG4HelperService.
     Mu2eG4Helper* _helper = &(*(art::ServiceHandle<Mu2eG4Helper>()));
 
@@ -717,7 +717,7 @@ namespace mu2e {
     const double mstmMagnetStandLegOffsetZ = stmMagnetSupportTableHalfLengths[2] - mstmMagnetStandLegRadius - 1.0*CLHEP::cm;
 
     CLHEP::HepRotationX RXForLegs(90.0*CLHEP::degree);
-    G4RotationMatrix *rotMatrixXforLegs = new G4RotationMatrix(RXForLegs);
+    G4RotationMatrix *rotMatrixXforLegs = reg.add(G4RotationMatrix(RXForLegs));
 
     if (pSTMMagnetSupportTableParams.build()){
       VolumeInfo mstmMagnetStandInfo = nestBox("mstmMagnetStandPlatform",
@@ -859,13 +859,13 @@ namespace mu2e {
     const double xoffset_hole1 = pSTMSSCollimatorParams.hole1xOffset();
     const double angleY1 = -1.0*std::atan( (xoffset_hole1/2.0)/(z_distance_tgt_coll/2.0) );
     CLHEP::HepRotationY RYForCone1(angleY1);
-    G4RotationMatrix *rotMatrixYforCone1 = new G4RotationMatrix(RYForCone1);
+    G4RotationMatrix *rotMatrixYforCone1 = reg.add(G4RotationMatrix(RYForCone1));
     const double z_shift1 = z_distance_tgt_coll/2.0*std::sin(std::abs(angleY1)) + pSTMSSCollimatorParams.hole1RadiusDnStr()*std::sin(std::abs(angleY1));
  
     const double xoffset_hole2 = pSTMSSCollimatorParams.hole2xOffset();
     const double angleY2 = -1.0*std::atan( (xoffset_hole2/2.0)/(z_distance_tgt_coll/2.0) );
     CLHEP::HepRotationY RYForCone2(angleY2);
-    G4RotationMatrix *rotMatrixYforCone2 = new G4RotationMatrix(RYForCone2);
+    G4RotationMatrix *rotMatrixYforCone2 = reg.add(G4RotationMatrix(RYForCone2));
     const double z_shift2 = z_distance_tgt_coll/2.0*std::sin(std::abs(angleY2)) + pSTMSSCollimatorParams.hole2RadiusDnStr()*std::sin(std::abs(angleY2));
     
 //     const double z_FOVColl_downstream = stmFOVCollPositionInMu2e1.z() + stmFOVCollHalfLength1;
@@ -1001,7 +1001,7 @@ namespace mu2e {
     const double mstmDetectorStandLegOffsetZ = stmDetectorSupportTableHalfLengths[2] - mstmDetectorStandLegRadius - 1.0*CLHEP::cm;
 
     //CLHEP::HepRotationX RXForLegs(90.0*CLHEP::degree);
-    //G4RotationMatrix *rotMatrixXforLegs = new G4RotationMatrix(RXForLegs);
+    //G4RotationMatrix *rotMatrixXforLegs = reg.add(G4RotationMatrix(RXForLegs));
 
     if (pSTMDetectorSupportTableParams.build()){
       VolumeInfo mstmDetectorStandInfo = nestBox("mstmDetectorStandPlatform",

--- a/Mu2eG4/src/constructSaddles.cc
+++ b/Mu2eG4/src/constructSaddles.cc
@@ -25,6 +25,7 @@
 #include "GeometryService/inc/WorldG4.hh"
 #include "Mu2eG4/inc/findMaterialOrThrow.hh"
 #include "Mu2eG4Helper/inc/VolumeInfo.hh"
+#include "Mu2eG4Helper/inc/Mu2eG4Helper.hh"
 #include "GeomPrimitives/inc/Tube.hh"
 #include "GeomPrimitives/inc/TubsParams.hh"
 #include "ConfigTools/inc/SimpleConfig.hh"
@@ -60,6 +61,7 @@ namespace mu2e {
 
     GeomHandle<Saddle> saddleSet;
 
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
     // Utility for converting orientations to rotations
     OrientationResolver* OR = new OrientationResolver();
 
@@ -141,7 +143,7 @@ namespace mu2e {
 	  // Make the needed rotation by parsing orientation
 	  std::string orientSAInit = orientsSA[i];
 
-	  CLHEP::HepRotation* itsSARotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	  CLHEP::HepRotation* itsSARotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	  OR->getRotationFromOrientation( *itsSARotat, orientSAInit );
 
 	  // ****************************************
@@ -199,7 +201,7 @@ namespace mu2e {
 					     windparams.data()[3], 
 					     windparams.data()[4]);
 	    
-	      CLHEP::HepRotation* windRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	      CLHEP::HepRotation* windRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	      OR->getRotationFromOrientation( *windRotat, holeOrientsSA[hID] );
 
 	      
@@ -248,7 +250,7 @@ namespace mu2e {
 					     tempDims[1],
 					     tempDims[2]);
 
-	      CLHEP::HepRotation* notchRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	      CLHEP::HepRotation* notchRotat(nullptr);
 
 
 	      if ( 0 == aSolid ) { 

--- a/Mu2eG4/src/constructSaddles.cc
+++ b/Mu2eG4/src/constructSaddles.cc
@@ -1,10 +1,10 @@
 // Function to build G4 rep of saddles for cryostats.
-// 
-// 
+//
+//
 // David Norvil Brown, University of Louisville, 02 June 2017, based
 // on constructExternalShielding, written November 2014
 //
-// 
+//
 
 #include "Mu2eG4/inc/constructSaddles.hh"
 
@@ -69,13 +69,13 @@ namespace mu2e {
     const auto geomOptions = art::ServiceHandle<GeometryService>()->geomOptions();
     geomOptions->loadEntry( config, "saddle", "saddle");
 
-    const bool saddleIsVisible     = geomOptions->isVisible("saddle"); 
-    const bool saddleIsSolid       = geomOptions->isSolid("saddle");     
-    const bool forceAuxEdgeVisible = geomOptions->forceAuxEdgeVisible("saddle"); 
-    const bool doSurfaceCheck      = geomOptions->doSurfaceCheck("saddle"); 
-    const bool placePV             = geomOptions->placePV("saddle"); 
-    
-  
+    const bool saddleIsVisible     = geomOptions->isVisible("saddle");
+    const bool saddleIsSolid       = geomOptions->isSolid("saddle");
+    const bool forceAuxEdgeVisible = geomOptions->forceAuxEdgeVisible("saddle");
+    const bool doSurfaceCheck      = geomOptions->doSurfaceCheck("saddle");
+    const bool placePV             = geomOptions->placePV("saddle");
+
+
     //================================================================
     // OK, so in version 1, Saddles were just extruded boxes that,
     // when taken as a whole, looked like a bunch of saddles and
@@ -83,7 +83,7 @@ namespace mu2e {
     // In version 2,3, Saddles are logical structures, each of which looks
     // like an individual saddle or stand.  Each saddle contains
     // an extruded box with holes and/or notches.
-    //================================================================    
+    //================================================================
 
     if ( saddleSet->getVersion() <= 3 ) {
       //----------------------------------------------------------------
@@ -111,216 +111,215 @@ namespace mu2e {
       int nBox = outlSA.size();
 
       for(int i = 0; i < nBox; i++)
-	{
-	  // combine the tolerances with the outline dimensions.
-	  std::vector<G4TwoVector> itsOutline;
-	  std::vector<std::vector<double> > vertices = outlSA[i];
-	  double du = tolsSA[i][0];
-	  double dv = tolsSA[i][1];
-	  double dw = tolsSA[i][2];
-	  double hlen = lengSA[i];
+        {
+          // combine the tolerances with the outline dimensions.
+          std::vector<G4TwoVector> itsOutline;
+          std::vector<std::vector<double> > vertices = outlSA[i];
+          double du = tolsSA[i][0];
+          double dv = tolsSA[i][1];
+          double dw = tolsSA[i][2];
+          double hlen = lengSA[i];
 
-	  for ( unsigned int idim = 0; idim < vertices.size(); idim++ ) {
-	    if ( vertices[idim][0] > -10.0 * CLHEP::mm) {
-	      vertices[idim][0] += du;
-	    } else {
-	      vertices[idim][0] -= du;
-	    }
-	    if (vertices[idim][1] > -10.0 * CLHEP::mm ) {
-	      vertices[idim][1] += dv;
-	    } else {
-	      vertices[idim][1] -= dv;
-	    }
-	    G4TwoVector vertex( vertices[idim][0], vertices[idim][1] );
-	    itsOutline.push_back(vertex);
-	  }
-	  hlen += dw;
-	  
-	  //  Make the name of the box
-	  std::ostringstream name;
-	  name << "SaddleBox_" << i+1 ;
+          for ( unsigned int idim = 0; idim < vertices.size(); idim++ ) {
+            if ( vertices[idim][0] > -10.0 * CLHEP::mm) {
+              vertices[idim][0] += du;
+            } else {
+              vertices[idim][0] -= du;
+            }
+            if (vertices[idim][1] > -10.0 * CLHEP::mm ) {
+              vertices[idim][1] += dv;
+            } else {
+              vertices[idim][1] -= dv;
+            }
+            G4TwoVector vertex( vertices[idim][0], vertices[idim][1] );
+            itsOutline.push_back(vertex);
+          }
+          hlen += dw;
 
-	  // Make the needed rotation by parsing orientation
-	  std::string orientSAInit = orientsSA[i];
+          //  Make the name of the box
+          std::ostringstream name;
+          name << "SaddleBox_" << i+1 ;
 
-	  CLHEP::HepRotation* itsSARotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	  OR->getRotationFromOrientation( *itsSARotat, orientSAInit );
+          // Make the needed rotation by parsing orientation
+          std::string orientSAInit = orientsSA[i];
 
-	  // ****************************************
-	  // Now add holes and notches
-	  // ***************************************
-	  if ( nHolesSA[i] + nNotchesSA[i] > 0 ) {
-	    
-	    // This box has at least one window or notch.  
-	    // Each is implemented as a
-	    // G4SubtractionSolid to allow for another volume placement
-	    // through it.  First go ahead and make the extrusion for the block.
-	    std::ostringstream name1;
-	    name1 << "SaddleBox_sub_" << i+1;
+          CLHEP::HepRotation* itsSARotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+          OR->getRotationFromOrientation( *itsSARotat, orientSAInit );
 
-	    G4ExtrudedSolid* block = new G4ExtrudedSolid( name1.str(),
-							  itsOutline,
-							  hlen,
-							  G4TwoVector(0,0), 1.,
-							  G4TwoVector(0,0), 1.);
-	  
-	    // Now create the volume for the block
-	    VolumeInfo extShieldVol(name.str(),
-				    sitesSA[i]-parent.centerInMu2e(),
-				    parent.centerInWorld);
+          // ****************************************
+          // Now add holes and notches
+          // ***************************************
+          if ( nHolesSA[i] + nNotchesSA[i] > 0 ) {
 
-	  
-	    // Create a subtraction solid that will become the solid for the 
-	    // volume.
+            // This box has at least one window or notch.
+            // Each is implemented as a
+            // G4SubtractionSolid to allow for another volume placement
+            // through it.  First go ahead and make the extrusion for the block.
+            std::ostringstream name1;
+            name1 << "SaddleBox_sub_" << i+1;
 
-	    G4SubtractionSolid* aSolid = 0;
+            G4ExtrudedSolid* block = new G4ExtrudedSolid( name1.str(),
+                                                          itsOutline,
+                                                          hlen,
+                                                          G4TwoVector(0,0), 1.,
+                                                          G4TwoVector(0,0), 1.);
 
-	    // Find the index of the first hole, for accessing info lists...
-	    int hID = holeIDSA[i];
-
-	    // Now loop over the holes and make them.
-	    for ( int jHole = 0; jHole < nHolesSA[i]; jHole++ ) {
-	      // Now make the window (AKA "Hole")
-	      name << "h" << jHole+1;
-	      //	    std::cout << __func__ << " making " << name.str() << std::endl;
-
-	      int thisHID = hID + jHole; // get pointer for right hole
-	      
-	      const TubsParams windparams(0.0,  //inner radius
-					  holeRadSA[thisHID], // outer
-					  holeLenSA[thisHID]  //obvious?
-					  );
-
-	      std::ostringstream name2;
-	      name2 << "SaddleBox" << i+1 << "hole" << jHole+1;
-
-	      G4Tubs* aWindTub = new G4Tubs( name2.str(), 
-					     windparams.data()[0], 
-					     windparams.data()[1], 
-					     windparams.data()[2]+2.,// to satisfy a G4SubtractionSolid feature
-					     windparams.data()[3], 
-					     windparams.data()[4]);
-	    
-	      CLHEP::HepRotation* windRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	      OR->getRotationFromOrientation( *windRotat, holeOrientsSA[hID] );
-
-	      
-	      if ( 0 == aSolid ) { 
-		aSolid = new G4SubtractionSolid( extShieldVol.name,
-						 block,
-						 aWindTub,
-						 windRotat,
-						 holeLocSA[thisHID]);
-	      } else {
-		G4SubtractionSolid * bSolid = new G4SubtractionSolid 
-		  ( extShieldVol.name,
-		    aSolid,
-		    aWindTub,
-		    windRotat,
-		    holeLocSA[thisHID]);
-		aSolid = bSolid;
-	      }
-	    } // End of loop over holes. Now loop over notches.
+            // Now create the volume for the block
+            VolumeInfo extShieldVol(name.str(),
+                                    sitesSA[i]-parent.centerInMu2e(),
+                                    parent.centerInWorld);
 
 
-	    // Find the index of the first notch, for accessing info lists...
-	    int notchID = notchIDSA[i];
-	    
-	    for ( int jNotch = 0; jNotch < nNotchesSA[i]; jNotch++ ) {
-	      int thisNID = notchID + jNotch; //index for this notch
+            // Create a subtraction solid that will become the solid for the
+            // volume.
 
-	      // Put notch(es) into box now
+            G4SubtractionSolid* aSolid = 0;
 
-	      // Each notch is implemented as a
-	      // G4SubtractionSolid to allow for another volume placement
-	      // through it
+            // Find the index of the first hole, for accessing info lists...
+            int hID = holeIDSA[i];
 
-	      // Now make the notch 
-	      name << "n" << jNotch+1;
+            // Now loop over the holes and make them.
+            for ( int jHole = 0; jHole < nHolesSA[i]; jHole++ ) {
+              // Now make the window (AKA "Hole")
+              name << "h" << jHole+1;
+              //            std::cout << __func__ << " making " << name.str() << std::endl;
 
+              int thisHID = hID + jHole; // get pointer for right hole
 
-	      // Get dimensions of this box
-	      std::vector<double>tempDims = notchDimSA[thisNID];
-	      
-	      std::ostringstream name2;
-	      name2 << "SaddleBox" << i+1 << "Notch" << jNotch+1;
+              const TubsParams windparams(0.0,  //inner radius
+                                          holeRadSA[thisHID], // outer
+                                          holeLenSA[thisHID]  //obvious?
+                                          );
 
-	      G4Box* aNotchBox = new G4Box(  name2.str(), 
-					     tempDims[0],
-					     tempDims[1],
-					     tempDims[2]);
+              std::ostringstream name2;
+              name2 << "SaddleBox" << i+1 << "hole" << jHole+1;
 
-	      CLHEP::HepRotation* notchRotat(nullptr);
+              G4Tubs* aWindTub = new G4Tubs( name2.str(),
+                                             windparams.data()[0],
+                                             windparams.data()[1],
+                                             windparams.data()[2]+2.,// to satisfy a G4SubtractionSolid feature
+                                             windparams.data()[3],
+                                             windparams.data()[4]);
 
-
-	      if ( 0 == aSolid ) { 
-		aSolid = new G4SubtractionSolid( extShieldVol.name,
-						 block,
-						 aNotchBox,
-						 notchRotat,
-						 notchLocSA[thisNID]);
-	      } else {
-		G4SubtractionSolid * bSolid = new G4SubtractionSolid 
-		  ( extShieldVol.name,
-		    aSolid,
-		    aNotchBox,
-		    notchRotat,
-		    notchLocSA[thisNID]);
-		aSolid = bSolid;
-	      }
-	    } // End of loop over notches
-
-	    extShieldVol.solid = aSolid;
-
-	    finishNesting(extShieldVol,
-			  findMaterialOrThrow(matsSA[i]),
-			  itsSARotat,
-			  extShieldVol.centerInParent,
-			  parent.logical,
-			  0,
-			  saddleIsVisible,
-			  G4Colour::Magenta(),
-			  saddleIsSolid,
-			  forceAuxEdgeVisible,
-			  placePV,
-			  doSurfaceCheck);
-	  } else {
-
-	    // Build each normal box here.  Normal means no holes or notches.
-
-	    VolumeInfo extShieldVol(name.str(),
-				    sitesSA[i]-parent.centerInMu2e(),
-				    parent.centerInWorld);
-
-	    extShieldVol.solid = new G4ExtrudedSolid( extShieldVol.name,
-						      itsOutline,
-						      hlen,
-						      G4TwoVector(0,0), 1.,
-						      G4TwoVector(0,0), 1.);
+              CLHEP::HepRotation* windRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+              OR->getRotationFromOrientation( *windRotat, holeOrientsSA[hID] );
 
 
-	    finishNesting(extShieldVol,
-			  findMaterialOrThrow(matsSA[i]),
-			  itsSARotat,
-			  extShieldVol.centerInParent,
-			  parent.logical,
-			  0,
-			  saddleIsVisible,
-			  G4Colour::Magenta(),
-			  saddleIsSolid,
-			  forceAuxEdgeVisible,
-			  placePV,
-			  doSurfaceCheck);
-	  
-	  } // end of if...else...
-	
-	} // end of for loop over saddles
-    
+              if ( 0 == aSolid ) {
+                aSolid = new G4SubtractionSolid( extShieldVol.name,
+                                                 block,
+                                                 aWindTub,
+                                                 windRotat,
+                                                 holeLocSA[thisHID]);
+              } else {
+                G4SubtractionSolid * bSolid = new G4SubtractionSolid
+                  ( extShieldVol.name,
+                    aSolid,
+                    aWindTub,
+                    windRotat,
+                    holeLocSA[thisHID]);
+                aSolid = bSolid;
+              }
+            } // End of loop over holes. Now loop over notches.
+
+
+            // Find the index of the first notch, for accessing info lists...
+            int notchID = notchIDSA[i];
+
+            for ( int jNotch = 0; jNotch < nNotchesSA[i]; jNotch++ ) {
+              int thisNID = notchID + jNotch; //index for this notch
+
+              // Put notch(es) into box now
+
+              // Each notch is implemented as a
+              // G4SubtractionSolid to allow for another volume placement
+              // through it
+
+              // Now make the notch
+              name << "n" << jNotch+1;
+
+
+              // Get dimensions of this box
+              std::vector<double>tempDims = notchDimSA[thisNID];
+
+              std::ostringstream name2;
+              name2 << "SaddleBox" << i+1 << "Notch" << jNotch+1;
+
+              G4Box* aNotchBox = new G4Box(  name2.str(),
+                                             tempDims[0],
+                                             tempDims[1],
+                                             tempDims[2]);
+
+              CLHEP::HepRotation* notchRotat(nullptr);
+
+
+              if ( 0 == aSolid ) {
+                aSolid = new G4SubtractionSolid( extShieldVol.name,
+                                                 block,
+                                                 aNotchBox,
+                                                 notchRotat,
+                                                 notchLocSA[thisNID]);
+              } else {
+                G4SubtractionSolid * bSolid = new G4SubtractionSolid
+                  ( extShieldVol.name,
+                    aSolid,
+                    aNotchBox,
+                    notchRotat,
+                    notchLocSA[thisNID]);
+                aSolid = bSolid;
+              }
+            } // End of loop over notches
+
+            extShieldVol.solid = aSolid;
+
+            finishNesting(extShieldVol,
+                          findMaterialOrThrow(matsSA[i]),
+                          itsSARotat,
+                          extShieldVol.centerInParent,
+                          parent.logical,
+                          0,
+                          saddleIsVisible,
+                          G4Colour::Magenta(),
+                          saddleIsSolid,
+                          forceAuxEdgeVisible,
+                          placePV,
+                          doSurfaceCheck);
+          } else {
+
+            // Build each normal box here.  Normal means no holes or notches.
+
+            VolumeInfo extShieldVol(name.str(),
+                                    sitesSA[i]-parent.centerInMu2e(),
+                                    parent.centerInWorld);
+
+            extShieldVol.solid = new G4ExtrudedSolid( extShieldVol.name,
+                                                      itsOutline,
+                                                      hlen,
+                                                      G4TwoVector(0,0), 1.,
+                                                      G4TwoVector(0,0), 1.);
+
+
+            finishNesting(extShieldVol,
+                          findMaterialOrThrow(matsSA[i]),
+                          itsSARotat,
+                          extShieldVol.centerInParent,
+                          parent.logical,
+                          0,
+                          saddleIsVisible,
+                          G4Colour::Magenta(),
+                          saddleIsSolid,
+                          forceAuxEdgeVisible,
+                          placePV,
+                          doSurfaceCheck);
+
+          } // end of if...else...
+
+        } // end of for loop over saddles
+
     } else { // end of version 1, 2, 3.  At this time, other versions are not
       // implemented.
       std::cout << "Requested Saddle version " << saddleSet->getVersion() << ".  Only versions 1 and 2 currently supported." << std::endl;
-    }  
+    }
   } // end of constructSaddles fn
 
 } // namespace mu2e
-

--- a/Mu2eG4/src/constructTS.cc
+++ b/Mu2eG4/src/constructTS.cc
@@ -81,7 +81,7 @@ namespace mu2e {
   // CONSTRUCT CRYOSTAT
   //__________________________________
 
-  void constructCryostat( VolumeInfo const& parent, 
+  void constructCryostat( VolumeInfo const& parent,
                           SimpleConfig const& config,
                           Beamline const& bl ) {
 
@@ -114,8 +114,8 @@ namespace mu2e {
     // Build upstream end wall of TS1
     strsec = ts->getTSCryo<StraightSection>(TransportSolenoid::TSRegion::TS1,TransportSolenoid::TSRadialPart::IN );
 
-    CLHEP::Hep3Vector pos( strsec->getGlobal().x(), 
-                           strsec->getGlobal().y(), 
+    CLHEP::Hep3Vector pos( strsec->getGlobal().x(),
+                           strsec->getGlobal().y(),
                            strsec->getGlobal().z()-strsec->getHalfLength()+ts->endWallU1_halfLength() );
 
     std::string tssName  = "TS1UpstreamEndwall";
@@ -129,12 +129,12 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
     if ( verbosityLevel ) {
       G4cout << __func__ << " Upstream TS1 endwall at: " << pos << G4endl;
@@ -152,7 +152,7 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     strsec = ts->getTSCryo<StraightSection>(TransportSolenoid::TSRegion::TS1,TransportSolenoid::TSRadialPart::IN);
@@ -168,17 +168,17 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
-    
+
     if ( verbosityLevel > 0) {
       G4cout << __func__ << " TS1(in)  OffsetInMu2e  : " << strsec->getGlobal()   << G4endl;
-      G4cout << __func__ << " TS1(in)  Extent        :[ " << strsec->getGlobal().z() - strsec->getHalfLength() <<","  
+      G4cout << __func__ << " TS1(in)  Extent        :[ " << strsec->getGlobal().z() - strsec->getHalfLength() <<","
            << strsec->getGlobal().z() + strsec->getHalfLength() << "]" << G4endl;
       G4cout << __func__ << " TS1(in)  rotation      : " << *(strsec->getRotation()) << G4endl;
      }
@@ -196,24 +196,24 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
-    
+
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
 
     if ( verbosityLevel > 0) {
       G4cout << __func__ << " TS1(out) OffsetInMu2e  : " << strsec->getGlobal()   << G4endl;
       G4cout << __func__ << " TS1(out) rotation      : " << *(strsec->getRotation()) << G4endl;
     }
-    
+
     // Build downstream partial end wall of TS1
-    CLHEP::Hep3Vector pos2( strsec->getGlobal().x(), 
-                            strsec->getGlobal().y(), 
+    CLHEP::Hep3Vector pos2( strsec->getGlobal().x(),
+                            strsec->getGlobal().y(),
                             strsec->getGlobal().z()+strsec->getHalfLength()+ts->endWallU2_halfLength() );
-  
+
     tssName = "TS1DownstreamEndwall";
     nestTubs( tssName,
               TubsParams( ts->endWallU2_rIn(),
@@ -225,17 +225,17 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
-              
+
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
 
     if ( verbosityLevel ) {
       G4cout << __func__ << " Downstream TS1 endwall at: " << pos2 << G4endl;
-      G4cout << __func__ << " Downstream TS1 extent   [: " << pos2.z()-ts->endWallU2_halfLength() 
+      G4cout << __func__ << " Downstream TS1 extent   [: " << pos2.z()-ts->endWallU2_halfLength()
            << "," << pos2.z() +ts->endWallU2_halfLength() << "]" << G4endl;
     }
 
@@ -255,13 +255,13 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     if(tsThermalShield) {
       VolumeInfo useAsParent = _helper->locateVolInfo( "TS1CryoInsVac" );
       addThermalShield(*ts, useAsParent, config, TransportSolenoid::TSRegion::TS1,
-		       thermalShieldMLIMaterial, thermalShieldMidMaterial, -1.);
+                       thermalShieldMLIMaterial, thermalShieldMidMaterial, -1.);
     }
 
     // Build TS2
@@ -274,7 +274,7 @@ namespace mu2e {
               parent,
               0,
               G4Color::Green(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     torsec = ts->getTSPolyLining(TransportSolenoid::TSRegion::TS2);
@@ -288,7 +288,7 @@ namespace mu2e {
                 ts2Vacuum,
                 0,
                 G4Color::Yellow(),
-		"TSPoly"
+                "TSPoly"
                 );
     }
 
@@ -305,12 +305,12 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
 
     torsec = ts->getTSCryo<TorusSection>(TransportSolenoid::TSRegion::TS2,TransportSolenoid::TSRadialPart::OUT );
@@ -326,12 +326,12 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
 
 
@@ -349,13 +349,13 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     if(tsThermalShield) {
       VolumeInfo useAsParent = _helper->locateVolInfo( "TS2CryoInsVac" );
       addThermalShield(*ts, useAsParent, config, TransportSolenoid::TSRegion::TS2,
-		       thermalShieldMLIMaterial, thermalShieldMidMaterial, -1.);
+                       thermalShieldMLIMaterial, thermalShieldMidMaterial, -1.);
     }
 
     // Build TS3
@@ -368,7 +368,7 @@ namespace mu2e {
               parent,
               0,
               G4Color::Green(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     double ts3InsVacRIn = strsec->rOut();
@@ -383,12 +383,12 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
 
     strsec = ts->getTSCryo<StraightSection>(TransportSolenoid::TSRegion::TS3,TransportSolenoid::TSRadialPart::OUT );
@@ -405,12 +405,12 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
 
     if ( verbosityLevel > 0) {
@@ -432,7 +432,7 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     if(tsThermalShield) {
@@ -440,45 +440,45 @@ namespace mu2e {
       double ts3WallThickness = config.getDouble("pbar.support.midThickness")*CLHEP::mm;
       VolumeInfo useAsParent = _helper->locateVolInfo( "TS3CryoInsVac" );
       addThermalShield(*ts, useAsParent, config, TransportSolenoid::TSRegion::TS3,
-		       thermalShieldMLIMaterial, thermalShieldMidMaterial, ts3WallThickness);
+                       thermalShieldMLIMaterial, thermalShieldMidMaterial, ts3WallThickness);
     }
 
     //Add TSu-TSd interconnect
     if(config.getBool("ts.tsudinterconnect.build", false)) {
-      //strsec = TS3 section 
+      //strsec = TS3 section
       std::string tsudinterconnect_material = config.getString("ts.tsudinterconnect.material");
       double tsudinterconnect_xoffset = config.getDouble("ts.tsudinterconnect.xoffset");
       double tsudinterconnect_rin = config.getDouble("ts.tsudinterconnect.rIn");
       double tsudinterconnect_rout = config.getDouble("ts.tsudinterconnect.rOut");
       double tsudinterconnect_halflength = config.getDouble("ts.tsudinterconnect.halfLength");
       G4Material* tsud_mat = findMaterialOrThrow(tsudinterconnect_material);
-      
+
       nestTubs( "TSudInterconnectu",
-		TubsParams( tsudinterconnect_rin,
-			    tsudinterconnect_rout,
-			    tsudinterconnect_halflength),
-		tsud_mat,
-		strsec->getRotation(),
-		strsec->getGlobal()-_hallOriginInMu2e 
-		+ CLHEP::Hep3Vector(tsudinterconnect_xoffset+tsudinterconnect_halflength, 0., 0.),
-		parent,
-		0,
-		G4Color::Red(),
-		"TSCryo"
-		);
+                TubsParams( tsudinterconnect_rin,
+                            tsudinterconnect_rout,
+                            tsudinterconnect_halflength),
+                tsud_mat,
+                strsec->getRotation(),
+                strsec->getGlobal()-_hallOriginInMu2e
+                + CLHEP::Hep3Vector(tsudinterconnect_xoffset+tsudinterconnect_halflength, 0., 0.),
+                parent,
+                0,
+                G4Color::Red(),
+                "TSCryo"
+                );
       nestTubs( "TSudInterconnectd",
-		TubsParams( tsudinterconnect_rin,
-			    tsudinterconnect_rout,
-			    tsudinterconnect_halflength),
-		tsud_mat,
-		strsec->getRotation(),
-		strsec->getGlobal()-_hallOriginInMu2e 
-		- CLHEP::Hep3Vector(tsudinterconnect_xoffset+tsudinterconnect_halflength, 0., 0.),
-		parent,
-		0,
-		G4Color::Red(),
-		"TSCryo"
-		);
+                TubsParams( tsudinterconnect_rin,
+                            tsudinterconnect_rout,
+                            tsudinterconnect_halflength),
+                tsud_mat,
+                strsec->getRotation(),
+                strsec->getGlobal()-_hallOriginInMu2e
+                - CLHEP::Hep3Vector(tsudinterconnect_xoffset+tsudinterconnect_halflength, 0., 0.),
+                parent,
+                0,
+                G4Color::Red(),
+                "TSCryo"
+                );
     }
 
     // Build TS4
@@ -491,7 +491,7 @@ namespace mu2e {
               parent,
               0,
               G4Color::Yellow(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     torsec = ts->getTSPolyLining(TransportSolenoid::TSRegion::TS4);
@@ -505,7 +505,7 @@ namespace mu2e {
                 ts4Vacuum,
                 0,
                 G4Color::Yellow(),
-		"TSPoly"
+                "TSPoly"
                 );
     }
 
@@ -521,12 +521,12 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
 
     torsec = ts->getTSCryo<TorusSection>(TransportSolenoid::TSRegion::TS4,TransportSolenoid::TSRadialPart::OUT );
@@ -541,12 +541,12 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
 
     // Put in the insulating vacuum, which will serve as the mother volume
@@ -562,19 +562,19 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
 
     if(tsThermalShield) {
       VolumeInfo useAsParent = _helper->locateVolInfo( "TS4CryoInsVac" );
       addThermalShield(*ts, useAsParent, config, TransportSolenoid::TSRegion::TS4,
-		       thermalShieldMLIMaterial, thermalShieldMidMaterial, -1.);
+                       thermalShieldMLIMaterial, thermalShieldMidMaterial, -1.);
     }
 
 
     // Build TS5.
-    strsec = ts->getTSCryo<StraightSection>(TransportSolenoid::TSRegion::TS5,TransportSolenoid::TSRadialPart::IN );    
+    strsec = ts->getTSCryo<StraightSection>(TransportSolenoid::TSRegion::TS5,TransportSolenoid::TSRadialPart::IN );
     CLHEP::Hep3Vector globalVac5Position = CLHEP::Hep3Vector(strsec->getGlobal().x(),
                                                              strsec->getGlobal().y(),
                                                              strsec->getGlobal().z() );
@@ -587,7 +587,7 @@ namespace mu2e {
               parent,
               0,
               G4Color::Green(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     double ts5InsVacRIn = strsec->rOut();
@@ -611,12 +611,12 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
 
     strsec = ts->getTSCryo<StraightSection>(TransportSolenoid::TSRegion::TS5,TransportSolenoid::TSRadialPart::OUT );
@@ -632,14 +632,14 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
-   
+
     if ( verbosityLevel > 0) {
       G4cout << __func__ << " TS5  OffsetInMu2e : " << strsec->getGlobal()   << G4endl;
       G4cout << __func__ << " TS5  rotation     : " << *(strsec->getRotation()) << G4endl;
@@ -663,14 +663,14 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
 
 
     if(tsThermalShield) {
       VolumeInfo useAsParent = _helper->locateVolInfo( "TS5CryoInsVac" );
       addThermalShield(*ts, useAsParent, config, TransportSolenoid::TSRegion::TS5,
-		       thermalShieldMLIMaterial, thermalShieldMidMaterial, -1.);
+                       thermalShieldMLIMaterial, thermalShieldMidMaterial, -1.);
     }
 
     // Build Rings (added April 1, 2015, David Norvil Brown)
@@ -700,43 +700,43 @@ namespace mu2e {
       double motherz = zr[iRing];
 
       VolumeInfo motherVol = nestTubs( ringMotherName.str(),
-				       TubsParams( rirs, rors, trs + lr/2.0 ),
-				       findMaterialOrThrow("G4_AIR"),
-				       ringRotat, 
-				       CLHEP::Hep3Vector(motherx,mothery,motherz
-							 ) - _hallOriginInMu2e,
-				       parent, 0, G4Color::Blue(),
-				       "TSCryo" );
+                                       TubsParams( rirs, rors, trs + lr/2.0 ),
+                                       findMaterialOrThrow("G4_AIR"),
+                                       ringRotat,
+                                       CLHEP::Hep3Vector(motherx,mothery,motherz
+                                                         ) - _hallOriginInMu2e,
+                                       parent, 0, G4Color::Blue(),
+                                       "TSCryo" );
       std::ostringstream leftName;
       leftName << "TSleftSideRing" << iRing;
 
       double lx = 0.0;
       double ly = 0.0;
-      double lz = - lr/2.0 - trs/2.0; 
+      double lz = - lr/2.0 - trs/2.0;
       nestTubs( leftName.str(),
-		TubsParams( rirs, rors, trs/2.0 ),
-		ringMaterial,
+                TubsParams( rirs, rors, trs/2.0 ),
+                ringMaterial,
                 noRotat,
-		CLHEP::Hep3Vector(lx,ly,lz),
-		motherVol,
-		0,
-		G4Color::Blue(),
-		"TSCryo"
-		);
+                CLHEP::Hep3Vector(lx,ly,lz),
+                motherVol,
+                0,
+                G4Color::Blue(),
+                "TSCryo"
+                );
 
       std::ostringstream centerName;
       centerName << "TScenterRing" << iRing;
 
       nestTubs( centerName.str(),
-		TubsParams( rir, ror, lr/2.0 ),
-		ringMaterial,
+                TubsParams( rir, ror, lr/2.0 ),
+                ringMaterial,
                 noRotat,
-		CLHEP::Hep3Vector(0,0,0),
-		motherVol,
-		0,
-		G4Color::Blue(),
-		"TSCryo"
-		);
+                CLHEP::Hep3Vector(0,0,0),
+                motherVol,
+                0,
+                G4Color::Blue(),
+                "TSCryo"
+                );
 
 
       std::ostringstream rightName;
@@ -744,18 +744,18 @@ namespace mu2e {
 
       double rx = 0.0;
       double ry = 0.0;
-      double rz = lr/2.0 + trs/2.0; 
+      double rz = lr/2.0 + trs/2.0;
 
       nestTubs( rightName.str(),
-		TubsParams( rirs, rors, trs/2.0 ),
-		ringMaterial,
+                TubsParams( rirs, rors, trs/2.0 ),
+                ringMaterial,
                 noRotat,
-		CLHEP::Hep3Vector(rx,ry,rz),
-		motherVol,
-		0,
-		G4Color::Blue(),
-		"TSCryo"
-		);
+                CLHEP::Hep3Vector(rx,ry,rz),
+                motherVol,
+                0,
+                G4Color::Blue(),
+                "TSCryo"
+                );
 
     } // End of building rings
 
@@ -765,45 +765,45 @@ namespace mu2e {
     int pbarAbsTS3Version = config.getInt("pbar.version",1);
       if ( pbarAbsTS3Version > 1 ) {
 
-	std::ostringstream PabsSupOutName;
-	PabsSupOutName << "PabsTS3SupOut";
-	CLHEP::HepRotation* pasubRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	pasubRotat->rotateY(90.0*CLHEP::degree);
-	double rPabsTS3SupOut_in  = rirs;
-	double rPabsTS3SupOut_out = config.getDouble("pbar.support.outROut", rors);
-	double rPabsTS3SupOut_HL  = config.getDouble("pbar.support.outHalfLength", trs);
-	nestTubs( PabsSupOutName.str(),
-		  TubsParams( rPabsTS3SupOut_in, rPabsTS3SupOut_out, rPabsTS3SupOut_HL ),
-		  ringMaterial,
-		  pasubRotat, 
-		  CLHEP::Hep3Vector(0,0,0)-_hallOriginInMu2e,
-		  parent,
-		  0,
-		  G4Color::Blue(),
-		  "TSCryo"
-		  );
+        std::ostringstream PabsSupOutName;
+        PabsSupOutName << "PabsTS3SupOut";
+        CLHEP::HepRotation* pasubRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+        pasubRotat->rotateY(90.0*CLHEP::degree);
+        double rPabsTS3SupOut_in  = rirs;
+        double rPabsTS3SupOut_out = config.getDouble("pbar.support.outROut", rors);
+        double rPabsTS3SupOut_HL  = config.getDouble("pbar.support.outHalfLength", trs);
+        nestTubs( PabsSupOutName.str(),
+                  TubsParams( rPabsTS3SupOut_in, rPabsTS3SupOut_out, rPabsTS3SupOut_HL ),
+                  ringMaterial,
+                  pasubRotat,
+                  CLHEP::Hep3Vector(0,0,0)-_hallOriginInMu2e,
+                  parent,
+                  0,
+                  G4Color::Blue(),
+                  "TSCryo"
+                  );
 
-	// Now do the next level in for the TS3 pabs window support - in cryo
-	// (acts as endwall for TSu and TSd cryo sections.
-	double rinner = config.getDouble("pbar.support.midRin")*CLHEP::mm;
-	double router = config.getDouble("pbar.support.midRout")*CLHEP::mm;
-	double halflen = config.getDouble("pbar.support.midThickness")*CLHEP::mm/2.0;
+        // Now do the next level in for the TS3 pabs window support - in cryo
+        // (acts as endwall for TSu and TSd cryo sections.
+        double rinner = config.getDouble("pbar.support.midRin")*CLHEP::mm;
+        double router = config.getDouble("pbar.support.midRout")*CLHEP::mm;
+        double halflen = config.getDouble("pbar.support.midThickness")*CLHEP::mm/2.0;
 
-	Mu2eG4Helper* _helper = &(*art::ServiceHandle<Mu2eG4Helper>() );
-	VolumeInfo useAsParent = _helper->locateVolInfo( "TS3CryoInsVac" );
+        Mu2eG4Helper* _helper = &(*art::ServiceHandle<Mu2eG4Helper>() );
+        VolumeInfo useAsParent = _helper->locateVolInfo( "TS3CryoInsVac" );
 
-	std::ostringstream PabsSupMidName;
-	PabsSupMidName << "PabsTS3MidOut";
-	nestTubs( PabsSupMidName.str(),
-		  TubsParams( rinner, router, halflen ),
-		  ringMaterial,
-		  0, 
-		  CLHEP::Hep3Vector(0,0,0)- useAsParent.centerInMu2e(),
-		  useAsParent,
-		  0,
-		  G4Color::Blue(),
-		  "TSCryo"
-		  );
+        std::ostringstream PabsSupMidName;
+        PabsSupMidName << "PabsTS3MidOut";
+        nestTubs( PabsSupMidName.str(),
+                  TubsParams( rinner, router, halflen ),
+                  ringMaterial,
+                  0,
+                  CLHEP::Hep3Vector(0,0,0)- useAsParent.centerInMu2e(),
+                  useAsParent,
+                  0,
+                  G4Color::Blue(),
+                  "TSCryo"
+                  );
 
       } //end of " if pbarAbsTS3Version..."
 
@@ -812,8 +812,8 @@ namespace mu2e {
 
     // Build downstream end wall of TS5
     // place flush with end of TS5
-    CLHEP::Hep3Vector pos3( strsec->getGlobal().x(), 
-                            strsec->getGlobal().y(), 
+    CLHEP::Hep3Vector pos3( strsec->getGlobal().x(),
+                            strsec->getGlobal().y(),
                             strsec->getGlobal().z()+strsec->getHalfLength()-ts->endWallD_halfLength() );
 
     tssName = "TS5DownstreamEndwall";
@@ -827,7 +827,7 @@ namespace mu2e {
               parent,
               0,
               G4Color::Red(),
-	      "TSCryo"
+              "TSCryo"
               );
     //if defined a second component of the end wall
     if(ts->build_endWallD2()) {
@@ -837,35 +837,35 @@ namespace mu2e {
       pos32 -= useAsParent.centerInMu2e();
       tssName = "TS5DownstreamEndwall2";
       nestPolycone( tssName,
-		    PolyconsParams(ts->endWallD2_z(),
-				   ts->endWallD2_rIn(),
-				   ts->endWallD2_rOut()),
-		    cryoMaterial,
-		    0,
-		    pos32,
-		    useAsParent,
-		    0,
-		    G4Color::Red(),
-		    "TSCryo"
-		    );
+                    PolyconsParams(ts->endWallD2_z(),
+                                   ts->endWallD2_rIn(),
+                                   ts->endWallD2_rOut()),
+                    cryoMaterial,
+                    0,
+                    pos32,
+                    useAsParent,
+                    0,
+                    G4Color::Red(),
+                    "TSCryo"
+                    );
     }
 
     verbosityLevel &&
-      G4cout << __func__ << " " << tssName << " Mass in kg: " 
-                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg 
+      G4cout << __func__ << " " << tssName << " Mass in kg: "
+                << _helper->locateVolInfo(tssName).logical->GetMass()/CLHEP::kg
                 << G4endl;
 
     if ( verbosityLevel ) {
       G4cout << __func__ << " Downstream TS5 endwall at: " << pos3 << G4endl;
     }
-  } 
+  }
 
   //__________________________________
   //
   // CONSTRUCT Coil Assemblies (CA) (Modules), a torus approximation for now
   //__________________________________
 
-  void constructCAs( VolumeInfo const& parent, 
+  void constructCAs( VolumeInfo const& parent,
                      SimpleConfig const& config,
                      Beamline const& bl ) {
 
@@ -890,93 +890,93 @@ namespace mu2e {
       Mu2eG4Helper* _helper = &(*art::ServiceHandle<Mu2eG4Helper>() );
 
       if ( its==tsCAReg_enum::TS2 || its==tsCAReg_enum::TS4 ) {
-        
+
         // these sections are toruses
         // fixme, make the base class TSSection more general to be used here instead the two
         caTorsec = ts.getTSCA<TorusSection>(its);
 
-	if ( its == tsCAReg_enum::TS2 ) {
-	  useAsParent = _helper->locateVolInfo( "TS2CryoInsVac" );
-	} else if ( its == tsCAReg_enum::TS4 ) {
-	  useAsParent = _helper->locateVolInfo( "TS4CryoInsVac" );
-	} else {  // Should never get here
-	  useAsParent = parent;
-	}
+        if ( its == tsCAReg_enum::TS2 ) {
+          useAsParent = _helper->locateVolInfo( "TS2CryoInsVac" );
+        } else if ( its == tsCAReg_enum::TS4 ) {
+          useAsParent = _helper->locateVolInfo( "TS4CryoInsVac" );
+        } else {  // Should never get here
+          useAsParent = parent;
+        }
 
 
         nestTorus(caName,
                   caTorsec->getParameters(),
                   findMaterialOrThrow(caTorsec->getMaterial()),
-		  0,
+                  0,
                   caTorsec->getGlobal()-useAsParent.centerInMu2e(),
                   useAsParent,
                   0,
                   G4Color::Yellow(),
                   "TSCA"
                   );
-	//                  caTorsec->getRotation(),
-      } else if ( its==tsCAReg_enum::TS1 
-                  || its==tsCAReg_enum::TS3u 
-                  || its==tsCAReg_enum::TS3d 
+        //                  caTorsec->getRotation(),
+      } else if ( its==tsCAReg_enum::TS1
+                  || its==tsCAReg_enum::TS3u
+                  || its==tsCAReg_enum::TS3d
                   || its==tsCAReg_enum::TS5
                   ) {
 
-	if ( its == tsCAReg_enum::TS1 ) {
-	  useAsParent = _helper->locateVolInfo( "TS1CryoInsVac" );
-	} else if ( its == tsCAReg_enum::TS3u || its == tsCAReg_enum::TS3d ) {
-	  useAsParent = _helper->locateVolInfo( "TS3CryoInsVac" );
-	} else if ( its == tsCAReg_enum::TS5 ) {
-	  useAsParent = _helper->locateVolInfo( "TS5CryoInsVac" );
-	} else { // Should never get here
-	  useAsParent = parent;
-	}
+        if ( its == tsCAReg_enum::TS1 ) {
+          useAsParent = _helper->locateVolInfo( "TS1CryoInsVac" );
+        } else if ( its == tsCAReg_enum::TS3u || its == tsCAReg_enum::TS3d ) {
+          useAsParent = _helper->locateVolInfo( "TS3CryoInsVac" );
+        } else if ( its == tsCAReg_enum::TS5 ) {
+          useAsParent = _helper->locateVolInfo( "TS5CryoInsVac" );
+        } else { // Should never get here
+          useAsParent = parent;
+        }
 
         caConsec = ts.getTSCA<ConeSection>(its);
 
-	CLHEP::Hep3Vector V = caConsec->getGlobal() - useAsParent.centerInMu2e();
-	CLHEP::HepRotation* rot = useAsParent.physical->GetRotation();
-	V = (*rot) * V;
+        CLHEP::Hep3Vector V = caConsec->getGlobal() - useAsParent.centerInMu2e();
+        CLHEP::HepRotation* rot = useAsParent.physical->GetRotation();
+        V = (*rot) * V;
 
 
         nestCons(caName,
                  caConsec->getParameters(),
                  findMaterialOrThrow(caConsec->getMaterial()),
-		 0,
+                 0,
                  V,
                  useAsParent,
                  0,
                  G4Color::Yellow(),
                  "TSCA"
                  );
-	//                 caConsec->getRotation(),
+        //                 caConsec->getRotation(),
       } else {
 
-	useAsParent = _helper->locateVolInfo("TS3CryoInsVac");
-	caStrsec = ts.getTSCA<StraightSection>(its);
-	CLHEP::Hep3Vector V = caStrsec->getGlobal() - useAsParent.centerInMu2e();
-	CLHEP::HepRotation* rot = useAsParent.physical->GetRotation();
-	V = (*rot) * V;
+        useAsParent = _helper->locateVolInfo("TS3CryoInsVac");
+        caStrsec = ts.getTSCA<StraightSection>(its);
+        CLHEP::Hep3Vector V = caStrsec->getGlobal() - useAsParent.centerInMu2e();
+        CLHEP::HepRotation* rot = useAsParent.physical->GetRotation();
+        V = (*rot) * V;
 
-	nestTubs(caName,
-		 TubsParams(caStrsec->rIn(),
-			    caStrsec->rOut(),
-			    caStrsec->getHalfLength()),
-		 findMaterialOrThrow(caStrsec->getMaterial()),
-		 0,
-		 V,
-		 useAsParent,
-		 0,
-		 G4Color::Cyan(),
-		 "TSCA"
-		 );
+        nestTubs(caName,
+                 TubsParams(caStrsec->rIn(),
+                            caStrsec->rOut(),
+                            caStrsec->getHalfLength()),
+                 findMaterialOrThrow(caStrsec->getMaterial()),
+                 0,
+                 V,
+                 useAsParent,
+                 0,
+                 G4Color::Cyan(),
+                 "TSCA"
+                 );
 
-	//caStrsec->getRotation(),
+        //caStrsec->getRotation(),
 
       }
 
-      verbosityLevel 
-        && G4cout << __func__ << " " << caName << " Mass in kg: " 
-                     << _helper->locateVolInfo(caName).logical->GetMass()/CLHEP::kg 
+      verbosityLevel
+        && G4cout << __func__ << " " << caName << " Mass in kg: "
+                     << _helper->locateVolInfo(caName).logical->GetMass()/CLHEP::kg
                      << G4endl;
     }
 
@@ -1005,54 +1005,54 @@ namespace mu2e {
       auto its = (TransportSolenoid::TSRegion::enum_type)iTS;
       int iC(0);
       for ( Coil const & coil : bl.getTS().getTSCoils( its ) ) {
-        
+
         ostringstream coilname ; coilname << "TS" << iTS << "_Coil" << ++iC ;
 
-	// Use insulating vacuums as mother volumes
-	ostringstream ivName;
-	ivName << "TS" << iTS << "CryoInsVac";
+        // Use insulating vacuums as mother volumes
+        ostringstream ivName;
+        ivName << "TS" << iTS << "CryoInsVac";
 
-	Mu2eG4Helper* _helper = &(*art::ServiceHandle<Mu2eG4Helper>() );
-	VolumeInfo useAsParent = _helper->locateVolInfo( ivName.str() );
+        Mu2eG4Helper* _helper = &(*art::ServiceHandle<Mu2eG4Helper>() );
+        VolumeInfo useAsParent = _helper->locateVolInfo( ivName.str() );
 
-	CLHEP::Hep3Vector V = coil.getGlobal() - useAsParent.centerInMu2e();
-
-
-	CLHEP::HepRotation* rot = useAsParent.physical->GetRotation();
-	V = (*rot) * V;
-	CLHEP::HepRotation invrot = rot->inverse();
-
-	if ( iTS == TransportSolenoid::TSRegion::TS2 || 
-	     iTS == TransportSolenoid::TSRegion::TS4 ) {
-
-	  CLHEP::HepRotation* twist = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	  twist->rotateX(90.0*CLHEP::degree);
-	  twist->rotateY(-coil.getRotation()->theta());
+        CLHEP::Hep3Vector V = coil.getGlobal() - useAsParent.centerInMu2e();
 
 
-	  nestTubs( coilname.str(),
-		    TubsParams( coil.rIn(), coil.rOut(), coil.halfLength() ),
-		    coilMaterial,
-		    twist,
-		    V,
-		    useAsParent,
-		    0,
-		    G4Color::Green(),
-		    "TSCoils"
-		    );
-	} else {
+        CLHEP::HepRotation* rot = useAsParent.physical->GetRotation();
+        V = (*rot) * V;
+        CLHEP::HepRotation invrot = rot->inverse();
 
-	  nestTubs( coilname.str(),
-		    TubsParams( coil.rIn(), coil.rOut(), coil.halfLength() ),
-		    coilMaterial,
-		    0,
-		    V,
-		    useAsParent,
-		    0,
-		    G4Color::Green(),
-		    "TSCoils"
-		    );
-	}
+        if ( iTS == TransportSolenoid::TSRegion::TS2 ||
+             iTS == TransportSolenoid::TSRegion::TS4 ) {
+
+          CLHEP::HepRotation* twist = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+          twist->rotateX(90.0*CLHEP::degree);
+          twist->rotateY(-coil.getRotation()->theta());
+
+
+          nestTubs( coilname.str(),
+                    TubsParams( coil.rIn(), coil.rOut(), coil.halfLength() ),
+                    coilMaterial,
+                    twist,
+                    V,
+                    useAsParent,
+                    0,
+                    G4Color::Green(),
+                    "TSCoils"
+                    );
+        } else {
+
+          nestTubs( coilname.str(),
+                    TubsParams( coil.rIn(), coil.rOut(), coil.halfLength() ),
+                    coilMaterial,
+                    0,
+                    V,
+                    useAsParent,
+                    0,
+                    G4Color::Green(),
+                    "TSCoils"
+                    );
+        }
         if ( verbosityLevel > 0 ) {
           G4cout << __func__ << " " << coilname.str() << " placed at: " << coil.getGlobal() << G4endl;
           G4cout << __func__ << "            rotation: " << -coil.getRotation()->getTheta()/CLHEP::degree << G4endl;
@@ -1061,8 +1061,8 @@ namespace mu2e {
 
       }
     }
-     
-  } 
+
+  }
 
   //__________________________________
   //
@@ -1072,7 +1072,7 @@ namespace mu2e {
   void constructCollimators( VolumeInfo const& parent,
                              SimpleConfig const& config,
                              Beamline const& bl ) {
-    
+
     // Flags
     const int  verbosityLevel      = config.getInt("ts.coll.verbosityLevel", 0);
 
@@ -1134,14 +1134,14 @@ namespace mu2e {
               _helper->locateVolInfo("TS1Vacuum"),
               0,
               G4Color::Cyan(),
-	      "TSColl"
+              "TSColl"
               );
 
     double tmpRout = coll1.rOut();
     if ( coll1.rIn4() > 1.0 ) tmpRout = coll1.rIn4();
 
     TubsParams coll1Param2 ( coll1.rIn3(),  tmpRout, coll1.halfLength()-2.*vdHalfLength);
- 
+
     nestTubs( "Coll12",
               coll1Param2,
               findMaterialOrThrow( coll1.material2() ),
@@ -1150,22 +1150,22 @@ namespace mu2e {
               _helper->locateVolInfo("TS1Vacuum"),
               0,
               G4Color::Blue(),
-	      "TSColl"
+              "TSColl"
               );
 
     if ( coll1.rIn4() > 1.0 && coll1.rOut() > coll1.rIn4() ) {
       // Make the sheath
       TubsParams coll1Param3 ( coll1.rIn4(),  coll1.rOut(), coll1.halfLength()-2.*vdHalfLength);
       nestTubs( "Coll13",
-		coll1Param3,
-		findMaterialOrThrow( coll1.material3() ),
-		0,
-		coll1.getLocal(),
-		_helper->locateVolInfo("TS1Vacuum"),
-		0,
-		G4Color::Blue(),
-		"TSColl"
-		);
+                coll1Param3,
+                findMaterialOrThrow( coll1.material3() ),
+                0,
+                coll1.getLocal(),
+                _helper->locateVolInfo("TS1Vacuum"),
+                0,
+                G4Color::Blue(),
+                "TSColl"
+                );
 
     } // end of adding sheath to Coll1
 
@@ -1187,13 +1187,13 @@ namespace mu2e {
     // Hole is the intersection of box and tube
     G4Box* coll3_hole_box = new G4Box("coll3_hole_box",
                                       coll31.holeRadius()+5.0,coll31.holeHalfHeight(),hDz+1.0);
-    // make the tube longer than the box to avoid overlapping surfaces 
+    // make the tube longer than the box to avoid overlapping surfaces
     G4Tubs* coll3_hole_circle = new G4Tubs("coll3_hole_circle",
                                            0.0,coll31.holeRadius(),hDz+2.0,
                                            0.0, CLHEP::twopi );
     G4IntersectionSolid* coll3_hole = new G4IntersectionSolid("coll3_hole",
-							   coll3_hole_box,
-							   coll3_hole_circle);
+                                                           coll3_hole_box,
+                                                           coll3_hole_circle);
 
 
     // Make collimators themselves. At this moment the collimators
@@ -1253,7 +1253,7 @@ namespace mu2e {
                   _helper->locateVolInfo("TS3Vacuum").logical,
                   0,
                   G4Color::Gray(),
-		  "TSColl");
+                  "TSColl");
 
     finishNesting(coll32Info,
                   findMaterialOrThrow( coll32.material() ),
@@ -1262,7 +1262,7 @@ namespace mu2e {
                   _helper->locateVolInfo("TS3Vacuum").logical,
                   0,
                   G4Color::Gray(),
-		  "TSColl");
+                  "TSColl");
 
     // **************************************************************
     // Now place the "flashblocks" for tests of mitigating beam flash
@@ -1270,43 +1270,43 @@ namespace mu2e {
 
     if (coll31.useFlashBlock()) {
       std::vector<double> boxPars = { coll31.flashBlockWidth()/2.0*CLHEP::mm,
-				      coll31.flashBlockHeight()/2.0*CLHEP::mm,
-				      coll31.flashBlockLength()/2.0*CLHEP::mm};
+                                      coll31.flashBlockHeight()/2.0*CLHEP::mm,
+                                      coll31.flashBlockLength()/2.0*CLHEP::mm};
 
       CLHEP::Hep3Vector displaceFB(coll31.flashBlockTranOff()*CLHEP::mm,
-				   coll31.holeDisplacement() - coll31.holeHalfHeight() + coll31.flashBlockHeight()/2.0*CLHEP::mm, 
-				   coll31.flashBlockLength()/2.0 - coll31.halfLength());
+                                   coll31.holeDisplacement() - coll31.holeHalfHeight() + coll31.flashBlockHeight()/2.0*CLHEP::mm,
+                                   coll31.flashBlockLength()/2.0 - coll31.halfLength());
 
       nestBox( "flashBlockUp",
-	       boxPars,
-	       findMaterialOrThrow(coll31.flashBlockMaterial()),
-	       coll31Rot,
-	       coll31.getLocal()+displaceFB,
-	       _helper->locateVolInfo("TS3Vacuum").logical,
-	       0,
-	       G4Colour::Gray(),
-	       "TSColl");
-    } 
+               boxPars,
+               findMaterialOrThrow(coll31.flashBlockMaterial()),
+               coll31Rot,
+               coll31.getLocal()+displaceFB,
+               _helper->locateVolInfo("TS3Vacuum").logical,
+               0,
+               G4Colour::Gray(),
+               "TSColl");
+    }
 
     if (coll32.useFlashBlock()) {
       std::vector<double> boxPars = { coll32.flashBlockWidth()/2.0*CLHEP::mm,
-				      coll32.flashBlockHeight()/2.0*CLHEP::mm,
-				      coll32.flashBlockLength()/2.0*CLHEP::mm};
+                                      coll32.flashBlockHeight()/2.0*CLHEP::mm,
+                                      coll32.flashBlockLength()/2.0*CLHEP::mm};
 
       CLHEP::Hep3Vector displaceFB(coll32.flashBlockTranOff()*CLHEP::mm,
-				   coll32.holeDisplacement() - coll32.holeHalfHeight() + coll32.flashBlockHeight()/2.0*CLHEP::mm, 
-				   coll32.flashBlockLength()/2*CLHEP::mm - coll32.halfLength());
+                                   coll32.holeDisplacement() - coll32.holeHalfHeight() + coll32.flashBlockHeight()/2.0*CLHEP::mm,
+                                   coll32.flashBlockLength()/2*CLHEP::mm - coll32.halfLength());
 
       nestBox( "flashBlockDn",
-	       boxPars,
-	       findMaterialOrThrow(coll32.flashBlockMaterial()),
-	       coll32Rot,
-	       coll32.getLocal()+displaceFB,
-	       _helper->locateVolInfo("TS3Vacuum").logical,
-	       0,
-	       G4Colour::Gray(),
-	       "TSColl");
-    } 
+               boxPars,
+               findMaterialOrThrow(coll32.flashBlockMaterial()),
+               coll32Rot,
+               coll32.getLocal()+displaceFB,
+               _helper->locateVolInfo("TS3Vacuum").logical,
+               0,
+               G4Colour::Gray(),
+               "TSColl");
+    }
 
 
     // Now add a Recorder at the Coll31 exit and Coll32 entrance
@@ -1323,7 +1323,7 @@ namespace mu2e {
               _helper->locateVolInfo("TS3Vacuum"),
               0,
               G4Color::Blue(),
-	      "TSColl"
+              "TSColl"
             );
 
     TubsParams coll32InRecordParam ( 0,  coll32.rOut(), vdHalfLength );
@@ -1338,7 +1338,7 @@ namespace mu2e {
               _helper->locateVolInfo("TS3Vacuum"),
               0,
               G4Color::Blue(),
-	      "TSColl"
+              "TSColl"
             );
 
     if ( verbosityLevel > 0) {
@@ -1356,9 +1356,9 @@ namespace mu2e {
       G4cout << __func__ << " TS5  Rotation      : " << ts5in->getRotation() << G4endl;
     }
 
-    CLHEP::Hep3Vector coll5OffsetInMu2e = ts5in->getGlobal() + 
+    CLHEP::Hep3Vector coll5OffsetInMu2e = ts5in->getGlobal() +
       ( ( ts5in->getRotation() != 0x0 ) ?
-        *(ts5in->getRotation()) * coll51.getLocal() : 
+        *(ts5in->getRotation()) * coll51.getLocal() :
         coll51.getLocal() );
 
     if ( verbosityLevel > 0) {
@@ -1376,7 +1376,7 @@ namespace mu2e {
               _helper->locateVolInfo("TS5Vacuum"),
               0,
               G4Color::Blue(),
-	      "TSColl"
+              "TSColl"
               );
 
 
@@ -1401,24 +1401,24 @@ namespace mu2e {
               _helper->locateVolInfo("TS5Vacuum"),
               0,
               G4Color::Blue(),
-	      "TSColl"
+              "TSColl"
               );
     if(coll52HLInTS4 > 0.) {
       TubsParams coll5Param2_TS4 ( coll52.rIn(),  coll52.rOut(), coll52HLInTS4);
       CLHEP::HepRotation* rotColl52 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
       rotColl52->rotateX(90.*CLHEP::degree);
       nestTubs( "Coll52InTS4",
-		coll5Param2_TS4,
-		findMaterialOrThrow( coll52.material() ),
-		rotColl52,
-		CLHEP::Hep3Vector(-ts4in->torusRadius(),coll52HLInTS4,0.), //downstream end of TS4
-		 _helper->locateVolInfo("TS4Vacuum"),
-		0,
-		G4Color::Blue(),
-		"TSColl"
-		);
+                coll5Param2_TS4,
+                findMaterialOrThrow( coll52.material() ),
+                rotColl52,
+                CLHEP::Hep3Vector(-ts4in->torusRadius(),coll52HLInTS4,0.), //downstream end of TS4
+                 _helper->locateVolInfo("TS4Vacuum"),
+                0,
+                G4Color::Blue(),
+                "TSColl"
+                );
     }
-    
+
     int coll53version = coll53.version();
     TubsParams coll5Param3 ( coll53.rIn(),  coll53.rOut(), coll53.halfLength()-2.*vdHalfLength);
     VolumeInfo useAsParent;
@@ -1434,52 +1434,52 @@ namespace mu2e {
       //adjust origin from inside TS5 to end of it
       offset.setZ(2.*(ts.endWallD_halfLength()));
       if(ts.ts5InnerRadius() > coll53.rIn()) { //split between ts5 vacuum and hall air
-	useAsParent = _helper->locateVolInfo("TS5Vacuum");
-	_useAsParentOriginInMu2e = useAsParent.centerInMu2e();
-	coll5Param3  = TubsParams(coll53.rIn(), ts.ts5InnerRadius(), coll53.halfLength()-2.*vdHalfLength);
-	nestTubs( "Coll53InTS5",
-		  coll5Param3,
-		  findMaterialOrThrow( coll53.material() ),
-		  0,
-		  strsec->getGlobal()-_useAsParentOriginInMu2e+coll53.getLocal() + offset,
-		  useAsParent,
-		  0,
-		  G4Color::Blue(),
-		  "TSColl"
-		  );
-	coll5Param3  = TubsParams(ts.ts5InnerRadius(), coll53.rOut(), coll53.halfLength()-2.*vdHalfLength);
+        useAsParent = _helper->locateVolInfo("TS5Vacuum");
+        _useAsParentOriginInMu2e = useAsParent.centerInMu2e();
+        coll5Param3  = TubsParams(coll53.rIn(), ts.ts5InnerRadius(), coll53.halfLength()-2.*vdHalfLength);
+        nestTubs( "Coll53InTS5",
+                  coll5Param3,
+                  findMaterialOrThrow( coll53.material() ),
+                  0,
+                  strsec->getGlobal()-_useAsParentOriginInMu2e+coll53.getLocal() + offset,
+                  useAsParent,
+                  0,
+                  G4Color::Blue(),
+                  "TSColl"
+                  );
+        coll5Param3  = TubsParams(ts.ts5InnerRadius(), coll53.rOut(), coll53.halfLength()-2.*vdHalfLength);
       }
       useAsParent = parent; //the rest of the flange is in hall air
       _useAsParentOriginInMu2e = parent.centerInMu2e();
     }
     nestTubs( "Coll53",
-	      coll5Param3,
-	      findMaterialOrThrow( coll53.material() ),
-	      0,
-	      strsec->getGlobal()-_useAsParentOriginInMu2e+coll53.getLocal() + offset,
-	      useAsParent,
-	      0,
-	      G4Color::Blue(),
-	      "TSColl"
-	      );
+              coll5Param3,
+              findMaterialOrThrow( coll53.material() ),
+              0,
+              strsec->getGlobal()-_useAsParentOriginInMu2e+coll53.getLocal() + offset,
+              useAsParent,
+              0,
+              G4Color::Blue(),
+              "TSColl"
+              );
   }
-  
+
   //__________________________________
   //
   // CONSTRUCT DEGRADER
   //__________________________________
-  
+
   void constructDegrader( VolumeInfo const& parent,
                           SimpleConfig const & config,
                           Beamline const& bl ) {
-    
+
     // Add muon degrader to the center of TS5
-    // Degrader is made of several layers. 
+    // Degrader is made of several layers.
     // Each layer is intersection of cylinder and trapezoid.
-    
+
     // Flag
     int const verbosityLevel = config.getInt("muondegrader.verbosityLevel", 0);
-    
+
     G4GeometryOptions* geomOptions = art::ServiceHandle<GeometryService>()->geomOptions();
     geomOptions->loadEntry( config, "MuonDegrader", "muondegrader" );
 
@@ -1497,26 +1497,26 @@ namespace mu2e {
       G4cout << __func__ << " Warning: MuonDegrader is not build - dimensions don't match." << G4endl;
       addDegrader = false;
     }
-    
+
     if( addDegrader ) {
-      
+
       G4Material* degraderMaterial  = findMaterialOrThrow( config.getString("muondegrader.materialName") );
-      
+
       for( unsigned int i=0; i<degraderR.size(); ++i ) {
-	
+
         VolumeInfo degraderInfo;
-	
+
         ostringstream dname;  dname << "MuonDegrader" << i;
         degraderInfo.name = dname.str();
-        
+
         ostringstream dsname1;  dsname1 << "MuonDegrader_disk" << i;
         ostringstream dsname2;  dsname2 << "MuonDegrader_trd" << i;
-        
+
         double R1 = degraderR[i];
         double R2 = ( i<=0 ) ? coll5.rIn() : degraderR[i-1];
         G4Tubs *degrader_disk = new G4Tubs(dsname1.str(),R1,R2,
                                            degraderDZB[i]/2.0,
-                                           (1.5-degraderPhi[i])*CLHEP::pi, 
+                                           (1.5-degraderPhi[i])*CLHEP::pi,
                                            degraderPhi[i]*CLHEP::twopi);
 
         G4Trd *degrader_trd = new G4Trd(dsname2.str(),
@@ -1572,29 +1572,29 @@ namespace mu2e {
     // ******* In version two, there are changes *****
     // - support structure is ~1 cm thick stainless with a window shaped
     //   like that of the COL3u and Col3d windows.
-    // - wedge is shaped like the 
+    // - wedge is shaped like the
     //   hole in the support structure.
     // ******* In version three, there are some more changes
-    // - The window in the support structure is circular with the circular 
+    // - The window in the support structure is circular with the circular
     //   disk to be placed inside, with a radius less than the inner cryo
-    //   shell.  
-    // - The wedge has a rectangular projection in the y-z plane.  
-    //   It is made of a series of rectangular sheets forming a 
+    //   shell.
+    // - The wedge has a rectangular projection in the y-z plane.
+    //   It is made of a series of rectangular sheets forming a
     //   "stairstep" structure.
     // ******* In Version 4, do the same as version 3 except allow the steps to have different
     //   thicknesses.  This will allow us to implement the geometry of doc-db 17519 p. 34
 
     G4GeometryOptions* geomOptions = art::ServiceHandle<GeometryService>()->geomOptions();
     geomOptions->loadEntry( config, "PbarAbs", "pbar" );
-    
+
     AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
 
     // Throw exception if pbarwedge.build is used - way out of date!
     if ( config.hasName("pbarwedge.build") )
       {
-	throw cet::exception("GEOM")<<
-	  " Variable pbarwedge.build is now deprecated. \n" <<
-	  " To use pbar wedge specify: pbar.Type = \"wedge\" \n" ;
+        throw cet::exception("GEOM")<<
+          " Variable pbarwedge.build is now deprecated. \n" <<
+          " To use pbar wedge specify: pbar.Type = \"wedge\" \n" ;
       }
 
     PbarWindow const & pbarWindow = bl.getTS().getPbarWindow();
@@ -1612,109 +1612,109 @@ namespace mu2e {
       // -- vacuum wall
 
       G4cout << "inside version 1 " << G4endl;
-      if (verbosityLevel > 0) G4cout << "TS3 pbar windows HalfLength : " << pbarWindow.halfLength() << G4endl; 
-        
+      if (verbosityLevel > 0) G4cout << "TS3 pbar windows HalfLength : " << pbarWindow.halfLength() << G4endl;
+
       if ( pbarWindow.shape() == "wedge" ||
-	   pbarWindow.shape() == "disk" ) {
+           pbarWindow.shape() == "disk" ) {
 
-	double pbarParams[5]  = { 0.0, pbarWindow.rOut(), pbarWindow.halfLength(), 0.0, CLHEP::twopi };
+        double pbarParams[5]  = { 0.0, pbarWindow.rOut(), pbarWindow.halfLength(), 0.0, CLHEP::twopi };
 
-	nestTubs( "PbarAbs",
-		  pbarParams,
-		  pbarMaterial,
-		  0,
-		  pbarWindow.getLocal(),
-		  parent,
-		  0,
-		  G4Color::Yellow()
-		  );
-      
+        nestTubs( "PbarAbs",
+                  pbarParams,
+                  pbarMaterial,
+                  0,
+                  pbarWindow.getLocal(),
+                  parent,
+                  0,
+                  G4Color::Yellow()
+                  );
+
       }
-        
-      //      if( pbarWindow.shape() == "wedge" ) 
-      if ( pbarWindow.shape() != "disk")
-	{
-	  if( pbarWindow.shape() == "wedge")
-	{
-	  // -- pbar wedge        
-	  double pbarWedge_y0  = pbarWindow.getY0();
-	  double pbarWedge_y1  = pbarWindow.getY1();
-	  double pbarWedge_dz0 = pbarWindow.getDZ0();
-	  double pbarWedge_dz1 = pbarWindow.getDZ1();
 
-	  VolumeInfo pbarWedgeInfo;
-      
-	  pbarWedgeInfo.name = "PbarAbsWedge";
-      
-	  double pbarWedge_dz = ( pbarWedge_dz0<pbarWedge_dz1 ) ? pbarWedge_dz1 : pbarWedge_dz0;
-	  double pbarWedge_h = pbarWedge_y1 - pbarWedge_y0;
-	  
-	  double pbarWedge_dy = (pbarWedge_y1 + pbarWedge_y0)/2.;
-      
-	  G4Tubs *pbarWedge_disk = new G4Tubs("PbarAbsWedge_disk",
-					      0,bl.getTS().innerRadius(),pbarWedge_dz/2.,0,CLHEP::twopi);
-      
-	  G4Trd *pbarWedge_trd = new G4Trd("PbarAbsWedge_trd",
-					   bl.getTS().innerRadius(),bl.getTS().innerRadius(),
-					   pbarWedge_dz0/2.,pbarWedge_dz1/2.,
-					   pbarWedge_h/2.);
-      
-	  AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
-	  G4RotationMatrix* pbarWedgeRot = reg.add(G4RotationMatrix());
-	  pbarWedgeRot->rotateX(90.0*CLHEP::degree);
-	  G4ThreeVector pbarWedgeTrans(0.0,pbarWedge_dy,0.0);
-	  
-	  pbarWedgeInfo.solid = new G4IntersectionSolid(pbarWedgeInfo.name,
-							pbarWedge_disk,
-							pbarWedge_trd,
-							pbarWedgeRot,
-							pbarWedgeTrans);
-	  
-	  finishNesting(pbarWedgeInfo,
-			pbarMaterial,
-			0,
-			G4ThreeVector(0.,0.,pbarWedge_dz/2+pbarWindow.halfLength() ),
-			parent.logical,
-			0,
-			G4Color::Yellow(),
-			"PbarAbs"
-			);
-	  
-	}
-      else if ( pbarWindow.shape() == "polycone" ) 
-	{
-	  // Define polycone parameters
-	  vector<double> tmp_zPlanesDs3 {-0.50,-0.06,0.06,0.50};
-	  vector<double> tmp_rOuterDs3  (4,239.5);
-	  vector<double> tmp_rInnerDs3  {239.5,0.,0.,239.5};
-	  
-	  
-	  CLHEP::Hep3Vector polyPositionInMu2e = bl.getTS().getTSCryo(TransportSolenoid::TSRegion::TS3,
-								      TransportSolenoid::TSRadialPart::IN)->getGlobal();
-        
-	  nestPolycone( "PbarAbsPolycone",
-			PolyconsParams(tmp_zPlanesDs3,
-				       tmp_rInnerDs3,
-				       tmp_rOuterDs3 ),
-			pbarMaterial,
-			0,
-			polyPositionInMu2e - parent.centerInMu2e(),
-			parent,
-			0,
-			G4Colour::Yellow(),
-			"PbarAbs"
-			);
-	}
+      //      if( pbarWindow.shape() == "wedge" )
+      if ( pbarWindow.shape() != "disk")
+        {
+          if( pbarWindow.shape() == "wedge")
+        {
+          // -- pbar wedge
+          double pbarWedge_y0  = pbarWindow.getY0();
+          double pbarWedge_y1  = pbarWindow.getY1();
+          double pbarWedge_dz0 = pbarWindow.getDZ0();
+          double pbarWedge_dz1 = pbarWindow.getDZ1();
+
+          VolumeInfo pbarWedgeInfo;
+
+          pbarWedgeInfo.name = "PbarAbsWedge";
+
+          double pbarWedge_dz = ( pbarWedge_dz0<pbarWedge_dz1 ) ? pbarWedge_dz1 : pbarWedge_dz0;
+          double pbarWedge_h = pbarWedge_y1 - pbarWedge_y0;
+
+          double pbarWedge_dy = (pbarWedge_y1 + pbarWedge_y0)/2.;
+
+          G4Tubs *pbarWedge_disk = new G4Tubs("PbarAbsWedge_disk",
+                                              0,bl.getTS().innerRadius(),pbarWedge_dz/2.,0,CLHEP::twopi);
+
+          G4Trd *pbarWedge_trd = new G4Trd("PbarAbsWedge_trd",
+                                           bl.getTS().innerRadius(),bl.getTS().innerRadius(),
+                                           pbarWedge_dz0/2.,pbarWedge_dz1/2.,
+                                           pbarWedge_h/2.);
+
+          AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
+          G4RotationMatrix* pbarWedgeRot = reg.add(G4RotationMatrix());
+          pbarWedgeRot->rotateX(90.0*CLHEP::degree);
+          G4ThreeVector pbarWedgeTrans(0.0,pbarWedge_dy,0.0);
+
+          pbarWedgeInfo.solid = new G4IntersectionSolid(pbarWedgeInfo.name,
+                                                        pbarWedge_disk,
+                                                        pbarWedge_trd,
+                                                        pbarWedgeRot,
+                                                        pbarWedgeTrans);
+
+          finishNesting(pbarWedgeInfo,
+                        pbarMaterial,
+                        0,
+                        G4ThreeVector(0.,0.,pbarWedge_dz/2+pbarWindow.halfLength() ),
+                        parent.logical,
+                        0,
+                        G4Color::Yellow(),
+                        "PbarAbs"
+                        );
+
+        }
+      else if ( pbarWindow.shape() == "polycone" )
+        {
+          // Define polycone parameters
+          vector<double> tmp_zPlanesDs3 {-0.50,-0.06,0.06,0.50};
+          vector<double> tmp_rOuterDs3  (4,239.5);
+          vector<double> tmp_rInnerDs3  {239.5,0.,0.,239.5};
+
+
+          CLHEP::Hep3Vector polyPositionInMu2e = bl.getTS().getTSCryo(TransportSolenoid::TSRegion::TS3,
+                                                                      TransportSolenoid::TSRadialPart::IN)->getGlobal();
+
+          nestPolycone( "PbarAbsPolycone",
+                        PolyconsParams(tmp_zPlanesDs3,
+                                       tmp_rInnerDs3,
+                                       tmp_rOuterDs3 ),
+                        pbarMaterial,
+                        0,
+                        polyPositionInMu2e - parent.centerInMu2e(),
+                        parent,
+                        0,
+                        G4Colour::Yellow(),
+                        "PbarAbs"
+                        );
+        }
       else if ( pbarWindow.shape() != "disk" )
-	{
-	  throw cet::exception("GEOM")<<
-		" Incorrect pbar window geometry requested! \n << pbarWindow.shape() = in version 1" << pbarWindow.shape() <<"\n";
-	    }
-	}
+        {
+          throw cet::exception("GEOM")<<
+                " Incorrect pbar window geometry requested! \n << pbarWindow.shape() = in version 1" << pbarWindow.shape() <<"\n";
+            }
+        }
     }  // end of if ( pbarAbsTS3Version == 1 )
     else if ( pbarAbsTS3Version == 2 ) {
       // =============== Now Version 2 of pbarAbs in TS3! ==============
-      // First, build the subtraction shape to represent the hole in the 
+      // First, build the subtraction shape to represent the hole in the
       // support.  Based on code in Collimator build function
       // Get collimators
 
@@ -1729,132 +1729,132 @@ namespace mu2e {
 
       // Hole is the intersection of box and tube
       G4Box* support_hole_box = new G4Box("support_hole_box",
-					coll31.holeRadius()+5.0,coll31.holeHalfHeight(),hDz+1.0);
-      // make the tube longer than the box to avoid overlapping surfaces 
+                                        coll31.holeRadius()+5.0,coll31.holeHalfHeight(),hDz+1.0);
+      // make the tube longer than the box to avoid overlapping surfaces
       G4Tubs* support_hole_circle = new G4Tubs("support_hole_circle",
-					     0.0,coll31.holeRadius(),hDz+2.0,
-					     0.0, CLHEP::twopi );
+                                             0.0,coll31.holeRadius(),hDz+2.0,
+                                             0.0, CLHEP::twopi );
       G4IntersectionSolid* support_hole = new G4IntersectionSolid("support_hole",
-								support_hole_box,
-								support_hole_circle);
+                                                                support_hole_box,
+                                                                support_hole_circle);
 
       // Now make the actual support
       G4Tubs* support_mother = new G4Tubs("PbarSupport_mother",
-					  0, coll31.rOut(), hDz,
-					  0.0, CLHEP::twopi );
+                                          0, coll31.rOut(), hDz,
+                                          0.0, CLHEP::twopi );
 
       supportInfo.solid = new G4SubtractionSolid("pBarTS3Support",
                                               support_mother,
                                               support_hole,
                                               0,
                                               G4ThreeVector(0,
-							    config.getDouble("pbar.support.holeDisp"),0));
+                                                            config.getDouble("pbar.support.holeDisp"),0));
 
       CLHEP::HepRotation * supportRot (nullptr);
       //      supportRot->rotateY(90.0*CLHEP::degree);
 
       finishNesting(supportInfo,
-		    findMaterialOrThrow(config.getString("pbar.support.material")),
-		    supportRot,
-		    G4ThreeVector(0,0,0),
-		    parent.logical,
-		    0,
-		    G4Color::Gray(),
-		    "PbarAbs");
+                    findMaterialOrThrow(config.getString("pbar.support.material")),
+                    supportRot,
+                    G4ThreeVector(0,0,0),
+                    parent.logical,
+                    0,
+                    G4Color::Gray(),
+                    "PbarAbs");
 
       // -- vacuum wall
 
-      if (verbosityLevel > 0) G4cout << "TS3 pbar windows HalfLength : " << pbarWindow.halfLength() << G4endl; 
+      if (verbosityLevel > 0) G4cout << "TS3 pbar windows HalfLength : " << pbarWindow.halfLength() << G4endl;
       if ( pbarWindow.shape() == "wedge" ||
-	   pbarWindow.shape() == "disk" ) {
+           pbarWindow.shape() == "disk" ) {
 
-	VolumeInfo pbarDiskInfo;
-	pbarDiskInfo.name = "PbarAbsDisk";
+        VolumeInfo pbarDiskInfo;
+        pbarDiskInfo.name = "PbarAbsDisk";
 
-	// Helper info
-	double pbarWedge_y0  = pbarWindow.getY0();
-	double pbarWedge_y1  = pbarWindow.getY1();
-	double pbarWedge_dy = (pbarWedge_y1 + pbarWedge_y0)/2.;
+        // Helper info
+        double pbarWedge_y0  = pbarWindow.getY0();
+        double pbarWedge_y1  = pbarWindow.getY1();
+        double pbarWedge_dy = (pbarWedge_y1 + pbarWedge_y0)/2.;
 
-	G4Tubs *pbarAbs_disk = new G4Tubs("PbarAbs_disk",
-					  0.0 ,pbarWindow.rOut(),
-					  pbarWindow.halfLength(),
-					  0.0,CLHEP::twopi);
+        G4Tubs *pbarAbs_disk = new G4Tubs("PbarAbs_disk",
+                                          0.0 ,pbarWindow.rOut(),
+                                          pbarWindow.halfLength(),
+                                          0.0,CLHEP::twopi);
 
-	pbarDiskInfo.solid = new G4IntersectionSolid(pbarDiskInfo.name,
-						     support_hole,
-						     pbarAbs_disk,
-						     0,
-						     G4ThreeVector(0,0,0));
-	  
-	  finishNesting(pbarDiskInfo,
-			pbarMaterial,
-			0,
-			G4ThreeVector(0,pbarWedge_dy,0),
-			parent.logical,
-			0,
-			G4Color::Yellow(),
-			"PbarAbs"
-			);
-	// nestTubs( "PbarAbs",
-	// 	  pbarParams,
-	// 	  pbarMaterial,
-	// 	  0,
-	// 	  pbarWindow.getLocal(),
-	// 	  parent,
-	// 	  0,
-	// 	  G4Color::Yellow()
-	// 	  );
+        pbarDiskInfo.solid = new G4IntersectionSolid(pbarDiskInfo.name,
+                                                     support_hole,
+                                                     pbarAbs_disk,
+                                                     0,
+                                                     G4ThreeVector(0,0,0));
+
+          finishNesting(pbarDiskInfo,
+                        pbarMaterial,
+                        0,
+                        G4ThreeVector(0,pbarWedge_dy,0),
+                        parent.logical,
+                        0,
+                        G4Color::Yellow(),
+                        "PbarAbs"
+                        );
+        // nestTubs( "PbarAbs",
+        //        pbarParams,
+        //        pbarMaterial,
+        //        0,
+        //        pbarWindow.getLocal(),
+        //        parent,
+        //        0,
+        //        G4Color::Yellow()
+        //        );
       }
 
-      if( pbarWindow.shape() == "wedge" ) 
-	{
-	  // -- pbar wedge        
-	  double pbarWedge_y0  = pbarWindow.getY0();
-	  double pbarWedge_y1  = pbarWindow.getY1();
-	  double pbarWedge_dz0 = pbarWindow.getDZ0();
-	  double pbarWedge_dz1 = pbarWindow.getDZ1();
-	  double pbarWedge_dz = ( pbarWedge_dz0<pbarWedge_dz1 ) ? pbarWedge_dz1 : pbarWedge_dz0;
-	  double pbarWedge_offsetZ = pbarWindow.getWedgeZOffset() + pbarWedge_dz/2.0;
-      
-	  VolumeInfo pbarWedgeInfo;
-      
-	  pbarWedgeInfo.name = "PbarAbsWedge";
-      
-	  double pbarWedge_h = pbarWedge_y1 - pbarWedge_y0;
-	  
-	  double pbarWedge_dy = (pbarWedge_y1 + pbarWedge_y0)/2.;
-            
-	  G4Trd *pbarWedge_trd = new G4Trd("PbarAbsWedge_trd",
-					   bl.getTS().innerRadius(),bl.getTS().innerRadius(),
-					   pbarWedge_dz0/2.,pbarWedge_dz1/2.,
-					   pbarWedge_h/2.);
+      if( pbarWindow.shape() == "wedge" )
+        {
+          // -- pbar wedge
+          double pbarWedge_y0  = pbarWindow.getY0();
+          double pbarWedge_y1  = pbarWindow.getY1();
+          double pbarWedge_dz0 = pbarWindow.getDZ0();
+          double pbarWedge_dz1 = pbarWindow.getDZ1();
+          double pbarWedge_dz = ( pbarWedge_dz0<pbarWedge_dz1 ) ? pbarWedge_dz1 : pbarWedge_dz0;
+          double pbarWedge_offsetZ = pbarWindow.getWedgeZOffset() + pbarWedge_dz/2.0;
 
-	  AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
-	  G4RotationMatrix* pbarWedgeRot = reg.add(G4RotationMatrix());
-	  pbarWedgeRot->rotateX(90.0*CLHEP::degree);
-	  G4ThreeVector pbarWedgeTrans(0.0,pbarWedge_dy,pbarWedge_offsetZ);
-	  
-	  pbarWedgeInfo.solid = new G4IntersectionSolid(pbarWedgeInfo.name,
-							support_hole,
-							pbarWedge_trd,
-							pbarWedgeRot,
-							G4ThreeVector(0,0,0));
-	  
-	  finishNesting(pbarWedgeInfo,
-			pbarMaterial,
-			0,
-			pbarWedgeTrans,
-			parent.logical,
-			0,
-			G4Color::Yellow(),
-			"PbarAbs"
-			);
-	} //end of if ( pbarWindow.shape == wedge )
+          VolumeInfo pbarWedgeInfo;
+
+          pbarWedgeInfo.name = "PbarAbsWedge";
+
+          double pbarWedge_h = pbarWedge_y1 - pbarWedge_y0;
+
+          double pbarWedge_dy = (pbarWedge_y1 + pbarWedge_y0)/2.;
+
+          G4Trd *pbarWedge_trd = new G4Trd("PbarAbsWedge_trd",
+                                           bl.getTS().innerRadius(),bl.getTS().innerRadius(),
+                                           pbarWedge_dz0/2.,pbarWedge_dz1/2.,
+                                           pbarWedge_h/2.);
+
+          AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
+          G4RotationMatrix* pbarWedgeRot = reg.add(G4RotationMatrix());
+          pbarWedgeRot->rotateX(90.0*CLHEP::degree);
+          G4ThreeVector pbarWedgeTrans(0.0,pbarWedge_dy,pbarWedge_offsetZ);
+
+          pbarWedgeInfo.solid = new G4IntersectionSolid(pbarWedgeInfo.name,
+                                                        support_hole,
+                                                        pbarWedge_trd,
+                                                        pbarWedgeRot,
+                                                        G4ThreeVector(0,0,0));
+
+          finishNesting(pbarWedgeInfo,
+                        pbarMaterial,
+                        0,
+                        pbarWedgeTrans,
+                        parent.logical,
+                        0,
+                        G4Color::Yellow(),
+                        "PbarAbs"
+                        );
+        } //end of if ( pbarWindow.shape == wedge )
     }  else if ( pbarAbsTS3Version == 3 || pbarAbsTS3Version == 4) {
 
       if ( verbosityLevel > 2) {
-	G4cout << __func__ <<"inside version " << pbarAbsTS3Version << G4endl;
+        G4cout << __func__ <<"inside version " << pbarAbsTS3Version << G4endl;
       }
       // =============== Now Version 3 of pbarAbs in TS3! ==============
       // Get collimators (we use the coll31 info)
@@ -1868,180 +1868,180 @@ namespace mu2e {
 
       // Now make the actual support
       G4Tubs* support_mother = new G4Tubs("PbarSupport_mother",
-					  pbarWindow.diskRadius(), 
-					  coll31.rOut(), hDz,
-					  0.0, CLHEP::twopi );
+                                          pbarWindow.diskRadius(),
+                                          coll31.rOut(), hDz,
+                                          0.0, CLHEP::twopi );
 
       supportInfo.solid = support_mother;
 
       CLHEP::HepRotation * supportRot (nullptr);
 
       finishNesting(supportInfo,
-		    findMaterialOrThrow(config.getString("pbar.support.material")),
-		    supportRot,
-		    G4ThreeVector(0,0,0),
-		    parent.logical,
-		    0,
-		    G4Color::Gray(),
-		    "PbarAbs");
+                    findMaterialOrThrow(config.getString("pbar.support.material")),
+                    supportRot,
+                    G4ThreeVector(0,0,0),
+                    parent.logical,
+                    0,
+                    G4Color::Gray(),
+                    "PbarAbs");
 
       // -- vacuum wall
 
-        
-      if ( pbarWindow.shape() == "wedge" ||
-	   pbarWindow.shape() == "disk" ) {
 
-	VolumeInfo pbarDiskInfo;
-	pbarDiskInfo.name = "PbarAbsDisk";
+      if ( pbarWindow.shape() == "wedge" ||
+           pbarWindow.shape() == "disk" ) {
+
+        VolumeInfo pbarDiskInfo;
+        pbarDiskInfo.name = "PbarAbsDisk";
 
         if (verbosityLevel > 0) {
-          G4cout << "TS3 pbar window thickness : " << pbarWindow.halfLength()*2. << G4endl; 
+          G4cout << "TS3 pbar window thickness : " << pbarWindow.halfLength()*2. << G4endl;
           if (verbosityLevel > 1){
             G4cout << " inside wedge or disk" << G4endl;
           }
         }
 
-	pbarDiskInfo.solid = new G4Tubs("PbarAbs_disk",
-					  0.0 ,pbarWindow.diskRadius(),
-					  pbarWindow.halfLength(),
-					  0.0,CLHEP::twopi);
-	  
-	  finishNesting(pbarDiskInfo,
-			pbarMaterial,
-			0,
-			G4ThreeVector(0,0,0),
-			parent.logical,
-			0,
-			G4Color::Yellow(),
-			"PbarAbs"
-			);
+        pbarDiskInfo.solid = new G4Tubs("PbarAbs_disk",
+                                          0.0 ,pbarWindow.diskRadius(),
+                                          pbarWindow.halfLength(),
+                                          0.0,CLHEP::twopi);
+
+          finishNesting(pbarDiskInfo,
+                        pbarMaterial,
+                        0,
+                        G4ThreeVector(0,0,0),
+                        parent.logical,
+                        0,
+                        G4Color::Yellow(),
+                        "PbarAbs"
+                        );
 
       }
 
-      if( pbarWindow.shape() == "wedge" ) 
-	{
-	  // Helper info
-	  // -- pbar wedge        
-	  double pbarWedge_y1  = pbarWindow.getY1();
+      if( pbarWindow.shape() == "wedge" )
+        {
+          // Helper info
+          // -- pbar wedge
+          double pbarWedge_y1  = pbarWindow.getY1();
           double pbarWedge_offsetZ = pbarWindow.getWedgeZOffset();
-	  VolumeInfo pbarWedgeInfo;
-      
-	  pbarWedgeInfo.name = "PbarAbsWedge";
-      	  
-	  // The plan here is to make the new wedge design as a 
-	  // "staircase".  That is, an extrusion whose face looks like
-	  // a series of steps.  
+          VolumeInfo pbarWedgeInfo;
 
-	  // First, get the extrusion HALF length
-	  double exHL = pbarWindow.width()*CLHEP::mm/2.0;
+          pbarWedgeInfo.name = "PbarAbsWedge";
 
-	  // Now the thickness of each step
-	  double stepThck = pbarWindow.stripThickness()*CLHEP::mm;
+          // The plan here is to make the new wedge design as a
+          // "staircase".  That is, an extrusion whose face looks like
+          // a series of steps.
 
-	  // The number of steps
-	  int nSteps = pbarWindow.nStrips();
+          // First, get the extrusion HALF length
+          double exHL = pbarWindow.width()*CLHEP::mm/2.0;
 
-	  // The height of the strips, which is like the length of the
-	  // steps if you look at it as steps.
-	  std::vector<double> stepLength = pbarWindow.heights();
+          // Now the thickness of each step
+          double stepThck = pbarWindow.stripThickness()*CLHEP::mm;
 
-	  //
-	  // the thickness of the steps, if variable
-	  std::vector<double> stepThickStrip;
-	  if (pbarAbsTS3Version==4) {
-	    stepThickStrip = pbarWindow.stripThicknesses();
-	  }
+          // The number of steps
+          int nSteps = pbarWindow.nStrips();
 
-	  // Sanity check.  There is no way we should get to this point
-	  // and have a stepLength vector with the wrong number of 
-	  // steps, so just check...
+          // The height of the strips, which is like the length of the
+          // steps if you look at it as steps.
+          std::vector<double> stepLength = pbarWindow.heights();
 
-	  if ( (unsigned int) nSteps != stepLength.size() ) {
-	    throw cet::exception("GEOM")<<
-	      " The size of the PbarWedge stripHeight vector, " 
-					<< stepLength.size() <<
-	      "\n Does not match the expected number of strips, "
-					<< nSteps << "\n" ;
-	  }
+          //
+          // the thickness of the steps, if variable
+          std::vector<double> stepThickStrip;
+          if (pbarAbsTS3Version==4) {
+            stepThickStrip = pbarWindow.stripThicknesses();
+          }
 
-	  if ( pbarAbsTS3Version == 4 && (unsigned int) nSteps != stepThickStrip.size() ) {
-	    throw cet::exception("GEOM")<<
-	      " The size of the PbarWedge stripThickness vector, " 
-					<< stepThickStrip.size() <<
-	      "\n Does not match the expected number of strips, "
-					<< nSteps << "\n" ;
-	  }
+          // Sanity check.  There is no way we should get to this point
+          // and have a stepLength vector with the wrong number of
+          // steps, so just check...
 
+          if ( (unsigned int) nSteps != stepLength.size() ) {
+            throw cet::exception("GEOM")<<
+              " The size of the PbarWedge stripHeight vector, "
+                                        << stepLength.size() <<
+              "\n Does not match the expected number of strips, "
+                                        << nSteps << "\n" ;
+          }
 
-	  // Now we'll map out the vertices.  If you imagine our wedge
-	  // as a staircase leading up to a building, the origin of our
-	  // coordinate system will be the corner of the stairs on the bottom
-	  // and against the wall of the building.  The x-axis will point
-	  // up, against the wall, and the y-axis will run along the ground,
-	  // perpendicularly outward from the building.
-
-	  std::vector<G4TwoVector> stairOutline;
-	  stairOutline.reserve(2*nSteps + 2);  // # of vertices to describe 
-
-	  // First point is (0,0)
-	  G4TwoVector tmpVertex(0,0);
-	  stairOutline.push_back(tmpVertex);
-	  double xCoord = 0.0;
-	  if (verbosityLevel > 2){
-	    G4cout << __func__ << "stepThck = " << stepThck << G4endl;
-	  }
-	  // Now loop over steps
-	  for ( int iStep = 0; iStep < nSteps; iStep++ ) {
-	    if ( verbosityLevel > 2) {
-	      G4cout << "istep, stair outline 1: " << iStep << " " << xCoord << " " << stepLength[iStep] << G4endl;
-	    }
-	    stairOutline.push_back(G4TwoVector(xCoord,-stepLength[iStep]));
-	      
-	    if (pbarAbsTS3Version == 3){
-	      xCoord += stepThck;
-	    } else  if (pbarAbsTS3Version == 4) {
-	      xCoord += stepThickStrip[iStep];
-	    }
-	    if ( verbosityLevel > 2) {
-	      G4cout << "istep, stair outline 2: " << iStep << " " << xCoord << " " << stepLength[iStep] << G4endl;
-	    }
-	    stairOutline.push_back(G4TwoVector(xCoord,-stepLength[iStep]));
-	  }
-      
-	  G4TwoVector tmpVertex2(xCoord,0);
-	  stairOutline.push_back(tmpVertex2);
-
-	  G4ExtrudedSolid * stairCase = new G4ExtrudedSolid( "PbarAbsWedge_ES",
-							     stairOutline,
-							     exHL,
-							     G4TwoVector(0,0),1.,
-							     G4TwoVector(0,0),1. );
+          if ( pbarAbsTS3Version == 4 && (unsigned int) nSteps != stepThickStrip.size() ) {
+            throw cet::exception("GEOM")<<
+              " The size of the PbarWedge stripThickness vector, "
+                                        << stepThickStrip.size() <<
+              "\n Does not match the expected number of strips, "
+                                        << nSteps << "\n" ;
+          }
 
 
-	  AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
-	  G4RotationMatrix* pbarWedgeRot = reg.add(G4RotationMatrix());
-	  pbarWedgeRot->rotateY(90.0*CLHEP::degree);
-	  G4ThreeVector pbarWedgeTrans(0.0,pbarWedge_y1,pbarWedge_offsetZ);
-	  if (verbosityLevel > 2){
-	    G4cout << "pbarWedgeTrans = " << pbarWedgeTrans << G4endl;
-	  }
-	  pbarWedgeInfo.solid = stairCase;
-	  G4Material* wedgeMaterial  = findMaterialOrThrow(pbarWindow.wedgeMaterial()); //defaults to window material if not specified
-	  finishNesting(pbarWedgeInfo,
-			wedgeMaterial,
-			pbarWedgeRot,
-			pbarWedgeTrans,
-			parent.logical,
-			0,
-			G4Color::Yellow(),
-			"PbarAbs"
-			);
-	} //end of if ( pbarWindow.shape == wedge )
+          // Now we'll map out the vertices.  If you imagine our wedge
+          // as a staircase leading up to a building, the origin of our
+          // coordinate system will be the corner of the stairs on the bottom
+          // and against the wall of the building.  The x-axis will point
+          // up, against the wall, and the y-axis will run along the ground,
+          // perpendicularly outward from the building.
+
+          std::vector<G4TwoVector> stairOutline;
+          stairOutline.reserve(2*nSteps + 2);  // # of vertices to describe
+
+          // First point is (0,0)
+          G4TwoVector tmpVertex(0,0);
+          stairOutline.push_back(tmpVertex);
+          double xCoord = 0.0;
+          if (verbosityLevel > 2){
+            G4cout << __func__ << "stepThck = " << stepThck << G4endl;
+          }
+          // Now loop over steps
+          for ( int iStep = 0; iStep < nSteps; iStep++ ) {
+            if ( verbosityLevel > 2) {
+              G4cout << "istep, stair outline 1: " << iStep << " " << xCoord << " " << stepLength[iStep] << G4endl;
+            }
+            stairOutline.push_back(G4TwoVector(xCoord,-stepLength[iStep]));
+
+            if (pbarAbsTS3Version == 3){
+              xCoord += stepThck;
+            } else  if (pbarAbsTS3Version == 4) {
+              xCoord += stepThickStrip[iStep];
+            }
+            if ( verbosityLevel > 2) {
+              G4cout << "istep, stair outline 2: " << iStep << " " << xCoord << " " << stepLength[iStep] << G4endl;
+            }
+            stairOutline.push_back(G4TwoVector(xCoord,-stepLength[iStep]));
+          }
+
+          G4TwoVector tmpVertex2(xCoord,0);
+          stairOutline.push_back(tmpVertex2);
+
+          G4ExtrudedSolid * stairCase = new G4ExtrudedSolid( "PbarAbsWedge_ES",
+                                                             stairOutline,
+                                                             exHL,
+                                                             G4TwoVector(0,0),1.,
+                                                             G4TwoVector(0,0),1. );
+
+
+          AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
+          G4RotationMatrix* pbarWedgeRot = reg.add(G4RotationMatrix());
+          pbarWedgeRot->rotateY(90.0*CLHEP::degree);
+          G4ThreeVector pbarWedgeTrans(0.0,pbarWedge_y1,pbarWedge_offsetZ);
+          if (verbosityLevel > 2){
+            G4cout << "pbarWedgeTrans = " << pbarWedgeTrans << G4endl;
+          }
+          pbarWedgeInfo.solid = stairCase;
+          G4Material* wedgeMaterial  = findMaterialOrThrow(pbarWindow.wedgeMaterial()); //defaults to window material if not specified
+          finishNesting(pbarWedgeInfo,
+                        wedgeMaterial,
+                        pbarWedgeRot,
+                        pbarWedgeTrans,
+                        parent.logical,
+                        0,
+                        G4Color::Yellow(),
+                        "PbarAbs"
+                        );
+        } //end of if ( pbarWindow.shape == wedge )
     }  else {
-	throw cet::exception("GEOM")<<
-	" Incorrect pbar window geometry requested! \n " << " pbarWindow.shape() = " << pbarWindow.shape() << G4endl;   
- 
-    } // end of else for pbarAbsTS3Version == ... 
+        throw cet::exception("GEOM")<<
+        " Incorrect pbar window geometry requested! \n " << " pbarWindow.shape() = " << pbarWindow.shape() << G4endl;
+
+    } // end of else for pbarAbsTS3Version == ...
 
 
     // =============================================
@@ -2124,7 +2124,7 @@ namespace mu2e {
                 motherVolume,
                 0,
                 G4Color::Yellow(),
-		"PbarAbs"
+                "PbarAbs"
               );
 
       // ***
@@ -2134,23 +2134,23 @@ namespace mu2e {
       int pbarTS1InVersion = config.getInt("pbar.coll1In.Version",1);
       if ( pbarTS1InVersion > 1 ) {
       // Support structure inner and outer radius, halflength, and material
-	double pbarTS1InSupRIn = config.getDouble("pbar.coll1In.supportRIn");
-	double pbarTS1InSupROut = config.getDouble("pbar.coll1In.supportROut");
-	double pbarTS1InSupHLen = config.getDouble("pbar.coll1In.supportHLen");
-	string pbarTS1InSupMaterial = config.getString("pbar.coll1In.supportMaterialName");
-	// Offset from Pbar window in z, and vector built from it
-	double pbarTS1InSupOffsetZ = config.getDouble("pbar.coll1In.supportOffsetZ");
-	CLHEP::Hep3Vector pbarTS1InSupRelPos(0,0,pbarTS1InSupOffsetZ);
-	
-	// set up the tube parameters
-	double pbarTS1InSuptParams[5]  = { pbarTS1InSupRIn, 
-					   pbarTS1InSupROut, 
-					   pbarTS1InSupHLen, 
-					   0.0, CLHEP::twopi }; 
+        double pbarTS1InSupRIn = config.getDouble("pbar.coll1In.supportRIn");
+        double pbarTS1InSupROut = config.getDouble("pbar.coll1In.supportROut");
+        double pbarTS1InSupHLen = config.getDouble("pbar.coll1In.supportHLen");
+        string pbarTS1InSupMaterial = config.getString("pbar.coll1In.supportMaterialName");
+        // Offset from Pbar window in z, and vector built from it
+        double pbarTS1InSupOffsetZ = config.getDouble("pbar.coll1In.supportOffsetZ");
+        CLHEP::Hep3Vector pbarTS1InSupRelPos(0,0,pbarTS1InSupOffsetZ);
+
+        // set up the tube parameters
+        double pbarTS1InSuptParams[5]  = { pbarTS1InSupRIn,
+                                           pbarTS1InSupROut,
+                                           pbarTS1InSupHLen,
+                                           0.0, CLHEP::twopi };
 
 
-	// Now put in the support ring
-	nestTubs( "PbarAbsTS1InSup",
+        // Now put in the support ring
+        nestTubs( "PbarAbsTS1InSup",
                 pbarTS1InSuptParams,
                 findMaterialOrThrow(pbarTS1InSupMaterial),
                 0,
@@ -2158,172 +2158,172 @@ namespace mu2e {
                 motherVolume,
                 0,
                 G4Color::Yellow(),
-		"PbarAbs"
+                "PbarAbs"
               );
 
-	// The frames between which the Pbar window is sandwiched are
-	// the same basic size and shape as the support ring, but with
-	// different material and offsets.  So build in the same way
-	// First get the new material and offset.
+        // The frames between which the Pbar window is sandwiched are
+        // the same basic size and shape as the support ring, but with
+        // different material and offsets.  So build in the same way
+        // First get the new material and offset.
 
-	string pbarTS1InFrameMaterial = config.getString("pbar.coll1In.frameMaterialName");
-	double pbarTS1InFrameOffsetZ = config.getDouble("pbar.coll1In.frameOffsetZ");
-	CLHEP::Hep3Vector pbarTS1InFrameRelPos(0,0,pbarTS1InFrameOffsetZ);
+        string pbarTS1InFrameMaterial = config.getString("pbar.coll1In.frameMaterialName");
+        double pbarTS1InFrameOffsetZ = config.getDouble("pbar.coll1In.frameOffsetZ");
+        CLHEP::Hep3Vector pbarTS1InFrameRelPos(0,0,pbarTS1InFrameOffsetZ);
 
-	nestTubs( "PbarAbsTS1InFrameUp",
-		  pbarTS1InSuptParams,
-		  findMaterialOrThrow(pbarTS1InFrameMaterial),
-		  0,
-		  pbarTS1InPos-pbarTS1InFrameRelPos,
-		  motherVolume,
-		  0,
-		  G4Color::Yellow(),
-		  "PbarAbs"
-		  );
-      
-
-	nestTubs( "PbarAbsTS1InFrameDown",
-		  pbarTS1InSuptParams,
-		  findMaterialOrThrow(pbarTS1InFrameMaterial),
-		  0,
-		  pbarTS1InPos+pbarTS1InFrameRelPos,
-		  motherVolume,
-		  0,
-		  G4Color::Yellow(),
-		  "PbarAbs"
-		  );
-      
-	// ***
-	// Add the tabs used to hold the support ring in place.  Tabs are
-	// located at 4, 8, and 12-o'clock
-	// ***
-	// Treat tab as a box.  Get half dimensions and material
-	std::vector<double> pbarTS1InTabDims;
-	config.getVectorDouble("pbar.coll1In.tabDims",pbarTS1InTabDims,3);
-	string pbarTS1InTabMaterial = config.getString("pbar.coll1In.tabMaterialName");
-	double pbarTS1InTabOffsetZ = config.getDouble("pbar.coll1In.tabOffsetZ");
-	double pbarTS1InTabOffsetRad = config.getDouble("pbar.coll1In.tabOffsetR");
-
-	CLHEP::Hep3Vector pbarTS1InTab1RelPos(0,
-					      pbarTS1InTabOffsetRad,
-					      pbarTS1InSupOffsetZ
-					      + pbarTS1InTabOffsetZ);
-	// first tab at 12 o'clock
-	nestBox( "PbarAbsTS1InSupTab1",
-		 pbarTS1InTabDims,
-		 findMaterialOrThrow(pbarTS1InTabMaterial),
-		 0, 
-		 pbarTS1InPos+pbarTS1InTab1RelPos,
-		 motherVolume,
-		 0,
-		 G4Color::Yellow(),
-		 "PbarAbs"
-		 );
-
-	// next tab at 4 o'clock (looking downstream)
-	CLHEP::Hep3Vector pbarTS1InTab2RelPos(-pbarTS1InTabOffsetRad*std::sin(120*CLHEP::degree),
-					      pbarTS1InTabOffsetRad*std::cos(120*CLHEP::degree),
-					      pbarTS1InSupOffsetZ+pbarTS1InTabOffsetZ);
-
-	CLHEP::HepRotation* rotaTab2 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	rotaTab2->rotateZ(-120*CLHEP::degree);
-
-	nestBox( "PbarAbsTS1InSupTab2",
-		 pbarTS1InTabDims,
-		 findMaterialOrThrow(pbarTS1InTabMaterial),
-		 rotaTab2, 
-		 pbarTS1InPos+pbarTS1InTab2RelPos,
-		 motherVolume,
-		 0,
-		 G4Color::Yellow(),
-		 "PbarAbs"
-		 );
-
-	// next tab at 8 o'clock (looking downstream)
-	CLHEP::Hep3Vector pbarTS1InTab3RelPos(pbarTS1InTabOffsetRad*std::sin(120*CLHEP::degree),
-					      pbarTS1InTabOffsetRad*std::cos(120*CLHEP::degree),
-					      pbarTS1InSupOffsetZ+pbarTS1InTabOffsetZ);
-
-	CLHEP::HepRotation* rotaTab3 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	rotaTab3->rotateZ(120*CLHEP::degree);
-
-	nestBox( "PbarAbsTS1InSupTab3",
-		 pbarTS1InTabDims,
-		 findMaterialOrThrow(pbarTS1InTabMaterial),
-		 rotaTab3, 
-		 pbarTS1InPos+pbarTS1InTab3RelPos,
-		 motherVolume,
-		 0,
-		 G4Color::Yellow(),
-		 "PbarAbs"
-		 );
-
-	// ****
-	// Now build the pegs used for handling.
-	// Treat as simple polycones.
-	// The pegs are located at 2, 6, and 10 o'clock around the z-axis  
-	// ****
-
-	// Get shape and material parameters
-	std::vector<double> pegIR;
-	config.getVectorDouble("pbar.coll1In.pegInnerRadii",pegIR,7);
-	std::vector<double> pegOR;
-	config.getVectorDouble("pbar.coll1In.pegOuterRadii",pegOR,7);
-	std::vector<double> pegZ;
-	config.getVectorDouble("pbar.coll1In.pegZPlanes",pegZ,7);
-	std::string pegMaterial = config.getString("pbar.coll1In.pegMaterialName");
-	double pegOffsetZ = config.getDouble("pbar.coll1In.pegOffsetZ");
-	double pegRad = config.getDouble("pbar.coll1In.pegRadialPosition");
-
-	//This one at 2 o'clock looking down the z axis
-	CLHEP::Hep3Vector peg1Pos(-pegRad*std::sin(60*CLHEP::degree),
-				  pegRad*std::cos(60*CLHEP::degree),
-				  -pegOffsetZ);
-
-	Polycone pegCone( pegZ, pegIR, pegOR, 
-		  pbarTS1InPos - peg1Pos,
-		  pegMaterial);
-
-	VolumeInfo pegInfo = nestPolycone( "PbarAbsTS1InPeg1",
-					   pegCone.getPolyconsParams(),
-					   findMaterialOrThrow(pegMaterial),
-					   0,
-					   pbarTS1InPos+peg1Pos,
-					   motherVolume,
-					   0,
-					   G4Colour::Yellow(),
-					   "PbarAbs"
-					   );
-
-	//This one at 6 o'clock looking down the z axis
-	CLHEP::Hep3Vector peg2Pos(0, -pegRad, -pegOffsetZ);
-	VolumeInfo peg2Info = nestPolycone( "PbarAbsTS1InPeg2",
-					   pegCone.getPolyconsParams(),
-					   findMaterialOrThrow(pegMaterial),
-					   0,
-					   pbarTS1InPos+peg2Pos,
-					   motherVolume,
-					   0,
-					   G4Colour::Yellow(),
-					   "PbarAbs"
-					   );
+        nestTubs( "PbarAbsTS1InFrameUp",
+                  pbarTS1InSuptParams,
+                  findMaterialOrThrow(pbarTS1InFrameMaterial),
+                  0,
+                  pbarTS1InPos-pbarTS1InFrameRelPos,
+                  motherVolume,
+                  0,
+                  G4Color::Yellow(),
+                  "PbarAbs"
+                  );
 
 
-	//This one at 10 o'clock looking down the z axis
-	CLHEP::Hep3Vector peg3Pos(pegRad*std::sin(60*CLHEP::degree),
-				  pegRad*std::cos(60*CLHEP::degree),
-				  -pegOffsetZ);
+        nestTubs( "PbarAbsTS1InFrameDown",
+                  pbarTS1InSuptParams,
+                  findMaterialOrThrow(pbarTS1InFrameMaterial),
+                  0,
+                  pbarTS1InPos+pbarTS1InFrameRelPos,
+                  motherVolume,
+                  0,
+                  G4Color::Yellow(),
+                  "PbarAbs"
+                  );
 
-	VolumeInfo peg3Info = nestPolycone( "PbarAbsTS1InPeg3",
-					   pegCone.getPolyconsParams(),
-					   findMaterialOrThrow(pegMaterial),
-					   0,
-					   pbarTS1InPos+peg3Pos,
-					   motherVolume,
-					   0,
-					   G4Colour::Yellow(),
-					   "PbarAbs"
-					   );
+        // ***
+        // Add the tabs used to hold the support ring in place.  Tabs are
+        // located at 4, 8, and 12-o'clock
+        // ***
+        // Treat tab as a box.  Get half dimensions and material
+        std::vector<double> pbarTS1InTabDims;
+        config.getVectorDouble("pbar.coll1In.tabDims",pbarTS1InTabDims,3);
+        string pbarTS1InTabMaterial = config.getString("pbar.coll1In.tabMaterialName");
+        double pbarTS1InTabOffsetZ = config.getDouble("pbar.coll1In.tabOffsetZ");
+        double pbarTS1InTabOffsetRad = config.getDouble("pbar.coll1In.tabOffsetR");
+
+        CLHEP::Hep3Vector pbarTS1InTab1RelPos(0,
+                                              pbarTS1InTabOffsetRad,
+                                              pbarTS1InSupOffsetZ
+                                              + pbarTS1InTabOffsetZ);
+        // first tab at 12 o'clock
+        nestBox( "PbarAbsTS1InSupTab1",
+                 pbarTS1InTabDims,
+                 findMaterialOrThrow(pbarTS1InTabMaterial),
+                 0,
+                 pbarTS1InPos+pbarTS1InTab1RelPos,
+                 motherVolume,
+                 0,
+                 G4Color::Yellow(),
+                 "PbarAbs"
+                 );
+
+        // next tab at 4 o'clock (looking downstream)
+        CLHEP::Hep3Vector pbarTS1InTab2RelPos(-pbarTS1InTabOffsetRad*std::sin(120*CLHEP::degree),
+                                              pbarTS1InTabOffsetRad*std::cos(120*CLHEP::degree),
+                                              pbarTS1InSupOffsetZ+pbarTS1InTabOffsetZ);
+
+        CLHEP::HepRotation* rotaTab2 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+        rotaTab2->rotateZ(-120*CLHEP::degree);
+
+        nestBox( "PbarAbsTS1InSupTab2",
+                 pbarTS1InTabDims,
+                 findMaterialOrThrow(pbarTS1InTabMaterial),
+                 rotaTab2,
+                 pbarTS1InPos+pbarTS1InTab2RelPos,
+                 motherVolume,
+                 0,
+                 G4Color::Yellow(),
+                 "PbarAbs"
+                 );
+
+        // next tab at 8 o'clock (looking downstream)
+        CLHEP::Hep3Vector pbarTS1InTab3RelPos(pbarTS1InTabOffsetRad*std::sin(120*CLHEP::degree),
+                                              pbarTS1InTabOffsetRad*std::cos(120*CLHEP::degree),
+                                              pbarTS1InSupOffsetZ+pbarTS1InTabOffsetZ);
+
+        CLHEP::HepRotation* rotaTab3 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+        rotaTab3->rotateZ(120*CLHEP::degree);
+
+        nestBox( "PbarAbsTS1InSupTab3",
+                 pbarTS1InTabDims,
+                 findMaterialOrThrow(pbarTS1InTabMaterial),
+                 rotaTab3,
+                 pbarTS1InPos+pbarTS1InTab3RelPos,
+                 motherVolume,
+                 0,
+                 G4Color::Yellow(),
+                 "PbarAbs"
+                 );
+
+        // ****
+        // Now build the pegs used for handling.
+        // Treat as simple polycones.
+        // The pegs are located at 2, 6, and 10 o'clock around the z-axis
+        // ****
+
+        // Get shape and material parameters
+        std::vector<double> pegIR;
+        config.getVectorDouble("pbar.coll1In.pegInnerRadii",pegIR,7);
+        std::vector<double> pegOR;
+        config.getVectorDouble("pbar.coll1In.pegOuterRadii",pegOR,7);
+        std::vector<double> pegZ;
+        config.getVectorDouble("pbar.coll1In.pegZPlanes",pegZ,7);
+        std::string pegMaterial = config.getString("pbar.coll1In.pegMaterialName");
+        double pegOffsetZ = config.getDouble("pbar.coll1In.pegOffsetZ");
+        double pegRad = config.getDouble("pbar.coll1In.pegRadialPosition");
+
+        //This one at 2 o'clock looking down the z axis
+        CLHEP::Hep3Vector peg1Pos(-pegRad*std::sin(60*CLHEP::degree),
+                                  pegRad*std::cos(60*CLHEP::degree),
+                                  -pegOffsetZ);
+
+        Polycone pegCone( pegZ, pegIR, pegOR,
+                  pbarTS1InPos - peg1Pos,
+                  pegMaterial);
+
+        VolumeInfo pegInfo = nestPolycone( "PbarAbsTS1InPeg1",
+                                           pegCone.getPolyconsParams(),
+                                           findMaterialOrThrow(pegMaterial),
+                                           0,
+                                           pbarTS1InPos+peg1Pos,
+                                           motherVolume,
+                                           0,
+                                           G4Colour::Yellow(),
+                                           "PbarAbs"
+                                           );
+
+        //This one at 6 o'clock looking down the z axis
+        CLHEP::Hep3Vector peg2Pos(0, -pegRad, -pegOffsetZ);
+        VolumeInfo peg2Info = nestPolycone( "PbarAbsTS1InPeg2",
+                                           pegCone.getPolyconsParams(),
+                                           findMaterialOrThrow(pegMaterial),
+                                           0,
+                                           pbarTS1InPos+peg2Pos,
+                                           motherVolume,
+                                           0,
+                                           G4Colour::Yellow(),
+                                           "PbarAbs"
+                                           );
+
+
+        //This one at 10 o'clock looking down the z axis
+        CLHEP::Hep3Vector peg3Pos(pegRad*std::sin(60*CLHEP::degree),
+                                  pegRad*std::cos(60*CLHEP::degree),
+                                  -pegOffsetZ);
+
+        VolumeInfo peg3Info = nestPolycone( "PbarAbsTS1InPeg3",
+                                           pegCone.getPolyconsParams(),
+                                           findMaterialOrThrow(pegMaterial),
+                                           0,
+                                           pbarTS1InPos+peg3Pos,
+                                           motherVolume,
+                                           0,
+                                           G4Colour::Yellow(),
+                                           "PbarAbs"
+                                           );
 
 
       } // end of building support structure
@@ -2331,7 +2331,7 @@ namespace mu2e {
 
 
 
-      double pbarTS1InRecordParams[5]  = { 0.0, pbarTS1InRecordROut, vdHalfLength, 0.0, CLHEP::twopi };  
+      double pbarTS1InRecordParams[5]  = { 0.0, pbarTS1InRecordROut, vdHalfLength, 0.0, CLHEP::twopi };
       CLHEP::Hep3Vector pbarTS1InRecordPos = pbarTS1InPos;
       pbarTS1InRecordPos.setZ(pbarTS1InPos.z() - pbarTS1InHalfLength - 2*vdHalfLength - pbarTS1InRecordParams[2]);
 
@@ -2373,7 +2373,7 @@ namespace mu2e {
       double pbarTS1OutPosz       = coll1.collarZ();
 
       if ( verbosityLevel > 0 ) {
-        G4cout << __func__ << " Pbar absorber at TS1 coll1 near exit halfLength : " << pbarTS1OutHalfLength << " rIn " << pbarTS1OutrIn 
+        G4cout << __func__ << " Pbar absorber at TS1 coll1 near exit halfLength : " << pbarTS1OutHalfLength << " rIn " << pbarTS1OutrIn
           << " pbarTS1OutPosz " << pbarTS1OutPosz << " phiBegin " << pbarTS1OutphiBegin << " dPhi " << pbarTS1OutphiDelta << G4endl;
       }
 
@@ -2382,22 +2382,22 @@ namespace mu2e {
       // pbarTS1OutPos.setZ( pbarTS1Outz - TS1VacuumPos.z() );
 
       if ( verbosityLevel > 1 ) {
-	// printout related to the old code below
-	G4cout << __func__ << " pbarTS1OutPos :                      " << pbarTS1OutPos << G4endl;
-	G4cout << __func__ << " pbarTS1OutPosz-(-4044)) :            " << pbarTS1OutPosz-(-4044) << G4endl;
-	G4cout << __func__ << " coll1.halfLength() :                 " << coll1.halfLength() << G4endl;
+        // printout related to the old code below
+        G4cout << __func__ << " pbarTS1OutPos :                      " << pbarTS1OutPos << G4endl;
+        G4cout << __func__ << " pbarTS1OutPosz-(-4044)) :            " << pbarTS1OutPosz-(-4044) << G4endl;
+        G4cout << __func__ << " coll1.halfLength() :                 " << coll1.halfLength() << G4endl;
       }
 
       // pbarTS1OutPos.setZ( pbarTS1OutPos.z() + (pbarTS1OutPosz-(-4044)) - coll1.halfLength() );
       pbarTS1OutPos.setZ( coll1.collarZ() - ((_helper->locateVolInfo("TS1Vacuum")).centerInMu2e()).z() );
 
       if ( verbosityLevel > 0 ) {
-	G4cout << __func__ << " PbarAbsTS1Out position in TS1Vacuum: " << pbarTS1OutPos << G4endl;
-	double zpos = pbarTS1OutPos.z()+((_helper->locateVolInfo("TS1Vacuum")).centerInMu2e()).z();
-	G4cout << __func__ << " PbarAbsTS1Out position in mu2e:      " << pbarTS1OutPos+(_helper->locateVolInfo("TS1Vacuum")).centerInMu2e() << G4endl;
-	G4cout << __func__ << " PbarAbsTS1Out Extent:               [" << zpos - pbarTS1OutHalfLength << ","
-	     << zpos + pbarTS1OutHalfLength << "]" << G4endl;
-	G4cout << __func__ << " PbarAbsTS1Out HalfLength :           " << pbarTS1OutHalfLength << G4endl;
+        G4cout << __func__ << " PbarAbsTS1Out position in TS1Vacuum: " << pbarTS1OutPos << G4endl;
+        double zpos = pbarTS1OutPos.z()+((_helper->locateVolInfo("TS1Vacuum")).centerInMu2e()).z();
+        G4cout << __func__ << " PbarAbsTS1Out position in mu2e:      " << pbarTS1OutPos+(_helper->locateVolInfo("TS1Vacuum")).centerInMu2e() << G4endl;
+        G4cout << __func__ << " PbarAbsTS1Out Extent:               [" << zpos - pbarTS1OutHalfLength << ","
+             << zpos + pbarTS1OutHalfLength << "]" << G4endl;
+        G4cout << __func__ << " PbarAbsTS1Out HalfLength :           " << pbarTS1OutHalfLength << G4endl;
       }
 
       nestTubs( "PbarAbsTS1Out",
@@ -2408,7 +2408,7 @@ namespace mu2e {
                 _helper->locateVolInfo("TS1Vacuum"),
                 0,
                 G4Color::Yellow(),
-		"PbarAbs"
+                "PbarAbs"
               );
     }
 
@@ -2435,7 +2435,7 @@ namespace mu2e {
                 _helper->locateVolInfo("TS3Vacuum"),
                 0,
                 G4Color::Yellow(),
-		"PbarAbs"
+                "PbarAbs"
               );
     }
 
@@ -2443,10 +2443,10 @@ namespace mu2e {
 
   //Helper function to add thermal shielding
   void addThermalShield ( TransportSolenoid const& ts, VolumeInfo const& useAsParent,
-			  SimpleConfig const& config,
-			  TransportSolenoid::TSRegion::enum_type TSRegion,
-			  G4Material* thermalShieldMLIMaterial, G4Material* thermalShieldMidMaterial,
-			  double centerWallThickness /* > 0 if exists in middle of region (TS3) */) {
+                          SimpleConfig const& config,
+                          TransportSolenoid::TSRegion::enum_type TSRegion,
+                          G4Material* thermalShieldMLIMaterial, G4Material* thermalShieldMidMaterial,
+                          double centerWallThickness /* > 0 if exists in middle of region (TS3) */) {
     //for convenience
     typedef TransportSolenoid::TSRegion tsr;
     typedef TransportSolenoid::TSRadialPart tsrad;
@@ -2471,135 +2471,135 @@ namespace mu2e {
       double  endPlateHalfLength = 0.;
       int side = (TSRegion == tsr::TS1) ? -1. : 1.; //which side of TS to add end plate to if adding it
       if(TSRegion == tsr::TS1 || TSRegion == tsr::TS5) { //only the TS1 and TS5 currently have plates
-	endPlateRIn          = config.getDouble("ts.ts" + region + ".thermalshield.endplate.rIn");
-	endPlateROut         = config.getDouble("ts.ts" + region + ".thermalshield.endplate.rOut");
-	endPlateHalfLength   = config.getDouble("ts.ts" + region + ".thermalshield.endplate.halfLength");
-	double endPlateZMid1 = config.getDouble("ts.ts" + region + ".thermalshield.endplate.mid.z1");
-	double endPlateZMid2 = config.getDouble("ts.ts" + region + ".thermalshield.endplate.mid.z2");
-	//calculate thickness of each blanket from total thickness - metal layer thickness
-	if(endPlateZMid1 > endPlateZMid2 || endPlateZMid2 > 2.* endPlateHalfLength)
-	  throw cet::exception("GEOM")
-	    << ("TS thermal shielding end plate in TS" + region + " has inconsistent Z positions!").c_str()
-	    << " Should have 0 < z mid1 < z mid2 < 2*end plate half thickness."
-	    << G4endl;
+        endPlateRIn          = config.getDouble("ts.ts" + region + ".thermalshield.endplate.rIn");
+        endPlateROut         = config.getDouble("ts.ts" + region + ".thermalshield.endplate.rOut");
+        endPlateHalfLength   = config.getDouble("ts.ts" + region + ".thermalshield.endplate.halfLength");
+        double endPlateZMid1 = config.getDouble("ts.ts" + region + ".thermalshield.endplate.mid.z1");
+        double endPlateZMid2 = config.getDouble("ts.ts" + region + ".thermalshield.endplate.mid.z2");
+        //calculate thickness of each blanket from total thickness - metal layer thickness
+        if(endPlateZMid1 > endPlateZMid2 || endPlateZMid2 > 2.* endPlateHalfLength)
+          throw cet::exception("GEOM")
+            << ("TS thermal shielding end plate in TS" + region + " has inconsistent Z positions!").c_str()
+            << " Should have 0 < z mid1 < z mid2 < 2*end plate half thickness."
+            << G4endl;
 
-	double midHalfLength = (endPlateZMid2 - endPlateZMid1)/2.; //z1 - z2
-	double mli1HalfLength = endPlateZMid1/2.; //0 - z1
-	double mli2HalfLength = endPlateHalfLength - endPlateZMid2/2.; //z2 - end
-	double dzOriginToEdge = strsec->getHalfLength() - 2.*endPlateHalfLength; //center vacuum to edge of thermal shielding tube
+        double midHalfLength = (endPlateZMid2 - endPlateZMid1)/2.; //z1 - z2
+        double mli1HalfLength = endPlateZMid1/2.; //0 - z1
+        double mli2HalfLength = endPlateHalfLength - endPlateZMid2/2.; //z2 - end
+        double dzOriginToEdge = strsec->getHalfLength() - 2.*endPlateHalfLength; //center vacuum to edge of thermal shielding tube
 
-	CLHEP::Hep3Vector mli1Origin(strsec->getGlobal()-useAsParent.centerInMu2e()
-				     + CLHEP::Hep3Vector(0.,0.,
-							 side*(dzOriginToEdge + mli1HalfLength)));
-	CLHEP::Hep3Vector midOrigin(mli1Origin + CLHEP::Hep3Vector(0.,0.,side*(mli1HalfLength+midHalfLength)));
-	CLHEP::Hep3Vector mli2Origin(midOrigin + CLHEP::Hep3Vector(0.,0.,side*(mli2HalfLength+midHalfLength)));
-	nestTubs( "TS"+region+"ThermalShieldEndPlateMLI1",
-		  TubsParams( endPlateRIn ,
-			      endPlateROut,
-			      mli1HalfLength),
-		  thermalShieldMLIMaterial,
-		  0,
-		  mli1Origin,
-		  useAsParent,
-		  0,
-		  G4Color::Red(),
-		  "TSCryo"
-		  );
-	nestTubs( "TS"+region+"ThermalShieldEndPlateMLI2",
-		  TubsParams( endPlateRIn ,
-			      endPlateROut,
-			      mli2HalfLength),
-		  thermalShieldMLIMaterial,
-		  0,
-		  mli2Origin,
-		  useAsParent,
-		  0,
-		  G4Color::Red(),
-		  "TSCryo"
-		  );
-	nestTubs( "TS"+region+"ThermalShieldEndPlateMid",
-		  TubsParams( endPlateRIn ,
-			      endPlateROut,
-			      midHalfLength),
-		  thermalShieldMidMaterial,
-		  0,
-		  midOrigin,
-		  useAsParent,
-		  0,
-		  G4Color::Red(),
-		  "TSCryo"
-		  );
+        CLHEP::Hep3Vector mli1Origin(strsec->getGlobal()-useAsParent.centerInMu2e()
+                                     + CLHEP::Hep3Vector(0.,0.,
+                                                         side*(dzOriginToEdge + mli1HalfLength)));
+        CLHEP::Hep3Vector midOrigin(mli1Origin + CLHEP::Hep3Vector(0.,0.,side*(mli1HalfLength+midHalfLength)));
+        CLHEP::Hep3Vector mli2Origin(midOrigin + CLHEP::Hep3Vector(0.,0.,side*(mli2HalfLength+midHalfLength)));
+        nestTubs( "TS"+region+"ThermalShieldEndPlateMLI1",
+                  TubsParams( endPlateRIn ,
+                              endPlateROut,
+                              mli1HalfLength),
+                  thermalShieldMLIMaterial,
+                  0,
+                  mli1Origin,
+                  useAsParent,
+                  0,
+                  G4Color::Red(),
+                  "TSCryo"
+                  );
+        nestTubs( "TS"+region+"ThermalShieldEndPlateMLI2",
+                  TubsParams( endPlateRIn ,
+                              endPlateROut,
+                              mli2HalfLength),
+                  thermalShieldMLIMaterial,
+                  0,
+                  mli2Origin,
+                  useAsParent,
+                  0,
+                  G4Color::Red(),
+                  "TSCryo"
+                  );
+        nestTubs( "TS"+region+"ThermalShieldEndPlateMid",
+                  TubsParams( endPlateRIn ,
+                              endPlateROut,
+                              midHalfLength),
+                  thermalShieldMidMaterial,
+                  0,
+                  midOrigin,
+                  useAsParent,
+                  0,
+                  G4Color::Red(),
+                  "TSCryo"
+                  );
       }
       if(centerWallThickness < 0.) { //no wall in the center of the region (TS1 and TS5)
-	std::vector<double> innerInRadii = {strsec->rIn(),
-				       config.getDouble("ts.ts" + region + "in.thermalshield.mid.rIn")+smallGap,
-				       config.getDouble("ts.ts" + region + "in.thermalshield.mid.rOut")+smallGap};
-	std::vector<double> innerOutRadii = {innerInRadii[1]-smallGap,
-					     innerInRadii[2]-smallGap,
-					     strsec->rOut()};
-	CLHEP::Hep3Vector innerOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
-				      - CLHEP::Hep3Vector(0.,0.,side*endPlateHalfLength));
-	double innerHalfLength = strsec->getHalfLength() - endPlateHalfLength;
-	addThermalShieldStraightSection(useAsParent, innerInRadii, innerOutRadii, innerHalfLength,
-					thermalShieldMLIMaterial, thermalShieldMidMaterial,
-					innerOrigin, "TS"+region+"Inner");
+        std::vector<double> innerInRadii = {strsec->rIn(),
+                                       config.getDouble("ts.ts" + region + "in.thermalshield.mid.rIn")+smallGap,
+                                       config.getDouble("ts.ts" + region + "in.thermalshield.mid.rOut")+smallGap};
+        std::vector<double> innerOutRadii = {innerInRadii[1]-smallGap,
+                                             innerInRadii[2]-smallGap,
+                                             strsec->rOut()};
+        CLHEP::Hep3Vector innerOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
+                                      - CLHEP::Hep3Vector(0.,0.,side*endPlateHalfLength));
+        double innerHalfLength = strsec->getHalfLength() - endPlateHalfLength;
+        addThermalShieldStraightSection(useAsParent, innerInRadii, innerOutRadii, innerHalfLength,
+                                        thermalShieldMLIMaterial, thermalShieldMidMaterial,
+                                        innerOrigin, "TS"+region+"Inner");
 
-	strsec = ts.getTSThermalShield<StraightSection>(TSRegion,tsrad::OUT);
-	std::vector<double> outerInRadii = {strsec->rIn(),
-					   config.getDouble("ts.ts" + region + "out.thermalshield.mid.rIn")+smallGap,
-					   config.getDouble("ts.ts" + region + "out.thermalshield.mid.rOut")+smallGap};
-	std::vector<double> outerOutRadii = {outerInRadii[1]-smallGap,
-					     outerInRadii[2]-smallGap,
-					     strsec->rOut()};
-	CLHEP::Hep3Vector outerOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
-				      - CLHEP::Hep3Vector(0.,0.,side*endPlateHalfLength));
-	double outerHalfLength = strsec->getHalfLength() - endPlateHalfLength;
-	addThermalShieldStraightSection(useAsParent, outerInRadii, outerOutRadii, outerHalfLength,
-					thermalShieldMLIMaterial, thermalShieldMidMaterial,
-					outerOrigin, "TS"+region+"Outer");
+        strsec = ts.getTSThermalShield<StraightSection>(TSRegion,tsrad::OUT);
+        std::vector<double> outerInRadii = {strsec->rIn(),
+                                           config.getDouble("ts.ts" + region + "out.thermalshield.mid.rIn")+smallGap,
+                                           config.getDouble("ts.ts" + region + "out.thermalshield.mid.rOut")+smallGap};
+        std::vector<double> outerOutRadii = {outerInRadii[1]-smallGap,
+                                             outerInRadii[2]-smallGap,
+                                             strsec->rOut()};
+        CLHEP::Hep3Vector outerOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
+                                      - CLHEP::Hep3Vector(0.,0.,side*endPlateHalfLength));
+        double outerHalfLength = strsec->getHalfLength() - endPlateHalfLength;
+        addThermalShieldStraightSection(useAsParent, outerInRadii, outerOutRadii, outerHalfLength,
+                                        thermalShieldMLIMaterial, thermalShieldMidMaterial,
+                                        outerOrigin, "TS"+region+"Outer");
       } //end no center wall
       else { //wall in the center of the region (TS3)
-	//split each volume into an upstream and downstream end
-	double tsrHalfLength = strsec->getHalfLength();
-	double tsrudHalfLength = tsrHalfLength/2. - centerWallThickness/4.; //half of region minus half of the wall half length
-	std::vector<double> innerInRadii = {strsec->rIn(),
-					    config.getDouble("ts.ts" + region + "in.thermalshield.mid.rIn")+smallGap,
-					    config.getDouble("ts.ts" + region + "in.thermalshield.mid.rOut")+smallGap};
-	std::vector<double> innerOutRadii = {innerInRadii[1]-smallGap,
-					     innerInRadii[2]-smallGap,
-					     strsec->rOut()};
-	CLHEP::Hep3Vector inneruOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
-				      - CLHEP::Hep3Vector(0.,0.,tsrHalfLength/2.+centerWallThickness/4.));
-	CLHEP::Hep3Vector innerdOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
-				      + CLHEP::Hep3Vector(0.,0.,tsrHalfLength/2.+centerWallThickness/4.));
+        //split each volume into an upstream and downstream end
+        double tsrHalfLength = strsec->getHalfLength();
+        double tsrudHalfLength = tsrHalfLength/2. - centerWallThickness/4.; //half of region minus half of the wall half length
+        std::vector<double> innerInRadii = {strsec->rIn(),
+                                            config.getDouble("ts.ts" + region + "in.thermalshield.mid.rIn")+smallGap,
+                                            config.getDouble("ts.ts" + region + "in.thermalshield.mid.rOut")+smallGap};
+        std::vector<double> innerOutRadii = {innerInRadii[1]-smallGap,
+                                             innerInRadii[2]-smallGap,
+                                             strsec->rOut()};
+        CLHEP::Hep3Vector inneruOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
+                                      - CLHEP::Hep3Vector(0.,0.,tsrHalfLength/2.+centerWallThickness/4.));
+        CLHEP::Hep3Vector innerdOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
+                                      + CLHEP::Hep3Vector(0.,0.,tsrHalfLength/2.+centerWallThickness/4.));
 
-	addThermalShieldStraightSection(useAsParent, innerInRadii, innerOutRadii, tsrudHalfLength,
-					thermalShieldMLIMaterial, thermalShieldMidMaterial,
-					inneruOrigin, "TS"+region+"uInner");
-	addThermalShieldStraightSection(useAsParent, innerInRadii, innerOutRadii, tsrudHalfLength,
-					thermalShieldMLIMaterial, thermalShieldMidMaterial,
-					innerdOrigin, "TS"+region+"dInner");
+        addThermalShieldStraightSection(useAsParent, innerInRadii, innerOutRadii, tsrudHalfLength,
+                                        thermalShieldMLIMaterial, thermalShieldMidMaterial,
+                                        inneruOrigin, "TS"+region+"uInner");
+        addThermalShieldStraightSection(useAsParent, innerInRadii, innerOutRadii, tsrudHalfLength,
+                                        thermalShieldMLIMaterial, thermalShieldMidMaterial,
+                                        innerdOrigin, "TS"+region+"dInner");
 
-	strsec = ts.getTSThermalShield<StraightSection>(TSRegion,tsrad::OUT);
-	tsrHalfLength = strsec->getHalfLength();
-	tsrudHalfLength = tsrHalfLength/2. - centerWallThickness/4.; //half of region minus half of the wall half length
-	std::vector<double> outerInRadii = {strsec->rIn(),
-					    config.getDouble("ts.ts" + region + "out.thermalshield.mid.rIn")+smallGap,
-					    config.getDouble("ts.ts" + region + "out.thermalshield.mid.rOut")+smallGap};
-	std::vector<double> outerOutRadii = {outerInRadii[1]-smallGap,
-					     outerInRadii[2]-smallGap,
-					     strsec->rOut()};
-	CLHEP::Hep3Vector outeruOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
-				       - CLHEP::Hep3Vector(0.,0.,tsrHalfLength/2.+centerWallThickness/4.));
-	CLHEP::Hep3Vector outerdOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
-				       + CLHEP::Hep3Vector(0.,0.,tsrHalfLength/2.+centerWallThickness/4.));
+        strsec = ts.getTSThermalShield<StraightSection>(TSRegion,tsrad::OUT);
+        tsrHalfLength = strsec->getHalfLength();
+        tsrudHalfLength = tsrHalfLength/2. - centerWallThickness/4.; //half of region minus half of the wall half length
+        std::vector<double> outerInRadii = {strsec->rIn(),
+                                            config.getDouble("ts.ts" + region + "out.thermalshield.mid.rIn")+smallGap,
+                                            config.getDouble("ts.ts" + region + "out.thermalshield.mid.rOut")+smallGap};
+        std::vector<double> outerOutRadii = {outerInRadii[1]-smallGap,
+                                             outerInRadii[2]-smallGap,
+                                             strsec->rOut()};
+        CLHEP::Hep3Vector outeruOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
+                                       - CLHEP::Hep3Vector(0.,0.,tsrHalfLength/2.+centerWallThickness/4.));
+        CLHEP::Hep3Vector outerdOrigin(strsec->getGlobal()-useAsParent.centerInMu2e()
+                                       + CLHEP::Hep3Vector(0.,0.,tsrHalfLength/2.+centerWallThickness/4.));
 
-	addThermalShieldStraightSection(useAsParent, outerInRadii, outerOutRadii, tsrudHalfLength,
-					thermalShieldMLIMaterial, thermalShieldMidMaterial,
-					outeruOrigin, "TS"+region+"uOuter");
-	addThermalShieldStraightSection(useAsParent, outerInRadii, outerOutRadii, tsrudHalfLength,
-					thermalShieldMLIMaterial, thermalShieldMidMaterial,
-					outerdOrigin, "TS"+region+"dOuter");
+        addThermalShieldStraightSection(useAsParent, outerInRadii, outerOutRadii, tsrudHalfLength,
+                                        thermalShieldMLIMaterial, thermalShieldMidMaterial,
+                                        outeruOrigin, "TS"+region+"uOuter");
+        addThermalShieldStraightSection(useAsParent, outerInRadii, outerOutRadii, tsrudHalfLength,
+                                        thermalShieldMLIMaterial, thermalShieldMidMaterial,
+                                        outerdOrigin, "TS"+region+"dOuter");
 
 
       }
@@ -2608,111 +2608,111 @@ namespace mu2e {
       auto torsec = ts.getTSThermalShield<TorusSection>(TSRegion,tsrad::IN );
       std::vector<double> torusInParams = {torsec->torusRadius(), torsec->phiStart(), torsec->deltaPhi()};
       std::vector<double> innerInRadii = {torsec->rIn(),
-					  config.getDouble("ts.ts" + region + "in.thermalshield.mid.rIn"),
-					  config.getDouble("ts.ts" + region + "in.thermalshield.mid.rOut")};
+                                          config.getDouble("ts.ts" + region + "in.thermalshield.mid.rIn"),
+                                          config.getDouble("ts.ts" + region + "in.thermalshield.mid.rOut")};
       std::vector<double> innerOutRadii = {innerInRadii[1],
-					   innerInRadii[2],
-					   torsec->rOut()};
+                                           innerInRadii[2],
+                                           torsec->rOut()};
       addThermalShieldTorusSection(useAsParent, innerInRadii, innerOutRadii, torusInParams,
-				   thermalShieldMLIMaterial, thermalShieldMidMaterial,
-				   torsec->getGlobal()-useAsParent.centerInMu2e(), "TS"+region+"Inner");
+                                   thermalShieldMLIMaterial, thermalShieldMidMaterial,
+                                   torsec->getGlobal()-useAsParent.centerInMu2e(), "TS"+region+"Inner");
 
       torsec = ts.getTSThermalShield<TorusSection>(TSRegion,tsrad::OUT );
       std::vector<double> torusOutParams = {torsec->torusRadius(), torsec->phiStart(), torsec->deltaPhi()};
       std::vector<double> outerInRadii = {torsec->rIn(),
-					  config.getDouble("ts.ts" + region + "out.thermalshield.mid.rIn"),
-					  config.getDouble("ts.ts" + region + "out.thermalshield.mid.rOut")};
+                                          config.getDouble("ts.ts" + region + "out.thermalshield.mid.rIn"),
+                                          config.getDouble("ts.ts" + region + "out.thermalshield.mid.rOut")};
       std::vector<double> outerOutRadii = {outerInRadii[1],
-					   outerInRadii[2],
-					   torsec->rOut()};
+                                           outerInRadii[2],
+                                           torsec->rOut()};
       addThermalShieldTorusSection(useAsParent, outerInRadii, outerOutRadii, torusOutParams,
-				   thermalShieldMLIMaterial, thermalShieldMidMaterial,
-				   torsec->getGlobal()-useAsParent.centerInMu2e(), "TS"+region+"Outer");
+                                   thermalShieldMLIMaterial, thermalShieldMidMaterial,
+                                   torsec->getGlobal()-useAsParent.centerInMu2e(), "TS"+region+"Outer");
     }
   } //end addThermalShield
 
   //add an individual straight section of thermal shielding
   void addThermalShieldStraightSection( VolumeInfo const& useAsParent, std::vector<double> innerRadii,
-					std::vector<double> outerRadii, double halfLength,
-					G4Material* thermalShieldMLIMaterial, G4Material* thermalShieldMidMaterial,
-					CLHEP::Hep3Vector const& origin, std::string name) {
+                                        std::vector<double> outerRadii, double halfLength,
+                                        G4Material* thermalShieldMLIMaterial, G4Material* thermalShieldMidMaterial,
+                                        CLHEP::Hep3Vector const& origin, std::string name) {
     unsigned nRadii = 3; //number expected
     if(innerRadii.size() != nRadii || outerRadii.size() != nRadii)
       throw cet::exception("GEOM")
-	<< "Incorrect amount of radii given for TS thermal shielding!"
-	<< G4endl;
+        << "Incorrect amount of radii given for TS thermal shielding!"
+        << G4endl;
 
     std::vector<std::string> names = {"ThermalShieldMLI1", "ThermalShieldMid", "ThermalShieldMLI2"};
     std::vector<G4Material*> materials = {thermalShieldMLIMaterial, thermalShieldMidMaterial, thermalShieldMLIMaterial};
     if(names.size() != nRadii)
       throw cet::exception("GEOM")
-	<< "Vector of shielding names not the correct size in constructTS::"
-	<< __func__ << "!"
-	<< G4endl;
+        << "Vector of shielding names not the correct size in constructTS::"
+        << __func__ << "!"
+        << G4endl;
     if(materials.size() != nRadii)
       throw cet::exception("GEOM")
-	<< "Vector of materials not the correct size in constructTS::"
-	<< __func__ << "!"
-	<< G4endl;
+        << "Vector of materials not the correct size in constructTS::"
+        << __func__ << "!"
+        << G4endl;
     for(unsigned index = 0; index < nRadii; ++index) {
       nestTubs( name+names[index],
-		TubsParams( innerRadii[index],
-			    outerRadii[index],
-			    halfLength ),
-		materials[index],
-		0,
-		origin,
-		useAsParent,
-		0,
-		G4Color::Red(),
-		"TSCryo"
-		);
+                TubsParams( innerRadii[index],
+                            outerRadii[index],
+                            halfLength ),
+                materials[index],
+                0,
+                origin,
+                useAsParent,
+                0,
+                G4Color::Red(),
+                "TSCryo"
+                );
     }
   } //end add thermal shield straight section
 
   void addThermalShieldTorusSection( VolumeInfo const& useAsParent, std::vector<double> innerRadii,
-				     std::vector<double> outerRadii, std::vector<double> torusParams,
-				     G4Material* thermalShieldMLIMaterial, G4Material* thermalShieldMidMaterial,
-				     CLHEP::Hep3Vector const& origin, std::string name) {
+                                     std::vector<double> outerRadii, std::vector<double> torusParams,
+                                     G4Material* thermalShieldMLIMaterial, G4Material* thermalShieldMidMaterial,
+                                     CLHEP::Hep3Vector const& origin, std::string name) {
     unsigned nRadii = 3; //number expected
     if(innerRadii.size() != nRadii || outerRadii.size() != nRadii)
       throw cet::exception("GEOM")
-	<< "Incorrect amount of radii given for TS thermal shielding!"
-	<< G4endl;   
+        << "Incorrect amount of radii given for TS thermal shielding!"
+        << G4endl;
     if(torusParams.size() != 3)
       throw cet::exception("GEOM")
-	<< "Incorrect amount of torus parameters given for TS thermal shielding (expect {rTorus, phi0, delta phi})!"
-	<< G4endl;
+        << "Incorrect amount of torus parameters given for TS thermal shielding (expect {rTorus, phi0, delta phi})!"
+        << G4endl;
 
     std::vector<std::string> names = {"ThermalShieldMLI1", "ThermalShieldMid", "ThermalShieldMLI2"};
     std::vector<G4Material*> materials = {thermalShieldMLIMaterial, thermalShieldMidMaterial, thermalShieldMLIMaterial};
     if(names.size() != nRadii)
       throw cet::exception("GEOM")
-	<< "Vector of shielding names not the correct size in constructTS::"
-	<< __func__ << "!"
-	<< G4endl;
+        << "Vector of shielding names not the correct size in constructTS::"
+        << __func__ << "!"
+        << G4endl;
     if(materials.size() != nRadii)
       throw cet::exception("GEOM")
-	<< "Vector of materials not the correct size in constructTS::"
-	<< __func__ << "!"
-	<< G4endl;
+        << "Vector of materials not the correct size in constructTS::"
+        << __func__ << "!"
+        << G4endl;
 
     for(unsigned index = 0; index < nRadii; ++index) {
       std::array<double,5> params {
-	{   innerRadii[index], outerRadii[index],
-	    torusParams[0], torusParams[1],
-	    torusParams[2] }
+        {   innerRadii[index], outerRadii[index],
+            torusParams[0], torusParams[1],
+            torusParams[2] }
       };
       nestTorus(name+names[index],
-		params,
-		materials[index],
-		0,
-		origin,
-		useAsParent,
-		0,
-		G4Color::Red(),
-		"TSCryo"
-		);
+                params,
+                materials[index],
+                0,
+                origin,
+                useAsParent,
+                0,
+                G4Color::Red(),
+                "TSCryo"
+                );
     }
 
   }//end add thermal shield torus section

--- a/Mu2eG4/src/constructTS.cc
+++ b/Mu2eG4/src/constructTS.cc
@@ -88,6 +88,7 @@ namespace mu2e {
     TransportSolenoid const * ts     ( &bl.getTS() );
     StraightSection   const * strsec (nullptr);
     TorusSection      const * torsec (nullptr);
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
 
     Mu2eG4Helper * const _helper = &(*art::ServiceHandle<Mu2eG4Helper>());
 
@@ -689,10 +690,10 @@ namespace mu2e {
       // Let's make a mother volume first for each ring.
       std::ostringstream ringMotherName;
       ringMotherName << "TSRingMother" << iRing;
-      CLHEP::HepRotation* ringRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+      CLHEP::HepRotation* ringRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
       double ringRotTheta = thetasRing[iRing]*CLHEP::degree;
       ringRotat->rotateY(ringRotTheta);
-      CLHEP::HepRotation* noRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+      CLHEP::HepRotation* noRotat (nullptr);
 
       double motherx = xr[iRing];
       double mothery = yr[iRing];
@@ -766,7 +767,7 @@ namespace mu2e {
 
 	std::ostringstream PabsSupOutName;
 	PabsSupOutName << "PabsTS3SupOut";
-	CLHEP::HepRotation* pasubRotat = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	CLHEP::HepRotation* pasubRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	pasubRotat->rotateY(90.0*CLHEP::degree);
 	double rPabsTS3SupOut_in  = rirs;
 	double rPabsTS3SupOut_out = config.getDouble("pbar.support.outROut", rors);
@@ -990,6 +991,8 @@ namespace mu2e {
                        SimpleConfig const& config,
                        Beamline const& bl ) {
 
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
+
     const int  verbosityLevel      = config.getInt("ts.coils.verbosityLevel", 0);
 
     G4GeometryOptions* geomOptions = art::ServiceHandle<GeometryService>()->geomOptions();
@@ -1022,7 +1025,7 @@ namespace mu2e {
 	if ( iTS == TransportSolenoid::TSRegion::TS2 || 
 	     iTS == TransportSolenoid::TSRegion::TS4 ) {
 
-	  CLHEP::HepRotation* twist = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	  CLHEP::HepRotation* twist = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	  twist->rotateX(90.0*CLHEP::degree);
 	  twist->rotateY(-coil.getRotation()->theta());
 
@@ -1402,7 +1405,7 @@ namespace mu2e {
               );
     if(coll52HLInTS4 > 0.) {
       TubsParams coll5Param2_TS4 ( coll52.rIn(),  coll52.rOut(), coll52HLInTS4);
-      CLHEP::HepRotation* rotColl52 = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+      CLHEP::HepRotation* rotColl52 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
       rotColl52->rotateX(90.*CLHEP::degree);
       nestTubs( "Coll52InTS4",
 		coll5Param2_TS4,
@@ -1584,6 +1587,7 @@ namespace mu2e {
     G4GeometryOptions* geomOptions = art::ServiceHandle<GeometryService>()->geomOptions();
     geomOptions->loadEntry( config, "PbarAbs", "pbar" );
     
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
 
     // Throw exception if pbarwedge.build is used - way out of date!
     if ( config.hasName("pbarwedge.build") )
@@ -1746,7 +1750,7 @@ namespace mu2e {
                                               G4ThreeVector(0,
 							    config.getDouble("pbar.support.holeDisp"),0));
 
-      CLHEP::HepRotation * supportRot = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+      CLHEP::HepRotation * supportRot (nullptr);
       //      supportRot->rotateY(90.0*CLHEP::degree);
 
       finishNesting(supportInfo,
@@ -1870,7 +1874,7 @@ namespace mu2e {
 
       supportInfo.solid = support_mother;
 
-      CLHEP::HepRotation * supportRot = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+      CLHEP::HepRotation * supportRot (nullptr);
 
       finishNesting(supportInfo,
 		    findMaterialOrThrow(config.getString("pbar.support.material")),
@@ -2221,7 +2225,7 @@ namespace mu2e {
 					      pbarTS1InTabOffsetRad*std::cos(120*CLHEP::degree),
 					      pbarTS1InSupOffsetZ+pbarTS1InTabOffsetZ);
 
-	CLHEP::HepRotation* rotaTab2 = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	CLHEP::HepRotation* rotaTab2 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	rotaTab2->rotateZ(-120*CLHEP::degree);
 
 	nestBox( "PbarAbsTS1InSupTab2",
@@ -2240,7 +2244,7 @@ namespace mu2e {
 					      pbarTS1InTabOffsetRad*std::cos(120*CLHEP::degree),
 					      pbarTS1InSupOffsetZ+pbarTS1InTabOffsetZ);
 
-	CLHEP::HepRotation* rotaTab3 = new CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY);
+	CLHEP::HepRotation* rotaTab3 = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
 	rotaTab3->rotateZ(120*CLHEP::degree);
 
 	nestBox( "PbarAbsTS1InSupTab3",

--- a/Mu2eG4/src/constructTargetPS.cc
+++ b/Mu2eG4/src/constructTargetPS.cc
@@ -54,20 +54,20 @@ using namespace std;
 namespace mu2e {
 
   void placeSubtractionVolumeBoxTubs(
-				     const std::string& name //volume info for main object
-				     ,const CLHEP::Hep3Vector& translation
-				     ,VolumeInfo const& parent
-				     ,G4Box*  boxCutout //action volume object
-				     ,G4Tubs* tubsCutout
-				     ,const CLHEP::HepRotation* rotAngle
-				     ,G4Material* material// finish nesting args
-				     ,G4RotationMatrix* rotOverall
-				     ,G4ThreeVector const& offset
-				     ,int const copyNo
-				     ,const G4Colour color
-				     ,const std::string& lookupToken
-				     ,const bool verbose = false
-				     )
+                                     const std::string& name //volume info for main object
+                                     ,const CLHEP::Hep3Vector& translation
+                                     ,VolumeInfo const& parent
+                                     ,G4Box*  boxCutout //action volume object
+                                     ,G4Tubs* tubsCutout
+                                     ,const CLHEP::HepRotation* rotAngle
+                                     ,G4Material* material// finish nesting args
+                                     ,G4RotationMatrix* rotOverall
+                                     ,G4ThreeVector const& offset
+                                     ,int const copyNo
+                                     ,const G4Colour color
+                                     ,const std::string& lookupToken
+                                     ,const bool verbose = false
+                                     )
   {
     VolumeInfo boxWithTubsCutoutInfo(name,translation,parent.centerInWorld);
     boxWithTubsCutoutInfo.solid = new G4SubtractionSolid(name,boxCutout,tubsCutout, rotOverall, offset);
@@ -87,7 +87,7 @@ namespace mu2e {
       //G4Material* psVacVesselMaterial = findMaterialOrThrow(psVacVesselInnerParams.materialName());
 
       verbosityLevel >0 &&
-	cout << __func__ << " verbosityLevel                   : " << verbosityLevel  << endl;
+        cout << __func__ << " verbosityLevel                   : " << verbosityLevel  << endl;
 
       //bool psVacuumSensitive = _config.getBool("PS.Vacuum.Sensitive", false);
 
@@ -107,21 +107,21 @@ namespace mu2e {
 
       TubsParams prodTargetMotherParams( 0., _clamp_supWheel_rOut, envHalfLength);
       VolumeInfo prodTargetMotherInfo   = nestTubs( "ProductionTargetMother",
-						    prodTargetMotherParams,
-						    parent.logical->GetMaterial(),
-						    0,
-						    tgt->position() - parent.centerInMu2e(),
-						    parent,
-						    0,
-						    G4Colour::Blue(),
-						    "PS"
-						    );
+                                                    prodTargetMotherParams,
+                                                    parent.logical->GetMaterial(),
+                                                    0,
+                                                    tgt->position() - parent.centerInMu2e(),
+                                                    parent,
+                                                    0,
+                                                    G4Colour::Blue(),
+                                                    "PS"
+                                                    );
       if(verbosityLevel > 0) {
-	G4cout << "inside clause 1 of " << __func__ << G4endl;
-	G4cout << "target position and hall origin = " << tgt->position() << "\n" << _hallOriginInMu2e << " " <<
-	  parent.centerInMu2e() << G4endl;
-	G4cout << "supWheel and envHalfLength = " << _clamp_supWheel_rOut  << "\n" <<
-	  envHalfLength << G4endl;
+        G4cout << "inside clause 1 of " << __func__ << G4endl;
+        G4cout << "target position and hall origin = " << tgt->position() << "\n" << _hallOriginInMu2e << " " <<
+          parent.centerInMu2e() << G4endl;
+        G4cout << "supWheel and envHalfLength = " << _clamp_supWheel_rOut  << "\n" <<
+          envHalfLength << G4endl;
       }
 
       double const _supWheel_trgtPS_rIn         = _config.getDouble("supWheel_trgtPS_rIn");
@@ -135,14 +135,14 @@ namespace mu2e {
 
       TubsParams suppWheelParams( _supWheel_trgtPS_rIn, _supWheel_trgtPS_rOut, _supWheel_trgtPS_halfLength);
       VolumeInfo suppWheelInfo   = nestTubs( "ProductionTargetSupportWheel",
-					     suppWheelParams,
-					     _suppWheelMaterial,
-					     0,
-					     _loclCenter,
-					     prodTargetMotherInfo,
-					     0,
-					     G4Colour::Gray()
-					     );
+                                             suppWheelParams,
+                                             _suppWheelMaterial,
+                                             0,
+                                             _loclCenter,
+                                             prodTargetMotherInfo,
+                                             0,
+                                             G4Colour::Gray()
+                                             );
 
       double const _clamp_supWheel_rIn         = _config.getDouble("clamp_supWheel_rIn");
       G4Material* _clampSpWheelMaterial = findMaterialOrThrow(_config.getString("clamp_supWheel_material"));
@@ -152,14 +152,14 @@ namespace mu2e {
 
       TubsParams clampSpWheelParams( _clamp_supWheel_rIn, _clamp_supWheel_rOut, _clamp_supWheel_halfLength);
       VolumeInfo clampSpWheelInfoR   = nestTubs( "ClampSupportWheel_R",
-						 clampSpWheelParams,
-						 _clampSpWheelMaterial,
-						 0,
-						 _clampPosR,
-						 prodTargetMotherInfo,
-						 0,
-						 G4Colour::Gray()
-						 );
+                                                 clampSpWheelParams,
+                                                 _clampSpWheelMaterial,
+                                                 0,
+                                                 _clampPosR,
+                                                 prodTargetMotherInfo,
+                                                 0,
+                                                 G4Colour::Gray()
+                                                 );
 
       //    G4ThreeVector _clampPosL(0.0,0.0,-(_supWheel_trgtPS_halfLength+_clamp_supWheel_halfLength));
       //
@@ -181,99 +181,99 @@ namespace mu2e {
       geomOptions->loadEntry( _config, "ProductionTarget", "targetPS" );
 
       VolumeInfo prodTargetInfo   = nestTubs( "ProductionTarget",
-					      prodTargetParams,
-					      prodTargetMaterial,
-					      &tgt->productionTargetRotation(),
-					      _loclCenter,
-					      prodTargetMotherInfo,
-					      0,
-					      G4Colour::Magenta()
-					      );
+                                              prodTargetParams,
+                                              prodTargetMaterial,
+                                              &tgt->productionTargetRotation(),
+                                              _loclCenter,
+                                              prodTargetMotherInfo,
+                                              0,
+                                              G4Colour::Magenta()
+                                              );
       if(verbosityLevel > 0)
-	G4cout << "_loclCenter for Tier 1 target = " << _loclCenter << G4endl;
+        G4cout << "_loclCenter for Tier 1 target = " << _loclCenter << G4endl;
       // Now add fins for version 2
       if ( tgt->version() > 1 ) {
-	// Length of fins must be calculated:
+        // Length of fins must be calculated:
 
-	double finHalfLength = (tgt->halfLength() * 2.0 - tgt->hubDistUS() 
-				- tgt->hubDistDS() - tgt->hubLenUS() - tgt->hubLenDS())/2.0;  // on the inner side, 
-	// adjacent to the main target body.
+        double finHalfLength = (tgt->halfLength() * 2.0 - tgt->hubDistUS()
+                                - tgt->hubDistDS() - tgt->hubLenUS() - tgt->hubLenDS())/2.0;  // on the inner side,
+        // adjacent to the main target body.
 
-	// Use the steeper of the two hub angles to angle the ends of the fin
-	double theAngle = tgt->hubAngleUS();
-	if ( tgt->hubAngleDS() > theAngle ) theAngle = tgt->hubAngleDS();
+        // Use the steeper of the two hub angles to angle the ends of the fin
+        double theAngle = tgt->hubAngleUS();
+        if ( tgt->hubAngleDS() > theAngle ) theAngle = tgt->hubAngleDS();
 
-	double finHalfLengthOut = finHalfLength + tgt->finHeight()*std::cos(theAngle*CLHEP::degree);  
+        double finHalfLengthOut = finHalfLength + tgt->finHeight()*std::cos(theAngle*CLHEP::degree);
 
-	G4Trd * myTrd = new G4Trd("FinTrapezoid",
-				  finHalfLength, finHalfLengthOut,
-				  tgt->finThickness()/2.0, tgt->finThickness()/2.0,
-				  tgt->finHeight()/2.0);
+        G4Trd * myTrd = new G4Trd("FinTrapezoid",
+                                  finHalfLength, finHalfLengthOut,
+                                  tgt->finThickness()/2.0, tgt->finThickness()/2.0,
+                                  tgt->finHeight()/2.0);
 
-	// std::vector<double> finDims = {tgt->finThickness()/2.0,tgt->finHeight()/2.0,finHalfLength};
-	double finZoff = (tgt->hubDistUS() - tgt->hubDistDS() + tgt->hubLenUS() - tgt->hubLenDS())/2.0; // z-offset for fin
-	double rToFin = tgt->rOut()+tgt->finHeight()/2.0+0.1;
+        // std::vector<double> finDims = {tgt->finThickness()/2.0,tgt->finHeight()/2.0,finHalfLength};
+        double finZoff = (tgt->hubDistUS() - tgt->hubDistDS() + tgt->hubLenUS() - tgt->hubLenDS())/2.0; // z-offset for fin
+        double rToFin = tgt->rOut()+tgt->finHeight()/2.0+0.1;
 
-	double xMove = finZoff * sin(tgt->productionTargetRotation().theta());
-	CLHEP::Hep3Vector finOffset1(xMove,-rToFin,finZoff);
-	CLHEP::Hep3Vector finOffset2(rToFin*cos(M_PI/6.0)+xMove,rToFin*sin(M_PI/6.0),finZoff-1.0);
-	CLHEP::Hep3Vector finOffset3(-rToFin*cos(M_PI/6.0)+xMove-0.1,rToFin*sin(M_PI/6.0)+0.02,finZoff+0.2);
-	CLHEP::HepRotation* rotFinBase = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	rotFinBase->rotateX(90.0*CLHEP::degree);
-	rotFinBase->rotateZ(90.0*CLHEP::degree);
+        double xMove = finZoff * sin(tgt->productionTargetRotation().theta());
+        CLHEP::Hep3Vector finOffset1(xMove,-rToFin,finZoff);
+        CLHEP::Hep3Vector finOffset2(rToFin*cos(M_PI/6.0)+xMove,rToFin*sin(M_PI/6.0),finZoff-1.0);
+        CLHEP::Hep3Vector finOffset3(-rToFin*cos(M_PI/6.0)+xMove-0.1,rToFin*sin(M_PI/6.0)+0.02,finZoff+0.2);
+        CLHEP::HepRotation* rotFinBase = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+        rotFinBase->rotateX(90.0*CLHEP::degree);
+        rotFinBase->rotateZ(90.0*CLHEP::degree);
 
-	CLHEP::HepRotation* rotFin1 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
-	CLHEP::HepRotation* rotFin2 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
-	CLHEP::HepRotation* rotFin3 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
-	rotFin1->rotateX(M_PI);
-	rotFin2->rotateX(M_PI/3.0);
-	rotFin3->rotateX(5.0*M_PI/3.0);
-	VolumeInfo fin1Vol("ProductionTargetFin1",
-			   _loclCenter,
-			   prodTargetMotherInfo.centerInWorld);
+        CLHEP::HepRotation* rotFin1 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
+        CLHEP::HepRotation* rotFin2 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
+        CLHEP::HepRotation* rotFin3 = reg.add(CLHEP::HepRotation((*rotFinBase)*tgt->productionTargetRotation()));
+        rotFin1->rotateX(M_PI);
+        rotFin2->rotateX(M_PI/3.0);
+        rotFin3->rotateX(5.0*M_PI/3.0);
+        VolumeInfo fin1Vol("ProductionTargetFin1",
+                           _loclCenter,
+                           prodTargetMotherInfo.centerInWorld);
 
-	VolumeInfo fin2Vol("ProductionTargetFin2",
-			   _loclCenter,
-			   prodTargetMotherInfo.centerInWorld);
+        VolumeInfo fin2Vol("ProductionTargetFin2",
+                           _loclCenter,
+                           prodTargetMotherInfo.centerInWorld);
 
-	VolumeInfo fin3Vol("ProductionTargetFin3",
-			   _loclCenter,
-			   prodTargetMotherInfo.centerInWorld);
+        VolumeInfo fin3Vol("ProductionTargetFin3",
+                           _loclCenter,
+                           prodTargetMotherInfo.centerInWorld);
 
-	fin1Vol.solid = myTrd;
-	fin2Vol.solid = myTrd;
-	fin3Vol.solid = myTrd;
+        fin1Vol.solid = myTrd;
+        fin2Vol.solid = myTrd;
+        fin3Vol.solid = myTrd;
 
-	finishNesting( fin1Vol,
-		       prodTargetMaterial,
-		       rotFin1,
-		       finOffset1,
-		       prodTargetMotherInfo.logical,
-		       0,
-		       G4Colour::Magenta(),
-		       "PS"
-		       );
+        finishNesting( fin1Vol,
+                       prodTargetMaterial,
+                       rotFin1,
+                       finOffset1,
+                       prodTargetMotherInfo.logical,
+                       0,
+                       G4Colour::Magenta(),
+                       "PS"
+                       );
 
-	finishNesting( fin2Vol,
-		       prodTargetMaterial,
-		       rotFin2,
-		       finOffset2,
-		       prodTargetMotherInfo.logical,
-		       0,
-		       G4Colour::Magenta(),
-		       "PS"
-		       );
+        finishNesting( fin2Vol,
+                       prodTargetMaterial,
+                       rotFin2,
+                       finOffset2,
+                       prodTargetMotherInfo.logical,
+                       0,
+                       G4Colour::Magenta(),
+                       "PS"
+                       );
 
-	finishNesting( fin3Vol,
-		       prodTargetMaterial,
-		       rotFin3,
-		       finOffset3,
-		       prodTargetMotherInfo.logical,
-		       0,
-		       G4Colour::Magenta(),
-		       "PS"
-		       );
-		    
+        finishNesting( fin3Vol,
+                       prodTargetMaterial,
+                       rotFin3,
+                       finOffset3,
+                       prodTargetMotherInfo.logical,
+                       0,
+                       G4Colour::Magenta(),
+                       "PS"
+                       );
+
       }
 
 
@@ -283,27 +283,27 @@ namespace mu2e {
 
       Polycone const & pHubRgtParams = *tgt->getHubsRgtPtr();
       VolumeInfo prodTargetHubRgtInfo  = nestPolycone("ProductionTargetHubRgt",
-						      pHubRgtParams.getPolyconsParams(),
-						      findMaterialOrThrow(pHubRgtParams.materialName()),
-						      &tgt->productionTargetRotation(),
-						      pHubRgtParams.originInMu2e(),
-						      prodTargetMotherInfo,
-						      0,
-						      G4Colour::Magenta(),
-						      "ProductionTarget"
-						      );
+                                                      pHubRgtParams.getPolyconsParams(),
+                                                      findMaterialOrThrow(pHubRgtParams.materialName()),
+                                                      &tgt->productionTargetRotation(),
+                                                      pHubRgtParams.originInMu2e(),
+                                                      prodTargetMotherInfo,
+                                                      0,
+                                                      G4Colour::Magenta(),
+                                                      "ProductionTarget"
+                                                      );
 
       Polycone const & pHubLftParams = *tgt->getHubsLftPtr();
       VolumeInfo prodTargetHubLftInfo  = nestPolycone("ProductionTargetHubLft",
-						      pHubLftParams.getPolyconsParams(),
-						      findMaterialOrThrow(pHubLftParams.materialName()),
-						      &tgt->productionTargetRotation(),
-						      pHubLftParams.originInMu2e(),
-						      prodTargetMotherInfo,
-						      0,
-						      G4Colour::Magenta(),
-						      "ProductionTarget"
-						      );
+                                                      pHubLftParams.getPolyconsParams(),
+                                                      findMaterialOrThrow(pHubLftParams.materialName()),
+                                                      &tgt->productionTargetRotation(),
+                                                      pHubLftParams.originInMu2e(),
+                                                      prodTargetMotherInfo,
+                                                      0,
+                                                      G4Colour::Magenta(),
+                                                      "ProductionTarget"
+                                                      );
 
       CLHEP::Hep3Vector zax(0,0,1);
       double spokeRad = 0.5*_config.getDouble("targetPS_Spoke_diameter");
@@ -325,112 +325,112 @@ namespace mu2e {
       const bool doSurfaceCheck      = geomOptions->doSurfaceCheck( "ProductionTarget" );
 
       for (std::map<double,CLHEP::Hep3Vector>::const_iterator iPnt=anchoringPntsRgt.begin(); iPnt!=anchoringPntsRgt.end(); ++iPnt) {
-	double tmpAngle = iPnt->first * CLHEP::deg;
-	CLHEP::Hep3Vector normalax(cos(tmpAngle),sin(tmpAngle),0.0);
-	CLHEP::Hep3Vector tmpAnchPnt = _supWheel_trgtPS_rIn*normalax;
-	CLHEP::Hep3Vector tmpDirVec = tmpAnchPnt-iPnt->second;
-	CLHEP::Hep3Vector tmpMidPnt(0.5*(tmpAnchPnt.x()+iPnt->second.x()),0.5*(tmpAnchPnt.y()+iPnt->second.y()),0.5*(tmpAnchPnt.z()+iPnt->second.z()));
-	double tmpSpokeLength = tmpDirVec.mag();
-	tmpDirVec = tmpDirVec.unit();
-	CLHEP::Hep3Vector tmpRotAxis = tmpDirVec.cross(zax);
-	double rotAngle = tmpDirVec.angle(zax);
-	double deepAngleWheel = tmpDirVec.angle(normalax);
+        double tmpAngle = iPnt->first * CLHEP::deg;
+        CLHEP::Hep3Vector normalax(cos(tmpAngle),sin(tmpAngle),0.0);
+        CLHEP::Hep3Vector tmpAnchPnt = _supWheel_trgtPS_rIn*normalax;
+        CLHEP::Hep3Vector tmpDirVec = tmpAnchPnt-iPnt->second;
+        CLHEP::Hep3Vector tmpMidPnt(0.5*(tmpAnchPnt.x()+iPnt->second.x()),0.5*(tmpAnchPnt.y()+iPnt->second.y()),0.5*(tmpAnchPnt.z()+iPnt->second.z()));
+        double tmpSpokeLength = tmpDirVec.mag();
+        tmpDirVec = tmpDirVec.unit();
+        CLHEP::Hep3Vector tmpRotAxis = tmpDirVec.cross(zax);
+        double rotAngle = tmpDirVec.angle(zax);
+        double deepAngleWheel = tmpDirVec.angle(normalax);
 
-	CLHEP::Hep3Vector normalaxHub(sin(normalOverhangRgt),0,cos(normalOverhangRgt));
-	normalaxHub.rotateZ(tmpAngle);
-	normalaxHub.transform(invTrgtRot);
-	double deepAngleHub = tmpDirVec.angle(normalaxHub);
+        CLHEP::Hep3Vector normalaxHub(sin(normalOverhangRgt),0,cos(normalOverhangRgt));
+        normalaxHub.rotateZ(tmpAngle);
+        normalaxHub.transform(invTrgtRot);
+        double deepAngleHub = tmpDirVec.angle(normalaxHub);
 
-	double fixOverlapWheel = spokeRad*tan(deepAngleWheel);
-	double fixOverlapHub = spokeRad*tan(deepAngleHub);
-	tmpSpokeLength-=(fixOverlapWheel+fixOverlapHub);
-	tmpMidPnt += 0.5*(fixOverlapHub-fixOverlapWheel)*tmpDirVec;
+        double fixOverlapWheel = spokeRad*tan(deepAngleWheel);
+        double fixOverlapHub = spokeRad*tan(deepAngleHub);
+        tmpSpokeLength-=(fixOverlapWheel+fixOverlapHub);
+        tmpMidPnt += 0.5*(fixOverlapHub-fixOverlapWheel)*tmpDirVec;
 
-	TubsParams iSpokeParams( 0.0, spokeRad, 0.5*tmpSpokeLength);
-	std::stringstream iSpokeName;
-	iSpokeName<<"ProductionTargetSpokeRgt_"<<iSpk;
+        TubsParams iSpokeParams( 0.0, spokeRad, 0.5*tmpSpokeLength);
+        std::stringstream iSpokeName;
+        iSpokeName<<"ProductionTargetSpokeRgt_"<<iSpk;
 
-	VolumeInfo iSpokeInfo   = nestTubs( iSpokeName.str(),
-					    iSpokeParams,
-					    spokeMaterial,
-					    reg.add(CLHEP::HepRotation(tmpRotAxis,rotAngle)),
-					    tmpMidPnt,
-					    prodTargetMotherInfo,
-					    0,
-					    prodTargetVisible,
-					    G4Colour::Gray(),
-					    prodTargetSolid,
-					    forceAuxEdgeVisible,
-					    placePV,
-					    doSurfaceCheck
-					    );
-	++iSpk;
+        VolumeInfo iSpokeInfo   = nestTubs( iSpokeName.str(),
+                                            iSpokeParams,
+                                            spokeMaterial,
+                                            reg.add(CLHEP::HepRotation(tmpRotAxis,rotAngle)),
+                                            tmpMidPnt,
+                                            prodTargetMotherInfo,
+                                            0,
+                                            prodTargetVisible,
+                                            G4Colour::Gray(),
+                                            prodTargetSolid,
+                                            forceAuxEdgeVisible,
+                                            placePV,
+                                            doSurfaceCheck
+                                            );
+        ++iSpk;
       }
 
       std::map<double,CLHEP::Hep3Vector> const & anchoringPntsLft = tgt->anchoringPntsLft();
 
       iSpk=0;
       for (std::map<double,CLHEP::Hep3Vector>::const_iterator iPnt=anchoringPntsLft.begin(); iPnt!=anchoringPntsLft.end(); ++iPnt) {
-	double tmpAngle = iPnt->first * CLHEP::deg;
-	CLHEP::Hep3Vector normalax(cos(tmpAngle),sin(tmpAngle),0.0);
-	CLHEP::Hep3Vector tmpAnchPnt = _supWheel_trgtPS_rIn*normalax;
-	CLHEP::Hep3Vector tmpDirVec = tmpAnchPnt-iPnt->second;
-	CLHEP::Hep3Vector tmpMidPnt(0.5*(tmpAnchPnt.x()+iPnt->second.x()),0.5*(tmpAnchPnt.y()+iPnt->second.y()),0.5*(tmpAnchPnt.z()+iPnt->second.z()));
-	double tmpSpokeLength = tmpDirVec.mag();
-	tmpDirVec = tmpDirVec.unit();
-	CLHEP::Hep3Vector tmpRotAxis = tmpDirVec.cross(zax);
-	double rotAngle = tmpDirVec.angle(zax);
-	double deepAngleWheel = tmpDirVec.angle(normalax);
+        double tmpAngle = iPnt->first * CLHEP::deg;
+        CLHEP::Hep3Vector normalax(cos(tmpAngle),sin(tmpAngle),0.0);
+        CLHEP::Hep3Vector tmpAnchPnt = _supWheel_trgtPS_rIn*normalax;
+        CLHEP::Hep3Vector tmpDirVec = tmpAnchPnt-iPnt->second;
+        CLHEP::Hep3Vector tmpMidPnt(0.5*(tmpAnchPnt.x()+iPnt->second.x()),0.5*(tmpAnchPnt.y()+iPnt->second.y()),0.5*(tmpAnchPnt.z()+iPnt->second.z()));
+        double tmpSpokeLength = tmpDirVec.mag();
+        tmpDirVec = tmpDirVec.unit();
+        CLHEP::Hep3Vector tmpRotAxis = tmpDirVec.cross(zax);
+        double rotAngle = tmpDirVec.angle(zax);
+        double deepAngleWheel = tmpDirVec.angle(normalax);
 
-	CLHEP::Hep3Vector normalaxHub(sin(normalOverhangLft),0,cos(normalOverhangLft));
-	normalaxHub.rotateZ(tmpAngle);
-	normalaxHub.transform(invTrgtRot);
-	double deepAngleHub = tmpDirVec.angle(normalaxHub);
-	//CLHEP::HepRotation *tmpSpokeRot = reg.add(CLHEP::HepRotation(tmpRotAxis,rotAngle));
+        CLHEP::Hep3Vector normalaxHub(sin(normalOverhangLft),0,cos(normalOverhangLft));
+        normalaxHub.rotateZ(tmpAngle);
+        normalaxHub.transform(invTrgtRot);
+        double deepAngleHub = tmpDirVec.angle(normalaxHub);
+        //CLHEP::HepRotation *tmpSpokeRot = reg.add(CLHEP::HepRotation(tmpRotAxis,rotAngle));
 
-	double fixOverlapWheel = spokeRad*tan(deepAngleWheel);
-	double fixOverlapHub = spokeRad*tan(deepAngleHub);
-	tmpSpokeLength-=(fixOverlapWheel+fixOverlapHub);
-	tmpMidPnt += 0.5*(fixOverlapHub-fixOverlapWheel)*tmpDirVec;
+        double fixOverlapWheel = spokeRad*tan(deepAngleWheel);
+        double fixOverlapHub = spokeRad*tan(deepAngleHub);
+        tmpSpokeLength-=(fixOverlapWheel+fixOverlapHub);
+        tmpMidPnt += 0.5*(fixOverlapHub-fixOverlapWheel)*tmpDirVec;
 
-	TubsParams iSpokeParams( 0.0, spokeRad, 0.5*tmpSpokeLength);
-	std::stringstream iSpokeName;
-	iSpokeName<<"ProductionTargetSpokeLft_"<<iSpk;
+        TubsParams iSpokeParams( 0.0, spokeRad, 0.5*tmpSpokeLength);
+        std::stringstream iSpokeName;
+        iSpokeName<<"ProductionTargetSpokeLft_"<<iSpk;
 
-	VolumeInfo iSpokeInfo   = nestTubs( iSpokeName.str(),
-					    iSpokeParams,
-					    spokeMaterial,
-					    reg.add(CLHEP::HepRotation(tmpRotAxis,rotAngle)),
-					    tmpMidPnt,
-					    prodTargetMotherInfo,
-					    0,
-					    prodTargetVisible,
-					    G4Colour::Gray(),
-					    prodTargetSolid,
-					    forceAuxEdgeVisible,
-					    placePV,
-					    doSurfaceCheck
-					    );
-	++iSpk;
+        VolumeInfo iSpokeInfo   = nestTubs( iSpokeName.str(),
+                                            iSpokeParams,
+                                            spokeMaterial,
+                                            reg.add(CLHEP::HepRotation(tmpRotAxis,rotAngle)),
+                                            tmpMidPnt,
+                                            prodTargetMotherInfo,
+                                            0,
+                                            prodTargetVisible,
+                                            G4Colour::Gray(),
+                                            prodTargetSolid,
+                                            forceAuxEdgeVisible,
+                                            placePV,
+                                            doSurfaceCheck
+                                            );
+        ++iSpk;
       }
     }
     else if (_config.getInt("targetPS_version") == ProductionTargetMaker::hayman_v_2_0){
      int verbosityLevel                  = _config.getInt("PSHayman.verbosityLevel");
       verbosityLevel >0 &&
-	cout << __func__ << " verbosityLevel on Hayman2.0              : " << verbosityLevel  << endl;
+        cout << __func__ << " verbosityLevel on Hayman2.0              : " << verbosityLevel  << endl;
       G4ThreeVector _hallOriginInMu2e = parent.centerInMu2e();
       // Create variable to avoid multiple look-up
 
       G4GeometryOptions* geomOptions = art::ServiceHandle<GeometryService>()->geomOptions();
-      
+
       bool prodTargetVisible   = geomOptions->isVisible( "ProductionTarget" );
       bool prodTargetSolid     = geomOptions->isSolid  ( "ProductionTarget" );
       bool forceAuxEdgeVisible = geomOptions->forceAuxEdgeVisible( "ProductionTarget" );
       bool placePV             = geomOptions->placePV( "ProductionTarget" );
       bool doSurfaceCheck      = geomOptions->doSurfaceCheck( "ProductionTarget" );
-      // 
+      //
 
-      // begin all names with ProductionTarget so when we build sensitive detectors we can make them all 
+      // begin all names with ProductionTarget so when we build sensitive detectors we can make them all
       // sensitive at once with LVname.find("ProductionTarget") !=std::string::npos
       //
       // Build the production target.
@@ -440,33 +440,33 @@ namespace mu2e {
       G4Material* prodTargetSupportRingMaterial = findMaterialOrThrow(tgt->supportRingMaterial());
 
       TubsParams prodTargetMotherParams( 0.
-      					 ,tgt->productionTargetMotherOuterRadius()
-      					 ,tgt->productionTargetMotherHalfLength());
+                                         ,tgt->productionTargetMotherOuterRadius()
+                                         ,tgt->productionTargetMotherHalfLength());
 
       G4ThreeVector _loclCenter(0.0,0.0,0.0);
       G4ThreeVector zeroTranslation(0.,0.,0.);
       G4RotationMatrix* targetRotation = reg.add(G4RotationMatrix(tgt->productionTargetRotation().inverse()));
       if (verbosityLevel > 2){G4cout << __PRETTY_FUNCTION__ << "target rotation  = " << *targetRotation << G4endl;}
       VolumeInfo prodTargetMotherInfo   = nestTubs( "ProductionTargetMother",
-						    prodTargetMotherParams,
-						    parent.logical->GetMaterial(),
-						    0,
-						    tgt->haymanProdTargetPosition() - parent.centerInMu2e(),
-						    parent,
-						    0,
+                                                    prodTargetMotherParams,
+                                                    parent.logical->GetMaterial(),
+                                                    0,
+                                                    tgt->haymanProdTargetPosition() - parent.centerInMu2e(),
+                                                    parent,
+                                                    0,
                                                     G4Colour::Blue(),
                                                     "PS"
-						    );
+                                                    );
 
       if (verbosityLevel > 0){
-	G4cout << "target position and hall origin = " 
-		  << tgt->haymanProdTargetPosition() << "\n" <<
-	  _hallOriginInMu2e << " " << parent.centerInMu2e() << G4endl;
+        G4cout << "target position and hall origin = "
+                  << tgt->haymanProdTargetPosition() << "\n" <<
+          _hallOriginInMu2e << " " << parent.centerInMu2e() << G4endl;
       }
       if (verbosityLevel > 2){
-	G4cout << __PRETTY_FUNCTION__ << "created prodTargetMotherInfo " 
-		  << tgt->productionTargetMotherOuterRadius() 
-		  << " " <<tgt->productionTargetMotherHalfLength() << G4endl;
+        G4cout << __PRETTY_FUNCTION__ << "created prodTargetMotherInfo "
+                  << tgt->productionTargetMotherOuterRadius()
+                  << " " <<tgt->productionTargetMotherHalfLength() << G4endl;
       }
       //
       // construct each section
@@ -506,7 +506,7 @@ namespace mu2e {
       //
       //other constants
       double cutoutHeightAboveTarget = tgt->supportRingInnerRadius() + tgt->supportRingCutoutThickness()/2. - magicOffset;
- 
+
       CLHEP::HepRotation* rotRing = reg.add(CLHEP::HepRotation(tgt->productionTargetRotation()));
 
       //
@@ -516,732 +516,732 @@ namespace mu2e {
       std::vector<CLHEP::HepRotation*> rotBoxesG4;
       std::vector<double> currentFinAngles;
       for (int ithFin = 0; ithFin < tgt->nHaymanFins(); ++ithFin){
-	rotFinsG4.emplace_back(reg.add(CLHEP::HepRotation(tgt->productionTargetRotation())));
-	rotBoxesG4.emplace_back(reg.add(CLHEP::HepRotation::IDENTITY));
-	//
-	// here I have a little confusing fix.  The fin is built along the y-axis.  But the rotation is given wrt the x axis.  Hence I need to
-	// subtract off that 90^o . Then the - sign is CLHEP vs G4
+        rotFinsG4.emplace_back(reg.add(CLHEP::HepRotation(tgt->productionTargetRotation())));
+        rotBoxesG4.emplace_back(reg.add(CLHEP::HepRotation::IDENTITY));
+        //
+        // here I have a little confusing fix.  The fin is built along the y-axis.  But the rotation is given wrt the x axis.  Hence I need to
+        // subtract off that 90^o . Then the - sign is CLHEP vs G4
         currentFinAngles.emplace_back(tgt->finAngles().at(ithFin));
-	rotFinsG4.at(ithFin)->rotateZ(-(-M_PI/2. + currentFinAngles.at(ithFin)));
-	rotBoxesG4.at(ithFin)->rotateZ(-(-M_PI/2. + currentFinAngles.at(ithFin)));
-	if (verbosityLevel > 1){G4cout << "rotFin " << ithFin << " " << *rotFinsG4.at(ithFin) << G4endl;}
+        rotFinsG4.at(ithFin)->rotateZ(-(-M_PI/2. + currentFinAngles.at(ithFin)));
+        rotBoxesG4.at(ithFin)->rotateZ(-(-M_PI/2. + currentFinAngles.at(ithFin)));
+        if (verbosityLevel > 1){G4cout << "rotFin " << ithFin << " " << *rotFinsG4.at(ithFin) << G4endl;}
       }
 
       G4Box* cutoutBox = reg.add(G4Box("cutoutBox",tgt->supportRingCutoutThickness()/2.+ magicOffset,
-					tgt->haymanFinThickness() + magicOffset,tgt->supportRingCutoutLength()/2.+ magicOffset));
+                                        tgt->haymanFinThickness() + magicOffset,tgt->supportRingCutoutLength()/2.+ magicOffset));
 
 
       // get real
       for (int ithSection = 0; ithSection < numberOfSections; ++ithSection){
-	int numberOfSegments = tgt->numberOfSegmentsPerSection().at(ithSection);
-	std::string startName = "ProductionTargetStartingCoreSection_" + std::to_string(ithSection+1);
-	//
-	// first place starting segment
+        int numberOfSegments = tgt->numberOfSegmentsPerSection().at(ithSection);
+        std::string startName = "ProductionTargetStartingCoreSection_" + std::to_string(ithSection+1);
+        //
+        // first place starting segment
 
-	TubsParams startingSegmentParams(0.,targetRadius,tgt->startingSectionThickness().at(ithSection)/2.);
-	double currentHalfStartingSegment = tgt->startingSectionThickness().at(ithSection)/2.;
-	//	
-	//set currentZ to be in the center of the starting section
-	_currentZ += tgt->startingSectionThickness().at(ithSection)/2.;
-	if (verbosityLevel > 3){
-	  G4cout << __PRETTY_FUNCTION__ << " ithSection , startingSegmentCenter at " << ithSection << " " <<_currentZ << G4endl;
-	  G4cout << "    and copy number for starting segment is now " << coreCopyNumber << G4endl;
-	}
- 	_startingSegmentCenter.setZ(_currentZ);
+        TubsParams startingSegmentParams(0.,targetRadius,tgt->startingSectionThickness().at(ithSection)/2.);
+        double currentHalfStartingSegment = tgt->startingSectionThickness().at(ithSection)/2.;
+        //
+        //set currentZ to be in the center of the starting section
+        _currentZ += tgt->startingSectionThickness().at(ithSection)/2.;
+        if (verbosityLevel > 3){
+          G4cout << __PRETTY_FUNCTION__ << " ithSection , startingSegmentCenter at " << ithSection << " " <<_currentZ << G4endl;
+          G4cout << "    and copy number for starting segment is now " << coreCopyNumber << G4endl;
+        }
+        _startingSegmentCenter.setZ(_currentZ);
 
-	CLHEP::Hep3Vector currentStartingSegmentCenter = tgt->productionTargetRotation().inverse()*_startingSegmentCenter;
-	VolumeInfo startingSegment = nestTubs(startName,
-					      startingSegmentParams,
-					      prodTargetCoreMaterial,
-					      &tgt->productionTargetRotation(),
-					      currentStartingSegmentCenter,
-					      prodTargetMotherInfo,
-					      ithSection,
-					      prodTargetVisible,
-					      G4Colour::Yellow(),
-					      prodTargetSolid,
-					      forceAuxEdgeVisible,
-					      placePV,
-					      doSurfaceCheck
-					      );
-	//build fins around starting segment
-	for (int ithFin = 0; ithFin < tgt->nHaymanFins(); ++ithFin)
-	  {
-	    const std::string name = "ProductionTargetFinStartingSection_" + std::to_string(ithSection+1) + "_Fin_" + std::to_string(ithFin);
- 	    if (verbosityLevel > 1)
-	      {G4cout << "Fin Section and Angle = " << name << " " << currentFinAngles.at(ithFin) << " fin copy number = " << finCopyNumber << G4endl;}
+        CLHEP::Hep3Vector currentStartingSegmentCenter = tgt->productionTargetRotation().inverse()*_startingSegmentCenter;
+        VolumeInfo startingSegment = nestTubs(startName,
+                                              startingSegmentParams,
+                                              prodTargetCoreMaterial,
+                                              &tgt->productionTargetRotation(),
+                                              currentStartingSegmentCenter,
+                                              prodTargetMotherInfo,
+                                              ithSection,
+                                              prodTargetVisible,
+                                              G4Colour::Yellow(),
+                                              prodTargetSolid,
+                                              forceAuxEdgeVisible,
+                                              placePV,
+                                              doSurfaceCheck
+                                              );
+        //build fins around starting segment
+        for (int ithFin = 0; ithFin < tgt->nHaymanFins(); ++ithFin)
+          {
+            const std::string name = "ProductionTargetFinStartingSection_" + std::to_string(ithSection+1) + "_Fin_" + std::to_string(ithFin);
+            if (verbosityLevel > 1)
+              {G4cout << "Fin Section and Angle = " << name << " " << currentFinAngles.at(ithFin) << " fin copy number = " << finCopyNumber << G4endl;}
 
-	    double finHalfHeightAboveTarget = (tgt->finOuterRadius() - tgt->rOut())/2.;
-	    G4Box* finBox = new G4Box("finBox",tgt->haymanFinThickness()/2.,finHalfHeightAboveTarget,currentHalfStartingSegment);
+            double finHalfHeightAboveTarget = (tgt->finOuterRadius() - tgt->rOut())/2.;
+            G4Box* finBox = new G4Box("finBox",tgt->haymanFinThickness()/2.,finHalfHeightAboveTarget,currentHalfStartingSegment);
 
-	    // 
-	    // this tubs is in the xy plane with an extent along z.  So phi goes in the xy plane.  
-	    // need extra length for visualization tool and overlap avoidance
-	    G4Tubs* tubCutout = new G4Tubs("finCutout",0.,tgt->rOut(),currentHalfStartingSegment + magicOffset,dSphi,dPphi);
-	    ++finCopyNumber;
-
-	    G4ThreeVector finTranslation = currentStartingSegmentCenter;
-	    //
-	    // G4 translates and then rotates.  I want to offset the fin to its final location relative to the core and then let G4 perform rotations,
-	    // both of the fin about the z axis and then the entire production target rotation angle
-	    double distanceFromCenter = finHalfHeightAboveTarget + tgt->rOut();
-	    CLHEP::Hep3Vector offsetRelativeToCore(distanceFromCenter*cos(currentFinAngles.at(ithFin))
-						   ,distanceFromCenter*sin(currentFinAngles.at(ithFin)),0.);
-	    // 
-	    // finTranslation was already put in the target rotated frame.  I have to rotate the offset vector as well
-	    offsetRelativeToCore *= tgt->productionTargetRotation().inverse();
-	    finTranslation = finTranslation + offsetRelativeToCore;
-	    
-	    CLHEP::Hep3Vector downshift = CLHEP::Hep3Vector(0.,-finHalfHeightAboveTarget - targetRadius*cos(angularSize), 0.);
-	    placeSubtractionVolumeBoxTubs(name
-					  ,finTranslation
-					  ,prodTargetMotherInfo
-					  ,finBox
-					  ,tubCutout
-					  ,rotFinsG4.at(ithFin)
-					  ,prodTargetFinMaterial
-					  ,nullptr
-					  ,downshift
-					  ,finCopyNumber
-					  ,G4Colour::Blue()
-					  ,"PS"
-					  ,verbosityLevel>1);
-
-	    //
-	    // for each fin, build the little section at the top that joins it to the next fin.  This will be  a G4Box with a cutout. 
-	    // Here make the cutout a little tubs without the fancy angular business, since I don't have fins overlapping fins up at the top.
-	    const std::string nameTop = "ProductionTargetFinTopStartingSection_" + std::to_string(ithSection+1) + "_Fin_" + std::to_string(ithFin);
-
-	    double gapRadius = tgt->thicknessOfGapPerSection().at(ithSection)/2.;
-	    double finTopHalfHeight =( tgt->finOuterRadius() - tgt->heightOfRectangularGapPerSection().at(ithSection))/2.;
-	    if (verbosityLevel > 2){G4cout << "finTopHalfHeight = " << finTopHalfHeight <<G4endl;}
-	    G4Box* finTopBox = new G4Box("finTopBox",tgt->haymanFinThickness()/2.,finTopHalfHeight,tgt->thicknessOfGapPerSection().at(ithSection)/2.);
-	    G4Tubs* finTopCutout = new G4Tubs("finTopCutout",0.,gapRadius + magicOffset,tgt->haymanFinThickness()/2. + magicOffset,0.,2.*M_PI);
-	    ++finTopCopyNumber;
-
-	    if (verbosityLevel > 2){G4cout << "current starting SegmentCenter, current HalfSegment, gap radius = " 
-					      << currentStartingSegmentCenter << " " << currentHalfStartingSegment 
-					      << " " << gapRadius << G4endl;}
-	    G4ThreeVector finTopLocation = currentStartingSegmentCenter 
-                      + tgt->productionTargetRotation().inverse()*CLHEP::Hep3Vector(0.,0.,currentHalfStartingSegment + gapRadius);
-	    //
-	    // for debugging
-	    CLHEP::Hep3Vector offsetTop(0.,0.,0.);
-	    //
-	    // rotate the offset vector 
-	    G4ThreeVector finTopTranslation = finTopLocation + offsetTop;
-	    double distanceTopFromCenter = tgt->finOuterRadius() - finTopHalfHeight; 
-	    CLHEP::Hep3Vector offsetTopRelativeToCore(distanceTopFromCenter*cos(currentFinAngles.at(ithFin))
-						      ,distanceTopFromCenter*sin(currentFinAngles.at(ithFin)),0.);
-	    // 
-	    // finTranslation was already put in the target rotated frame.  I have to rotate the offset vector as well
-	    offsetTopRelativeToCore *= tgt->productionTargetRotation().inverse();
-	    finTopTranslation = finTopTranslation + offsetTopRelativeToCore;
-	    if (verbosityLevel > 2){G4cout << "finTopTranslation = " << finTopTranslation << G4endl;}
-	    CLHEP::Hep3Vector downshiftTopBox = CLHEP::Hep3Vector(0.,-finTopHalfHeight, 0.);
-	    //
-	    // these are oriented with gap radius along z.  Recall still in mother volume so this axis is OK
-	    G4RotationMatrix* tubTopRotation = reg.add(G4RotationMatrix(CLHEP::HepRotation::IDENTITY));
-
-	    tubTopRotation->rotateY(M_PI/2.);
-
-	    VolumeInfo finTopWithCutoutInfo(nameTop,finTopTranslation,prodTargetMotherInfo.centerInWorld);
-	    finTopWithCutoutInfo.solid = new G4SubtractionSolid(nameTop,finTopBox,finTopCutout,tubTopRotation,downshiftTopBox);
-	    finishNesting(finTopWithCutoutInfo
-			  ,prodTargetFinMaterial
-			  ,rotFinsG4.at(ithFin)
-			  ,finTopTranslation
-			  ,prodTargetMotherInfo.logical
-			  ,finTopCopyNumber
-			  ,G4Colour::White()
-			  ,"ProductionTarget"
-			  ,verbosityLevel>1);
-	    //
-	    // this check also uses finWithCutout.  Indirectly it's a way of forcing an overlap check or it won't compile, since finWithCutout is never used otherwise.
-	    //	    if (doSurfaceCheck){checkForOverlaps(finTopWithCutout,_config,0);}
-
-	  }
-
-	//
-	// for very first starting section, we need to build the support ring
-	//
-	// build support ring at this end.  I need to build an annulus with cutouts for the fins.
-	int boxCopyNumber = 0;
-	if (ithSection==0){
-	  std::string name = "ProductionTargetNegativeEndRing";
-	  G4Tubs* supportRing = new G4Tubs(name,
-					   tgt->supportRingInnerRadius(),
-					   tgt->supportRingOuterRadius(),
-					   tgt->supportRingLength()/2.,
-					   0.,
-					   2.*M_PI);
-
-	  if (verbosityLevel > 0){
-	    G4cout << __PRETTY_FUNCTION__ << ": \n " << name.c_str() << ":\n  (rin, rout, half length) = (" 
-		   << tgt->supportRingInnerRadius() << ", " << tgt->supportRingOuterRadius() 
-		   << ", " << tgt->supportRingLength()/2. << ")" << G4endl;
-	  }
-	  // move ring to end of target and then back by cutout size (signs for negative side)
-	  G4ThreeVector ringTranslation = currentStartingSegmentCenter 
-	    - tgt->productionTargetRotation().inverse()*CLHEP::Hep3Vector(0.,0.,tgt->supportRingLength()/2.);
-
-	  if (verbosityLevel > 0){
-	    G4cout << "  center = (0., 0., -" << (currentStartingSegmentCenter.mag() + tgt->supportRingLength()/2.) << ")" << G4endl;
-	    G4cout << "  center (wrt target mother) = " << ringTranslation << G4endl;
-	  }
-	  // the way we handle the cutout is a little different; the tubs is centered on zero, not offset from the z axis
-	  // build one cutout box for each fin.  This ignores the extra cutouts (easy enough to put in later) and the mounting mechanisms,
-	  // which won't matter for muon yield, heat deposition, etc -- just looks like tungsten for those purposes
-
-	  //
-	  // this is all so I can add multiple cutouts to the ring and only do one placement.
-	  //	  std::vector<G4SubtractionSolid*> ringWithCutoutSolid;
-	  std::vector<G4SubtractionSolid*> ringWithCutoutSolid;
-
-	  std::string nameRing = "ProductionTargetNegativeRingCutout";
-
-	  for (int ithFin = 0; ithFin < tgt->nHaymanFins(); ++ithFin){
-	    double currentFinAngle = tgt->finAngles().at(ithFin);
-	    const std::string name = "ProductionTargetNegativeRingCutout_" + std::to_string(ithSection) 
-	      + "_Segment_" +"_Fin_" + std::to_string(ithFin);
-	    ++boxCopyNumber;
-
-	    if (verbosityLevel > 6)
-	      {G4cout << "Fin Section and Angle = " << name << " " << currentFinAngle << " fin copy number = " << finCopyNumber << G4endl;}
-	    if (verbosityLevel > 2){G4cout << " cutoutHeightAboveTarget = " << tgt->supportRingInnerRadius() << " " 
-					      << " " << tgt->supportRingCutoutThickness() << " " << cutoutHeightAboveTarget << G4endl;}
-
-	    //
-	    // G4 translates and then rotates.  I want to offset the fin to its final location relative to the core and then let G4 perform rotations,
-	    // both of the fin about the z axis and then the entire production target rotation angle
-	    double distanceFromCenter = cutoutHeightAboveTarget;
-	    CLHEP::Hep3Vector boxShift(distanceFromCenter*cos(currentFinAngles.at(ithFin)),distanceFromCenter*sin(currentFinAngles.at(ithFin)),0.);
-	    CLHEP::Hep3Vector offsetRelativeToCore(distanceFromCenter*cos(currentFinAngles.at(ithFin)),distanceFromCenter*sin(currentFinAngles.at(ithFin)), 
-	    						   tgt->supportRingCutoutLength()/2. + magicOffset);
-
-	    if (verbosityLevel > 3){
-	      G4cout << "production target rotation angle = " << tgt->productionTargetRotation().getTheta() << G4endl;
-	      G4cout << "fin dump: " << currentFinAngles.at(ithFin) << " " << distanceFromCenter << " " << offsetRelativeToCore << G4endl;
-	      G4cout << "ithfin; current fin angle; rotFin; finTranslation = " << ithFin << " " 
-		     << currentFinAngles.at(ithFin)  << " " << *rotFinsG4.at(ithFin) << " " << ringTranslation << G4endl;
-	      G4cout << "production target rotation = " << tgt->productionTargetRotation() << G4endl;
-	    }
-
-	    if (ithFin == 0){
-	      	      ringWithCutoutSolid.push_back(new G4SubtractionSolid(name,supportRing,cutoutBox,rotBoxesG4.at(ithFin),offsetRelativeToCore));
-	    }else {
-	      	      ringWithCutoutSolid.push_back(new G4SubtractionSolid(name,ringWithCutoutSolid.at(ithFin-1),cutoutBox,rotBoxesG4.at(ithFin),offsetRelativeToCore));
-	    }
-	  }
-	
-	  
-	  if (verbosityLevel > 0){
-	    G4cout << "  center (at end) = (0., 0., " << ringTranslation.mag() << ")" <<G4endl;
-	    G4cout << "  center (wrt target mother at end) = " << ringTranslation << G4endl;
-	    
-	    G4cout << "  rotation = " << rotRing << G4endl;
-	  }
-
-	  VolumeInfo ringWithCutoutNegative(name,ringTranslation,prodTargetMotherInfo.centerInWorld);
-          ringWithCutoutNegative.solid = ringWithCutoutSolid.at(tgt->nHaymanFins() - 1);  
-	  finishNesting(ringWithCutoutNegative
-			,prodTargetSupportRingMaterial
-			,rotRing
-			,ringTranslation
-			,prodTargetMotherInfo.logical
-			,finCopyNumber
-			,G4Colour::White()
-			,"ProductionTarget"
-			,verbosityLevel>1);
-	  
-
-	}
-
-
-	/*    -------------------end of support ring, first starting section  ---------------------*/
-
-	//
-	// set current z to be at the end of this starting segment before beginning loop on sections
-	_currentZ += tgt->startingSectionThickness().at(ithSection)/2.;
-	if (verbosityLevel > 0){G4cout << __PRETTY_FUNCTION__ << " ithSection , startingSegment Z ends at " << ithSection << " " <<_currentZ << G4endl;}
-	double currentGap = tgt->thicknessOfGapPerSection().at(ithSection);
-	double currentHalfSegment = tgt->thicknessOfSegmentPerSection().at(ithSection)/2.;
-
-	for (int ithSegment = 0; ithSegment < numberOfSegments; ++ithSegment){
-	  std::string name = "ProductionTargetCoreSection_" + std::to_string(ithSection+1) 
-	    + "_Segment_" + std::to_string(ithSegment);
-	  if (verbosityLevel > 0) {
-	    G4cout << __PRETTY_FUNCTION__ << "name = " << name << " and core copy number = " << coreCopyNumber << G4endl;
-	    G4cout << __PRETTY_FUNCTION__ << "gap, and segment half = " << currentGap << " " << currentHalfSegment << G4endl;
-	  }
-	  TubsParams segmentParams(0.,targetRadius,currentHalfSegment);
-	  _currentZ += currentHalfSegment + currentGap;
-	  if (verbosityLevel > 0){
-	    G4cout << __PRETTY_FUNCTION__ << " ithSection , current Z for segment center is at " << ithSection << " " 
-		      << ithSegment << " "  <<_currentZ << G4endl;
-	  }
- 	  _segmentCenter.setZ(_currentZ);
-	  G4ThreeVector currentSegmentCenter = tgt->productionTargetRotation().inverse()*_segmentCenter;
-	  //CLHEP::Hep3Vector currentSegmentCenter = tgt->productionTargetRotation()*_segmentCenter;
-	  //	  CLHEP::Hep3Vector currentSegmentCenter = _segmentCenter;
-	  VolumeInfo coreSegment = nestTubs(name,
-					    segmentParams,
-					    prodTargetCoreMaterial,
-					    &tgt->productionTargetRotation(),
-					    currentSegmentCenter,
-					    prodTargetMotherInfo,
-					    coreCopyNumber,
-					    prodTargetVisible,
-					    G4Colour::Yellow(),
-					    prodTargetSolid,
-					    forceAuxEdgeVisible,
-					    placePV,
-					    doSurfaceCheck
-					    );
-	  if (verbosityLevel > 2){G4cout << "segment center after volumeinfo = " << _segmentCenter << G4endl;}
-
-	  //
-	  //now add fins surrounding this core segment.  Build them as simple rectangles with a G4 subtraction volume for the core.
-	  
-	  for (int ithFin = 0; ithFin < tgt->nHaymanFins(); ++ithFin)
-	    //		    	    	    	  for (int ithFin = 0; ithFin < 1; ++ithFin)
-	    {
-	      const std::string name = "ProductionTargetFinSection_" + std::to_string(ithSection+1) + "_Segment_" + std::to_string(ithSegment) + "_Fin_" + std::to_string(ithFin);
-	      if (verbosityLevel > 1)
-		{G4cout << "Fin Section and Angle = " << name << " " << currentFinAngles.at(ithFin) << " fin copy number = " << finCopyNumber << G4endl;}
-	      // divide by 2 to make box half-height since I gave it the "radius" to start with; arbitrary convention. 
-	      double finHalfHeightAboveTarget = (tgt->finOuterRadius() - tgt->rOut())/2.;
-	      if (verbosityLevel > 2){G4cout << "finHeightAboveTarget = " << tgt->finOuterRadius() << " " 
-						 << tgt->rOut() << " " << finHalfHeightAboveTarget << G4endl;}
-	      G4Box* finBox = new G4Box("finBox",tgt->haymanFinThickness()/2.,finHalfHeightAboveTarget,currentHalfSegment);
-	      // 
-	      // this tubs is in the xy plane with an extent along z.  So phi goes in the xy plane.
-	      G4Tubs* tubCutout = new G4Tubs("finCutout",0.,tgt->rOut(),currentHalfSegment + magicOffset,dSphi,dPphi);// need extra length for visualization tool
-	      //
-	      // I now have two G4Solids, a box and a cutout.  Combine them to make a logical volume. the box is 
-	      // oriented so that it is "z" thick and "radius" high.  the tubs is made to be the same, so no rotation
-	      // and also no translation needed 
-
-	      ++finCopyNumber;
-
-	      //
-	      //for debugging
-	      CLHEP::Hep3Vector offset(0.,0.,0.);
-	      G4ThreeVector finTranslation = currentSegmentCenter;
-
-	      double distanceFromCenter = finHalfHeightAboveTarget + tgt->rOut();
-	      CLHEP::Hep3Vector offsetRelativeToCore(distanceFromCenter*cos(currentFinAngles.at(ithFin)),distanceFromCenter*sin(currentFinAngles.at(ithFin)),0.);
-	      // 
-	      // finTranslation was already put in the target rotated frame.  I have to rotate the offset vector as well
-	      offsetRelativeToCore *= tgt->productionTargetRotation().inverse();
-	      finTranslation = finTranslation + offsetRelativeToCore;
-
-
-	      CLHEP::Hep3Vector downshift = CLHEP::Hep3Vector(0.,-finHalfHeightAboveTarget - targetRadius*cos(angularSize), 0.);
-	      placeSubtractionVolumeBoxTubs(name
-					    ,finTranslation
-					    ,prodTargetMotherInfo
-					    ,finBox
-					    ,tubCutout
-					    ,rotFinsG4.at(ithFin)
-					    ,prodTargetFinMaterial
-					    ,nullptr
-					    ,downshift
-					    ,finCopyNumber
-					    ,G4Colour::Blue()
-					    ,"PS"
-					    ,verbosityLevel>1);
-	    //
-	    // for each fin, build the little section at the top that joins it to the next fin.  This will be  a G4Box with a cutout. 
-	    // Here make the cutout a little tubs without the fancy angular business, since I don't have fins overlapping fins up at the top.
-	    const std::string nameTop = "ProductionTargetFinTopSection_" + std::to_string(ithSection+1) 
-	      + "_Segment_" + std::to_string(ithSegment) + "_Fin_" + std::to_string(ithFin);
-  
-	    //Much easier to visualize but the code is equally yucky
-	    double gapRadius = tgt->thicknessOfGapPerSection().at(ithSection)/2.;
-	    double finTopHalfHeight =( tgt->finOuterRadius() - tgt->heightOfRectangularGapPerSection().at(ithSection))/2.;
-	    if (verbosityLevel > 2){G4cout << "finTopHalfHeight = " << finTopHalfHeight <<G4endl;} 
-	    G4Box* finTopBox = new G4Box("finTopBox",tgt->haymanFinThickness()/2.,finTopHalfHeight,tgt->thicknessOfGapPerSection().at(ithSection)/2.);
-	    G4Tubs* finTopCutout = new G4Tubs("finTopCutout",0.,gapRadius + magicOffset,tgt->haymanFinThickness()/2. + magicOffset,0.,2.*M_PI);
-	    ++finTopCopyNumber;
-
-	    if (verbosityLevel > 2){G4cout << "current starting SegmentCenter, current HalfSegment, gap radius = " 
-					      << currentStartingSegmentCenter << " " << currentHalfStartingSegment << " " 
-					      << gapRadius << G4endl;}
-	    G4ThreeVector finTopBoxLocation = currentSegmentCenter 
-                      + tgt->productionTargetRotation().inverse()*CLHEP::Hep3Vector(0.,0.,currentHalfSegment + gapRadius);
-	    //
-	    // for debugging
-	    CLHEP::Hep3Vector offsetTop(0.,0.,0.);
-	    //
-	    // rotate the offset vector 
-	    G4ThreeVector finTopTranslation = finTopBoxLocation + offsetTop;
-	    //
-	    // G4 translates and then rotates.  I want to offset the fin to its final location relative to the core and then let G4 perform rotations,
-	    // both of the fin about the z axis and then the entire production target rotation angle
-	    double distanceTopFromCenter = tgt->finOuterRadius() - finTopHalfHeight; 
- 
-	    CLHEP::Hep3Vector offsetTopRelativeToCore(distanceTopFromCenter*cos(currentFinAngles.at(ithFin)),distanceTopFromCenter*sin(currentFinAngles.at(ithFin)),0.);
-	    // 
-	    // finTranslation was already put in the target rotated frame.  I have to rotate the offset vector as well
-	    offsetTopRelativeToCore *= tgt->productionTargetRotation().inverse();
-	    finTopTranslation = finTopTranslation + offsetTopRelativeToCore;
-	    if (verbosityLevel > 2){G4cout << "finTopTranslation = " << finTopTranslation << G4endl;}
-	    CLHEP::Hep3Vector downshiftTopBox = CLHEP::Hep3Vector(0.,-finTopHalfHeight, 0.);
-
-	    //
-	    // these are oriented with gap radius along z.  Recall still in mother volume so this axis is OK
-	    G4RotationMatrix* tubTopRotation = reg.add(G4RotationMatrix(CLHEP::HepRotation::IDENTITY));
-	    tubTopRotation->rotateY(M_PI/2.);
-	    
-	    VolumeInfo finTopWithCutoutInfo(nameTop,finTopTranslation,prodTargetMotherInfo.centerInWorld);
-	    finTopWithCutoutInfo.solid = new G4SubtractionSolid(nameTop,finTopBox,finTopCutout,tubTopRotation,downshiftTopBox);
-	    finishNesting(finTopWithCutoutInfo
-			  ,prodTargetFinMaterial
-			  ,rotFinsG4.at(ithFin)
-			  ,finTopTranslation
-			  ,prodTargetMotherInfo.logical
-			  ,finTopCopyNumber
-			  ,G4Colour::White()
-			  ,"ProductionTarget"
-			  ,verbosityLevel>1);
-	    
-	    }
-	  _currentZ += currentHalfSegment;
-	  //
-	  // if this is the last segment, add another gap before next section starts!
-	  if (ithSegment == numberOfSegments-1) {
-	    if (verbosityLevel > 0){G4cout << " z before = " << _currentZ << G4endl;}
-	    _currentZ += currentGap;
-	    if (verbosityLevel > 0){G4cout << " z after = " << _currentZ << G4endl;}
-	  }
-	  if (verbosityLevel > 0){G4cout << __PRETTY_FUNCTION__ << " ending at z=" << _currentZ << G4endl;}
-	}
-	  ++coreCopyNumber;
-	//
-	// if this is the last section, add on one more beginning block. decided not to extend vectors and have zero segments, just ugly
-	if (ithSection == (numberOfSections -1) ){
-	  startName = "ProductionTargetStartingCoreSection_" + std::to_string(ithSection+1+1);
-	  TubsParams startingSegmentParamsEnd(0.,targetRadius,tgt->startingSectionThickness().at(ithSection)/2.);
-
-	  //	
-	  //set currentZ to be in the center of the starting section
-	  _currentZ += tgt->startingSectionThickness().at(ithSection)/2.;
-	  if (verbosityLevel > 0){G4cout << __PRETTY_FUNCTION__ << " ithSection+1 , startingSegmentCenter at " << ithSection+1 << " " <<_currentZ << G4endl;}
-	  _startingSegmentCenter.setZ(_currentZ);
-	  CLHEP::Hep3Vector currentStartingSegmentCenter = tgt->productionTargetRotation().inverse()*_startingSegmentCenter;
-	  double currentHalfStartingSegment = tgt->startingSectionThickness().at(ithSection)/2.;
-	  startingSegment = nestTubs(startName,
-				     startingSegmentParamsEnd,
-				     prodTargetCoreMaterial,
-				     &tgt->productionTargetRotation(),
-				     currentStartingSegmentCenter,
-				     prodTargetMotherInfo,
-				     ithSection+1,
-				     prodTargetVisible,
-				     G4Colour::Yellow(),
-				     prodTargetSolid,
-				     forceAuxEdgeVisible,
-				     placePV,
-				     doSurfaceCheck
-				     );
-
-	  //build fins around starting segment
-	  for (int ithFin = 0; ithFin < tgt->nHaymanFins(); ++ithFin){
-
-	    double currentFinAngle = tgt->finAngles().at(ithFin);
-	    const std::string name = "ProductionTargetFinStartingSection_" + std::to_string(ithSection+1+1) + "_Fin_" + std::to_string(ithFin);
-
-	    if (verbosityLevel > 1)
-	      {G4cout << "Fin Section and Angle = " << name << " " << currentFinAngle << " fin copy number = " << finCopyNumber << G4endl;}
-
-	    double finHalfHeightAboveTarget = (tgt->finOuterRadius() - tgt->rOut())/2.;
-	    G4Box* finBox = new G4Box("finBox",tgt->haymanFinThickness()/2.,finHalfHeightAboveTarget,currentHalfStartingSegment);
-	    // 
-	    // this tubs is in the xy plane with an extent along z.  So phi goes in the xy plane.
+            //
+            // this tubs is in the xy plane with an extent along z.  So phi goes in the xy plane.
             // need extra length for visualization tool and overlap avoidance
-	    G4Tubs* tubCutout = new G4Tubs("finCutout",0.,tgt->rOut(),currentHalfStartingSegment + magicOffset,dSphi,dPphi);
+            G4Tubs* tubCutout = new G4Tubs("finCutout",0.,tgt->rOut(),currentHalfStartingSegment + magicOffset,dSphi,dPphi);
+            ++finCopyNumber;
+
+            G4ThreeVector finTranslation = currentStartingSegmentCenter;
+            //
+            // G4 translates and then rotates.  I want to offset the fin to its final location relative to the core and then let G4 perform rotations,
+            // both of the fin about the z axis and then the entire production target rotation angle
+            double distanceFromCenter = finHalfHeightAboveTarget + tgt->rOut();
+            CLHEP::Hep3Vector offsetRelativeToCore(distanceFromCenter*cos(currentFinAngles.at(ithFin))
+                                                   ,distanceFromCenter*sin(currentFinAngles.at(ithFin)),0.);
+            //
+            // finTranslation was already put in the target rotated frame.  I have to rotate the offset vector as well
+            offsetRelativeToCore *= tgt->productionTargetRotation().inverse();
+            finTranslation = finTranslation + offsetRelativeToCore;
+
+            CLHEP::Hep3Vector downshift = CLHEP::Hep3Vector(0.,-finHalfHeightAboveTarget - targetRadius*cos(angularSize), 0.);
+            placeSubtractionVolumeBoxTubs(name
+                                          ,finTranslation
+                                          ,prodTargetMotherInfo
+                                          ,finBox
+                                          ,tubCutout
+                                          ,rotFinsG4.at(ithFin)
+                                          ,prodTargetFinMaterial
+                                          ,nullptr
+                                          ,downshift
+                                          ,finCopyNumber
+                                          ,G4Colour::Blue()
+                                          ,"PS"
+                                          ,verbosityLevel>1);
+
+            //
+            // for each fin, build the little section at the top that joins it to the next fin.  This will be  a G4Box with a cutout.
+            // Here make the cutout a little tubs without the fancy angular business, since I don't have fins overlapping fins up at the top.
+            const std::string nameTop = "ProductionTargetFinTopStartingSection_" + std::to_string(ithSection+1) + "_Fin_" + std::to_string(ithFin);
+
+            double gapRadius = tgt->thicknessOfGapPerSection().at(ithSection)/2.;
+            double finTopHalfHeight =( tgt->finOuterRadius() - tgt->heightOfRectangularGapPerSection().at(ithSection))/2.;
+            if (verbosityLevel > 2){G4cout << "finTopHalfHeight = " << finTopHalfHeight <<G4endl;}
+            G4Box* finTopBox = new G4Box("finTopBox",tgt->haymanFinThickness()/2.,finTopHalfHeight,tgt->thicknessOfGapPerSection().at(ithSection)/2.);
+            G4Tubs* finTopCutout = new G4Tubs("finTopCutout",0.,gapRadius + magicOffset,tgt->haymanFinThickness()/2. + magicOffset,0.,2.*M_PI);
+            ++finTopCopyNumber;
+
+            if (verbosityLevel > 2){G4cout << "current starting SegmentCenter, current HalfSegment, gap radius = "
+                                              << currentStartingSegmentCenter << " " << currentHalfStartingSegment
+                                              << " " << gapRadius << G4endl;}
+            G4ThreeVector finTopLocation = currentStartingSegmentCenter
+                      + tgt->productionTargetRotation().inverse()*CLHEP::Hep3Vector(0.,0.,currentHalfStartingSegment + gapRadius);
+            //
+            // for debugging
+            CLHEP::Hep3Vector offsetTop(0.,0.,0.);
+            //
+            // rotate the offset vector
+            G4ThreeVector finTopTranslation = finTopLocation + offsetTop;
+            double distanceTopFromCenter = tgt->finOuterRadius() - finTopHalfHeight;
+            CLHEP::Hep3Vector offsetTopRelativeToCore(distanceTopFromCenter*cos(currentFinAngles.at(ithFin))
+                                                      ,distanceTopFromCenter*sin(currentFinAngles.at(ithFin)),0.);
+            //
+            // finTranslation was already put in the target rotated frame.  I have to rotate the offset vector as well
+            offsetTopRelativeToCore *= tgt->productionTargetRotation().inverse();
+            finTopTranslation = finTopTranslation + offsetTopRelativeToCore;
+            if (verbosityLevel > 2){G4cout << "finTopTranslation = " << finTopTranslation << G4endl;}
+            CLHEP::Hep3Vector downshiftTopBox = CLHEP::Hep3Vector(0.,-finTopHalfHeight, 0.);
+            //
+            // these are oriented with gap radius along z.  Recall still in mother volume so this axis is OK
+            G4RotationMatrix* tubTopRotation = reg.add(G4RotationMatrix(CLHEP::HepRotation::IDENTITY));
+
+            tubTopRotation->rotateY(M_PI/2.);
+
+            VolumeInfo finTopWithCutoutInfo(nameTop,finTopTranslation,prodTargetMotherInfo.centerInWorld);
+            finTopWithCutoutInfo.solid = new G4SubtractionSolid(nameTop,finTopBox,finTopCutout,tubTopRotation,downshiftTopBox);
+            finishNesting(finTopWithCutoutInfo
+                          ,prodTargetFinMaterial
+                          ,rotFinsG4.at(ithFin)
+                          ,finTopTranslation
+                          ,prodTargetMotherInfo.logical
+                          ,finTopCopyNumber
+                          ,G4Colour::White()
+                          ,"ProductionTarget"
+                          ,verbosityLevel>1);
+            //
+            // this check also uses finWithCutout.  Indirectly it's a way of forcing an overlap check or it won't compile, since finWithCutout is never used otherwise.
+            //      if (doSurfaceCheck){checkForOverlaps(finTopWithCutout,_config,0);}
+
+          }
+
+        //
+        // for very first starting section, we need to build the support ring
+        //
+        // build support ring at this end.  I need to build an annulus with cutouts for the fins.
+        int boxCopyNumber = 0;
+        if (ithSection==0){
+          std::string name = "ProductionTargetNegativeEndRing";
+          G4Tubs* supportRing = new G4Tubs(name,
+                                           tgt->supportRingInnerRadius(),
+                                           tgt->supportRingOuterRadius(),
+                                           tgt->supportRingLength()/2.,
+                                           0.,
+                                           2.*M_PI);
+
+          if (verbosityLevel > 0){
+            G4cout << __PRETTY_FUNCTION__ << ": \n " << name.c_str() << ":\n  (rin, rout, half length) = ("
+                   << tgt->supportRingInnerRadius() << ", " << tgt->supportRingOuterRadius()
+                   << ", " << tgt->supportRingLength()/2. << ")" << G4endl;
+          }
+          // move ring to end of target and then back by cutout size (signs for negative side)
+          G4ThreeVector ringTranslation = currentStartingSegmentCenter
+            - tgt->productionTargetRotation().inverse()*CLHEP::Hep3Vector(0.,0.,tgt->supportRingLength()/2.);
+
+          if (verbosityLevel > 0){
+            G4cout << "  center = (0., 0., -" << (currentStartingSegmentCenter.mag() + tgt->supportRingLength()/2.) << ")" << G4endl;
+            G4cout << "  center (wrt target mother) = " << ringTranslation << G4endl;
+          }
+          // the way we handle the cutout is a little different; the tubs is centered on zero, not offset from the z axis
+          // build one cutout box for each fin.  This ignores the extra cutouts (easy enough to put in later) and the mounting mechanisms,
+          // which won't matter for muon yield, heat deposition, etc -- just looks like tungsten for those purposes
+
+          //
+          // this is all so I can add multiple cutouts to the ring and only do one placement.
+          //      std::vector<G4SubtractionSolid*> ringWithCutoutSolid;
+          std::vector<G4SubtractionSolid*> ringWithCutoutSolid;
+
+          std::string nameRing = "ProductionTargetNegativeRingCutout";
+
+          for (int ithFin = 0; ithFin < tgt->nHaymanFins(); ++ithFin){
+            double currentFinAngle = tgt->finAngles().at(ithFin);
+            const std::string name = "ProductionTargetNegativeRingCutout_" + std::to_string(ithSection)
+              + "_Segment_" +"_Fin_" + std::to_string(ithFin);
+            ++boxCopyNumber;
+
+            if (verbosityLevel > 6)
+              {G4cout << "Fin Section and Angle = " << name << " " << currentFinAngle << " fin copy number = " << finCopyNumber << G4endl;}
+            if (verbosityLevel > 2){G4cout << " cutoutHeightAboveTarget = " << tgt->supportRingInnerRadius() << " "
+                                              << " " << tgt->supportRingCutoutThickness() << " " << cutoutHeightAboveTarget << G4endl;}
+
+            //
+            // G4 translates and then rotates.  I want to offset the fin to its final location relative to the core and then let G4 perform rotations,
+            // both of the fin about the z axis and then the entire production target rotation angle
+            double distanceFromCenter = cutoutHeightAboveTarget;
+            CLHEP::Hep3Vector boxShift(distanceFromCenter*cos(currentFinAngles.at(ithFin)),distanceFromCenter*sin(currentFinAngles.at(ithFin)),0.);
+            CLHEP::Hep3Vector offsetRelativeToCore(distanceFromCenter*cos(currentFinAngles.at(ithFin)),distanceFromCenter*sin(currentFinAngles.at(ithFin)),
+                                                           tgt->supportRingCutoutLength()/2. + magicOffset);
+
+            if (verbosityLevel > 3){
+              G4cout << "production target rotation angle = " << tgt->productionTargetRotation().getTheta() << G4endl;
+              G4cout << "fin dump: " << currentFinAngles.at(ithFin) << " " << distanceFromCenter << " " << offsetRelativeToCore << G4endl;
+              G4cout << "ithfin; current fin angle; rotFin; finTranslation = " << ithFin << " "
+                     << currentFinAngles.at(ithFin)  << " " << *rotFinsG4.at(ithFin) << " " << ringTranslation << G4endl;
+              G4cout << "production target rotation = " << tgt->productionTargetRotation() << G4endl;
+            }
+
+            if (ithFin == 0){
+                      ringWithCutoutSolid.push_back(new G4SubtractionSolid(name,supportRing,cutoutBox,rotBoxesG4.at(ithFin),offsetRelativeToCore));
+            }else {
+                      ringWithCutoutSolid.push_back(new G4SubtractionSolid(name,ringWithCutoutSolid.at(ithFin-1),cutoutBox,rotBoxesG4.at(ithFin),offsetRelativeToCore));
+            }
+          }
+
+
+          if (verbosityLevel > 0){
+            G4cout << "  center (at end) = (0., 0., " << ringTranslation.mag() << ")" <<G4endl;
+            G4cout << "  center (wrt target mother at end) = " << ringTranslation << G4endl;
+
+            G4cout << "  rotation = " << rotRing << G4endl;
+          }
+
+          VolumeInfo ringWithCutoutNegative(name,ringTranslation,prodTargetMotherInfo.centerInWorld);
+          ringWithCutoutNegative.solid = ringWithCutoutSolid.at(tgt->nHaymanFins() - 1);
+          finishNesting(ringWithCutoutNegative
+                        ,prodTargetSupportRingMaterial
+                        ,rotRing
+                        ,ringTranslation
+                        ,prodTargetMotherInfo.logical
+                        ,finCopyNumber
+                        ,G4Colour::White()
+                        ,"ProductionTarget"
+                        ,verbosityLevel>1);
+
+
+        }
+
+
+        /*    -------------------end of support ring, first starting section  ---------------------*/
+
+        //
+        // set current z to be at the end of this starting segment before beginning loop on sections
+        _currentZ += tgt->startingSectionThickness().at(ithSection)/2.;
+        if (verbosityLevel > 0){G4cout << __PRETTY_FUNCTION__ << " ithSection , startingSegment Z ends at " << ithSection << " " <<_currentZ << G4endl;}
+        double currentGap = tgt->thicknessOfGapPerSection().at(ithSection);
+        double currentHalfSegment = tgt->thicknessOfSegmentPerSection().at(ithSection)/2.;
+
+        for (int ithSegment = 0; ithSegment < numberOfSegments; ++ithSegment){
+          std::string name = "ProductionTargetCoreSection_" + std::to_string(ithSection+1)
+            + "_Segment_" + std::to_string(ithSegment);
+          if (verbosityLevel > 0) {
+            G4cout << __PRETTY_FUNCTION__ << "name = " << name << " and core copy number = " << coreCopyNumber << G4endl;
+            G4cout << __PRETTY_FUNCTION__ << "gap, and segment half = " << currentGap << " " << currentHalfSegment << G4endl;
+          }
+          TubsParams segmentParams(0.,targetRadius,currentHalfSegment);
+          _currentZ += currentHalfSegment + currentGap;
+          if (verbosityLevel > 0){
+            G4cout << __PRETTY_FUNCTION__ << " ithSection , current Z for segment center is at " << ithSection << " "
+                      << ithSegment << " "  <<_currentZ << G4endl;
+          }
+          _segmentCenter.setZ(_currentZ);
+          G4ThreeVector currentSegmentCenter = tgt->productionTargetRotation().inverse()*_segmentCenter;
+          //CLHEP::Hep3Vector currentSegmentCenter = tgt->productionTargetRotation()*_segmentCenter;
+          //      CLHEP::Hep3Vector currentSegmentCenter = _segmentCenter;
+          VolumeInfo coreSegment = nestTubs(name,
+                                            segmentParams,
+                                            prodTargetCoreMaterial,
+                                            &tgt->productionTargetRotation(),
+                                            currentSegmentCenter,
+                                            prodTargetMotherInfo,
+                                            coreCopyNumber,
+                                            prodTargetVisible,
+                                            G4Colour::Yellow(),
+                                            prodTargetSolid,
+                                            forceAuxEdgeVisible,
+                                            placePV,
+                                            doSurfaceCheck
+                                            );
+          if (verbosityLevel > 2){G4cout << "segment center after volumeinfo = " << _segmentCenter << G4endl;}
+
+          //
+          //now add fins surrounding this core segment.  Build them as simple rectangles with a G4 subtraction volume for the core.
+
+          for (int ithFin = 0; ithFin < tgt->nHaymanFins(); ++ithFin)
+            //                                    for (int ithFin = 0; ithFin < 1; ++ithFin)
+            {
+              const std::string name = "ProductionTargetFinSection_" + std::to_string(ithSection+1) + "_Segment_" + std::to_string(ithSegment) + "_Fin_" + std::to_string(ithFin);
+              if (verbosityLevel > 1)
+                {G4cout << "Fin Section and Angle = " << name << " " << currentFinAngles.at(ithFin) << " fin copy number = " << finCopyNumber << G4endl;}
+              // divide by 2 to make box half-height since I gave it the "radius" to start with; arbitrary convention.
+              double finHalfHeightAboveTarget = (tgt->finOuterRadius() - tgt->rOut())/2.;
+              if (verbosityLevel > 2){G4cout << "finHeightAboveTarget = " << tgt->finOuterRadius() << " "
+                                                 << tgt->rOut() << " " << finHalfHeightAboveTarget << G4endl;}
+              G4Box* finBox = new G4Box("finBox",tgt->haymanFinThickness()/2.,finHalfHeightAboveTarget,currentHalfSegment);
+              //
+              // this tubs is in the xy plane with an extent along z.  So phi goes in the xy plane.
+              G4Tubs* tubCutout = new G4Tubs("finCutout",0.,tgt->rOut(),currentHalfSegment + magicOffset,dSphi,dPphi);// need extra length for visualization tool
+              //
+              // I now have two G4Solids, a box and a cutout.  Combine them to make a logical volume. the box is
+              // oriented so that it is "z" thick and "radius" high.  the tubs is made to be the same, so no rotation
+              // and also no translation needed
+
+              ++finCopyNumber;
+
+              //
+              //for debugging
+              CLHEP::Hep3Vector offset(0.,0.,0.);
+              G4ThreeVector finTranslation = currentSegmentCenter;
+
+              double distanceFromCenter = finHalfHeightAboveTarget + tgt->rOut();
+              CLHEP::Hep3Vector offsetRelativeToCore(distanceFromCenter*cos(currentFinAngles.at(ithFin)),distanceFromCenter*sin(currentFinAngles.at(ithFin)),0.);
+              //
+              // finTranslation was already put in the target rotated frame.  I have to rotate the offset vector as well
+              offsetRelativeToCore *= tgt->productionTargetRotation().inverse();
+              finTranslation = finTranslation + offsetRelativeToCore;
+
+
+              CLHEP::Hep3Vector downshift = CLHEP::Hep3Vector(0.,-finHalfHeightAboveTarget - targetRadius*cos(angularSize), 0.);
+              placeSubtractionVolumeBoxTubs(name
+                                            ,finTranslation
+                                            ,prodTargetMotherInfo
+                                            ,finBox
+                                            ,tubCutout
+                                            ,rotFinsG4.at(ithFin)
+                                            ,prodTargetFinMaterial
+                                            ,nullptr
+                                            ,downshift
+                                            ,finCopyNumber
+                                            ,G4Colour::Blue()
+                                            ,"PS"
+                                            ,verbosityLevel>1);
+            //
+            // for each fin, build the little section at the top that joins it to the next fin.  This will be  a G4Box with a cutout.
+            // Here make the cutout a little tubs without the fancy angular business, since I don't have fins overlapping fins up at the top.
+            const std::string nameTop = "ProductionTargetFinTopSection_" + std::to_string(ithSection+1)
+              + "_Segment_" + std::to_string(ithSegment) + "_Fin_" + std::to_string(ithFin);
+
+            //Much easier to visualize but the code is equally yucky
+            double gapRadius = tgt->thicknessOfGapPerSection().at(ithSection)/2.;
+            double finTopHalfHeight =( tgt->finOuterRadius() - tgt->heightOfRectangularGapPerSection().at(ithSection))/2.;
+            if (verbosityLevel > 2){G4cout << "finTopHalfHeight = " << finTopHalfHeight <<G4endl;}
+            G4Box* finTopBox = new G4Box("finTopBox",tgt->haymanFinThickness()/2.,finTopHalfHeight,tgt->thicknessOfGapPerSection().at(ithSection)/2.);
+            G4Tubs* finTopCutout = new G4Tubs("finTopCutout",0.,gapRadius + magicOffset,tgt->haymanFinThickness()/2. + magicOffset,0.,2.*M_PI);
+            ++finTopCopyNumber;
+
+            if (verbosityLevel > 2){G4cout << "current starting SegmentCenter, current HalfSegment, gap radius = "
+                                              << currentStartingSegmentCenter << " " << currentHalfStartingSegment << " "
+                                              << gapRadius << G4endl;}
+            G4ThreeVector finTopBoxLocation = currentSegmentCenter
+                      + tgt->productionTargetRotation().inverse()*CLHEP::Hep3Vector(0.,0.,currentHalfSegment + gapRadius);
+            //
+            // for debugging
+            CLHEP::Hep3Vector offsetTop(0.,0.,0.);
+            //
+            // rotate the offset vector
+            G4ThreeVector finTopTranslation = finTopBoxLocation + offsetTop;
+            //
+            // G4 translates and then rotates.  I want to offset the fin to its final location relative to the core and then let G4 perform rotations,
+            // both of the fin about the z axis and then the entire production target rotation angle
+            double distanceTopFromCenter = tgt->finOuterRadius() - finTopHalfHeight;
+
+            CLHEP::Hep3Vector offsetTopRelativeToCore(distanceTopFromCenter*cos(currentFinAngles.at(ithFin)),distanceTopFromCenter*sin(currentFinAngles.at(ithFin)),0.);
+            //
+            // finTranslation was already put in the target rotated frame.  I have to rotate the offset vector as well
+            offsetTopRelativeToCore *= tgt->productionTargetRotation().inverse();
+            finTopTranslation = finTopTranslation + offsetTopRelativeToCore;
+            if (verbosityLevel > 2){G4cout << "finTopTranslation = " << finTopTranslation << G4endl;}
+            CLHEP::Hep3Vector downshiftTopBox = CLHEP::Hep3Vector(0.,-finTopHalfHeight, 0.);
+
+            //
+            // these are oriented with gap radius along z.  Recall still in mother volume so this axis is OK
+            G4RotationMatrix* tubTopRotation = reg.add(G4RotationMatrix(CLHEP::HepRotation::IDENTITY));
+            tubTopRotation->rotateY(M_PI/2.);
+
+            VolumeInfo finTopWithCutoutInfo(nameTop,finTopTranslation,prodTargetMotherInfo.centerInWorld);
+            finTopWithCutoutInfo.solid = new G4SubtractionSolid(nameTop,finTopBox,finTopCutout,tubTopRotation,downshiftTopBox);
+            finishNesting(finTopWithCutoutInfo
+                          ,prodTargetFinMaterial
+                          ,rotFinsG4.at(ithFin)
+                          ,finTopTranslation
+                          ,prodTargetMotherInfo.logical
+                          ,finTopCopyNumber
+                          ,G4Colour::White()
+                          ,"ProductionTarget"
+                          ,verbosityLevel>1);
+
+            }
+          _currentZ += currentHalfSegment;
+          //
+          // if this is the last segment, add another gap before next section starts!
+          if (ithSegment == numberOfSegments-1) {
+            if (verbosityLevel > 0){G4cout << " z before = " << _currentZ << G4endl;}
+            _currentZ += currentGap;
+            if (verbosityLevel > 0){G4cout << " z after = " << _currentZ << G4endl;}
+          }
+          if (verbosityLevel > 0){G4cout << __PRETTY_FUNCTION__ << " ending at z=" << _currentZ << G4endl;}
+        }
+          ++coreCopyNumber;
+        //
+        // if this is the last section, add on one more beginning block. decided not to extend vectors and have zero segments, just ugly
+        if (ithSection == (numberOfSections -1) ){
+          startName = "ProductionTargetStartingCoreSection_" + std::to_string(ithSection+1+1);
+          TubsParams startingSegmentParamsEnd(0.,targetRadius,tgt->startingSectionThickness().at(ithSection)/2.);
+
+          //
+          //set currentZ to be in the center of the starting section
+          _currentZ += tgt->startingSectionThickness().at(ithSection)/2.;
+          if (verbosityLevel > 0){G4cout << __PRETTY_FUNCTION__ << " ithSection+1 , startingSegmentCenter at " << ithSection+1 << " " <<_currentZ << G4endl;}
+          _startingSegmentCenter.setZ(_currentZ);
+          CLHEP::Hep3Vector currentStartingSegmentCenter = tgt->productionTargetRotation().inverse()*_startingSegmentCenter;
+          double currentHalfStartingSegment = tgt->startingSectionThickness().at(ithSection)/2.;
+          startingSegment = nestTubs(startName,
+                                     startingSegmentParamsEnd,
+                                     prodTargetCoreMaterial,
+                                     &tgt->productionTargetRotation(),
+                                     currentStartingSegmentCenter,
+                                     prodTargetMotherInfo,
+                                     ithSection+1,
+                                     prodTargetVisible,
+                                     G4Colour::Yellow(),
+                                     prodTargetSolid,
+                                     forceAuxEdgeVisible,
+                                     placePV,
+                                     doSurfaceCheck
+                                     );
+
+          //build fins around starting segment
+          for (int ithFin = 0; ithFin < tgt->nHaymanFins(); ++ithFin){
+
+            double currentFinAngle = tgt->finAngles().at(ithFin);
+            const std::string name = "ProductionTargetFinStartingSection_" + std::to_string(ithSection+1+1) + "_Fin_" + std::to_string(ithFin);
+
+            if (verbosityLevel > 1)
+              {G4cout << "Fin Section and Angle = " << name << " " << currentFinAngle << " fin copy number = " << finCopyNumber << G4endl;}
+
+            double finHalfHeightAboveTarget = (tgt->finOuterRadius() - tgt->rOut())/2.;
+            G4Box* finBox = new G4Box("finBox",tgt->haymanFinThickness()/2.,finHalfHeightAboveTarget,currentHalfStartingSegment);
+            //
+            // this tubs is in the xy plane with an extent along z.  So phi goes in the xy plane.
+            // need extra length for visualization tool and overlap avoidance
+            G4Tubs* tubCutout = new G4Tubs("finCutout",0.,tgt->rOut(),currentHalfStartingSegment + magicOffset,dSphi,dPphi);
 
             CLHEP::HepRotation* rotFin = reg.add(CLHEP::HepRotation(tgt->productionTargetRotation().inverse()));
             CLHEP::HepRotation* rotFinG4 = reg.add(CLHEP::HepRotation(tgt->productionTargetRotation()));
-	    // 
-	    // ok here I have a little confusing fix.  The fin is built along the y-axis.  But the rotation is given wrt the x axis.  Hence I need to
-	    // subtract off that 90^o 
-	    double rotAdj = -M_PI/2 + currentFinAngle;
-	    rotFin->rotateZ(rotAdj);
-	    //
-	    // g4 version.
-	    rotFinG4->rotateZ(-rotAdj);
-	    ++finCopyNumber;
+            //
+            // ok here I have a little confusing fix.  The fin is built along the y-axis.  But the rotation is given wrt the x axis.  Hence I need to
+            // subtract off that 90^o
+            double rotAdj = -M_PI/2 + currentFinAngle;
+            rotFin->rotateZ(rotAdj);
+            //
+            // g4 version.
+            rotFinG4->rotateZ(-rotAdj);
+            ++finCopyNumber;
 
-	    //
-	    // for debugging
-	    CLHEP::Hep3Vector offset(0.,0.,0.);
-	      //
-	      // rotate the offset vector 
-	    G4ThreeVector finTranslation = currentStartingSegmentCenter;
-	    //
-	    // G4 translates and then rotates.  I want to offset the fin to its final location relative to the core and then let G4 perform rotations,
-	    // both of the fin about the z axis and then the entire production target rotation angle
-	    double distanceFromCenter = finHalfHeightAboveTarget + tgt->rOut();
-	    CLHEP::Hep3Vector offsetRelativeToCore(distanceFromCenter*cos(currentFinAngle),distanceFromCenter*sin(currentFinAngle),0.);
-	    // 
-	    // finTranslation was already put in the target rotated frame.  I have to rotate the offset vector as well
-	    offsetRelativeToCore *= tgt->productionTargetRotation().inverse();
-	    finTranslation = finTranslation + offsetRelativeToCore;
-	    if (verbosityLevel > 2){G4cout << "finTranslation = " << finTranslation << G4endl;}
-	    CLHEP::Hep3Vector downshift = CLHEP::Hep3Vector(0.,-finHalfHeightAboveTarget - targetRadius*cos(angularSize), 0.);
+            //
+            // for debugging
+            CLHEP::Hep3Vector offset(0.,0.,0.);
+              //
+              // rotate the offset vector
+            G4ThreeVector finTranslation = currentStartingSegmentCenter;
+            //
+            // G4 translates and then rotates.  I want to offset the fin to its final location relative to the core and then let G4 perform rotations,
+            // both of the fin about the z axis and then the entire production target rotation angle
+            double distanceFromCenter = finHalfHeightAboveTarget + tgt->rOut();
+            CLHEP::Hep3Vector offsetRelativeToCore(distanceFromCenter*cos(currentFinAngle),distanceFromCenter*sin(currentFinAngle),0.);
+            //
+            // finTranslation was already put in the target rotated frame.  I have to rotate the offset vector as well
+            offsetRelativeToCore *= tgt->productionTargetRotation().inverse();
+            finTranslation = finTranslation + offsetRelativeToCore;
+            if (verbosityLevel > 2){G4cout << "finTranslation = " << finTranslation << G4endl;}
+            CLHEP::Hep3Vector downshift = CLHEP::Hep3Vector(0.,-finHalfHeightAboveTarget - targetRadius*cos(angularSize), 0.);
 
-	    VolumeInfo finWithCutoutInfo(name,finTranslation,prodTargetMotherInfo.centerInWorld);
-	    finWithCutoutInfo.solid = new G4SubtractionSolid(name,finBox,tubCutout,nullptr,downshift);
-	    finishNesting(finWithCutoutInfo
-			  ,prodTargetFinMaterial
-			  ,rotFinsG4.at(ithFin)
-			  ,finTranslation
-			  ,prodTargetMotherInfo.logical
-			  ,finCopyNumber
-			  ,G4Colour::White()
-			  ,"ProductionTarget"
-			  ,verbosityLevel>1);
-	    
-	  }
-	  //
-	  // set current z to be at the end of this starting segment as a final check
-	  _currentZ += tgt->startingSectionThickness().at(ithSection)/2.;
-	  if (verbosityLevel > 0){
-	    G4cout << __PRETTY_FUNCTION__ << " ithSection+1 , startingSegment Z ends at " << ithSection+1 << " " <<_currentZ << G4endl;
-	    G4cout << "             with copy number for last segment  = " << ithSection+1 << G4endl;
-	  }
-	  /***********and now the final end ring  ***********/
-	  std::string name = "ProductionTargetPositiveEndRing";
-	  G4Tubs* supportRing = new G4Tubs(name,
-					   tgt->supportRingInnerRadius(),
-					   tgt->supportRingOuterRadius(),
-					   tgt->supportRingLength()/2.,
-					   0.,
-					   2.*M_PI);
-	  if (verbosityLevel > 0){
-	    G4cout << __PRETTY_FUNCTION__ << ": \n " << name.c_str() << ":\n  (rin, rout, half length) = (" 
-		   << tgt->supportRingInnerRadius() << ", " << tgt->supportRingOuterRadius() 
-		   << ", " << tgt->supportRingLength()/2. << ")" << G4endl;
-	  }
-	  // move ring to end of target and then back by cutout size (signs for positive side)
-	  G4ThreeVector ringTranslation = currentStartingSegmentCenter 
-	    + tgt->productionTargetRotation().inverse()*CLHEP::Hep3Vector(0.,0.,tgt->supportRingLength()/2.);
+            VolumeInfo finWithCutoutInfo(name,finTranslation,prodTargetMotherInfo.centerInWorld);
+            finWithCutoutInfo.solid = new G4SubtractionSolid(name,finBox,tubCutout,nullptr,downshift);
+            finishNesting(finWithCutoutInfo
+                          ,prodTargetFinMaterial
+                          ,rotFinsG4.at(ithFin)
+                          ,finTranslation
+                          ,prodTargetMotherInfo.logical
+                          ,finCopyNumber
+                          ,G4Colour::White()
+                          ,"ProductionTarget"
+                          ,verbosityLevel>1);
 
-	  if (verbosityLevel > 0){
-	    G4cout << "  center = (0., 0., " << (currentStartingSegmentCenter.mag() + tgt->supportRingLength()/2.) << ")" << G4endl;
-	    G4cout << "  center (wrt target mother) = " << ringTranslation << G4endl;
-	  }
-	  std::vector<G4SubtractionSolid*> ringWithCutoutSolid;
-	  std::string nameRing = "ProductionTargetPositiveRingCutout";
+          }
+          //
+          // set current z to be at the end of this starting segment as a final check
+          _currentZ += tgt->startingSectionThickness().at(ithSection)/2.;
+          if (verbosityLevel > 0){
+            G4cout << __PRETTY_FUNCTION__ << " ithSection+1 , startingSegment Z ends at " << ithSection+1 << " " <<_currentZ << G4endl;
+            G4cout << "             with copy number for last segment  = " << ithSection+1 << G4endl;
+          }
+          /***********and now the final end ring  ***********/
+          std::string name = "ProductionTargetPositiveEndRing";
+          G4Tubs* supportRing = new G4Tubs(name,
+                                           tgt->supportRingInnerRadius(),
+                                           tgt->supportRingOuterRadius(),
+                                           tgt->supportRingLength()/2.,
+                                           0.,
+                                           2.*M_PI);
+          if (verbosityLevel > 0){
+            G4cout << __PRETTY_FUNCTION__ << ": \n " << name.c_str() << ":\n  (rin, rout, half length) = ("
+                   << tgt->supportRingInnerRadius() << ", " << tgt->supportRingOuterRadius()
+                   << ", " << tgt->supportRingLength()/2. << ")" << G4endl;
+          }
+          // move ring to end of target and then back by cutout size (signs for positive side)
+          G4ThreeVector ringTranslation = currentStartingSegmentCenter
+            + tgt->productionTargetRotation().inverse()*CLHEP::Hep3Vector(0.,0.,tgt->supportRingLength()/2.);
 
-	  for (int ithFin = 0; ithFin < tgt->nHaymanFins(); ++ithFin){
-	    double currentFinAngle = tgt->finAngles().at(ithFin);
-            const std::string name = "ProductionTargetPositiveRingCutout_" + std::to_string(ithSection) 
-	      + "_Segment_" +"_Fin_" + std::to_string(ithFin);
-	    ++boxCopyNumber;
+          if (verbosityLevel > 0){
+            G4cout << "  center = (0., 0., " << (currentStartingSegmentCenter.mag() + tgt->supportRingLength()/2.) << ")" << G4endl;
+            G4cout << "  center (wrt target mother) = " << ringTranslation << G4endl;
+          }
+          std::vector<G4SubtractionSolid*> ringWithCutoutSolid;
+          std::string nameRing = "ProductionTargetPositiveRingCutout";
+
+          for (int ithFin = 0; ithFin < tgt->nHaymanFins(); ++ithFin){
+            double currentFinAngle = tgt->finAngles().at(ithFin);
+            const std::string name = "ProductionTargetPositiveRingCutout_" + std::to_string(ithSection)
+              + "_Segment_" +"_Fin_" + std::to_string(ithFin);
+            ++boxCopyNumber;
 
 
-	    //
-	    // G4 translates and then rotates.  I want to offset the fin to its final location relative to the core and then let G4 perform rotations,
-	    // both of the fin about the z axis and then the entire production target rotation angle
-	    double distanceFromCenter = cutoutHeightAboveTarget;
+            //
+            // G4 translates and then rotates.  I want to offset the fin to its final location relative to the core and then let G4 perform rotations,
+            // both of the fin about the z axis and then the entire production target rotation angle
+            double distanceFromCenter = cutoutHeightAboveTarget;
 
-	    CLHEP::Hep3Vector boxShift(distanceFromCenter*cos(currentFinAngle),distanceFromCenter*sin(currentFinAngle),0.);
-	    CLHEP::Hep3Vector offsetRelativeToCore(distanceFromCenter*cos(currentFinAngle),distanceFromCenter*sin(currentFinAngle), 
-						   -tgt->supportRingCutoutLength()/2. - magicOffset);// note flipped sign from other end of target
+            CLHEP::Hep3Vector boxShift(distanceFromCenter*cos(currentFinAngle),distanceFromCenter*sin(currentFinAngle),0.);
+            CLHEP::Hep3Vector offsetRelativeToCore(distanceFromCenter*cos(currentFinAngle),distanceFromCenter*sin(currentFinAngle),
+                                                   -tgt->supportRingCutoutLength()/2. - magicOffset);// note flipped sign from other end of target
 
-	    CLHEP::Hep3Vector downshift = CLHEP::Hep3Vector(0.,0.,0.);//for debugging
-	    offsetRelativeToCore = offsetRelativeToCore + downshift;
-	    if (ithFin == 0){
-	      ringWithCutoutSolid.push_back(new G4SubtractionSolid(name,supportRing,cutoutBox,rotBoxesG4.at(ithFin),offsetRelativeToCore));
-	    }else {
-	      ringWithCutoutSolid.push_back(new G4SubtractionSolid(name,ringWithCutoutSolid.at(ithFin-1),cutoutBox,rotBoxesG4.at(ithFin),offsetRelativeToCore));
-	    }
-	  }
+            CLHEP::Hep3Vector downshift = CLHEP::Hep3Vector(0.,0.,0.);//for debugging
+            offsetRelativeToCore = offsetRelativeToCore + downshift;
+            if (ithFin == 0){
+              ringWithCutoutSolid.push_back(new G4SubtractionSolid(name,supportRing,cutoutBox,rotBoxesG4.at(ithFin),offsetRelativeToCore));
+            }else {
+              ringWithCutoutSolid.push_back(new G4SubtractionSolid(name,ringWithCutoutSolid.at(ithFin-1),cutoutBox,rotBoxesG4.at(ithFin),offsetRelativeToCore));
+            }
+          }
 
-	  
-	  if (verbosityLevel > 0){
-	    G4cout << "  center (at end) = (0., 0., " << ringTranslation.mag() << ")" <<G4endl;
-	    G4cout << "  center (wrt target mother at end) = " << ringTranslation << G4endl;
-	    
-	    G4cout << "  rotation = " << rotRing << G4endl;
-	  }
-	  VolumeInfo ringWithCutoutPositive(name,ringTranslation,prodTargetMotherInfo.centerInWorld);
-          ringWithCutoutPositive.solid = ringWithCutoutSolid.at(tgt->nHaymanFins() - 1); // what does this =  mean?  
-	  finishNesting(ringWithCutoutPositive
-			,prodTargetSupportRingMaterial
-			,rotRing
-			,ringTranslation
-			,prodTargetMotherInfo.logical
-			,finCopyNumber
-			,G4Colour::White()
-			,"ProductionTarget"
-			,verbosityLevel>1);
-	  
-	} //end if(ithSection == (numberOfSections -1) )
+
+          if (verbosityLevel > 0){
+            G4cout << "  center (at end) = (0., 0., " << ringTranslation.mag() << ")" <<G4endl;
+            G4cout << "  center (wrt target mother at end) = " << ringTranslation << G4endl;
+
+            G4cout << "  rotation = " << rotRing << G4endl;
+          }
+          VolumeInfo ringWithCutoutPositive(name,ringTranslation,prodTargetMotherInfo.centerInWorld);
+          ringWithCutoutPositive.solid = ringWithCutoutSolid.at(tgt->nHaymanFins() - 1); // what does this =  mean?
+          finishNesting(ringWithCutoutPositive
+                        ,prodTargetSupportRingMaterial
+                        ,rotRing
+                        ,ringTranslation
+                        ,prodTargetMotherInfo.logical
+                        ,finCopyNumber
+                        ,G4Colour::White()
+                        ,"ProductionTarget"
+                        ,verbosityLevel>1);
+
+        } //end if(ithSection == (numberOfSections -1) )
       } //end for(int ithSection...)
 
       //Add support structures for the production target
       if(tgt->supportsBuild()) {
-	G4Material* suppWheelMaterial = findMaterialOrThrow(tgt->supportWheelMaterial());
-	G4ThreeVector localWheelCenter(0.0,0.0,0.0); //no offset
-	double suppWheelParams[] = {tgt->supportWheelRIn(), tgt->supportWheelROut(), tgt->supportWheelHL()};
-	//create the volume info for the support wheel+rods
-	VolumeInfo suppWheelInfo( "ProductionTargetSupportWheel", localWheelCenter, prodTargetMotherInfo.centerInMu2e());
-	suppWheelInfo.solid = new G4Tubs("ProductionTargetSupportWheel_wheel", suppWheelParams[0], suppWheelParams[1],
-					 suppWheelParams[2], 0., CLHEP::twopi);
-					       // suppWheelParams,
-					       // suppWheelMaterial,
-					       // 0,
-					       // localWheelCenter,
-					       // prodTargetMotherInfo,
-					       // 0,
-					       // G4Colour::Gray(),
-					       // "PS"
-					       // );
+        G4Material* suppWheelMaterial = findMaterialOrThrow(tgt->supportWheelMaterial());
+        G4ThreeVector localWheelCenter(0.0,0.0,0.0); //no offset
+        double suppWheelParams[] = {tgt->supportWheelRIn(), tgt->supportWheelROut(), tgt->supportWheelHL()};
+        //create the volume info for the support wheel+rods
+        VolumeInfo suppWheelInfo( "ProductionTargetSupportWheel", localWheelCenter, prodTargetMotherInfo.centerInMu2e());
+        suppWheelInfo.solid = new G4Tubs("ProductionTargetSupportWheel_wheel", suppWheelParams[0], suppWheelParams[1],
+                                         suppWheelParams[2], 0., CLHEP::twopi);
+                                               // suppWheelParams,
+                                               // suppWheelMaterial,
+                                               // 0,
+                                               // localWheelCenter,
+                                               // prodTargetMotherInfo,
+                                               // 0,
+                                               // G4Colour::Gray(),
+                                               // "PS"
+                                               // );
 
-	// add spokes //
+        // add spokes //
 
-	//spoke info
-	const int nspokesperside = tgt->nSpokesPerSide();
-	G4Material* spokeMaterial = findMaterialOrThrow(tgt->spokeMaterial());
-	//target info
-	double rTarget = tgt->supportRingOuterRadius(); //radius of the support ring to attach to
-	double zTarget = tgt->halfHaymanLength(); //where along the target to attach
-	double smallGap = 0.001; //for adding small offsets to avoid overlaps due to precision
-	//initialize parameter vectors
-	//features on wheel
-	const vector<double> supportWheelFeatureAngles = tgt->supportWheelFeatureAngles();
-	const vector<double> supportWheelFeatureArcs   = tgt->supportWheelFeatureArcs  ();
-	const vector<double> supportWheelFeatureRIns   = tgt->supportWheelFeatureRIns  ();
-	//support rods in wheel
-	const vector<double> supportWheelRodHL           = tgt->supportWheelRodHL          ();
-	const vector<double> supportWheelRodOffset       = tgt->supportWheelRodOffset      ();
-	const vector<double> supportWheelRodRadius       = tgt->supportWheelRodRadius      ();
-	const vector<double> supportWheelRodRadialOffset = tgt->supportWheelRodRadialOffset();
-	const vector<double> supportWheelRodWireOffsetD  = tgt->supportWheelRodWireOffsetD ();
-	const vector<double> supportWheelRodWireOffsetU  = tgt->supportWheelRodWireOffsetU ();
-	const vector<double> supportWheelRodAngles       = tgt->supportWheelRodAngles      ();
-	//spoke (support wire) angles
-	const vector<double> spokeTargetAnglesD = tgt->spokeTargetAnglesD();
-	const vector<double> spokeTargetAnglesU = tgt->spokeTargetAnglesU();
-	if(verbosityLevel > 0)
-	  std::cout << "Printing information about production target supports:\n";
+        //spoke info
+        const int nspokesperside = tgt->nSpokesPerSide();
+        G4Material* spokeMaterial = findMaterialOrThrow(tgt->spokeMaterial());
+        //target info
+        double rTarget = tgt->supportRingOuterRadius(); //radius of the support ring to attach to
+        double zTarget = tgt->halfHaymanLength(); //where along the target to attach
+        double smallGap = 0.001; //for adding small offsets to avoid overlaps due to precision
+        //initialize parameter vectors
+        //features on wheel
+        const vector<double> supportWheelFeatureAngles = tgt->supportWheelFeatureAngles();
+        const vector<double> supportWheelFeatureArcs   = tgt->supportWheelFeatureArcs  ();
+        const vector<double> supportWheelFeatureRIns   = tgt->supportWheelFeatureRIns  ();
+        //support rods in wheel
+        const vector<double> supportWheelRodHL           = tgt->supportWheelRodHL          ();
+        const vector<double> supportWheelRodOffset       = tgt->supportWheelRodOffset      ();
+        const vector<double> supportWheelRodRadius       = tgt->supportWheelRodRadius      ();
+        const vector<double> supportWheelRodRadialOffset = tgt->supportWheelRodRadialOffset();
+        const vector<double> supportWheelRodWireOffsetD  = tgt->supportWheelRodWireOffsetD ();
+        const vector<double> supportWheelRodWireOffsetU  = tgt->supportWheelRodWireOffsetU ();
+        const vector<double> supportWheelRodAngles       = tgt->supportWheelRodAngles      ();
+        //spoke (support wire) angles
+        const vector<double> spokeTargetAnglesD = tgt->spokeTargetAnglesD();
+        const vector<double> spokeTargetAnglesU = tgt->spokeTargetAnglesU();
+        if(verbosityLevel > 0)
+          std::cout << "Printing information about production target supports:\n";
 
-	const double targetAngle = tgt->rotHaymanY(); //assume target angle is only in the x-z plane for supports
-	CLHEP::HepRotation* rodRot = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
-	rodRot->rotateY(-1.*targetAngle);
-	
-	for(int istream = 0; istream < 2; ++istream) {
-	  for(int ispoke = 0; ispoke < nspokesperside; ++ispoke) {
-	    const double wheelAngle =  supportWheelRodAngles[ispoke]*CLHEP::degree;
-	    //get angle of the support rod on the wheel and the angle on the target the wire connects to
-	    const double targetWireAngle = (istream == 0) ? spokeTargetAnglesD[ispoke]*CLHEP::degree 
-	      : spokeTargetAnglesU[ispoke]*CLHEP::degree;
-	    double rWheel = supportWheelRodRadialOffset[ispoke]; // radius of the wheel to attach to
-	    CLHEP::Hep3Vector rodCenter(rWheel*cos(wheelAngle), rWheel*sin(wheelAngle), 0.);
-	    const double rodOffset = supportWheelRodOffset[ispoke];
-	    rodCenter += CLHEP::Hep3Vector(sin(targetAngle)*rodOffset, 0., cos(targetAngle)*rodOffset);
-	    if(istream == 0) { //only do once
-	      //add the features near the support rods in the bicycle wheel
-	      const double featureAngle = supportWheelFeatureAngles[ispoke]*CLHEP::degree; //angle of feature center
-	      const double featureArc   = supportWheelFeatureArcs[ispoke]*CLHEP::degree; //width in angle
-	      const double featureRIn   = supportWheelFeatureRIns[ispoke]; //inner radius of feature
-	      const double featureROut = tgt->supportWheelRIn() + smallGap; //ensure they overlap for union
-	      // double featureR = (featureRIn + featureROut)/2.; //radius of feature center
-	      // CLHEP::Hep3Vector featureCenter(featureR*cos(featureAngle), featureR*sin(featureAngle), 0.);
-	      CLHEP::Hep3Vector featureCenter(localWheelCenter); //center is wheel center
-	      double featureParams[] = {featureRIn, featureROut, tgt->supportWheelHL(), featureAngle - featureArc/2. /*phi0*/, featureArc /*dphi*/};
-	      G4Tubs* featureTubs = new G4Tubs("ProductionTargetSupportFeature_" +std::to_string(ispoke),
-					       featureParams[0], featureParams[1], featureParams[2], featureParams[3], featureParams[4]);
-	      suppWheelInfo.solid = new G4UnionSolid("ProductionTargetSupportWheelFeature_union_"+std::to_string(ispoke),
-						     suppWheelInfo.solid, featureTubs, 0, featureCenter);
-	      //add the support rod to the wheel
-	      G4Tubs* rodTubs = new G4Tubs("ProductionTargetSupportRod_" +std::to_string(ispoke),
-					   0., supportWheelRodRadius[ispoke], supportWheelRodHL[ispoke], 0., CLHEP::twopi);
-	      suppWheelInfo.solid = new G4UnionSolid("ProductionTargetSupportWheelRod_union_"+std::to_string(ispoke),
-						     suppWheelInfo.solid, rodTubs, rodRot, rodCenter);
-	    }
-	    const int side = (1-2*istream); //+1 or -1
-	    //info about wire connection
-	    //get end of the rod on this side
-	    CLHEP::Hep3Vector rodAxis(sin(targetAngle), 0., cos(targetAngle));
-	    CLHEP::Hep3Vector wheelPos(rodCenter);
-	    wheelPos += side*supportWheelRodHL[ispoke]*rodAxis;
-	    //translate from rod center to edge
-	    CLHEP::Hep3Vector rodCenterToWire(cos(wheelAngle)*cos(targetAngle),
-					      sin(wheelAngle)*cos(targetAngle),
-					      -cos(wheelAngle)*sin(targetAngle)); 
-	    wheelPos -= supportWheelRodRadius[ispoke]*rodCenterToWire;
-	    double zWireRodOffset = (istream == 0) ? supportWheelRodWireOffsetD[ispoke] : supportWheelRodWireOffsetU[ispoke];
-	    wheelPos -= side*zWireRodOffset*rodAxis;
+        const double targetAngle = tgt->rotHaymanY(); //assume target angle is only in the x-z plane for supports
+        CLHEP::HepRotation* rodRot = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+        rodRot->rotateY(-1.*targetAngle);
 
-	    //get wire position on target
-	    CLHEP::Hep3Vector targetPos(rTarget*cos(targetWireAngle), rTarget*sin(targetWireAngle), side*zTarget);
-	    targetPos = tgt->productionTargetRotation().inverse()*targetPos; //rotate from target frame to mother frame
-	    CLHEP::Hep3Vector spokeAxis((wheelPos-targetPos).unit());
-	    CLHEP::Hep3Vector targetAxis(0.,0.,side);
-	    targetAxis = tgt->productionTargetRotation().inverse()*targetAxis;
-	    CLHEP::Hep3Vector zax(0.,0.,1.);
-	    if(verbosityLevel > 0)
-	      std::cout << "istream " << istream << " ispoke " << ispoke << std::endl
-			<< "target pos " << targetPos << "\nwheel pos " << wheelPos << std::endl
-			<< "Target axis " << targetAxis << "\nSpoke axis " << spokeAxis << std::endl
-			<< "Rod axis " << rodAxis << "\nRod center to wire axis " << rodCenterToWire << std::endl;
-	    //to remove overlaps where the wire connects, need angle of wire and surface connecting to
-	    //remove overlap at target
-	    double wireTargetAngle = targetAxis.angle(-1.*spokeAxis);
-	    double deltaLength = (abs(tan(wireTargetAngle)) > 1.e-6) ? abs(tgt->spokeRadius()/tan(wireTargetAngle)) : 0.; //give up if ~paralle
-	    targetPos += (deltaLength+0.1)*spokeAxis; //subtract off the length
-	    if(verbosityLevel > 0)
-	      std::cout << "wire target angle " << wireTargetAngle << " delta L " << deltaLength 
-			<< " target pos " << targetPos <<std::endl;
+        for(int istream = 0; istream < 2; ++istream) {
+          for(int ispoke = 0; ispoke < nspokesperside; ++ispoke) {
+            const double wheelAngle =  supportWheelRodAngles[ispoke]*CLHEP::degree;
+            //get angle of the support rod on the wheel and the angle on the target the wire connects to
+            const double targetWireAngle = (istream == 0) ? spokeTargetAnglesD[ispoke]*CLHEP::degree
+              : spokeTargetAnglesU[ispoke]*CLHEP::degree;
+            double rWheel = supportWheelRodRadialOffset[ispoke]; // radius of the wheel to attach to
+            CLHEP::Hep3Vector rodCenter(rWheel*cos(wheelAngle), rWheel*sin(wheelAngle), 0.);
+            const double rodOffset = supportWheelRodOffset[ispoke];
+            rodCenter += CLHEP::Hep3Vector(sin(targetAngle)*rodOffset, 0., cos(targetAngle)*rodOffset);
+            if(istream == 0) { //only do once
+              //add the features near the support rods in the bicycle wheel
+              const double featureAngle = supportWheelFeatureAngles[ispoke]*CLHEP::degree; //angle of feature center
+              const double featureArc   = supportWheelFeatureArcs[ispoke]*CLHEP::degree; //width in angle
+              const double featureRIn   = supportWheelFeatureRIns[ispoke]; //inner radius of feature
+              const double featureROut = tgt->supportWheelRIn() + smallGap; //ensure they overlap for union
+              // double featureR = (featureRIn + featureROut)/2.; //radius of feature center
+              // CLHEP::Hep3Vector featureCenter(featureR*cos(featureAngle), featureR*sin(featureAngle), 0.);
+              CLHEP::Hep3Vector featureCenter(localWheelCenter); //center is wheel center
+              double featureParams[] = {featureRIn, featureROut, tgt->supportWheelHL(), featureAngle - featureArc/2. /*phi0*/, featureArc /*dphi*/};
+              G4Tubs* featureTubs = new G4Tubs("ProductionTargetSupportFeature_" +std::to_string(ispoke),
+                                               featureParams[0], featureParams[1], featureParams[2], featureParams[3], featureParams[4]);
+              suppWheelInfo.solid = new G4UnionSolid("ProductionTargetSupportWheelFeature_union_"+std::to_string(ispoke),
+                                                     suppWheelInfo.solid, featureTubs, 0, featureCenter);
+              //add the support rod to the wheel
+              G4Tubs* rodTubs = new G4Tubs("ProductionTargetSupportRod_" +std::to_string(ispoke),
+                                           0., supportWheelRodRadius[ispoke], supportWheelRodHL[ispoke], 0., CLHEP::twopi);
+              suppWheelInfo.solid = new G4UnionSolid("ProductionTargetSupportWheelRod_union_"+std::to_string(ispoke),
+                                                     suppWheelInfo.solid, rodTubs, rodRot, rodCenter);
+            }
+            const int side = (1-2*istream); //+1 or -1
+            //info about wire connection
+            //get end of the rod on this side
+            CLHEP::Hep3Vector rodAxis(sin(targetAngle), 0., cos(targetAngle));
+            CLHEP::Hep3Vector wheelPos(rodCenter);
+            wheelPos += side*supportWheelRodHL[ispoke]*rodAxis;
+            //translate from rod center to edge
+            CLHEP::Hep3Vector rodCenterToWire(cos(wheelAngle)*cos(targetAngle),
+                                              sin(wheelAngle)*cos(targetAngle),
+                                              -cos(wheelAngle)*sin(targetAngle));
+            wheelPos -= supportWheelRodRadius[ispoke]*rodCenterToWire;
+            double zWireRodOffset = (istream == 0) ? supportWheelRodWireOffsetD[ispoke] : supportWheelRodWireOffsetU[ispoke];
+            wheelPos -= side*zWireRodOffset*rodAxis;
 
-	    //next remove overlap at rod
-	    // 
-	    double wireRodAngle = abs((rodCenterToWire).angle(spokeAxis)); 
-	    deltaLength = abs(tan(wireRodAngle)/tgt->spokeRadius());
-	    wheelPos -= (deltaLength+1.)*spokeAxis;
-	    if(verbosityLevel > 0)
-	      std::cout << "wire rod angle " << wireRodAngle << " delta L " << deltaLength 
-			<< " wheel pos " << wheelPos <<std::endl;
+            //get wire position on target
+            CLHEP::Hep3Vector targetPos(rTarget*cos(targetWireAngle), rTarget*sin(targetWireAngle), side*zTarget);
+            targetPos = tgt->productionTargetRotation().inverse()*targetPos; //rotate from target frame to mother frame
+            CLHEP::Hep3Vector spokeAxis((wheelPos-targetPos).unit());
+            CLHEP::Hep3Vector targetAxis(0.,0.,side);
+            targetAxis = tgt->productionTargetRotation().inverse()*targetAxis;
+            CLHEP::Hep3Vector zax(0.,0.,1.);
+            if(verbosityLevel > 0)
+              std::cout << "istream " << istream << " ispoke " << ispoke << std::endl
+                        << "target pos " << targetPos << "\nwheel pos " << wheelPos << std::endl
+                        << "Target axis " << targetAxis << "\nSpoke axis " << spokeAxis << std::endl
+                        << "Rod axis " << rodAxis << "\nRod center to wire axis " << rodCenterToWire << std::endl;
+            //to remove overlaps where the wire connects, need angle of wire and surface connecting to
+            //remove overlap at target
+            double wireTargetAngle = targetAxis.angle(-1.*spokeAxis);
+            double deltaLength = (abs(tan(wireTargetAngle)) > 1.e-6) ? abs(tgt->spokeRadius()/tan(wireTargetAngle)) : 0.; //give up if ~paralle
+            targetPos += (deltaLength+0.1)*spokeAxis; //subtract off the length
+            if(verbosityLevel > 0)
+              std::cout << "wire target angle " << wireTargetAngle << " delta L " << deltaLength
+                        << " target pos " << targetPos <<std::endl;
 
-	    CLHEP::Hep3Vector spokeCenter((wheelPos+targetPos)/2.);
-	    double spokeLength = abs((wheelPos-targetPos).mag());
-	    TubsParams spokeParams(0., tgt->spokeRadius(), 0.5*spokeLength);
-	    CLHEP::HepRotation* spokeRot = reg.add(CLHEP::HepRotation(spokeAxis.cross(zax), spokeAxis.angle(zax)));
-	    std::stringstream spokeName;
-	    spokeName << "ProductionTargetSpokeWire_" ;
-	    if(istream == 0)
-	      spokeName << "Downstream_";
-	    else
-	      spokeName << "Upstream_";
-	    spokeName << ispoke;
+            //next remove overlap at rod
+            //
+            double wireRodAngle = abs((rodCenterToWire).angle(spokeAxis));
+            deltaLength = abs(tan(wireRodAngle)/tgt->spokeRadius());
+            wheelPos -= (deltaLength+1.)*spokeAxis;
+            if(verbosityLevel > 0)
+              std::cout << "wire rod angle " << wireRodAngle << " delta L " << deltaLength
+                        << " wheel pos " << wheelPos <<std::endl;
 
-	    VolumeInfo spokeInfo   = nestTubs( spokeName.str(),
-					       spokeParams,
-					       spokeMaterial,
-					       spokeRot,
-					       spokeCenter,
-					       prodTargetMotherInfo,
-					       0,
-					       G4Colour::Gray(),
-					       "PS"
-					       );
-	  
-	  } //end spokes loop
-	} //end stream loop
-	finishNesting(suppWheelInfo,
-		      suppWheelMaterial,
-		      0,
-		      localWheelCenter,
-		      prodTargetMotherInfo.logical,
-		      0,
-		      G4Colour::Gray(),
-		      "PS"
-		      );
+            CLHEP::Hep3Vector spokeCenter((wheelPos+targetPos)/2.);
+            double spokeLength = abs((wheelPos-targetPos).mag());
+            TubsParams spokeParams(0., tgt->spokeRadius(), 0.5*spokeLength);
+            CLHEP::HepRotation* spokeRot = reg.add(CLHEP::HepRotation(spokeAxis.cross(zax), spokeAxis.angle(zax)));
+            std::stringstream spokeName;
+            spokeName << "ProductionTargetSpokeWire_" ;
+            if(istream == 0)
+              spokeName << "Downstream_";
+            else
+              spokeName << "Upstream_";
+            spokeName << ispoke;
+
+            VolumeInfo spokeInfo   = nestTubs( spokeName.str(),
+                                               spokeParams,
+                                               spokeMaterial,
+                                               spokeRot,
+                                               spokeCenter,
+                                               prodTargetMotherInfo,
+                                               0,
+                                               G4Colour::Gray(),
+                                               "PS"
+                                               );
+
+          } //end spokes loop
+        } //end stream loop
+        finishNesting(suppWheelInfo,
+                      suppWheelMaterial,
+                      0,
+                      localWheelCenter,
+                      prodTargetMotherInfo.logical,
+                      0,
+                      G4Colour::Gray(),
+                      "PS"
+                      );
 
       } //end adding support structures
     } //end ProductionTargetMaker::hayman_v_2_0
@@ -1249,4 +1249,3 @@ namespace mu2e {
 } //end namespace mu2e
 
  // end Mu2eWorld::constructPS
-


### PR DESCRIPTION
Used AntiLeakRegistry for rotation matrices where it was missing to avoid memory leaks and used nullptr for identity rotations in Geant4 volume placements to avoid unnecessary calculations.
(The whitespace change was replacing tabs with spaces and trailing space removal)

The code change should not modify any actual volume placements, but it should be tested as a precaution.
