### PR TITLE
Replacing deprecated G4VisAttributes::Invisible with G4VisAttributes::GetInvisible()

### DIFF
--- a/Mu2eG4/src/HelicalProtonAbsorber.cc
+++ b/Mu2eG4/src/HelicalProtonAbsorber.cc
@@ -118,7 +118,7 @@ HelicalProtonAbsorber::HelicalProtonAbsorber(double z_start, double length_i, do
         //creating logical and physical volumes
         pabs_logic = new G4LogicalVolume(pabs_solid, material, "helical_pabs_log");
         pabs_phys = new G4PVPlacement(0,position,pabs_logic,"helical_pabs_phys", World, false, 0);
-        pabs_logic->SetVisAttributes(G4VisAttributes::Invisible);
+        pabs_logic->SetVisAttributes(G4VisAttributes::GetInvisible());
 }
 
 HelicalProtonAbsorber::~HelicalProtonAbsorber()

--- a/Mu2eG4/src/constructCRV.cc
+++ b/Mu2eG4/src/constructCRV.cc
@@ -92,7 +92,7 @@ namespace mu2e
       // visibility attributes
       if (!scintillatorShieldVisible) 
       {
-        scintillatorBarLogical->SetVisAttributes(G4VisAttributes::Invisible);
+        scintillatorBarLogical->SetVisAttributes(G4VisAttributes::GetInvisible());
       }
       else 
       {
@@ -122,7 +122,7 @@ namespace mu2e
       // visibility attributes
       if (!scintillatorShieldVisible) 
       {
-        CMBLogical->SetVisAttributes(G4VisAttributes::Invisible);
+        CMBLogical->SetVisAttributes(G4VisAttributes::GetInvisible());
       }
       else 
       {
@@ -255,7 +255,7 @@ if(!_config.getBool("crs.hideCRVCMBs"))
 
           if(!scintillatorShieldVisible) 
           {
-            absorberLogical->SetVisAttributes(G4VisAttributes::Invisible);
+            absorberLogical->SetVisAttributes(G4VisAttributes::GetInvisible());
           }
           else 
           {
@@ -305,7 +305,7 @@ if(!_config.getBool("crs.hideCRVCMBs"))
 
           if(!scintillatorShieldVisible) 
           {
-            aluminumSheetLogical->SetVisAttributes(G4VisAttributes::Invisible);
+            aluminumSheetLogical->SetVisAttributes(G4VisAttributes::GetInvisible());
           }
           else 
           {
@@ -355,7 +355,7 @@ if(!_config.getBool("crs.hideCRVCMBs"))
 
           if(!scintillatorShieldVisible) 
           {
-            FEBLogical->SetVisAttributes(G4VisAttributes::Invisible);
+            FEBLogical->SetVisAttributes(G4VisAttributes::GetInvisible());
           }
           else 
           {
@@ -408,7 +408,7 @@ if(!_config.getBool("crs.hideCRVCMBs"))
 
       if(!scintillatorShieldVisible) 
       {
-        supportStructureLogical->SetVisAttributes(G4VisAttributes::Invisible);
+        supportStructureLogical->SetVisAttributes(G4VisAttributes::GetInvisible());
       }
       else 
       {

--- a/Mu2eG4/src/constructDiskCalorimeter.cc
+++ b/Mu2eG4/src/constructDiskCalorimeter.cc
@@ -1193,7 +1193,7 @@ namespace mu2e {
      {
         G4LogicalVolume* logical = new G4LogicalVolume(solid, mat, name);
         G4VisAttributes* visAtt = new G4VisAttributes(isVisible, color);
-        if (!isVisible) logical->SetVisAttributes(G4VisAttributes::Invisible);
+        if (!isVisible) logical->SetVisAttributes(G4VisAttributes::GetInvisible());
         else 
         {
           visAtt->SetForceSolid(isSolid);

--- a/Mu2eG4/src/constructStoppingTarget.cc
+++ b/Mu2eG4/src/constructStoppingTarget.cc
@@ -197,7 +197,7 @@ namespace mu2e {
         doSurfaceCheck && checkForOverlaps( pv, config, verbosity>0);
 
         if (!stoppingTargetIsVisible) {
-          foilInfo.logical->SetVisAttributes(G4VisAttributes::Invisible);
+          foilInfo.logical->SetVisAttributes(G4VisAttributes::GetInvisible());
         } else {
           G4VisAttributes* visAtt = reg.add(G4VisAttributes(true, G4Colour::Magenta()));
           visAtt->SetForceAuxEdgeVisible(config.getBool("g4.forceAuxEdgeVisible",false));
@@ -307,7 +307,7 @@ namespace mu2e {
         doSurfaceCheck && checkForOverlaps( pv, config, verbosity>0);
 
         if (!stoppingTargetIsVisible) {
-          supportStructureInfo.logical->SetVisAttributes(G4VisAttributes::Invisible);
+          supportStructureInfo.logical->SetVisAttributes(G4VisAttributes::GetInvisible());
         } else {
           G4VisAttributes* visAtt = reg.add(G4VisAttributes(true, G4Colour::Blue()));
           visAtt->SetForceAuxEdgeVisible(config.getBool("g4.forceAuxEdgeVisible",false));

--- a/Mu2eG4/src/finishNesting.cc
+++ b/Mu2eG4/src/finishNesting.cc
@@ -134,7 +134,7 @@ namespace mu2e {
 
     if (!isVisible) {
 
-      info.logical->SetVisAttributes(G4VisAttributes::Invisible);
+      info.logical->SetVisAttributes(G4VisAttributes::GetInvisible());
 
     } else {
 


### PR DESCRIPTION
Used G4VisAttributes::GetInvisible() instead of deprecated Invisible
No changes in behavior expected 