### PR TITLE
Only enable ExtMonFNALPixelSD when it is configured to be enabled.

### DIFF
--- a/Mu2eG4/src/Mu2eWorld.cc
+++ b/Mu2eG4/src/Mu2eWorld.cc
@@ -966,7 +966,7 @@ namespace mu2e {
 
 
     /************************** ExtMonFNALPixelSD **************************/
-    if(true) { // this SD does not derive from Mu2eG4SensitiveDetector as it does not produce StepPointMCCollection
+    if(  sdHelper_->extMonPixelsEnabled() ) {
       GeomHandle<mu2e::ExtMonFNAL::ExtMon> extmon;
       //SDman->AddNewDetector(new ExtMonFNALPixelSD(_config, *extmon));
 


### PR DESCRIPTION
Hot fix to creation of the Sensitive Detector for the ExtMon pixels.  Previously it was always created and registered with G4 even if the configuration said not to.  This led to seg faults because it was not serviced by SenstitiveDetectorHelper, which did obey the configuration. 
