### PR TITLE
Provide geometry files with reduced BField coverage to save space

### DIFF
--- a/Mu2eG4/geom/bfgeom_no_ds_v01.txt
+++ b/Mu2eG4/geom/bfgeom_no_ds_v01.txt
@@ -1,0 +1,32 @@
+//
+// Variant of the bfield maps without the DS.
+//
+// Used to save memory in production running of G4 jobs
+// in which the DS is hidden by stopping rules in G4.
+// An example is stage 1 POT jobs.
+//
+// Warning:
+//  There are multiple points of maintenance when you change bfield.innerMaps
+//    - bfgeom_v01.txt       ( the base geometry  )
+//    - bfgeom_no_ds_v01.txt ( DS map removed     )
+//    - bfgeom_reco_v01.txt  ( only maps needed for reconstruction )
+//
+//  If more variants are added, update the comments in all relevant files.
+
+#include "Mu2eG4/geom/bfgeom_v01.txt"
+
+vector<string> bfield.innerMaps = {
+  "BFieldMaps/Mau13/PSMap.header",
+  "BFieldMaps/Mau13/TSuMap_fix.header",
+  "BFieldMaps/Mau13/TSdMap.header",
+  "BFieldMaps/Mau13/PStoDumpAreaMap.header",
+  "BFieldMaps/Mau13/ProtonDumpAreaMap.header",
+  "BFieldMaps/Mau13/DSExtension.header"
+};
+
+
+//
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/bfgeom_no_ds_v01.txt
+++ b/Mu2eG4/geom/bfgeom_no_ds_v01.txt
@@ -7,9 +7,10 @@
 //
 // Warning:
 //  There are multiple points of maintenance when you change bfield.innerMaps
-//    - bfgeom_v01.txt       ( the base geometry  )
-//    - bfgeom_no_ds_v01.txt ( DS map removed     )
-//    - bfgeom_reco_v01.txt  ( only maps needed for reconstruction )
+//    - bfgeom_v01.txt           ( the base geometry  )
+//    - bfgeom_no_ds_v01.txt     ( DS map removed     )
+//    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
+//    - bfgeom_no_tsu_ps_v01.txt ( PS and TSu maps removed.
 //
 //  If more variants are added, update the comments in all relevant files.
 

--- a/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt
+++ b/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt
@@ -1,6 +1,10 @@
 //
-// Variant of the B field maps used for reconstruction.  All B field maps
-// not needed for reconstruction have been removed.
+// Variant of the bfield maps without the PS and TSu maps.
+//
+// Used to save memory in production running of G4 jobs
+// when it is safe to do so.  We will use this in MDC2020
+// for resampling jobs, both from the stopping planes in stage
+// 1 and from stops in the DS.
 //
 // Warning:
 //  There are multiple points of maintenance when you change bfield.innerMaps
@@ -14,10 +18,12 @@
 #include "Mu2eG4/geom/bfgeom_v01.txt"
 
 vector<string> bfield.innerMaps = {
-  "BFieldMaps/Mau13/DSMap.header"
+  "BFieldMaps/Mau13/DSMap.header",
+  "BFieldMaps/Mau13/TSdMap.header",
+  "BFieldMaps/Mau13/PStoDumpAreaMap.header",
+  "BFieldMaps/Mau13/ProtonDumpAreaMap.header",
+  "BFieldMaps/Mau13/DSExtension.header"
 };
-
-vector<string> bfield.outerMaps = {};
 
 
 //

--- a/Mu2eG4/geom/bfgeom_reco_v01.txt
+++ b/Mu2eG4/geom/bfgeom_reco_v01.txt
@@ -13,7 +13,7 @@
 #include "Mu2eG4/geom/bfgeom_v01.txt"
 
 vector<string> bfield.innerMaps = {
-  "BFieldMaps/Mau13/DSMap.header",
+  "BFieldMaps/Mau13/DSMap.header"
 };
 
 vector<string> bfield.outerMaps = {};

--- a/Mu2eG4/geom/bfgeom_reco_v01.txt
+++ b/Mu2eG4/geom/bfgeom_reco_v01.txt
@@ -1,0 +1,26 @@
+//
+// Variant of the B field maps used for reconstruction.  All B field maps
+// not needed for reconstruction have been removed.
+//
+// Warning:
+//  There are multiple points of maintenance when you change bfield.innerMaps
+//    - bfgeom_v01.txt       ( the base geometry  )
+//    - bfgeom_no_ds_v01.txt ( DS map removed     )
+//    - bfgeom_reco_v01.txt  ( only maps needed for reconstruction )
+//
+//  If more variants are added, update the comments in all relevant files.
+
+#include "Mu2eG4/geom/bfgeom_v01.txt"
+
+vector<string> bfield.innerMaps = {
+  "BFieldMaps/Mau13/DSMap.header",
+};
+
+vector<string> bfield.outerMaps = {};
+
+
+//
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/bfgeom_v01.txt
+++ b/Mu2eG4/geom/bfgeom_v01.txt
@@ -1,0 +1,62 @@
+//
+// BField information maintained as a separate file.
+//
+// Warning:
+//  There are multiple points of maintenance when you change bfield.innerMaps
+//    - bfgeom_v01.txt       ( the base geometry  )
+//    - bfgeom_no_ds_v01.txt ( DS map removed     )
+//    - bfgeom_reco_v01.txt  ( only maps needed for reconstruction )
+//
+
+// Form of DS field: 0 is full field;
+//                   1 is full upstream, const downstream;
+//                   2 is const throughout
+int detSolFieldForm = 0;
+
+vector<string> bfield.innerMaps = {
+  "BFieldMaps/Mau13/DSMap.header",
+  "BFieldMaps/Mau13/PSMap.header",
+  "BFieldMaps/Mau13/TSuMap_fix.header",
+  "BFieldMaps/Mau13/TSdMap.header",
+  "BFieldMaps/Mau13/PStoDumpAreaMap.header",
+  "BFieldMaps/Mau13/ProtonDumpAreaMap.header",
+  "BFieldMaps/Mau13/DSExtension.header"
+};
+
+// Value of the uniform magnetic field with the DS volume (only for
+// detSolFieldForm>0)
+double toyDS.bz            = 1.0;
+
+// Gradient of field in DS2 volume. Applied only in the case
+// of detSolFieldForm=1 or detSolFieldForm=2.
+double toyDS.gradient      = 0.0; // Tesla/m
+
+// This is recommended field map. See geom_mecofield.txt to use the meco field.
+string bfield.format  = "G4BL";
+
+// The other option is "meco"
+string bfield.interpolationStyle = trilinear;
+
+int  bfield.verbosityLevel =  0;
+bool bfield.writeG4BLBinaries     =  false;
+
+vector<string> bfield.outerMaps = {
+  "BFieldMaps/Mau9/ExtMonUCIInternal1AreaMap.header",
+  "BFieldMaps/Mau9/ExtMonUCIInternal2AreaMap.header",
+  "BFieldMaps/Mau9/ExtMonUCIAreaMap.header",
+  "BFieldMaps/Mau13/PSAreaMap.header",
+  "BFieldMaps/Mau13/WorldMap.header"
+};
+
+// This scale factor is of limited use.
+// It can make approximate sense to scale the PS field to get a rough
+// answer; the answer will be wrong in detail.
+// It never makes sense to scale the TS field.
+// Not sure if it ever makes sense to scale the PS field.
+double bfield.scaleFactor = 1.0;
+
+//
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/bfgeom_v01.txt
+++ b/Mu2eG4/geom/bfgeom_v01.txt
@@ -3,9 +3,11 @@
 //
 // Warning:
 //  There are multiple points of maintenance when you change bfield.innerMaps
-//    - bfgeom_v01.txt       ( the base geometry  )
-//    - bfgeom_no_ds_v01.txt ( DS map removed     )
-//    - bfgeom_reco_v01.txt  ( only maps needed for reconstruction )
+//  There are multiple points of maintenance when you change bfield.innerMaps
+//    - bfgeom_v01.txt           ( the base geometry  )
+//    - bfgeom_no_ds_v01.txt     ( DS map removed     )
+//    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
+//    - bfgeom_no_tsu_ps_v01.txt ( PS and TSu maps removed.
 //
 
 // Form of DS field: 0 is full field;

--- a/Mu2eG4/geom/geom_2021_PhaseI.txt
+++ b/Mu2eG4/geom/geom_2021_PhaseI.txt
@@ -80,56 +80,8 @@ double mu2e.detectorSystemZ0 = 10171.;   // mm  G4BL: (17730-7292=9801 mm)
 //CRV counters
 #include "Mu2eG4/geom/crv_counters_v08.txt"
 
-
-//-------------------------------------------
-// Magnetic field
-//-------------------------------------------
-
-// Form of DS field: 0 is full field;
-//                   1 is full upstream, const downstream;
-//                   2 is const throughout
-int detSolFieldForm = 0;
-vector<string> bfield.innerMaps = {
-  "BFieldMaps/Mau13/DSMap.header",
-  "BFieldMaps/Mau13/PSMap.header",
-  "BFieldMaps/Mau13/TSuMap_fix.header",
-  "BFieldMaps/Mau13/TSdMap.header",
-  "BFieldMaps/Mau13/PStoDumpAreaMap.header",
-  "BFieldMaps/Mau13/ProtonDumpAreaMap.header",
-  "BFieldMaps/Mau13/DSExtension.header"
-};
-
-// Value of the uniform magnetic field with the DS volume (only for
-// detSolFieldForm>0)
-double toyDS.bz            = 1.0;
-
-// Gradient of field in DS2 volume. Applied only in the case
-// of detSolFieldForm=1 or detSolFieldForm=2.
-double toyDS.gradient      = 0.0; // Tesla/m
-
-// This is recommended field map. See geom_mecofield.txt to use the meco field.
-string bfield.format  = "G4BL";
-
-// The other option is "meco"
-string bfield.interpolationStyle = trilinear;
-
-int  bfield.verbosityLevel =  0;
-bool bfield.writeG4BLBinaries     =  false;
-
-vector<string> bfield.outerMaps = {
-  "BFieldMaps/Mau9/ExtMonUCIInternal1AreaMap.header",
-  "BFieldMaps/Mau9/ExtMonUCIInternal2AreaMap.header",
-  "BFieldMaps/Mau9/ExtMonUCIAreaMap.header",
-  "BFieldMaps/Mau13/PSAreaMap.header",
-  "BFieldMaps/Mau13/WorldMap.header"
-};
-
-// This scale factor is of limited use.
-// It can make approximate sense to scale the PS field to get a rough
-// answer; the answer will be wrong in detail.
-// It never makes sense to scale the TS field.
-// Not sure if it ever makes sense to scale the PS field.
-double bfield.scaleFactor = 1.0;
+// Magnetic field maps
+#include "Mu2eG4/geom/bfgeom_v01.txt"
 
 //---------------------------------------
 // Virtual detectors

--- a/Mu2eG4/geom/geom_common_no_ds.txt
+++ b/Mu2eG4/geom/geom_common_no_ds.txt
@@ -1,0 +1,13 @@
+//
+// Variant on geom_common.txt for production running of G4 jobs
+// in which the DS is hidden by stopping rules in G4.
+// The DS field map is removed to save space
+//
+
+#include "Mu2eG4/geom/geom_2021_PhaseI.txt"
+#include "Mu2eG4/geom/bfgeom_no_ds_v01.txt"
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_no_tsu_ps.txt
+++ b/Mu2eG4/geom/geom_common_no_tsu_ps.txt
@@ -1,0 +1,13 @@
+//
+// Variant on geom_common.txt for production running of G4 jobs
+// in which the DS is hidden by stopping rules in G4.
+// The DS field map is removed to save space
+//
+
+#include "Mu2eG4/geom/geom_2021_PhaseI.txt"
+#include "Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_reco.txt
+++ b/Mu2eG4/geom/geom_common_reco.txt
@@ -1,0 +1,14 @@
+//
+// Variant on geom_common.txt for running reco jobs.
+//
+// The first variant removes all bfield maps that
+// are not needed for reco.
+//
+
+#include "Mu2eG4/geom/geom_2021_PhaseI.txt"
+#include "Mu2eG4/geom/bfgeom_reco_v01.txt"
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:


### PR DESCRIPTION
I refactored Mu2eG4/geom/geom_2021_PhaseI.txt to remove all bfield information and replace it with a #include of a new file
Mu2eG4/geom/bfgeom_v01.txt, that contains the removed information.  I verified that  adding this to the .fcl file

<pre>
 services.GeometryService.printConfig : true
</pre>

produces identical geometry printtout.

I also provided two new variants of bfgeom_v01.txt.  One has the DSMap removed, which will save 113 MB and is useful for early stage simulation jobs in which particles never see the DS.  The other has all except the DSMap removed.  This is useful for reco jobs, and trigger jobs, that use only the DSMap; this will save about 280MB  The files are:

<pre>
Mu2eG4/geom/bfgeom_no_ds_v01.txt
Mu2eG4/geom/bfgeom_reco_v01.txt
</pre>

I also provided two variants of geom_common, that use the two above files to override the bfield definition:

<pre>
Mu2eG4/geom/geom_common_no_ds.txt
Mu2eG4/geom/geom_common_reco.txt
 </pre>

These have had limited testing.  I have only tested that g4test_03.fcl runs with no errors for two events ( it won't produce sensible output for the no_ds variant). And I have checked that the printConfig option on the geometry service produces the expected output.

If requested I can also provide variants of geom_common_current.txt.

The Mu2eII people can decide what to do with their branch.

I don't plan to retroactively update the historical geometry files.
