### PR TITLE
remove obsolete test target

### DIFF
--- a/scripts/build/SConscript
+++ b/scripts/build/SConscript
@@ -14,7 +14,7 @@ if 'MUSE_WORK_DIR' in env:
     command = "Offline/"+command
 
 # each of these generates a useful file or runs a test
-targets = ["DEPS","GDML","ROVERLAPS","TEST03","GITPACK","RMSO","VAL0"]
+targets = ["DEPS","GDML","ROVERLAPS","TEST03","GITPACK","RMSO"]
 
 for target in targets:
     exe_env.AlwaysBuild(exe_env.Alias(target, [], 

--- a/scripts/build/bin/procs.sh
+++ b/scripts/build/bin/procs.sh
@@ -138,16 +138,6 @@ elif [ "$COMMAND" == "RMSO" ]; then
 	find . -name "*.o"  -delete
     fi
     rm -f .sconsign.dblite
-elif [ "$COMMAND" == "VAL0" ]; then
-    mkdir -p ${OUT}gen/val
-    mu2e -n 5 -c ${IN}Validation/fcl/ceSimReco.fcl -o ceSimReco.art -T /dev/null
-    [ $? -ne 0 ] && RC=1
-    mu2e -s ceSimReco.art -T ${OUT}gen/val/ceSimReco_5000.root -c ${IN}Validation/fcl/val.fcl
-    [ $? -ne 0 ] && RC=1
-    rm -f ceSimReco.art
-else
-  echo "[$(date)] procs.sh did not parse argument: $@"
-  exit 1
 fi
 
 if [ $RC -ne 0 ]; then


### PR DESCRIPTION
Remove the "VAL0" test target which will break once JobConfig is split in #468 
I don't think this is urgent since I think only the jenkins tagged Offline build uses it.
Also very low risk - this one use case is tested.