### PR TITLE
mchistory

### DIFF
--- a/EventGenerator/src/CeEndpoint_module.cc
+++ b/EventGenerator/src/CeEndpoint_module.cc
@@ -16,6 +16,7 @@
 #include "CLHEP/Units/PhysicalConstants.h"
 
 #include "fhiclcpp/types/Atom.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
 
 #include "art/Framework/Core/EDFilter.h"
 #include "art/Framework/Core/ModuleMacros.h"

--- a/EventGenerator/src/CeEndpoint_module.cc
+++ b/EventGenerator/src/CeEndpoint_module.cc
@@ -1,0 +1,139 @@
+// Generates electron at the endpoint energy that will be attached to a mu- in
+// the input SimParticleCollection.   If no suitable muon is found, the
+// filter does not pass the event.
+//
+// Andrei Gaponenko, 2021
+
+#include <iostream>
+#include <string>
+#include <cmath>
+#include <memory>
+
+#include "CLHEP/Vector/ThreeVector.h"
+#include "CLHEP/Vector/LorentzVector.h"
+#include "CLHEP/Random/RandomEngine.h"
+#include "CLHEP/Random/RandExponential.h"
+#include "CLHEP/Units/PhysicalConstants.h"
+
+#include "fhiclcpp/types/Atom.h"
+
+#include "art/Framework/Core/EDFilter.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+
+#include "SeedService/inc/SeedService.hh"
+#include "GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "GlobalConstantsService/inc/ParticleDataTable.hh"
+#include "GlobalConstantsService/inc/PhysicsParams.hh"
+#include "Mu2eUtilities/inc/RandomUnitSphere.hh"
+#include "DataProducts/inc/PDGCode.hh"
+#include "MCDataProducts/inc/StageParticle.hh"
+
+namespace mu2e {
+
+  //================================================================
+  class CeEndpoint : public art::EDFilter {
+  public:
+    struct Config {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      fhicl::Atom<art::InputTag> inputSimParticles{Name("inputSimParticles"),
+          Comment("A SimParticleCollection with input stopped muons.")};
+      fhicl::Atom<std::string> stoppingTargetMaterial{
+        Name("stoppingTargetMaterial"),
+          Comment("Material determines endpoint energy and muon life time.  Material must be known to the GlobalConstantsService."),
+          "Al" };
+      fhicl::Atom<unsigned> verbosity{Name("verbosity"),0};
+    };
+
+    using Parameters= art::EDFilter::Table<Config>;
+    explicit CeEndpoint(const Parameters& conf);
+
+    virtual bool filter(art::Event& event) override;
+
+    //----------------------------------------------------------------
+  private:
+    const PDGCode::type electronId_ = PDGCode::e_minus;
+    double electronMass_;
+    double endPointEnergy_;
+    double endPointMomentum_;
+    double muonLifeTime_;
+
+    art::ProductToken<SimParticleCollection> const simsToken_;
+
+    unsigned verbosity_;
+
+    art::RandomNumberGenerator::base_engine_t& eng_;
+    CLHEP::RandExponential randExp_;
+    RandomUnitSphere   randomUnitSphere_;
+  };
+
+  //================================================================
+  CeEndpoint::CeEndpoint(const Parameters& conf)
+    : EDFilter{conf}
+    , electronMass_(GlobalConstantsHandle<ParticleDataTable>()->particle(electronId_).ref().mass().value())
+    , endPointEnergy_{GlobalConstantsHandle<PhysicsParams>()->getEndpointEnergy(conf().stoppingTargetMaterial())}
+    , endPointMomentum_{ endPointEnergy_*sqrt(1 - std::pow(electronMass_/endPointEnergy_,2)) }
+    , muonLifeTime_{GlobalConstantsHandle<PhysicsParams>()->getDecayTime(conf().stoppingTargetMaterial())}
+    , simsToken_{consumes<SimParticleCollection>(conf().inputSimParticles())}
+    , verbosity_{conf().verbosity()}
+    , eng_{createEngine(art::ServiceHandle<SeedService>()->getSeed())}
+    , randExp_{eng_}
+    , randomUnitSphere_{eng_}
+  {
+    produces<mu2e::StageParticleCollection>();
+    if(verbosity_ > 0) {
+      mf::LogInfo log("CeEndpoint");
+      log<<"stoppingTargetMaterial = "<<conf().stoppingTargetMaterial()
+         <<", endpoint energy = "<<endPointEnergy_
+         <<", muon lifetime = "<<muonLifeTime_
+         <<std::endl;
+    }
+  }
+
+  //================================================================
+  bool CeEndpoint::filter(art::Event& event) {
+    auto output{std::make_unique<StageParticleCollection>()};
+
+    const auto simh = event.getValidHandle<SimParticleCollection>(simsToken_);
+
+    const auto& sims = *simh;
+    if(!sims.empty()) {
+      const auto stage = sims.back().second.simStage();
+
+      // We want to find a single stopped muon.   Even if an event contains multiple
+      // mu stops, we should not create multiple conversion electrons per event.
+      art::Ptr<SimParticle> mustop;
+
+      for(auto i = sims.rbegin(); i != sims.rend(); ++i) {
+        const auto& inpart = i->second;
+        if((inpart.simStage() == stage) &&
+           (inpart.pdgId() == PDGCode::mu_minus) &&
+           (inpart.stoppingCode() == ProcessCode::muMinusCaptureAtRest)) // G4 sets this code for both decay and capture cases
+          {
+            mustop = art::Ptr<SimParticle>(simh, i->first.asInt());
+            break;
+          }
+      }
+
+      if(mustop) {
+        output->emplace_back(mustop,
+                             ProcessCode::muMinusConversionAtRest,
+                             PDGCode::e_minus,
+                             mustop->endPosition(),
+                             CLHEP::HepLorentzVector{randomUnitSphere_.fire(endPointMomentum_), endPointEnergy_},
+                             mustop->endGlobalTime() + randExp_.fire(muonLifeTime_)
+                             );
+      }
+    }
+
+    const bool passed = !output->empty();
+    event.put(std::move(output));
+    return passed;
+  }
+
+  //================================================================
+} // namespace mu2e
+
+DEFINE_ART_MODULE(mu2e::CeEndpoint);

--- a/EventGenerator/test/CeEndpoint.fcl
+++ b/EventGenerator/test/CeEndpoint.fcl
@@ -1,0 +1,25 @@
+#include "fcl/minimalMessageService.fcl"
+#include "fcl/standardProducers.fcl"
+#include "fcl/standardServices.fcl"
+
+process_name: CeEndpoint
+
+source: { module_type: RootInput }
+
+services: @local::Services.Sim
+
+physics : {
+   filters: {
+      generate: {
+         module_type: CeEndpoint
+         inputSimParticles: "TargetStopFilter"
+         verbosity: 1
+      }
+   }
+
+   p1: [ generate ]
+   trigger_paths : [ p1 ]
+}
+
+services.SeedService.maxUniqueEngines: 20
+services.SeedService.baseSeed: 1

--- a/MCDataProducts/inc/StageParticle.hh
+++ b/MCDataProducts/inc/StageParticle.hh
@@ -1,0 +1,60 @@
+// In some cases we want to re-sample an existing SimParticle and
+// generate its daughters "by hand" rather than letting G4 do it.
+// This class holds information produced by such custom generators
+// and is used as input to Mu2eG4.
+//
+// Andrei Gaponenko, 2021
+
+#ifndef MCDataProducts_StageParticle_hh
+#define MCDataProducts_StageParticle_hh
+
+#include "DataProducts/inc/PDGCode.hh"
+#include "CLHEP/Vector/LorentzVector.h"
+#include "CLHEP/Vector/ThreeVector.h"
+
+#include "canvas/Persistency/Common/Ptr.h"
+#include "MCDataProducts/inc/SimParticle.hh"
+
+#include <vector>
+
+namespace mu2e {
+
+  class StageParticle {
+  public:
+
+    StageParticle() = default;
+
+    StageParticle(art::Ptr<SimParticle> parent,
+                  ProcessCode creationCode,
+                  PDGCode::type pdgId,
+                  CLHEP::Hep3Vector position,
+                  CLHEP::HepLorentzVector momentum,
+                  double time)
+      : parent_(parent)
+      , creationCode_{creationCode}
+      , pdgId_{pdgId}
+      , position_{position}
+      , momentum_{momentum}
+      , time_{time}
+    {}
+
+    art::Ptr<SimParticle> parent() const { return parent_; }
+    ProcessCode creationCode() const { return creationCode_; }
+    PDGCode::type pdgId() const { return pdgId_; }
+    double time() const { return time_;}
+    const CLHEP::Hep3Vector& position() const { return position_;}
+    const CLHEP::HepLorentzVector& momentum() const { return momentum_;}
+
+  private:
+    art::Ptr<SimParticle> parent_;
+    ProcessCode creationCode_;
+    PDGCode::type pdgId_ = PDGCode::null;
+    CLHEP::Hep3Vector position_;
+    CLHEP::HepLorentzVector momentum_;
+    double time_ = 0;
+  };
+
+  typedef std::vector<mu2e::StageParticle> StageParticleCollection;
+}
+
+#endif /* MCDataProducts_StageParticle_hh */

--- a/MCDataProducts/src/classes.h
+++ b/MCDataProducts/src/classes.h
@@ -20,6 +20,7 @@
 #include "MCDataProducts/inc/GenSimParticleLink.hh"
 #include "MCDataProducts/inc/GenEventCount.hh"
 #include "MCDataProducts/inc/FixedTimeMap.hh"
+#include "MCDataProducts/inc/StageParticle.hh"
 
 // simulation
 #include "MCDataProducts/inc/StatusG4.hh"

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -34,7 +34,9 @@
  <class name="mu2e::FixedTimeMap"/>
  <class name="art::Wrapper<mu2e::FixedTimeMap>" />
 
-
+ <class name="mu2e::StageParticle"/>
+ <class name="mu2e::StageParticleCollection"/>
+ <class name="art::Wrapper<mu2e::StageParticleCollection>"/>
 
 <!--  ********* simulation  ********* -->
  <class name="mu2e::StatusG4"/>

--- a/Mu2eG4/fcl/g4test_mustops.fcl
+++ b/Mu2eG4/fcl/g4test_mustops.fcl
@@ -21,7 +21,6 @@ physics : {
          module_type: ResamplingMixer
          fileNames: [ "mustops/sim.brownd.TargetStops.MDC2020c.001202_00000000.art" ]
          mu2e: {
-            nSecondaries: 1
             products: {
                genParticleMixer: { mixingMap: [ [ "beamResampler", "" ] ] }
                simParticleMixer: { mixingMap: [ [ "TargetStopFilter", "" ] ] }

--- a/Mu2eG4/fcl/g4test_mustops.fcl
+++ b/Mu2eG4/fcl/g4test_mustops.fcl
@@ -1,0 +1,103 @@
+# Mu2eG4 config file to test a continuation stage of a multistage job
+# in a resampling setup that uses StageParticles.
+#
+# Andrei Gaponenko, 2021
+
+#include "fcl/minimalMessageService.fcl"
+#include "fcl/standardProducers.fcl"
+#include "fcl/standardServices.fcl"
+
+# Give this job a name.
+process_name : g4mu1
+
+source : { module_type : EmptyEvent maxEvents: 10 }
+
+services : { @table::Services.Sim }
+
+physics : {
+
+   filters: {
+      rsmix: {
+         module_type: ResamplingMixer
+         fileNames: [ "mustops/sim.brownd.TargetStops.MDC2020c.001202_00000000.art" ]
+         mu2e: {
+            nSecondaries: 1
+            products: {
+               genParticleMixer: { mixingMap: [ [ "beamResampler", "" ] ] }
+               simParticleMixer: { mixingMap: [ [ "TargetStopFilter", "" ] ] }
+               stepPointMCMixer: { mixingMap: [
+                     [ "TargetStopFilter:virtualdetector", ":" ]
+                  ] }
+               volumeInfoMixer: {
+                  srInput: "compressPVTargetStops"
+                  evtOutInstanceName: "eventlevel"
+               }
+            }
+         }
+      }
+
+      generate: {
+         module_type: CeEndpoint
+         inputSimParticles: "rsmix"
+         verbosity: 1
+      }
+   }
+
+   producers: {
+      g4run : @local::g4run
+
+      # Save state of the random number engines.
+      randomsaver : @local::randomsaver
+   }
+
+   analyzers: {
+      validation : { module_type : Validation }
+   }
+
+   p1 : [rsmix, generate, g4run]
+   e1:  [validation, fullOutput,uncompressedOutput]
+   trigger_paths: [p1]
+   end_paths: [e1]
+}
+
+outputs: {
+   fullOutput : {
+      module_type : RootOutput
+      fileName    : "sim.owner.g4test_mix1-full.ver.seq.art"
+   }
+
+   uncompressedOutput : {
+      module_type : RootOutput
+      outputCommands: [
+         "keep *_*_*_*",
+         "drop *_*_eventlevel_*",
+         "drop *_rsmix_*_*",
+         "keep mu2e::GenParticles_*_*_*",
+         "keep art::EventIDs_*_*_*"
+      ]
+      fileName    : "sim.owner.g4test_mix1-uc.ver.seq.art"
+   }
+}
+
+
+physics.producers.g4run.physics.physicsListName: "QGSP_BERT" # faster than default
+physics.producers.g4run.SDConfig.enableSD: [virtualdetector ]
+physics.producers.g4run.SimParticlePrinter: { enabled: true prefix: "Mu2eG4" }
+physics.producers.g4run.Mu2eG4CommonCut: @local::mu2eg4CutDeltaElectrons
+physics.producers.g4run.inputs: {
+   primaryType: StageParticles
+   primaryTag: "generate"
+   inputMCTrajectories: ""
+
+   simStageOverride: 2
+   inputPhysVolumeMultiInfo: "rsmix"
+   updateEventLevelVolumeInfos: {
+      input: "rsmix:eventlevel"
+      outInstance: "eventlevel"
+   }
+}
+
+services.TFileService.fileName: "nts.owner.g4test_mu1.ver.seq.root"
+
+services.SeedService.baseSeed         :  8
+services.SeedService.maxUniqueEngines :  20

--- a/Mu2eG4/fcl/g4test_mustops.fcl
+++ b/Mu2eG4/fcl/g4test_mustops.fcl
@@ -34,15 +34,15 @@ physics : {
             }
          }
       }
+   }
 
+   producers: {
       generate: {
          module_type: CeEndpoint
          inputSimParticles: "rsmix"
          verbosity: 1
       }
-   }
 
-   producers: {
       g4run : @local::g4run
 
       # Save state of the random number engines.

--- a/Mu2eG4/inc/Mu2eG4PrimaryType.hh
+++ b/Mu2eG4/inc/Mu2eG4PrimaryType.hh
@@ -32,6 +32,7 @@
   X( GenParticles )                                  \
   X( StepPoints )                                    \
   X( SimParticleLeaves )                             \
+  X( StageParticles )                                \
   /**/
 
 namespace mu2e {

--- a/Mu2eG4/inc/SimParticlePrimaryHelper.hh
+++ b/Mu2eG4/inc/SimParticlePrimaryHelper.hh
@@ -21,8 +21,6 @@
 #include "MCDataProducts/inc/GenParticle.hh"
 #include "MCDataProducts/inc/SimParticle.hh"
 
-namespace art { class Event; }
-
 namespace mu2e {
 
   class StepPointMC;
@@ -39,8 +37,7 @@ namespace mu2e {
     InputParticle;
 
 
-    SimParticlePrimaryHelper(const art::Event* event,
-                             const art::ProductID& simProdID,
+    SimParticlePrimaryHelper(const art::ProductID& simProdID,
                              const art::EDProductGetter* sim_prod_getter);
 
     art::Ptr<GenParticle> genParticlePtr(int g4TrkID) const;
@@ -60,7 +57,6 @@ namespace mu2e {
 
     // need these to create art::Ptr to the new SimParticles
     art::ProductID simProdID_;
-    const art::Event* event_;
     const art::EDProductGetter* simProductGetter_;
   };
 }

--- a/Mu2eG4/inc/SimParticlePrimaryHelper.hh
+++ b/Mu2eG4/inc/SimParticlePrimaryHelper.hh
@@ -30,6 +30,14 @@ namespace mu2e {
 
   class SimParticlePrimaryHelper {
   public:
+    // We need to keep the original art::Ptr just for GenParticles.
+    // For other cases a Ptr to the new collection will have to be created anyway, so do not bother.
+    typedef std::variant<art::Ptr<GenParticle>,
+                         const SimParticle*,
+                         const StepPointMC*,
+                         const StageParticle*>
+    InputParticle;
+
 
     SimParticlePrimaryHelper(const art::Event* event,
                              const art::ProductID& simProdID,
@@ -38,19 +46,14 @@ namespace mu2e {
     art::Ptr<GenParticle> genParticlePtr(int g4TrkID) const;
     art::Ptr<SimParticle> simParticlePrimaryPtr(int g4TrkID) const;
 
+
+    InputParticle getEntry(int g4TrkID) const;
+
     template<class T> void addEntry(T t) {
       entries_.emplace_back(t);
     }
 
   private:
-
-    // We need to keep the original art::Ptr just for GenParticles.
-    // For other cases a Ptr to the new collection will have to be created anyway, so do not bother.
-    typedef std::variant<art::Ptr<GenParticle>,
-                         const SimParticle*,
-                         const StepPointMC*,
-                         const StageParticle*>
-    InputParticle;
 
     typedef std::vector<InputParticle> Entries;
     Entries entries_;

--- a/Mu2eG4/inc/SimParticlePrimaryHelper.hh
+++ b/Mu2eG4/inc/SimParticlePrimaryHelper.hh
@@ -1,5 +1,5 @@
 // A G4 primary can be created from a GenParticle or from a
-// StepPointMC from a previous simulation stage.  This is a
+// supported object from a previous simulation stage.  This is a
 // bookkeeping helper to provide GenParticle and parent Ptrs for
 // SimParticles that are primary in the current simulation stage.
 // PrimaryGeneratorAction puts information in, and TrackingAction
@@ -7,24 +7,26 @@
 // to an existing collection, while SimParticle Ptrs point to the
 // one which is being produced by the current G4 job.
 //
-// Andrei Gaponenko, 2013
+// Andrei Gaponenko, 2013, 2021
 
 #ifndef Mu2eG4_inc_SimParticlePrimaryHelper
 #define Mu2eG4_inc_SimParticlePrimaryHelper
 
 #include <vector>
+#include <variant>
 
 #include "canvas/Persistency/Common/Ptr.h"
 #include "art/Framework/Principal/Handle.h"
 
 #include "MCDataProducts/inc/GenParticle.hh"
-#include "MCDataProducts/inc/GenParticleCollection.hh"
 #include "MCDataProducts/inc/SimParticle.hh"
-#include "MCDataProducts/inc/SimParticleCollection.hh"
 
 namespace art { class Event; }
 
 namespace mu2e {
+
+  class StepPointMC;
+  class StageParticle;
 
   class SimParticlePrimaryHelper {
   public:
@@ -33,38 +35,30 @@ namespace mu2e {
                              const art::ProductID& simProdID,
                              const art::EDProductGetter* sim_prod_getter);
 
-    unsigned numPrimaries() const { return entries_.size(); }
+    art::Ptr<GenParticle> genParticlePtr(int g4TrkID) const;
+    art::Ptr<SimParticle> simParticlePrimaryPtr(int g4TrkID) const;
 
-    const art::Ptr<GenParticle>& genParticlePtr(int g4TrkID) const {
-      return entries_.at(g4TrkID - 1).genParticlePtr;
+    template<class T> void addEntry(T t) {
+      entries_.emplace_back(t);
     }
-
-    const art::Ptr<SimParticle>& simParticlePrimaryPtr(int g4TrkID) const {
-      return entries_.at(g4TrkID - 1).simParticlePrimaryPtr;
-    }
-
-    void addEntryFromGenParticle(const art::ValidHandle<GenParticleCollection>& gensHandle, unsigned genId);
-
-    void addEntryFromSimParticleId (SimParticleCollection::key_type simId);
 
   private:
 
-    struct Entry {
-      art::Ptr<GenParticle> genParticlePtr;
-      art::Ptr<SimParticle> simParticlePrimaryPtr;
-      Entry(const art::Ptr<GenParticle>& g, const art::Ptr<SimParticle>& p)
-        : genParticlePtr(g), simParticlePrimaryPtr(p)
-      {}
-    };
+    // We need to keep the original art::Ptr just for GenParticles.
+    // For other cases a Ptr to the new collection will have to be created anyway, so do not bother.
+    typedef std::variant<art::Ptr<GenParticle>,
+                         const SimParticle*,
+                         const StepPointMC*,
+                         const StageParticle*>
+    InputParticle;
 
-    typedef std::vector<Entry> Entries;
+    typedef std::vector<InputParticle> Entries;
     Entries entries_;
 
-    // need these to create art::Ptr to SimParticles
+    // need these to create art::Ptr to the new SimParticles
     art::ProductID simProdID_;
     const art::Event* event_;
     const art::EDProductGetter* simProductGetter_;
-
   };
 }
 

--- a/Mu2eG4/src/Mu2eG4EventAction.cc
+++ b/Mu2eG4/src/Mu2eG4EventAction.cc
@@ -11,7 +11,6 @@
 #include "Mu2eG4/inc/Mu2eG4SteppingAction.hh"
 #include "Mu2eG4/inc/SensitiveDetectorHelper.hh"
 #include "Mu2eG4/inc/SimParticleHelper.hh"
-#include "Mu2eG4/inc/SimParticlePrimaryHelper.hh"
 #include "MCDataProducts/inc/ExtMonFNALSimHitCollection.hh"
 #include "MCDataProducts/inc/SimParticleRemapping.hh"
 #include "Mu2eG4/inc/IMu2eG4Cut.hh"

--- a/Mu2eG4/src/Mu2eG4IOConfigHelper.cc
+++ b/Mu2eG4/src/Mu2eG4IOConfigHelper.cc
@@ -11,6 +11,7 @@
 #include "MCDataProducts/inc/SimParticleCollection.hh"
 #include "MCDataProducts/inc/SimParticleRemapping.hh"
 #include "MCDataProducts/inc/StepPointMCCollection.hh"
+#include "MCDataProducts/inc/StageParticle.hh"
 #include "MCDataProducts/inc/MCTrajectoryCollection.hh"
 #include "MCDataProducts/inc/PhysicalVolumeInfoMultiCollection.hh"
 
@@ -51,6 +52,10 @@ namespace mu2e {
 
     case Mu2eG4PrimaryType::SimParticleLeaves:
       cc.consumes<SimParticleCollection>(inputs_.primaryTag());
+      break;
+
+    case Mu2eG4PrimaryType::StageParticles:
+      cc.consumes<StageParticleCollection>(inputs_.primaryTag());
       break;
     }
 

--- a/Mu2eG4/src/Mu2eG4MT_module.cc
+++ b/Mu2eG4/src/Mu2eG4MT_module.cc
@@ -20,8 +20,6 @@
 #include "Mu2eG4/inc/checkConfigRelics.hh"
 #include "Mu2eG4/inc/Mu2eG4WorkerRunManager.hh"
 #include "Mu2eG4/inc/MTMasterThread.hh"
-#include "Mu2eG4/inc/SimParticleHelper.hh"
-#include "Mu2eG4/inc/SimParticlePrimaryHelper.hh"
 #include "Mu2eG4/inc/Mu2eG4Config.hh"
 #include "Mu2eG4/inc/Mu2eG4IOConfigHelper.hh"
 #include "Mu2eG4/inc/writePhysicalVolumes.hh"

--- a/Mu2eG4/src/Mu2eG4PerThreadStorage.cc
+++ b/Mu2eG4/src/Mu2eG4PerThreadStorage.cc
@@ -29,7 +29,7 @@ namespace mu2e {
     art::EDProductGetter const* simProductGetter = evt->productGetter(simPartId);
 
     simParticleHelper.emplace(simStage, ioconf.inputs(), simPartId, evt, simProductGetter);
-    simParticlePrimaryHelper.emplace(evt, simPartId, simProductGetter);
+    simParticlePrimaryHelper.emplace(simPartId, simProductGetter);
 
     // Output collections
     simPartCollection = std::unique_ptr<SimParticleCollection>( new SimParticleCollection );

--- a/Mu2eG4/src/Mu2eG4PrimaryGeneratorAction.cc
+++ b/Mu2eG4/src/Mu2eG4PrimaryGeneratorAction.cc
@@ -90,7 +90,7 @@ namespace mu2e {
                       genpart.properTime(),
                       genpart.momentum());
 
-        perThreadObjects_->simParticlePrimaryHelper->addEntryFromGenParticle(h, i);
+        perThreadObjects_->simParticlePrimaryHelper->addEntry(art::Ptr<GenParticle>(h, i));
       }
     }
       break; // GenParticles
@@ -108,7 +108,7 @@ namespace mu2e {
                       hit.properTime(),
                       hit.momentum());
 
-        perThreadObjects_->simParticlePrimaryHelper->addEntryFromSimParticleId(hit.simParticle()->id());
+        perThreadObjects_->simParticlePrimaryHelper->addEntry(&hit);
       }
     }
       break; // StepPoints
@@ -130,7 +130,7 @@ namespace mu2e {
                         particle.endProperTime(),
                         particle.endMomentum());
 
-          perThreadObjects_->simParticlePrimaryHelper->addEntryFromSimParticleId(particle.id());
+          perThreadObjects_->simParticlePrimaryHelper->addEntry(&particle);
         }
       }
     }
@@ -151,7 +151,7 @@ namespace mu2e {
                       0, //proper
                       s.momentum());
 
-        perThreadObjects_->simParticlePrimaryHelper->addEntryFromSimParticleId(s.parent()->id());
+        perThreadObjects_->simParticlePrimaryHelper->addEntry(&s);
       }
     }
       break; // SimParticles

--- a/Mu2eG4/src/Mu2eG4PrimaryGeneratorAction.cc
+++ b/Mu2eG4/src/Mu2eG4PrimaryGeneratorAction.cc
@@ -29,6 +29,7 @@
 #include "Mu2eUtilities/inc/ThreeVectorUtil.hh"
 #include "MCDataProducts/inc/GenParticleCollection.hh"
 #include "MCDataProducts/inc/StepPointMCCollection.hh"
+#include "MCDataProducts/inc/StageParticle.hh"
 #include "GeometryService/inc/GeomHandle.hh"
 #include "GeometryService/inc/WorldG4.hh"
 #include "DataProducts/inc/PDGCode.hh"
@@ -131,6 +132,26 @@ namespace mu2e {
 
           perThreadObjects_->simParticlePrimaryHelper->addEntryFromSimParticleId(particle.id());
         }
+      }
+    }
+      break; // SimParticles
+
+    case Mu2eG4PrimaryType::StageParticles: {
+      auto const h = artEvent->getValidHandle<StageParticleCollection>(inputs.primaryTag());
+      for(const auto& s : *h) {
+        addG4Particle(event,
+                      s.pdgId(),
+
+                      0.0, // no excited ions here
+                      0,
+
+                      // Transform into G4 world coordinate system
+                      s.position() + mu2eOrigin,
+                      s.time(),
+                      0, //proper
+                      s.momentum());
+
+        perThreadObjects_->simParticlePrimaryHelper->addEntryFromSimParticleId(s.parent()->id());
       }
     }
       break; // SimParticles

--- a/Mu2eG4/src/SimParticlePrimaryHelper.cc
+++ b/Mu2eG4/src/SimParticlePrimaryHelper.cc
@@ -7,9 +7,6 @@
 
 #include "cetlib_except/exception.h"
 
-#include <iostream>
-#define AGDEBUG(stuff) std::cerr<<"AG: "<<__FILE__<<", line "<<__LINE__<<": "<<stuff<<std::endl;
-
 namespace mu2e {
 
   //================================================================
@@ -63,7 +60,6 @@ namespace mu2e {
 
   //================================================================
   SimParticlePrimaryHelper::InputParticle SimParticlePrimaryHelper::getEntry(int g4TrkID) const {
-    AGDEBUG("size = "<<entries_.size()<<", g4TrkID = "<<g4TrkID);
     return entries_.at(g4TrkID-1);
   }
 

--- a/Mu2eG4/src/SimParticlePrimaryHelper.cc
+++ b/Mu2eG4/src/SimParticlePrimaryHelper.cc
@@ -3,6 +3,11 @@
 #include "Mu2eG4/inc/SimParticlePrimaryHelper.hh"
 #include "art/Framework/Principal/Event.h"
 
+#include "MCDataProducts/inc/StepPointMC.hh"
+#include "MCDataProducts/inc/StageParticle.hh"
+
+#include "cetlib_except/exception.h"
+
 namespace mu2e {
   SimParticlePrimaryHelper::SimParticlePrimaryHelper(const art::Event* event,
                                                      const art::ProductID& simProdID,
@@ -12,19 +17,44 @@ namespace mu2e {
     simProductGetter_(sim_prod_getter)
   {}
 
-  void SimParticlePrimaryHelper::addEntryFromGenParticle(const art::ValidHandle<GenParticleCollection>& gensHandle, unsigned genId)
-  {
-    entries_.emplace_back(art::Ptr<GenParticle>(gensHandle, genId),
-                          art::Ptr<SimParticle>(simProdID_) );
+  art::Ptr<GenParticle> SimParticlePrimaryHelper::genParticlePtr(int g4TrkID) const {
+    art::Ptr<GenParticle> res;
+    auto pgen = std::get_if<art::Ptr<GenParticle> >(&entries_.at(g4TrkID - 1));
+    if(pgen) {
+      res = *pgen;
+    }
+    return res;
   }
 
+  art::Ptr<SimParticle>  SimParticlePrimaryHelper::simParticlePrimaryPtr(int g4TrkID) const {
+    auto& v = entries_.at(g4TrkID - 1);
 
-  void SimParticlePrimaryHelper::addEntryFromSimParticleId(SimParticleCollection::key_type simId)
-  {
-    art::Handle<GenParticleCollection> gensHandle;
-    entries_.emplace_back(art::Ptr<GenParticle>(gensHandle.id()),
-                          art::Ptr<SimParticle>(simProdID_,
-                                                simId.asUint(),
-                                                simProductGetter_));
+    if(std::holds_alternative<art::Ptr<GenParticle>>(v)) {
+      return art::Ptr<SimParticle>();
+    }
+    else {
+
+      SimParticle::key_type id;
+      if(std::holds_alternative<const SimParticle*>(v)) {
+        std::cout<<"simParticlePrimaryPtr from SimParticle*"<<std::endl;
+        id = std::get<const SimParticle*>(v)->id();
+      }
+      else if(std::holds_alternative<const  StepPointMC*>(v)) {
+        std::cout<<"simParticlePrimaryPtr from StepPointMC*"<<std::endl;
+        id = std::get<const StepPointMC*>(v)->simParticle()->id();
+      }
+      else if(std::holds_alternative<const StageParticle*>(v)) {
+        std::cout<<"simParticlePrimaryPtr from StageParticle*"<<std::endl;
+        id = std::get<const StageParticle*>(v)->parent()->id();
+      }
+
+      try { id.ensure_valid(); }
+      catch(cet::exception& e) {
+        throw cet::exception("ImplementationError", "SimParticlePrimaryHelper::simParticlePrimaryPtr(int) missed a variant alternative", e);
+      }
+
+      return art::Ptr<SimParticle>(simProdID_, id.asUint(), simProductGetter_);
+    }
   }
+
 }

--- a/Mu2eG4/src/SimParticlePrimaryHelper.cc
+++ b/Mu2eG4/src/SimParticlePrimaryHelper.cc
@@ -1,7 +1,6 @@
 // Andrei Gaponenko, 2013
 
 #include "Mu2eG4/inc/SimParticlePrimaryHelper.hh"
-#include "art/Framework/Principal/Event.h"
 
 #include "MCDataProducts/inc/StepPointMC.hh"
 #include "MCDataProducts/inc/StageParticle.hh"
@@ -14,11 +13,9 @@
 namespace mu2e {
 
   //================================================================
-  SimParticlePrimaryHelper::SimParticlePrimaryHelper(const art::Event* event,
-                                                     const art::ProductID& simProdID,
+  SimParticlePrimaryHelper::SimParticlePrimaryHelper(const art::ProductID& simProdID,
                                                      const art::EDProductGetter* sim_prod_getter):
     simProdID_(simProdID),
-    event_(event),
     simProductGetter_(sim_prod_getter)
   {}
 

--- a/Mu2eG4/src/SimParticlePrimaryHelper.cc
+++ b/Mu2eG4/src/SimParticlePrimaryHelper.cc
@@ -8,7 +8,12 @@
 
 #include "cetlib_except/exception.h"
 
+#include <iostream>
+#define AGDEBUG(stuff) std::cerr<<"AG: "<<__FILE__<<", line "<<__LINE__<<": "<<stuff<<std::endl;
+
 namespace mu2e {
+
+  //================================================================
   SimParticlePrimaryHelper::SimParticlePrimaryHelper(const art::Event* event,
                                                      const art::ProductID& simProdID,
                                                      const art::EDProductGetter* sim_prod_getter):
@@ -17,6 +22,7 @@ namespace mu2e {
     simProductGetter_(sim_prod_getter)
   {}
 
+  //================================================================
   art::Ptr<GenParticle> SimParticlePrimaryHelper::genParticlePtr(int g4TrkID) const {
     art::Ptr<GenParticle> res;
     auto pgen = std::get_if<art::Ptr<GenParticle> >(&entries_.at(g4TrkID - 1));
@@ -26,6 +32,7 @@ namespace mu2e {
     return res;
   }
 
+  //================================================================
   art::Ptr<SimParticle>  SimParticlePrimaryHelper::simParticlePrimaryPtr(int g4TrkID) const {
     auto& v = entries_.at(g4TrkID - 1);
 
@@ -56,5 +63,13 @@ namespace mu2e {
       return art::Ptr<SimParticle>(simProdID_, id.asUint(), simProductGetter_);
     }
   }
+
+  //================================================================
+  SimParticlePrimaryHelper::InputParticle SimParticlePrimaryHelper::getEntry(int g4TrkID) const {
+    AGDEBUG("size = "<<entries_.size()<<", g4TrkID = "<<g4TrkID);
+    return entries_.at(g4TrkID-1);
+  }
+
+  //================================================================
 
 }

--- a/Mu2eG4/src/SimParticlePrimaryHelper.cc
+++ b/Mu2eG4/src/SimParticlePrimaryHelper.cc
@@ -19,7 +19,8 @@ namespace mu2e {
   //================================================================
   art::Ptr<GenParticle> SimParticlePrimaryHelper::genParticlePtr(int g4TrkID) const {
     art::Ptr<GenParticle> res;
-    auto pgen = std::get_if<art::Ptr<GenParticle> >(&entries_.at(g4TrkID - 1));
+    auto orig = getEntry(g4TrkID);
+    auto pgen = std::get_if<art::Ptr<GenParticle> >(&orig);
     if(pgen) {
       res = *pgen;
     }
@@ -28,25 +29,25 @@ namespace mu2e {
 
   //================================================================
   art::Ptr<SimParticle>  SimParticlePrimaryHelper::simParticlePrimaryPtr(int g4TrkID) const {
-    auto& v = entries_.at(g4TrkID - 1);
+    auto orig = getEntry(g4TrkID);
 
-    if(std::holds_alternative<art::Ptr<GenParticle>>(v)) {
+    if(std::holds_alternative<art::Ptr<GenParticle>>(orig)) {
       return art::Ptr<SimParticle>();
     }
     else {
 
       SimParticle::key_type id;
-      if(std::holds_alternative<const SimParticle*>(v)) {
+      if(std::holds_alternative<const SimParticle*>(orig)) {
         std::cout<<"simParticlePrimaryPtr from SimParticle*"<<std::endl;
-        id = std::get<const SimParticle*>(v)->id();
+        id = std::get<const SimParticle*>(orig)->id();
       }
-      else if(std::holds_alternative<const  StepPointMC*>(v)) {
+      else if(std::holds_alternative<const  StepPointMC*>(orig)) {
         std::cout<<"simParticlePrimaryPtr from StepPointMC*"<<std::endl;
-        id = std::get<const StepPointMC*>(v)->simParticle()->id();
+        id = std::get<const StepPointMC*>(orig)->simParticle()->id();
       }
-      else if(std::holds_alternative<const StageParticle*>(v)) {
+      else if(std::holds_alternative<const StageParticle*>(orig)) {
         std::cout<<"simParticlePrimaryPtr from StageParticle*"<<std::endl;
-        id = std::get<const StageParticle*>(v)->parent()->id();
+        id = std::get<const StageParticle*>(orig)->parent()->id();
       }
 
       try { id.ensure_valid(); }


### PR DESCRIPTION
This PR implements infrastructure for resampling stopped muons while preserving MC history of SimParticles, as presented in Mu2e Software meetings on May 12 and May 19.    Support for setting dedicated creationCode-s for SimParticles from Mu2e custom generators has been added since the meeting.   The infrastructure is complete,  I think it is ready for review and merge.

The remaining work related to this development is adding more generators for StageParticles - in particular, updating the pileup generator.  Also potentially updating the list of ProcessCodes.   Those developments may trigger discussions orthogonal to the current infrastructure PR and will be best handled by separate pull requests.