### PR TITLE
valCompare one-file mode

### DIFF
--- a/Validation/inc/TValCompare.hh
+++ b/Validation/inc/TValCompare.hh
@@ -36,6 +36,9 @@ public:
   void SetFile1(TString x) { fFileN1 = x; }
   void SetFile2(TString x) { fFileN2 = x; }
 
+  // open and traverse the first file
+  virtual Int_t GetDirs();
+  virtual Int_t OneFile(Option_t* Opt="");
   virtual Int_t Analyze(Option_t* Opt="");
   // get a histogram based on searching name, path and title
   TValHist* GetHist(TString str);
@@ -43,8 +46,8 @@ public:
   virtual void Summary(Option_t* Opt="");
   virtual void Display(Option_t* Opt="");
   virtual void SaveAs(const char *filename="",Option_t *option="") const;
-  //Int_t Write(const char *name=0, Int_t option=0, Int_t bufsize=0);
-  //Int_t Write(const char *name=0, Int_t option=0, Int_t bufsize=0) const;
+  // save for one file option
+  virtual void SaveAs1(const char *filename="",Option_t *option="") const;
 
   virtual void  Delete(Option_t* Opt="");
   void SetVerbose(Int_t x) { fVerbose = x; }
@@ -59,6 +62,7 @@ protected:
   TValPar fPar;
 
   TObjArray fList; // list of histogram objects being compared
+  TObjArray fDirs; // list of directories to analyze
 
   Int_t fVerbose;
   Int_t fMinStat;

--- a/Validation/root/TValCompare.cc
+++ b/Validation/root/TValCompare.cc
@@ -24,41 +24,52 @@ void TValCompare::Delete(Option_t* Opt) {
   }
   //fPar.Clear();
   fList.Delete();
+  fDirs.Delete();
 }
 
 //_____________________________________________________________________________
-Int_t TValCompare::Analyze(Option_t* Opt) {
+Int_t TValCompare::GetDirs() {
 
-  Delete(); // remove any previous analysis
 
-  fFile1 = TFile::Open(fFileN1.Data());
-  fFile2 = TFile::Open(fFileN2.Data());
-  if( !( fFile1 && fFile2 ) ) {
-    printf("Error opening one of the files\n");
+
+  fFile1 = TFile::Open(fFileN1.Data(),"READ");
+  if( !fFile1 ) {
+    printf("Error opening one file 1\n");
     return 1;
   }
-  if( !( fFile1->IsOpen() && fFile2->IsOpen() ) ) {
-    printf("Error opening one of the files\n");
+  if( !fFile1->IsOpen() ) {
+    printf("Error opening file 1\n");
     return 1;
   }
+  if(fFileN2.Length()>0) {
+    fFile2 = TFile::Open(fFileN2.Data(),"READ");
+    if( !fFile2 ) {
+      printf("Error opening file 2\n");
+      return 1;
+    }
+    if( !fFile2->IsOpen() ) {
+      printf("Error opening file 2\n");
+      return 1;
+    }
+  }
+
 
   // don't create objects in the file
   gROOT->cd();
 
   // scan the first file, make a list of directories
-  TObjArray dirs;  // list of pointers to TDirectory
 
   TObjArray todo; // temp list of directotires to check for subdirectories
   todo.Add(fFile1); // prime with the top of file1
 
   int itodo = 0;
-  TObject *oo,*o1,*o2;
+  TObject *oo;
   TKey* kk;
 
   while(itodo < todo.GetEntries()) {
     TDirectory* dd = (TDirectory*) todo[itodo];
     if(fVerbose>9) printf("scanning %s\n",dd->GetName());
-    dirs.AddLast((TObject*)dd);
+    fDirs.AddLast((TObject*)dd);
 
     // look in this directory for subdirectories
     TIter it(dd->GetListOfKeys());
@@ -73,19 +84,83 @@ Int_t TValCompare::Analyze(Option_t* Opt) {
   }
 
   // List the directories, if requested
-  TDirectory *di,*dj;
-  TIter itd = TIter(&dirs);
+  TIter itd = TIter(&fDirs);
   if( fVerbose > 5 ) {
-    printf("List of %d directories in file 1:\n",dirs.GetEntries());
-    itd = TIter(&dirs);
+    printf("List of %d directories in file 1:\n",fDirs.GetEntries());
+    itd = TIter(&fDirs);
     TDirectory* di;
     while ( (di = (TDirectoryFile*) itd.Next()) ) {      
       printf("%s\n",di->GetPath());
      }
   }
 
+  return 0;
+}
+
+
+//_____________________________________________________________________________
+Int_t TValCompare::OneFile(Option_t* Opt) {
+
+  Delete(); // remove any previous analysis
+
+  // traverse the first file and get subdirectories
+  int rc = GetDirs();
+  if(rc!=0) return rc;
+
   // now process all objects in the list of directories
-  itd = TIter(&dirs);
+  TDirectory *di;
+  TObject *hh;
+  TKey* kk;
+  TString path,combo;
+
+  TIter itd = TIter(&fDirs);
+  while ( (di = (TDirectory*) itd.Next()) ) {
+    path = di->GetPath();
+    int ind = path.Index(":"); // strip leading file name
+    path = path(ind+2,path.Length()); 
+    if(fVerbose > 1) printf("Processing %s\n",path.Data());
+
+    // look in this directory for histograms
+    TIter ith(di->GetListOfKeys());
+    while ( (kk = (TKey*) ith.Next()) ) {
+      hh = di->Get(kk->GetName());
+
+      if(hh->ClassName() == TString("TH1F") ||
+	 hh->ClassName() == TString("TH1D") ||
+	 hh->ClassName() == TString("TProfile") ||
+	 hh->ClassName() == TString("TEfficiency") ) {
+	// have to pack path and name together
+	combo=path+"/"+TString(hh->GetName());
+	((TNamed*)hh)->SetName(combo);
+	  fList.Add(hh);
+      }
+    }
+    
+  
+  } // end loop over list of directories in file 1
+
+
+
+
+  return 0;
+
+}
+
+//_____________________________________________________________________________
+Int_t TValCompare::Analyze(Option_t* Opt) {
+
+  Delete(); // remove any previous analysis
+
+  // traverse the first file and get subdirectories
+  int rc = GetDirs();
+  if(rc!=0) return rc;
+
+  // now process all objects in the list of directories
+  TDirectory *di,*dj;
+  TObject *o1,*o2;
+  TKey* kk;
+
+  TIter itd = TIter(&fDirs);
   while ( (di = (TDirectory*) itd.Next()) ) {
     TString path = di->GetPath();
     int ind = path.Index(":"); // strip leading file name
@@ -453,6 +528,143 @@ void TValCompare::SaveAs(const char *filename, Option_t *option) const {
 
 }
 
+
+//_____________________________________________________________________________
+void TValCompare::SaveAs1(const char *filename, Option_t *option) const {
+
+  TString file(filename);
+  TString opt(option);
+  opt.ToUpper();
+
+  bool qPDF = file.EndsWith("pdf");
+  bool qWeb = file.EndsWith("html");
+  if( !(qPDF || qWeb) ) {
+    printf("ERRR - SaveAs1 file does not end with pdf or html");
+    return;
+  }
+
+
+  /*  only in ValHist
+  TH1* hh;
+  TIter it(&fList);
+  while ( (hh = (TH1*) it.Next()) ) hh->SetFontScale(sf);
+  */
+
+  TCanvas* ccc = nullptr;
+
+  Bool_t qBatch = gROOT->IsBatch();
+  gROOT->SetBatch(kTRUE);
+
+
+
+  if(qPDF) {
+
+    bool q12 = opt.Contains("1X2");
+    bool q22 = opt.Contains("2X2");
+
+    int cx = 700; // canvas size
+    int cy = 500;
+
+    int clim = 1;  // plots per page
+    if(qPDF && !q22) q12 = true;
+    if(q12) clim = 2;
+    if(q22) clim = 4;
+    
+    if(q12) {
+      cy = (11.0/8.5)*cx;
+    } else if(q22) {
+      cx = 800;
+      cy = cx;
+    }
+
+    TH1* hh;
+
+    ccc = new TCanvas("ccc-p","TValCompare-pdf",cx,cy);
+    TPDF* pdf =new TPDF(file);
+    TIter it(&fList);
+    int ind = 0;
+    while ( (hh = (TH1*) it.Next()) ) {      
+      if((ind%clim)==0) {
+	ccc->Clear();
+	if(q12) ccc->Divide(1,2);
+	if(q22) ccc->Divide(2,2);
+      }
+      ccc->cd(ind%clim+1);
+      ccc->Update();
+      hh->Draw();
+      ind++;
+    }    
+    //ccc->Destructor();
+    delete ccc;
+    ccc = nullptr;
+    pdf->Close();
+  }
+
+
+  if(qWeb) {
+    std::ofstream inf;
+    inf.open(file);
+    if(!inf.is_open()) {
+      printf("ERROR - could not open web file %s\n",file.Data());
+      return;
+    }
+    TString dir("./");
+    int c = int(file.Last('/'));
+    if(c>=0) dir = file(0,c+1);
+
+    inf <<"<html>\n<body>\n ";
+    inf <<"<title>valCompare one file</title>\n";
+    inf << "<BR><BR>\n";
+    inf <<"<h2>"<< fFileN1 << " &nbsp&nbsp </h2> <BR>";
+
+    inf << "<TABLE>\n";
+    inf << "<TD align=center>Name</TD>\n";
+    inf << "<TD align=center>Title</TD>\n";
+    inf << "</TR>\n";
+
+    ccc = new TCanvas("ccc-w","TValCompare",700,500);
+    TIter it(&fList);
+    TString color;
+    TString gifFile,gifName;
+    TString gifFileLog,gifNameLog;
+    TH1* hh;
+    while ( (hh = (TH1*) it.Next()) ) {
+      // TEfficiency does not handle log scale well 
+      bool qDoLog = (hh->ClassName()!=TString("TEfficiency"));
+      hh->Draw();
+      //gifName = hh->GetTag()+"/"+hh->GetName();
+      gifName = hh->GetName();
+      gifName.ReplaceAll("/","_");
+      gifNameLog = gifName;
+      gifName.Append(".gif");
+      gifNameLog.Append("_log.gif");
+      gifFile = dir+gifName;
+      gifFileLog = dir+gifNameLog;
+      ccc->SaveAs(gifFile);
+      if(qDoLog) {
+	gPad->SetLogy(1);
+	ccc->SaveAs(gifFileLog);
+	gPad->SetLogy(0);
+      }
+      
+      inf << "<TR><TD>";
+      
+      inf<< "<a href=\""<<gifName << "\">" <<  hh->GetName() <<"</a> ";
+      if(qDoLog) {
+	inf<< " &nbsp <a href=\""<<gifNameLog << "\">log</a> ";
+      }
+      inf << "</TD><TD>";
+      inf << hh->GetTitle();
+      inf << "</TD></TR>\n";
+      
+    } // hist loop
+    delete ccc;
+    ccc = nullptr;
+  }
+  
+  gROOT->SetBatch(qBatch);
+
+}
 
 
 //_____________________________________________________________________________

--- a/Validation/root/TValHistH.cc
+++ b/Validation/root/TValHistH.cc
@@ -92,6 +92,7 @@ Int_t TValHistH::Analyze(Option_t* Opt) {
     if (TMath::Abs(s1-s2) > maxDiff) maxDiff = TMath::Abs(s1-s2);
   }
   fFrProb = 1.0 - maxDiff/s1; // 1 is the standard
+  if(fFrProb<0.0) fFrProb = 0.0;
 
   TString qual;
   if(fPar.GetUnder()==0) qual.Append("U");

--- a/Validation/src/valCompare_main.cc
+++ b/Validation/src/valCompare_main.cc
@@ -40,6 +40,9 @@ void valCompare_usage() {
 "    - put all comparisons into a pdf file with 2x2 on a page\n"
 "    valCompare -2 -p result.pdf FILE1 FILE2\n"
 "  \n"
+"  The command can also be run with one file on the command line.\n"
+"  In this case, the web output switch must be on, and simple plots will be made. \n"
+"  \n"
 "  -h print help\n"
 "  -v INT verbose level (default=1)\n"
 "  -l INT  select plots to show - lower limit to status (0-11)\n"
@@ -60,7 +63,8 @@ void valCompare_usage() {
 "  -u ignore underflows in comparison\n"
 "  -o ignore overflows in comparison\n"
 "  -p FILE  PDF file output like dir/results.pdf\n"
-"  -w FILE  web page output like dir/dir/results.html\n"
+"  -w FILE  web page output like dir/dir/result.html\n"
+"          if only one file is given on the command line, make histgram plots\n"
 	 << std::endl;
   return;
 }
@@ -163,11 +167,37 @@ int main (int argc, char **argv)
         return 1;
       }
 
-  if( optind >= argc ) {
-    printf("ERROR - need two histogram file names on the command line\n");
+  std::string opt;
+  if(q12) {
+    opt.append("1X2");
+  } else if (q22) {
+    opt.append("2X2");
+  }
+
+  int nFile = argc-optind;
+
+  if( nFile <= 0 ) {
+    printf("ERROR - no histogram files on the command line\n");
     valCompare_usage();
     return 1;
+  } else if( nFile == 1 ) {
+    if(!webPage && !pdfFile) {
+      printf("ERROR - one histogram file specified, but no output requested\n");
+      valCompare_usage();
+      return 1;
+    }
+
+    TValCompare pp;
+    pp.SetVerbose(verbose);
+    pp.SetFile1(argv[optind]);
+    pp.OneFile();
+    if(pdfFile) pp.SaveAs(pdfFile,opt.c_str());
+    if(webPage) pp.SaveAs1(webPage);
+    return 0;
   }
+
+  // 2-file comparison mode
+
   TValCompare pp;
   pp.SetVerbose(verbose);
   pp.SetFile1(argv[optind]);
@@ -190,12 +220,6 @@ int main (int argc, char **argv)
   pp.Analyze();
   if(qReport) pp.Report();
   if(qSummary) pp.Summary();
-  std::string opt;
-  if(q12) {
-    opt.append("1X2");
-  } else if (q22) {
-    opt.append("2X2");
-  }
   if(qBrowse) pp.Display(opt.c_str());
   if(pdfFile) pp.SaveAs(pdfFile,opt.c_str());
   if(webPage) pp.SaveAs(webPage,opt.c_str());


### PR DESCRIPTION
Usually valCompare compares two files.  If given only one file, and a request to make a web page or a pdf file, then write output in a format appropriate for displaying one file.  This is just a convenient way to display and share the histograms of one file.