### PR TITLE
Keeping the EventID of primary event in cosmic resampling

### DIFF
--- a/EventGenerator/fcl/prolog.fcl
+++ b/EventGenerator/fcl/prolog.fcl
@@ -58,11 +58,11 @@ mu2e.IPAMuonStops: {
 
 # Generate Event
 generate: {
-     module_type          : EventGenerator
-     inputfile            : "Mu2eG4/test/genconfig_02.txt"
-     allowReplacement     : true
-     messageOnReplacement : true
- }
+    module_type          : EventGenerator
+    inputfile            : "Mu2eG4/test/genconfig_02.txt"
+    allowReplacement     : true
+    messageOnReplacement : true
+}
 
 # provided for consistency in some production scripts
 dummyGenerator : {

--- a/EventGenerator/fcl/prolog.fcl
+++ b/EventGenerator/fcl/prolog.fcl
@@ -56,14 +56,6 @@ mu2e.IPAMuonStops: {
     verbosityLevel        : 0
 }
 
-# Generate Event
-generate: {
-    module_type          : EventGenerator
-    inputfile            : "Mu2eG4/test/genconfig_02.txt"
-    allowReplacement     : true
-    messageOnReplacement : true
-}
-
 # provided for consistency in some production scripts
 dummyGenerator : {
   module_type : EventGenerator

--- a/EventGenerator/fcl/prolog.fcl
+++ b/EventGenerator/fcl/prolog.fcl
@@ -56,6 +56,14 @@ mu2e.IPAMuonStops: {
     verbosityLevel        : 0
 }
 
+# Generate Event
+generate: {
+     module_type          : EventGenerator
+     inputfile            : "Mu2eG4/test/genconfig_02.txt"
+     allowReplacement     : true
+     messageOnReplacement : true
+ }
+
 # provided for consistency in some production scripts
 dummyGenerator : {
   module_type : EventGenerator

--- a/JobConfig/cosmic/S1DSStops.fcl
+++ b/JobConfig/cosmic/S1DSStops.fcl
@@ -10,7 +10,6 @@ services: @local::Services.Sim
 
 physics: {
   producers : {
-    generate: @local::generate
     g4run : @local::mu2e.physics.producers.g4run.muons
     genCounter: { module_type: GenEventCounter }
     compressPV: @local::Cosmic.compressPV

--- a/JobConfig/cosmic/S1DSStopsCORSIKA.fcl
+++ b/JobConfig/cosmic/S1DSStopsCORSIKA.fcl
@@ -20,15 +20,7 @@ source: {
 }
 
 
-physics.producers.generate.module_type  : CORSIKAEventGenerator
-physics.producers.generate.corsikaModuleLabel: "FromCorsikaBinary"
-physics.producers.generate.refPointChoice: "UNDEFINED"
-physics.producers.generate.projectToTargetBox : true
-physics.producers.generate.targetBoxYmax : 5000
-physics.producers.generate.intDist: -1
-
-physics.producers.generate.inputFile    : @erase
-physics.producers.generate.stashSize    : @erase
+physics.producers.generate : @local::Cosmic.generateCORSIKA
 
 services.GeometryService.inputFile : "JobConfig/cosmic/geom_cosmic.txt"
 services.GeometryService.simulatedDetector : { tool_type: "Mu2e" }

--- a/JobConfig/cosmic/S1DSStopsCRY.fcl
+++ b/JobConfig/cosmic/S1DSStopsCRY.fcl
@@ -1,4 +1,4 @@
 #include "JobConfig/cosmic/S1DSStops.fcl"
 
-physics.producers.generate.inputFile    : "EventGenerator/defaultConfigs/defaultCRYconfig.txt"
-physics.producers.generate.module_type  : CRYEventGenerator
+physics.producers.generate : @local::Cosmic.generateCRY
+outputs.Output.fileName : "sim.owner.CosmicDSStopsCRY.version.sequencer.art"

--- a/JobConfig/cosmic/S2Resampler.fcl
+++ b/JobConfig/cosmic/S2Resampler.fcl
@@ -18,12 +18,10 @@ physics.producers.g4run.Mu2eG4CommonCut: @local::Cosmic.Mu2eG4CommonCutCosmicS2
 physics.producers.g4run.SDConfig.preSimulatedHits:  ["cosmicResample:CRV"]
 physics.producers.FindMCPrimary.PrimaryGenIds: ["CosmicCRY", "CosmicCORSIKA"]
 
-resampler.mu2e.writeEventIDs : true
-
+physics.filters.cosmicResample.mu2e.writeEventIDs : true
 
 physics.TriggerPath: [cosmicResample, @sequence::Primary.TriggerSequence]
 outputs.Output.fileName        : "dts.owner.Cosmic.version.sequencer.art"
 outputs.Output.outputCommands : [@sequence::Primary.KeptProducts, "keep art::EventIDs_*_*_*"]
 
-// Test on the file with events that deposited lower than 14 MeV in CRV
-//physics.filters.cosmicResample.fileNames: ["/mu2e/app/users/srsoleti/sim.owner.CosmicDSStops.version.sequencer.art"]
+//physics.filters.cosmicResample.fileNames: ["/mu2e/app/users/srsoleti/sim.owner.CosmicDSStopsCORSIKA.version.sequencer.art"]

--- a/JobConfig/cosmic/S2Resampler.fcl
+++ b/JobConfig/cosmic/S2Resampler.fcl
@@ -17,7 +17,13 @@ physics.producers.g4run.inputs.updateEventLevelVolumeInfos.outInstance: "eventle
 physics.producers.g4run.Mu2eG4CommonCut: @local::Cosmic.Mu2eG4CommonCutCosmicS2
 physics.producers.g4run.SDConfig.preSimulatedHits:  ["cosmicResample:CRV"]
 physics.producers.FindMCPrimary.PrimaryGenIds: ["CosmicCRY", "CosmicCORSIKA"]
+
+resampler.mu2e.writeEventIDs : true
+
+
 physics.TriggerPath: [cosmicResample, @sequence::Primary.TriggerSequence]
 outputs.Output.fileName        : "dts.owner.Cosmic.version.sequencer.art"
+outputs.Output.outputCommands : [@sequence::Primary.KeptProducts, "keep art::EventIDs_*_*_*"]
+
 // Test on the file with events that deposited lower than 14 MeV in CRV
 //physics.filters.cosmicResample.fileNames: ["/mu2e/app/users/srsoleti/sim.owner.CosmicDSStops.version.sequencer.art"]

--- a/JobConfig/cosmic/S2Resampler.fcl
+++ b/JobConfig/cosmic/S2Resampler.fcl
@@ -24,4 +24,4 @@ physics.TriggerPath: [cosmicResample, @sequence::Primary.TriggerSequence]
 outputs.Output.fileName        : "dts.owner.Cosmic.version.sequencer.art"
 outputs.Output.outputCommands : [@sequence::Primary.KeptProducts, "keep art::EventIDs_*_*_*"]
 
-//physics.filters.cosmicResample.fileNames: ["/mu2e/app/users/srsoleti/sim.owner.CosmicDSStopsCORSIKA.version.sequencer.art"]
+//physics.filters.cosmicResample.fileNames: ["/pnfs/mu2e/persistent/users/srsoleti/cosmic/sim.srsoleti.CosmicDSStops.20210512.1.art"]

--- a/JobConfig/cosmic/S2ResamplerHigh.fcl
+++ b/JobConfig/cosmic/S2ResamplerHigh.fcl
@@ -5,9 +5,9 @@
 physics.filters.filterS1.cutEDepMin: 16
 physics.filters.filterS1: {
          module_type: FilterCosmicsStage1
-         inputs : [ "dsResample:CRV" ]
+         inputs : [ "cosmicResample:CRV" ]
          cutEDepMin: 16  // Filter events that deposit lower than 16 MeV in CRV
 }
-physics.TriggerPath: [dsResample, filterS1, @sequence::Primary.TriggerSequence]
+physics.TriggerPath: [cosmicResample, filterS1, @sequence::Primary.TriggerSequence]
 physics.filters.DetStepFilter.MaximumPartMom: 500
 outputs.Output.fileName        : "dts.owner.CosmicHigh.version.sequencer.art"

--- a/JobConfig/cosmic/prolog.fcl
+++ b/JobConfig/cosmic/prolog.fcl
@@ -125,6 +125,18 @@ Cosmic: {
          }
       }
    }
+   generateCRY: {
+       module_type: CRYEventGenerator
+       inputFile    : "EventGenerator/defaultConfigs/defaultCRYconfig.txt"
+   }
+   generateCORSIKA: {
+       module_type  : CORSIKAEventGenerator
+       corsikaModuleLabel: "FromCorsikaBinary"
+       refPointChoice: "UNDEFINED"
+       projectToTargetBox : true
+       targetBoxYmax : 5000
+       intDist: -1
+   }
    Mu2eG4CommonCutCosmicS2:{
       type: union
       pars:


### PR DESCRIPTION
This small edit in the cosmic resampling fcl file allows to keep the EventId of the primary event when resampling, so that we can test for over-sampling.