### PR TITLE
Minor updates to the magnetic field configuration

### DIFF
--- a/Mu2eG4/geom/bfgeom_no_ds_v01.txt
+++ b/Mu2eG4/geom/bfgeom_no_ds_v01.txt
@@ -21,8 +21,7 @@ vector<string> bfield.innerMaps = {
   "BFieldMaps/Mau13/TSuMap_fix.header",
   "BFieldMaps/Mau13/TSdMap.header",
   "BFieldMaps/Mau13/PStoDumpAreaMap.header",
-  "BFieldMaps/Mau13/ProtonDumpAreaMap.header",
-  "BFieldMaps/Mau13/DSExtension.header"
+  "BFieldMaps/Mau13/ProtonDumpAreaMap.header"
 };
 
 

--- a/Mu2eG4/geom/bfgeom_no_ds_v01.txt
+++ b/Mu2eG4/geom/bfgeom_no_ds_v01.txt
@@ -6,7 +6,7 @@
 // An example is stage 1 POT jobs.
 //
 // Warning:
-//  There are multiple points of maintenance when you change bfield.innerMaps
+//  There are multiple points of maintenance when you change any bfield maps.
 //    - bfgeom_v01.txt           ( the base geometry  )
 //    - bfgeom_no_ds_v01.txt     ( DS map removed     )
 //    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )

--- a/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt
+++ b/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt
@@ -1,5 +1,15 @@
 //
 // Variant of the bfield maps without the PS and TSu maps.
+// Also remove the maps between the PS and the ExtMon
+//
+// innerMaps removed:
+//    "BFieldMaps/Mau13/PSMap.header",
+//    "BFieldMaps/Mau13/TSuMap_fix.header",
+//    "BFieldMaps/Mau13/PStoDumpAreaMap.header",
+//    "BFieldMaps/Mau13/ProtonDumpAreaMap.header",
+//
+// outerMaps removed:
+//   "BFieldMaps/Mau13/PSAreaMap.header",
 //
 // Used to save memory in production running of G4 jobs
 // when it is safe to do so.  We will use this in MDC2020
@@ -7,7 +17,7 @@
 // 1 and from stops in the DS.
 //
 // Warning:
-//  There are multiple points of maintenance when you change bfield.innerMaps
+//  There are multiple points of maintenance when you change any bfield maps.
 //    - bfgeom_v01.txt           ( the base geometry  )
 //    - bfgeom_no_ds_v01.txt     ( DS map removed     )
 //    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
@@ -20,9 +30,11 @@
 vector<string> bfield.innerMaps = {
   "BFieldMaps/Mau13/DSMap.header",
   "BFieldMaps/Mau13/TSdMap.header",
-  "BFieldMaps/Mau13/PStoDumpAreaMap.header",
-  "BFieldMaps/Mau13/ProtonDumpAreaMap.header",
   "BFieldMaps/Mau13/DSExtension.header"
+};
+
+vector<string> bfield.outerMaps = {
+  "BFieldMaps/Mau13/WorldMap.header"
 };
 
 

--- a/Mu2eG4/geom/bfgeom_reco_v01.txt
+++ b/Mu2eG4/geom/bfgeom_reco_v01.txt
@@ -14,7 +14,8 @@
 #include "Mu2eG4/geom/bfgeom_v01.txt"
 
 vector<string> bfield.innerMaps = {
-  "BFieldMaps/Mau13/DSMap.header"
+  "BFieldMaps/Mau13/DSMap.header",
+  "BFieldMaps/Mau13/DSExtension.header"
 };
 
 vector<string> bfield.outerMaps = {};

--- a/Mu2eG4/geom/bfgeom_reco_v01.txt
+++ b/Mu2eG4/geom/bfgeom_reco_v01.txt
@@ -3,7 +3,7 @@
 // not needed for reconstruction have been removed.
 //
 // Warning:
-//  There are multiple points of maintenance when you change bfield.innerMaps
+//  There are multiple points of maintenance when you change any bfield maps.
 //    - bfgeom_v01.txt           ( the base geometry  )
 //    - bfgeom_no_ds_v01.txt     ( DS map removed     )
 //    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
@@ -14,8 +14,7 @@
 #include "Mu2eG4/geom/bfgeom_v01.txt"
 
 vector<string> bfield.innerMaps = {
-  "BFieldMaps/Mau13/DSMap.header",
-  "BFieldMaps/Mau13/DSExtension.header"
+  "BFieldMaps/Mau13/DSMap.header"
 };
 
 vector<string> bfield.outerMaps = {};

--- a/Mu2eG4/geom/bfgeom_v01.txt
+++ b/Mu2eG4/geom/bfgeom_v01.txt
@@ -43,9 +43,6 @@ int  bfield.verbosityLevel =  0;
 bool bfield.writeG4BLBinaries     =  false;
 
 vector<string> bfield.outerMaps = {
-  "BFieldMaps/Mau9/ExtMonUCIInternal1AreaMap.header",
-  "BFieldMaps/Mau9/ExtMonUCIInternal2AreaMap.header",
-  "BFieldMaps/Mau9/ExtMonUCIAreaMap.header",
   "BFieldMaps/Mau13/PSAreaMap.header",
   "BFieldMaps/Mau13/WorldMap.header"
 };


### PR DESCRIPTION
The "reco" configuration is unchanged (reverted earlier changes).

Yuri confirms that he does not want us to use DSSweepExtension; we should use DSExtension.  No changes wrt this map.

Removed the DSExtension map from the "no ds" configuration.  This will save about 30MiB of memory footprint in those jobs.

Removed three more maps from the no_tsu_ps configuration. All three are between the PS and the beam dump.  Total savings of 7.0 MiB of memory.

Removed the three ExtMonUCI maps from the outermaps definition.  These field maps are obsolete.  They describe the magnetic field in the region where the UC Irving design for the Extinction Monitor would have been located.  That region is outside the world maps and is currently filled with dirt and concrete.  This removes about 7.5MiB from the memory footprint of a running job.

To see a figure of where ExtMonUCI maps are located, see pages 22 and 3 of https://mu2e-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=32091  .  