### PR TITLE
updates to the Trigger code + small fix in CaloHitMakerFast

### DIFF
--- a/CalPatRec/fcl/prolog_trigger.fcl
+++ b/CalPatRec/fcl/prolog_trigger.fcl
@@ -126,7 +126,7 @@ CprTrigger : { @table::CprTrigger
 	    minClusterEnergy                            : 50.    # MeV
 	    minClusterSize                              : 2      # number of crystals
 	    minClusterTime                              : 500.   # ns
-	    dtOffset                                    : -41.8 #FIXME! this is necessary because CaloClusterFast returns an uncalibrated time!
+	    dtOffset                                    : -61. #-41.8 #FIXME! this is necessary because CaloClusterFast returns an uncalibrated time!
 	}
 
 	TTCalHelixFinder             : { @table::CalPatRec.filters.CalHelixFinder

--- a/CalPatRec/src/CalTimePeakFinderDiag_tool.cc
+++ b/CalPatRec/src/CalTimePeakFinderDiag_tool.cc
@@ -121,7 +121,7 @@ namespace mu2e {
     Hist->nseeds = Dir->make<TH1F>("nseeds0", "number of track candidates"  , 21, -0.5, 20.5);
     Hist->ncl    = Dir->make<TH1F>("ncl"    , "N(calorimeter clusters)"     , 500, 0, 500);
     Hist->ncl50  = Dir->make<TH1F>("ncl50"  , "N(calorimeter clusters) E>50", 100, 0, 100);
-    Hist->dt     = Dir->make<TH1F>("dt"     , "hit dt"                      , 200, -100, 100);
+    Hist->dt     = Dir->make<TH1F>("dt"     , "hit dt; #Delta t = t_{cl} - (t_{ch}+TOF-<t_{drift}>) [ns]", 200, -100, 100);
     return 0;
   }
     

--- a/CaloReco/src/CaloHitMakerFast_module.cc
+++ b/CaloReco/src/CaloHitMakerFast_module.cc
@@ -108,23 +108,25 @@ namespace mu2e {
        for (const auto& caloDigi : caloDigis)
        {
            int crystalID   = cal.caloIDMapper().crystalIDFromSiPMID(caloDigi.SiPMID());
-
-           double baseline = (caloDigi.waveform().at(0)+caloDigi.waveform().at(1)+caloDigi.waveform().at(2)+caloDigi.waveform().at(3))/4.0; 
-           double eDep     = (caloDigi.waveform().at(caloDigi.peakpos())-baseline)*calorimeterCalibrations->ADC2MeV(caloDigi.SiPMID()); 
+	   size_t nSamPed  = caloDigi.peakpos() > 3 ? 4 : std::max(caloDigi.peakpos()-1, 1);
+           double baseline(0);
+	   for (size_t i=0; i<nSamPed; ++i){ baseline += caloDigi.waveform().at(i);}
+	   baseline /= nSamPed;
+           double eDep     = (caloDigi.waveform().at(caloDigi.peakpos())-baseline)*calorimeterCalibrations->ADC2MeV(caloDigi.SiPMID());//FIXME! we should use the function ::Peak2MeV, I also think that we should: (i) discard the hit if eDep is <0 (noise/stange pulse), (ii) require a minimum pulse length. gianipez 
            double time     = caloDigi.t0() + caloDigi.peakpos()*digiSampling_;                      //Giani's definition
            //double time     = caloDigi.t0() + (caloDigi.peakpos()+0.5)*digiSampling_ - shiftTime_; //Bertrand's definition
 
            addPulse(pulseMap, crystalID, time, eDep);
-           if (diagLevel_ > 2) std::cout<<"[FastRecoDigiFromDigi] extracted Digi with crystalID="<<crystalID<<" eDep="<<eDep<<"\t time=" <<time<<std::endl;
+           if (diagLevel_ > 2) std::cout<<"[CaloHitMakerFast] extracted Digi with crystalID="<<crystalID<<" eDep="<<eDep<<"\t time=" <<time<<std::endl;
        }
 
        for (auto& crystal : pulseMap)
        {
-	   int crID = crystal.first;
+	   int  crID     = crystal.first;
            bool isCaphri = std::find(caphriCrystalID_.begin(), caphriCrystalID_.end(), crID) != caphriCrystalID_.end();
 	   for (auto& info : crystal.second)
            {
-               if (diagLevel_ > 1) std::cout<<"[FastRecoDigiFromDigi] extracted Hit with crystalID="<<crID<<" eDep="<<info.eDep_<<"\t time=" <<info.time_<<"\t nSiPM= "<<info.nSiPM_<<std::endl;
+               if (diagLevel_ > 1) std::cout<<"[CaloHitMakerFast] extracted Hit with crystalID="<<crID<<" eDep="<<info.eDep_<<"\t time=" <<info.time_<<"\t nSiPM= "<<info.nSiPM_<<std::endl;
                if (isCaphri) caphriHitsColl.emplace_back(CaloHit(crID, info.nSiPM_, info.time_,info.eDep_));
                else          caloHitsColl.emplace_back(  CaloHit(crID, info.nSiPM_, info.time_,info.eDep_)); 
 	   }

--- a/Mu2eUtilities/inc/TriggerResultsNavigator.hh
+++ b/Mu2eUtilities/inc/TriggerResultsNavigator.hh
@@ -24,11 +24,13 @@ namespace mu2e {
       return _trigPathsNames.size();
     }
     
-    std::vector<std::string> const& getTrigPaths() const  { return _trigPathsNames; }
-    std::string              const& getTrigPath(unsigned int const i) const { return _trigPathsNames.at(i); }
+    std::vector<std::string> const& getTrigPaths   () const  { return _trigPathsNames; }
+    std::string              const& getTrigPath    (unsigned int const i) const { return _trigPathsNames.at(i); }
+    std::string              const  getTrigPathName(unsigned int const i) const;
 
     size_t    findTrigPath(std::string const& name) const;
     size_t    find(std::map<std::string, unsigned int> const& posmap, std::string const& name) const;
+    size_t    findTrigPathID(std::string const& name) const;
 
     // Has ith path accepted the event?
     bool      accepted(std::string const& name) const;
@@ -48,6 +50,7 @@ namespace mu2e {
     const art::TriggerResults*           _trigResults;
     std::vector<std::string>             _trigPathsNames;
     std::map<std::string, unsigned int>  _trigMap;
+    std::map<std::string, unsigned int>  _trigPathMap;
   };
   
   

--- a/Mu2eUtilities/src/TriggerResultsNavigator.cc
+++ b/Mu2eUtilities/src/TriggerResultsNavigator.cc
@@ -41,9 +41,24 @@ namespace mu2e {
     }  
 
     //loop over trigResults to fill the map <string, unsigned int)
+    std::string   delimeter=":";
     for (unsigned int i=0; i< _trigPathsNames.size(); ++i){
-      _trigMap.insert(std::pair<std::string, unsigned int>(_trigPathsNames[i], i));
+      size_t       pos      = _trigPathsNames[i].find(delimeter);
+      unsigned int bit      = std::stoi(_trigPathsNames[i].substr(0, pos));
+      std::string  pathName = _trigPathsNames[i].substr(pos+1, _trigPathsNames[i].length());
+      _trigMap.insert(std::pair<std::string, unsigned int>(pathName, i));
+      _trigPathMap.insert(std::pair<std::string, unsigned int>(pathName, bit));
     }
+  }
+
+
+  std::string const
+  TriggerResultsNavigator::getTrigPathName(unsigned int const i) const
+  {
+    std::string   delimeter =":";
+    size_t        pos       = _trigPathsNames[i].find(delimeter);
+    if (pos > _trigPathsNames[i].length()) return "TRIG PATH NOT FOUND";
+    return _trigPathsNames[i].substr(pos+1, _trigPathsNames[i].length());
   }
 
   size_t
@@ -61,6 +76,12 @@ namespace mu2e {
     } else {
       return pos->second;
     }
+  }
+
+  size_t
+  TriggerResultsNavigator::findTrigPathID(std::string const& name) const
+  {
+    return find(_trigPathMap, name);
   }
 
   // Has ith path accepted the event?

--- a/Trigger/data/ExtrPosTrigMenu.config
+++ b/Trigger/data/ExtrPosTrigMenu.config
@@ -1,7 +1,2 @@
-unbiased
-minimumbiasSDCount
-largeSDCount
-minimumbiasCDCount
-largeCDCount
 caloCalibCosmic
 cstSeed

--- a/Trigger/data/OffSpillTrigMenu.config
+++ b/Trigger/data/OffSpillTrigMenu.config
@@ -1,8 +1,3 @@
-unbiased
-minimumbiasSDCount
-largeSDCount
-minimumbiasCDCount
-largeCDCount
 caloMVACE
 caloPhoton
 caloCalibCosmic

--- a/Trigger/data/OnSpillTrigMenu.config
+++ b/Trigger/data/OnSpillTrigMenu.config
@@ -1,8 +1,3 @@
-unbiased
-minimumbiasSDCount
-largeSDCount
-minimumbiasCDCount
-largeCDCount
 tprSeedDeM
 tprSeedDeP
 cprSeedDeM

--- a/Trigger/python/genTriggerFcl.py
+++ b/Trigger/python/genTriggerFcl.py
@@ -240,7 +240,7 @@ def generate(configFileText="allPaths", verbose=True, doWrite=True):
     #
 
     configFile = open(configFileName, "r")
-
+    pathID     = 100 #we start the Reco paths from 100
     for line in configFile:
 
         line = line.strip() # strip whitespace
@@ -270,7 +270,8 @@ def generate(configFileText="allPaths", verbose=True, doWrite=True):
 
             digi_path = "@sequence::Trigger.PrepareDigis, "
             
-            new_path = ("\nphysics."+pathName+"_trigger"+" : [ "+ digi_path +"@sequence::Trigger.paths."+pathName+" ] \n")
+            new_path = ("\nphysics."+pathName+"_trigger"+" : [ "+ digi_path +"@sequence::Trigger.paths."+pathName+" ] \nphysics.trigger_paths["+str(pathID)+"] : "+pathName+"_trigger \n")
+            pathID   += 1
             timing_paths = []
             if "Seed" in pathName:
                 nFilters = 3

--- a/Trigger/src/ReadTriggerInfo_module.cc
+++ b/Trigger/src/ReadTriggerInfo_module.cc
@@ -835,7 +835,7 @@ namespace mu2e {
       for (int k=0; k<nLabels; ++k){
        	label_ref = VecLabels.at(k).c_str();
 	for (int j=0; j<nbins; ++j){
-	  if (j == i)      break;
+	  //if (j == i)      break;
 	  label =   _sumHist._h2DTrigInfo[1]->GetYaxis()->GetBinLabel(j+1);
 	  if (std::strcmp(label_ref, label) != 0)        continue;
 	  NCorrelated += _sumHist._h2DTrigInfo[1]->GetBinContent(i+1, j+1);

--- a/Trigger/src/ReadTriggerInfo_module.cc
+++ b/Trigger/src/ReadTriggerInfo_module.cc
@@ -36,11 +36,11 @@
 #include "RecoDataProducts/inc/CaloTrigSeed.hh"
 #include "RecoDataProducts/inc/HelixSeed.hh"
 #include "RecoDataProducts/inc/KalSeed.hh"
+#include "RecoDataProducts/inc/TrkQual.hh"
 #include "RecoDataProducts/inc/TriggerInfo.hh"
 #include "RecoDataProducts/inc/ComboHit.hh"
 #include "RecoDataProducts/inc/StrawDigi.hh"
 #include "RecoDataProducts/inc/StrawDigiCollection.hh"
-#include "RecoDataProducts/inc/CaloDigi.hh"
 #include "RecoDataProducts/inc/CaloDigi.hh"
 #include "DataProducts/inc/XYZVec.hh"
 
@@ -69,7 +69,6 @@
 #include <string>
 // #include <map>
 #include <vector>
-
 
 
 namespace mu2e {
@@ -114,14 +113,14 @@ namespace mu2e {
       int           exclusive_counts;
       std::string   label;
       
-      trigInfo_ ():counts(0), exclusive_counts(0){}
+      trigInfo_ ():counts(0), exclusive_counts(0), label(""){}
     };
 
     struct  summaryInfoHist_  {
       TH1F *_hTrigInfo  [kNTrigInfo];
       TH2F *_h2DTrigInfo[kNTrigInfo];
       TH1F *_hTrigBDW   [kNTrigInfo];
-      
+
       TH1F *_hTrigBits;
 
       summaryInfoHist_() {
@@ -180,7 +179,7 @@ namespace mu2e {
 	  }
 	}
       }
-    };
+   };
     
     struct  occupancyHist_       {
       TH1F *_hOccInfo  [kNOcc][kNOccVar];
@@ -227,6 +226,11 @@ namespace mu2e {
     void     findCorrelatedEvents (std::vector<string>& VecLabels, double &NCorrelated);
     void     evalTriggerRate      ();
 
+    void     fillTrackEfficiencyHist(const mu2e::KalSeedCollection*     KsCol, 
+				     const mu2e::TrkQualCollection*     TrkQualCol, 
+				     const art::TriggerResults*         TrigResults,
+				     const mu2e::StepPointMCCollection* Steps);
+    bool     goodTrkTanDip(const mu2e::KalSeed*Ks);
   private:
 
     int                       _diagLevel;
@@ -241,9 +245,19 @@ namespace mu2e {
     art::InputTag             _chTag;    
     art::InputTag             _cdTag;
     art::InputTag             _evtWeightTag;
+    art::InputTag             _hsCprTag;
+    art::InputTag             _hsTprTag;
+    art::InputTag             _ksTag;
+    art::InputTag             _trkQualTag;
+    art::InputTag             _vdTag;
+   
     double                    _duty_cycle;
     string                    _processName;
-
+    std::vector<size_t>       _effBits;
+    float                     _trkMinTanDip;
+    float                     _trkMaxTanDip;
+    float                     _trkMaxD0;    
+    float                     _trkMinMVA;   
     float                     _nProcess;
     double                    _bz0;
 
@@ -271,13 +285,17 @@ namespace mu2e {
     const mu2e::StrawDigiMCCollection* _mcdigis;
     const mu2e::ComboHitCollection*    _chcol;
     const art::Event*                  _event;
+    const mu2e::HelixSeedCollection*   _hsCprCol;
+    const mu2e::HelixSeedCollection*   _hsTprCol;
+
+    float  _minPOT, _maxPOT;
   };
 
 
   ReadTriggerInfo::ReadTriggerInfo(fhicl::ParameterSet const& pset) :
     art::EDAnalyzer(pset), 
     _diagLevel     (pset.get<int>   ("diagLevel", 0)),
-    _nMaxTrig      (pset.get<size_t>("nFilters", 70)),
+    _nMaxTrig      (pset.get<size_t>("nPathIDs", 200)),
     _nTrackTrig    (pset.get<size_t>("nTrackTriggers", 4)),
     _nCaloTrig     (pset.get<size_t>("nCaloTriggers", 4)),
     _nCaloCalibTrig(pset.get<size_t>("nCaloCalibTriggers", 4)),
@@ -286,10 +304,21 @@ namespace mu2e {
     _sdTag         (pset.get<art::InputTag>("strawDigiCollection"  , "makeSD")),
     _chTag         (pset.get<art::InputTag>("comboHitCollection"   , "TTmakeSH")),
     _cdTag         (pset.get<art::InputTag>("caloDigiCollection"   , "CaloDigiFromShower")),
-    _evtWeightTag  (pset.get<art::InputTag>("protonBunchIntensity" , "protonBunchIntensity")),
+    _evtWeightTag  (pset.get<art::InputTag>("protonBunchIntensity" , "PBIsim")),
+    _hsCprTag      (pset.get<art::InputTag>("cprHelixSeedCollection", "CalHelixFinderDe:Positive")), // , "KFFDeMHPar")),
+    _hsTprTag      (pset.get<art::InputTag>("tprHelixSeedCollection", "HelixFinderDe:Positive")), // , "KFFDeMHPar")),
+    _ksTag         (pset.get<art::InputTag>("kalSeedCollection"  , "KFFDeMHPar")),
+    _trkQualTag    (pset.get<art::InputTag>("trackQualCollection", "TrkQualDeMHPar")),
+    _vdTag         (pset.get<art::InputTag>("vdStepPoints","NOTNOW")), // , "compressDigiMCs:virtualdetector")),
     _duty_cycle    (pset.get<float> ("dutyCycle", 1.)),
     _processName   (pset.get<string> ("processName", "globalTrigger")),
-    _nProcess      (pset.get<float> ("nEventsProcessed", 1.))
+    _effBits       (pset.get<std::vector<size_t>>("effBits", std::vector<size_t>{2,8})),
+    _trkMinTanDip  (pset.get<float> ("trkMinTanDip", 0.5)),
+    _trkMaxTanDip  (pset.get<float> ("trkMaxTanDip", 1.)),
+    _trkMaxD0      (pset.get<float> ("trkMaxD0", 100.)),
+    _trkMinMVA     (pset.get<float> ("trkMinMVA", 0.8)),
+    _nProcess      (pset.get<float> ("nEventsProcessed", 1.)),
+    _minPOT(1e6), _maxPOT(4e8)
   {
     _trigAll.      resize(_nMaxTrig);	     
     _trigFinal.    resize(_nMaxTrig);    
@@ -298,6 +327,7 @@ namespace mu2e {
     _trigTrack.    resize(_nMaxTrig);    
     _trigHelix.    resize(_nMaxTrig);    
     _trigEvtPS.    resize(_nMaxTrig);    
+
   }
   
   
@@ -319,7 +349,11 @@ namespace mu2e {
   //--------------------------------------------------------------------------------//
   void     ReadTriggerInfo::bookTrigInfoHist         (art::ServiceHandle<art::TFileService> & Tfs, summaryInfoHist_       &Hist){
     art::TFileDirectory trigInfoDir = Tfs->mkdir("trigInfo");
-    Hist._hTrigBits      = trigInfoDir.make<TH1F>("hTrigInfo_bits"      , "Trigger bits"                               , 31, -0.5, 30.5);       
+    Hist._hTrigBits      = trigInfoDir.make<TH1F>("hTrigInfo_bits"      , "Trigger bits"                               , 51, -0.5, 50.5);       
+    for (size_t i=0; i< _trigPaths.size(); ++i){
+      Hist._hTrigBits->GetXaxis()->SetBinLabel(i+1, _trigPaths[i].c_str());
+    }
+
     Hist._hTrigInfo[0]   = trigInfoDir.make<TH1F>("hTrigInfo_global"    , "Global Trigger rejection"                   , (_nMaxTrig+2), -0.5, (_nMaxTrig+1.5));       
     Hist._hTrigInfo[1]   = trigInfoDir.make<TH1F>("hTrigInfo_track"     , "Calo-only Triggers rejection"               , (_nMaxTrig+2), -0.5, (_nMaxTrig+1.5));       
     Hist._hTrigInfo[2]   = trigInfoDir.make<TH1F>("hTrigInfo_calo"      , "Track Triggers rejection"                   , (_nMaxTrig+2), -0.5, (_nMaxTrig+1.5));       
@@ -332,6 +366,14 @@ namespace mu2e {
     Hist._hTrigInfo[11]  = trigInfoDir.make<TH1F>("hTrigInfo_unique"    , "Events found only by each Trig path"        , (_nMaxTrig+2), -0.5, (_nMaxTrig+1.5));       
 
     Hist._hTrigInfo[15]  = trigInfoDir.make<TH1F>("hTrigInfo_paths"     , "Rejection of all the Trigger paths"         , (_nMaxTrig+2), -0.5, (_nMaxTrig+1.5));       
+    
+    
+    Hist._hTrigInfo[16]  = trigInfoDir.make<TH1F>("hTrksVsPOT","nOfflineTracks vs inst lum; p/pulse; nOfflieTracks",  1000, _minPOT, _maxPOT);
+    Hist._hTrigInfo[17]  = trigInfoDir.make<TH1F>("hTrksTrigVsPOT","nOfflineTracks triggered vs inst lum; p/pulse; nOfflieTracks triggered",  1000, _minPOT, _maxPOT);
+    Hist._hTrigInfo[18]  = trigInfoDir.make<TH1F>("hNormVsPOT","events vs inst lum; p/pulse; Entries",  1000, _minPOT, _maxPOT);
+    Hist._hTrigInfo[19]  = trigInfoDir.make<TH1F>("hNPOT","nPOT; p/pulse; Entries",  1000, _minPOT, _maxPOT);
+    Hist._hTrigInfo[20]  = trigInfoDir.make<TH1F>("hCprNorm","cpr Good Offline tracks;p/pulse; Entries",  1000, _minPOT, _maxPOT);
+    Hist._hTrigInfo[21]  = trigInfoDir.make<TH1F>("hTprNorm","tpr Good Offline tracks;p/pulse; Entries",  1000, _minPOT, _maxPOT);
 
 
     Hist._h2DTrigInfo[0] = trigInfoDir.make<TH2F>("h2DTrigInfo_map_all" , "Trigger correlation map from all filters"   , (_nMaxTrig+2), -0.5, (_nMaxTrig+1.5), (_nMaxTrig+2), -0.5, (_nMaxTrig+1.5));       
@@ -367,12 +409,9 @@ namespace mu2e {
       Hist._hTrkInfo[i][19] = trkInfoDir.make<TH1F>(Form("hPDGM_%i" , i), "PDG Mother Id; PdgId-mother"          , 2253,   -30.5,   2222.5);
       Hist._hTrkInfo[i][20] = trkInfoDir.make<TH1F>(Form("hEMC_%i"  , i), "MC Energy; E_{MC} [MeV]"              , 400,   0,   200);
 
-
       Hist._hTrkInfo[i][40] = trkInfoDir.make<TH1F>(Form("hNTrigTracks_%i" , i), "NTracks trigger matched; NTracks trigger matched", 11, -0.5, 10);
-
+  
     }
-  
-  
   }
   //--------------------------------------------------------------------------------//
   void     ReadTriggerInfo::bookHelixInfoHist        (art::ServiceHandle<art::TFileService> & Tfs, helixInfoHist_         &Hist){
@@ -381,11 +420,11 @@ namespace mu2e {
       Hist._hHelInfo[i][0] = helInfoDir.make<TH1F>(Form("hP_%i"        , i), "Helix Momentum; p[MeV/c]", 400, 0, 200);
       Hist._hHelInfo[i][1] = helInfoDir.make<TH1F>(Form("hPt_%i"       , i), "Helix Pt; p_{t} [MeV/c]", 400, 0, 200);
       Hist._hHelInfo[i][2] = helInfoDir.make<TH1F>(Form("hNSh_%i"      , i), "N-StrawHits; nStrawHits", 101, -0.5, 100.5);
-      Hist._hHelInfo[i][3] = helInfoDir.make<TH1F>(Form("hD0_%i"       , i), "Helix impact parameter; d0 [mm]", 800, -800, 800);//801, -400.5, 400.5);
+      Hist._hHelInfo[i][3] = helInfoDir.make<TH1F>(Form("hD0_%i"       , i), "Helix impact parameter; d0 [mm]", 801, -400.5, 400.5);
       Hist._hHelInfo[i][4] = helInfoDir.make<TH1F>(Form("hChi2dXY_%i"  , i), "Helix #chi^{2}_{xy}/ndof;#chi^{2}_{xy}/ndof"      , 100, 0, 50);
       Hist._hHelInfo[i][5] = helInfoDir.make<TH1F>(Form("hChi2dZPhi_%i", i), "Helix #chi^{2}_{z#phi}/ndof;#chi^{2}_{z#phi}/ndof", 100, 0, 50);
       Hist._hHelInfo[i][6] = helInfoDir.make<TH1F>(Form("hClE_%i"      , i), "calorimeter Cluster energy; E [MeV]", 240, 0, 120);
-      Hist._hHelInfo[i][7] = helInfoDir.make<TH1F>(Form("hLambda_%i"   , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 600);//500, 0, 500);
+      Hist._hHelInfo[i][7] = helInfoDir.make<TH1F>(Form("hLambda_%i"   , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 500);
       Hist._hHelInfo[i][8] = helInfoDir.make<TH1F>(Form("hNLoops_%i"   , i), "Helix nLoops; nLoops", 500, 0, 50);
       Hist._hHelInfo[i][9] = helInfoDir.make<TH1F>(Form("hHitRatio_%i" , i), "Helix hitRatio; NComboHits/nExpectedComboHits", 200, 0, 2);
 
@@ -411,7 +450,7 @@ namespace mu2e {
       Hist._hHelInfo[i][26] = helInfoDir.make<TH1F>(Form("hMuMinusPDG_%i"  , i), "PDG Id; PdgId"                        , 2253,   -30.5,   2222.5);
       Hist._hHelInfo[i][27] = helInfoDir.make<TH1F>(Form("hMuMinusGenZ_%i" , i), "origin; z-origin [mm]", 300,   0,   15000);
       Hist._hHelInfo[i][28] = helInfoDir.make<TH1F>(Form("hMuMinusGenR_%i" , i), "r origin; r-origin [mm]",500,   0,   5000);
-      Hist._hHelInfo[i][29] = helInfoDir.make<TH1F>(Form("hMuMinusLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 600);
+      Hist._hHelInfo[i][29] = helInfoDir.make<TH1F>(Form("hMuMinusLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 500);
      
       Hist._hHelInfo[i][30] = helInfoDir.make<TH1F>(Form("hMuPlusPMC_%i" , i), "MC Track Momentum @ tracker front; p[MeV/c]", 400, 0, 200);
       Hist._hHelInfo[i][31] = helInfoDir.make<TH1F>(Form("hMuPlusP_%i", i), "Track P; p [MeV/c]" , 400, 0, 200);
@@ -422,7 +461,7 @@ namespace mu2e {
       Hist._hHelInfo[i][36] = helInfoDir.make<TH1F>(Form("hMuPlusPDG_%i"  , i), "PDG Id; PdgId"                        , 2253,   -30.5,   2222.5);
       Hist._hHelInfo[i][37] = helInfoDir.make<TH1F>(Form("hMuPlusGenZ_%i" , i), "origin; z-origin [mm];", 300,   0,   15000);
       Hist._hHelInfo[i][38] = helInfoDir.make<TH1F>(Form("hMuPlusGenR_%i" , i), "r origin;  r-origin [mm]", 500,   0,   5000);
-      Hist._hHelInfo[i][39] = helInfoDir.make<TH1F>(Form("hMuPlusLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 600);
+      Hist._hHelInfo[i][39] = helInfoDir.make<TH1F>(Form("hMuPlusLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 500);
 
       Hist._hHelInfo[i][40] = helInfoDir.make<TH1F>(Form("hIPAMuPMC_%i" , i), "MC Track Momentum @ tracker front; p[MeV/c]", 400, 0, 200);
       Hist._hHelInfo[i][41] = helInfoDir.make<TH1F>(Form("hIPAMuP_%i", i), "Track P; p [MeV/c]" , 400, 0, 200);
@@ -433,7 +472,7 @@ namespace mu2e {
       Hist._hHelInfo[i][46] = helInfoDir.make<TH1F>(Form("hIPAMuPDG_%i"  , i), "PDG Id; PdgId"                        , 2253,   -30.5,   2222.5);
       Hist._hHelInfo[i][47] = helInfoDir.make<TH1F>(Form("hIPAMuGenZ_%i" , i), "z origin; z-origin [mm]", 300,   0,   15000);
       Hist._hHelInfo[i][48] = helInfoDir.make<TH1F>(Form("hIPAMuGenR_%i" , i), "r origin; r-origin [mm]", 500,   0,   5000);
-      Hist._hHelInfo[i][49] = helInfoDir.make<TH1F>(Form("hIPAMuLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 600);
+      Hist._hHelInfo[i][49] = helInfoDir.make<TH1F>(Form("hIPAMuLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 500);
 
       Hist._hHelInfo[i][50] = helInfoDir.make<TH1F>(Form("hGammaPMC_%i" , i), "MC Track Momentum @ tracker front; p[MeV/c]", 400, 0, 200);
       Hist._hHelInfo[i][51] = helInfoDir.make<TH1F>(Form("hGammaP_%i", i), "Track P; p [MeV/c]" , 400, 0, 200);
@@ -444,7 +483,7 @@ namespace mu2e {
       Hist._hHelInfo[i][56] = helInfoDir.make<TH1F>(Form("hGammaPDG_%i"  , i), "PDG Id; PdgId"                        , 2253,   -30.5,   2222.5);
       Hist._hHelInfo[i][57] = helInfoDir.make<TH1F>(Form("hGammaGenZ_%i" , i), "origin; z-origin [mm]", 300,   0,   15000);
       Hist._hHelInfo[i][58] = helInfoDir.make<TH1F>(Form("hGammaGenR_%i" , i), "radial position origin; r-origin [mm]", 500,   0,   5000);
-      Hist._hHelInfo[i][59] = helInfoDir.make<TH1F>(Form("hGammaLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 600);
+      Hist._hHelInfo[i][59] = helInfoDir.make<TH1F>(Form("hGammaLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 500);
 
       Hist._hHelInfo[i][60] = helInfoDir.make<TH1F>(Form("hProtonPMC_%i" , i), "MC Track Momentum @ tracker front; p[MeV/c]", 400, 0, 200);
       Hist._hHelInfo[i][61] = helInfoDir.make<TH1F>(Form("hProtonP_%i", i), "Track P; p [MeV/c]" , 400, 0, 200);
@@ -455,7 +494,7 @@ namespace mu2e {
       Hist._hHelInfo[i][66] = helInfoDir.make<TH1F>(Form("hProtonPDG_%i"  , i), "PDG Id; PdgId"                        , 2253,   -30.5,   2222.5);
       Hist._hHelInfo[i][67] = helInfoDir.make<TH1F>(Form("hProtonGenZ_%i" , i), "origin; z-origin [mm]", 300,   0,   15000);
       Hist._hHelInfo[i][68] = helInfoDir.make<TH1F>(Form("hProtonGenR_%i" , i), "radial position origin; r-origin [mm]", 500,   0,   5000);
-      Hist._hHelInfo[i][69] = helInfoDir.make<TH1F>(Form("hProtonLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 600);
+      Hist._hHelInfo[i][69] = helInfoDir.make<TH1F>(Form("hProtonLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 500);
 
       Hist._hHelInfo[i][70] = helInfoDir.make<TH1F>(Form("hN0PMC_%i" , i), "MC Track Momentum @ tracker front; p[MeV/c]", 400, 0, 200);
       Hist._hHelInfo[i][71] = helInfoDir.make<TH1F>(Form("hN0P_%i", i), "Track P; p [MeV/c]" , 400, 0, 200);
@@ -466,7 +505,7 @@ namespace mu2e {
       Hist._hHelInfo[i][76] = helInfoDir.make<TH1F>(Form("hN0PDG_%i"  , i), "PDG Id; PdgId"                        , 2253,   -30.5,   2222.5);
       Hist._hHelInfo[i][77] = helInfoDir.make<TH1F>(Form("hN0GenZ_%i" , i), "origin; z-origin [mm]", 300,   0,   15000);
       Hist._hHelInfo[i][78] = helInfoDir.make<TH1F>(Form("hN0GenR_%i" , i), "radial position origin; r-origin [mm]", 500,   0,   5000);
-      Hist._hHelInfo[i][79] = helInfoDir.make<TH1F>(Form("hN0Lambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 600);
+      Hist._hHelInfo[i][79] = helInfoDir.make<TH1F>(Form("hN0Lambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 500);
       
       Hist._hHelInfo[i][80] = helInfoDir.make<TH1F>(Form("hPiMinusPMC_%i" , i), "MC Track Momentum @ tracker front; p[MeV/c]", 400, 0, 200);
       Hist._hHelInfo[i][81] = helInfoDir.make<TH1F>(Form("hPiMinusP_%i", i), "Track P; p [MeV/c]" , 400, 0, 200);
@@ -477,7 +516,7 @@ namespace mu2e {
       Hist._hHelInfo[i][86] = helInfoDir.make<TH1F>(Form("hPiMinusPDG_%i"  , i), "PDG Id; PdgId"                        , 2253,   -30.5,   2222.5);
       Hist._hHelInfo[i][87] = helInfoDir.make<TH1F>(Form("hPiMinusGenZ_%i" , i), "origin; z-origin [mm]", 300,   0,   15000);
       Hist._hHelInfo[i][88] = helInfoDir.make<TH1F>(Form("hPiMinusGenR_%i" , i), "r origin; r-origin [mm]",500,   0,   5000);
-      Hist._hHelInfo[i][89] = helInfoDir.make<TH1F>(Form("hPiMinusLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 600);
+      Hist._hHelInfo[i][89] = helInfoDir.make<TH1F>(Form("hPiMinusLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 500);
      
       Hist._hHelInfo[i][90] = helInfoDir.make<TH1F>(Form("hPiPlusPMC_%i" , i), "MC Track Momentum @ tracker front; p[MeV/c]", 400, 0, 200);
       Hist._hHelInfo[i][91] = helInfoDir.make<TH1F>(Form("hPiPlusP_%i", i), "Track P; p [MeV/c]" , 400, 0, 200);
@@ -488,9 +527,9 @@ namespace mu2e {
       Hist._hHelInfo[i][96] = helInfoDir.make<TH1F>(Form("hPiPlusPDG_%i"  , i), "PDG Id; PdgId"                        , 2253,   -30.5,   2222.5);
       Hist._hHelInfo[i][97] = helInfoDir.make<TH1F>(Form("hPiPlusGenZ_%i" , i), "origin; z-origin [mm];", 300,   0,   15000);
       Hist._hHelInfo[i][98] = helInfoDir.make<TH1F>(Form("hPiPlusGenR_%i" , i), "r origin;  r-origin [mm]", 500,   0,   5000);
-      Hist._hHelInfo[i][99] = helInfoDir.make<TH1F>(Form("hPiPlusLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 600);
+      Hist._hHelInfo[i][99] = helInfoDir.make<TH1F>(Form("hPiPlusLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 500);
 
-      Hist._hHelInfo[i][100] = helInfoDir.make<TH1F>(Form("hEMinusPMC_%i" , i), "MC Track Momentum @ tracker front; p[MeV/c]", 400, 0, 200);
+ Hist._hHelInfo[i][100] = helInfoDir.make<TH1F>(Form("hEMinusPMC_%i" , i), "MC Track Momentum @ tracker front; p[MeV/c]", 400, 0, 200);
       Hist._hHelInfo[i][101] = helInfoDir.make<TH1F>(Form("hEMinusP_%i", i), "Track P; p [MeV/c]" , 400, 0, 250);
       Hist._hHelInfo[i][102] = helInfoDir.make<TH1F>(Form("hEMinusD0_%i", i), "Helix impact parameter; d0 [mm]", 800, -800, 800);
       Hist._hHelInfo[i][103] = helInfoDir.make<TH1F>(Form("hEMinusDP_%i"  , i), "#Delta p @ tracker front; #Delta p = p_{hel} - p_{MC} [MeV/c]"     , 800, -200, 200);
@@ -513,64 +552,61 @@ namespace mu2e {
       Hist._hHelInfo[i][119] = helInfoDir.make<TH1F>(Form("hEPlusLambda_%i" , i), "Helix #lambda=dz/d#phi; |#lambda| [mm/rad]", 500, 0, 600);
 
 
-      Hist._hHelInfo[i][120] = helInfoDir.make<TH1F>(Form("hNTrigHelixes_%i" , i), "NHelixes trigger matched; NHelixes trigger matched", 11, -0.5, 10)
-	;
+      Hist._hHelInfo[i][120] = helInfoDir.make<TH1F>(Form("hNTrigHelixes_%i" , i), "NHelixes trigger matched; NHelixes trigger matched", 11, -0.5, 10);
     }
   }
   //--------------------------------------------------------------------------------//
   void     ReadTriggerInfo::bookCaloTrigSeedInfoHist (art::ServiceHandle<art::TFileService> & Tfs, caloTrigSeedHist_      &Hist){
     for (int i=0; i<_nCaloTrig; ++i){
       art::TFileDirectory caloInfoDir = Tfs->mkdir(Form("caloOnly_%i",i));
-      Hist._hCaloOnlyInfo[i][0]  = caloInfoDir.make<TH1F>(Form("hEPeak_%i"   , i), "peak energy; E[MeV]"        , 400, 0, 200);
-      Hist._hCaloOnlyInfo[i][1]  = caloInfoDir.make<TH1F>(Form("hR1Max1_%i"   , i), "ring1 max; ring1max [MeV]" , 400, 0, 200);
-      Hist._hCaloOnlyInfo[i][2]  = caloInfoDir.make<TH1F>(Form("hR1Max2_%i"   , i), "ring1 max; ring1max2 [MeV]", 400, 0, 200);    
-      Hist._hCaloOnlyInfo[i][20] = caloInfoDir.make<TH1F>(Form("hNTrigCaloClusters_%i" , i), "NCaloClusters trigger matched; NCaloClusters trigger matched", 11, -0.5, 10);
+      Hist._hCaloOnlyInfo[i][0] = caloInfoDir.make<TH1F>(Form("hEPeak_%i"   , i), "peak energy; E[MeV]"        , 400, 0, 200);
+      Hist._hCaloOnlyInfo[i][1] = caloInfoDir.make<TH1F>(Form("hR1Max1_%i"   , i), "ring1 max; ring1max [MeV]" , 400, 0, 200);
+      Hist._hCaloOnlyInfo[i][2] = caloInfoDir.make<TH1F>(Form("hR1Max2_%i"   , i), "ring1 max; ring1max2 [MeV]", 400, 0, 200);    
     }
   }
   //--------------------------------------------------------------------------------//
   void     ReadTriggerInfo::bookCaloCalibInfoHist    (art::ServiceHandle<art::TFileService> & Tfs, caloCalibrationHist_   &Hist){      
     for (int i=0; i<_nCaloCalibTrig; ++i){
       art::TFileDirectory caloCalibInfoDir = Tfs->mkdir(Form("caloCalib_%i",i));
-      Hist._hCaloCalibInfo[i][0]  = caloCalibInfoDir.make<TH1F>(Form("hE_%i"   , i), "Cluster energy; E[MeV]", 800, 0, 800);
-      Hist._hCaloCalibInfo[i][1]  = caloCalibInfoDir.make<TH1F>(Form("hN_%i"   , i), "Cluster size; nCrystalHits", 101, -0.5, 100.5);
-      Hist._hCaloCalibInfo[i][20] = caloCalibInfoDir.make<TH1F>(Form("hNTrigCaloCalibs_%i" , i), "NCaloCalibs trigger matched; NCaloCalibs trigger matched", 11, -0.5, 10);
+      Hist._hCaloCalibInfo[i][0] = caloCalibInfoDir.make<TH1F>(Form("hE_%i"   , i), "Cluster energy; E[MeV]", 800, 0, 800);
+      Hist._hCaloCalibInfo[i][1] = caloCalibInfoDir.make<TH1F>(Form("hN_%i"   , i), "Cluster size; nCrystalHits", 101, -0.5, 100.5);
     }    
   }
 
   //--------------------------------------------------------------------------------//
   //--------------------------------------------------------------------------------//
   void     ReadTriggerInfo::bookOccupancyInfoHist         (art::ServiceHandle<art::TFileService> & Tfs, occupancyHist_       &Hist){
-
+    
     for (int i=0; i<_nTrackTrig; ++i){
       art::TFileDirectory occInfoDir = Tfs->mkdir(Form("occInfoTrk_%i", i));
-      Hist._hOccInfo  [i][0]  = occInfoDir.make<TH1F>(Form("hInstLum_%i"  ,i),"distrbution of instantaneous lum; p/#mu-bunch"  ,  1000, 1e6, 4e8);
+      Hist._hOccInfo  [i][0]  = occInfoDir.make<TH1F>(Form("hInstLum_%i"  ,i),"distrbution of instantaneous lum; p/#mu-bunch"  ,  1000, _minPOT, _maxPOT);
       
-      Hist._h2DOccInfo[i][0]  = occInfoDir.make<TH2F>(Form("hNSDVsLum_%i" ,i),"inst lum vs nStrawDigi; p/#mu-bunch; nStrawDigi",  1000, 1e6, 4e8, 5000, 0., 20000.);
-      Hist._h2DOccInfo[i][1]  = occInfoDir.make<TH2F>(Form("hNCDVsLum_%i" ,i),"inst lum vs nCaloDigi; p/#mu-bunch; nCaloDigi"  ,  1000, 1e6, 4e8, 5000, 0., 20000.);
+      Hist._h2DOccInfo[i][0]  = occInfoDir.make<TH2F>(Form("hNSDVsLum_%i" ,i),"inst lum vs nStrawDigi; p/#mu-bunch; nStrawDigi",  1000, _minPOT, _maxPOT, 5000, 0., 20000.);
+      Hist._h2DOccInfo[i][1]  = occInfoDir.make<TH2F>(Form("hNCDVsLum_%i" ,i),"inst lum vs nCaloDigi; p/#mu-bunch; nCaloDigi"  ,  1000, _minPOT, _maxPOT, 5000, 0., 20000.);
     }
     
     for (int i=_nTrackTrig; i<_nTrackTrig*2; ++i){
       art::TFileDirectory occInfoDir = Tfs->mkdir(Form("occInfoHel_%i", i));
-      Hist._hOccInfo  [i][0]  = occInfoDir.make<TH1F>(Form("hInstLum_%i"  ,i),"distrbution of instantaneous lum; p/#mu-bunch"  ,  1000, 1e6, 4e8);
+      Hist._hOccInfo  [i][0]  = occInfoDir.make<TH1F>(Form("hInstLum_%i"  ,i),"distrbution of instantaneous lum; p/#mu-bunch"  ,  1000, _minPOT, _maxPOT);
       
-      Hist._h2DOccInfo[i][0]  = occInfoDir.make<TH2F>(Form("hNSDVsLum_%i" ,i),"inst lum vs nStrawDigi; p/#mu-bunch; nStrawDigi",  1000, 1e6, 4e8, 5000, 0., 20000.);
-      Hist._h2DOccInfo[i][1]  = occInfoDir.make<TH2F>(Form("hNCDVsLum_%i" ,i),"inst lum vs nCaloDigi; p/#mu-bunch; nCaloDigi"  ,  1000, 1e6, 4e8, 5000, 0., 20000.);
+      Hist._h2DOccInfo[i][0]  = occInfoDir.make<TH2F>(Form("hNSDVsLum_%i" ,i),"inst lum vs nStrawDigi; p/#mu-bunch; nStrawDigi",  1000, _minPOT, _maxPOT, 5000, 0., 20000.);
+      Hist._h2DOccInfo[i][1]  = occInfoDir.make<TH2F>(Form("hNCDVsLum_%i" ,i),"inst lum vs nCaloDigi; p/#mu-bunch; nCaloDigi"  ,  1000, _minPOT, _maxPOT, 5000, 0., 20000.);
     }
     
     for (int i=_nTrackTrig*2; i<_nTrackTrig*2+_nCaloTrig; ++i){
       art::TFileDirectory occInfoDir = Tfs->mkdir(Form("occInfoCaloTrig_%i", i));
-      Hist._hOccInfo  [i][0]  = occInfoDir.make<TH1F>(Form("hInstLum_%i"  ,i),"distrbution of instantaneous lum; p/#mu-bunch"  ,  1000, 1e6, 4e8);
+      Hist._hOccInfo  [i][0]  = occInfoDir.make<TH1F>(Form("hInstLum_%i"  ,i),"distrbution of instantaneous lum; p/#mu-bunch"  ,  1000, _minPOT, _maxPOT);
       			    
-      Hist._h2DOccInfo[i][0]  = occInfoDir.make<TH2F>(Form("hNSDVsLum_%i" ,i),"inst lum vs nStrawDigi; p/#mu-bunch; nStrawDigi",  1000, 1e6, 4e8, 5000, 0., 20000.);
-      Hist._h2DOccInfo[i][1]  = occInfoDir.make<TH2F>(Form("hNCDVsLum_%i" ,i),"inst lum vs nCaloDigi; p/#mu-bunch; nCaloDigi"  ,  1000, 1e6, 4e8, 5000, 0., 20000.);
+      Hist._h2DOccInfo[i][0]  = occInfoDir.make<TH2F>(Form("hNSDVsLum_%i" ,i),"inst lum vs nStrawDigi; p/#mu-bunch; nStrawDigi",  1000, _minPOT, _maxPOT, 5000, 0., 20000.);
+      Hist._h2DOccInfo[i][1]  = occInfoDir.make<TH2F>(Form("hNCDVsLum_%i" ,i),"inst lum vs nCaloDigi; p/#mu-bunch; nCaloDigi"  ,  1000, _minPOT, _maxPOT, 5000, 0., 20000.);
     }
     
-    int    index_last = _nTrackTrig+_nCaloTrig;
-    art::TFileDirectory occInfoDir = Tfs->mkdir("occInfoGeneral");
-    Hist._hOccInfo  [index_last][0]  = occInfoDir.make<TH1F>(Form("hInstLum_%i"  ,index_last),"distrbution of instantaneous lum; p/#mu-bunch"  ,  1000, 1e6, 4e8);
+     int    index_last = _nTrackTrig+_nCaloTrig;
+     art::TFileDirectory occInfoDir = Tfs->mkdir("occInfoGeneral");
+     Hist._hOccInfo  [index_last][0]  = occInfoDir.make<TH1F>(Form("hInstLum_%i"  ,index_last),"distrbution of instantaneous lum; p/#mu-bunch"  ,  1000, _minPOT, _maxPOT);
       
-    Hist._h2DOccInfo[index_last][0]  = occInfoDir.make<TH2F>(Form("hNSDVsLum_%i" ,index_last),"inst lum vs nStrawDigi; p/#mu-bunch; nStrawDigi",  1000, 1e6, 4e8, 5000, 0., 20000.);
-    Hist._h2DOccInfo[index_last][1]  = occInfoDir.make<TH2F>(Form("hNCDVsLum_%i" ,index_last),"inst lum vs nCaloDigi; p/#mu-bunch; nCaloDigi"  ,  1000, 1e6, 4e8, 5000, 0., 20000.);
+     Hist._h2DOccInfo[index_last][0]  = occInfoDir.make<TH2F>(Form("hNSDVsLum_%i" ,index_last),"inst lum vs nStrawDigi; p/#mu-bunch; nStrawDigi",  1000, _minPOT, _maxPOT, 5000, 0., 20000.);
+     Hist._h2DOccInfo[index_last][1]  = occInfoDir.make<TH2F>(Form("hNCDVsLum_%i" ,index_last),"inst lum vs nCaloDigi; p/#mu-bunch; nCaloDigi"  ,  1000, _minPOT, _maxPOT, 5000, 0., 20000.);
  
 	
     
@@ -646,9 +682,7 @@ namespace mu2e {
       }   
     }
 
-
     int    indexTrigInfo11(0);
-
     //fill the histograms
     for (size_t i=0; i<_trigAll.size(); ++i ){
       _sumHist._hTrigInfo  [0]->GetXaxis()->SetBinLabel(i+1, _trigAll[i].label.c_str());
@@ -826,6 +860,105 @@ namespace mu2e {
 
   void ReadTriggerInfo::endSubRun(const art::SubRun& sr){}
 
+  bool ReadTriggerInfo::goodTrkTanDip(const mu2e::KalSeed*Ks){
+    const mu2e::KalSegment* kSeg = &(Ks->segments().at(0));
+    float tanDip = kSeg->helix().tanDip();
+    if ( (tanDip > _trkMinTanDip) && (tanDip< _trkMaxTanDip) ) return true;
+
+    return false;
+  }
+
+  void ReadTriggerInfo::fillTrackEfficiencyHist(const mu2e::KalSeedCollection* KsCol, 
+						const mu2e::TrkQualCollection* TrkQualCol, 
+						const art::TriggerResults*     TrigResults,
+						const mu2e::StepPointMCCollection* Steps){
+
+    float pCEleCuts[2]={103., 105.};
+    float pCPosCuts[2]={90.5, 92.5};
+
+    const mu2e::HelixSeed* hs(0);
+
+    if (KsCol != NULL){
+      const mu2e::KalSeed*ks(0);
+      for (size_t i=0; i<KsCol->size(); ++i){
+	ks = &KsCol->at(i);
+	const mu2e::KalSegment* kSeg = &(ks->segments().at(0));
+	float p = kSeg->mom();
+
+	if (ks->particle() == PDGCode::e_minus){
+	    if ((p<pCEleCuts[0]) || (p>pCEleCuts[1]) )
+	      continue;
+	} else 	if  (ks->particle() == PDGCode::e_plus){
+	  if ((p<pCPosCuts[0]) || (p>pCPosCuts[1]) )
+	    continue;
+	}
+	if ( (TrkQualCol->at(i).MVAOutput()<_trkMinMVA) || 
+	     (!goodTrkTanDip(ks)) || // [0.5, 1.0]
+	     (std::abs(kSeg->helix().d0()) > _trkMaxD0) ) continue;
+	_sumHist._hTrigInfo[16]->Fill(_nPOT);
+	
+	float ks_t0 = ks->t0()._t0;
+	float t0Toll(80.);
+	bool  hasCprHelix(false), hasTprHelix(false);
+	for (size_t i=0; i<_hsCprCol->size(); ++i){
+	  hs = &_hsCprCol->at(i);
+	  float  hs_t0 = hs->t0()._t0;
+	  if (std::abs(hs_t0 - ks_t0)<t0Toll){
+	    hasCprHelix = true;
+	    break;
+	  }
+	}
+
+	for (size_t i=0; i<_hsTprCol->size(); ++i){
+	  hs = &_hsTprCol->at(i);
+	  float  hs_t0 = hs->t0()._t0;
+	  if (std::abs(hs_t0 - ks_t0)<t0Toll){
+	    hasTprHelix = true;
+	    break;
+	  }
+	}
+	
+	if ( hasCprHelix){
+	  _sumHist._hTrigInfo[20]->Fill(_nPOT);	  
+	}
+	if ( hasTprHelix ){
+	  _sumHist._hTrigInfo[21]->Fill(_nPOT);	  	
+	}
+	
+	for (size_t j=0; j<_effBits.size(); ++j){
+	  if (TrigResults->accept(_effBits[j])){
+	    _sumHist._hTrigInfo[17]->Fill(_nPOT);	  
+	    break;
+	  }
+	}//end loop over the good effBits
+      }//end loop over the tracks
+    }
+
+    if (Steps != NULL){
+      const mu2e::StepPointMC* step(0);
+      for ( size_t i=0; i<Steps->size(); ++i ){
+	step = &Steps->at(i);
+	int id = step->volumeId();
+	if ( (id == 13) || (id == 14)){//Tracker front face
+	  if ( !(step->simParticle()->fromGenerator()) )                    continue;
+	  if (step->simParticle()->genParticle()->generatorId().id() != 43) continue;
+	
+	  int   pdg = step->simParticle()->pdgId();
+	  float p   = step->momentum().mag();
+	
+	  if ( (pdg == 11) && (p>=pCEleCuts[0]) && (p<=pCEleCuts[1])){
+	    _sumHist._hTrigInfo[18]->Fill(_nPOT);
+	    break;
+	  }else if ( (pdg == -11) && (p>=pCPosCuts[0]) && (p<=pCPosCuts[1])){
+	    _sumHist._hTrigInfo[18]->Fill(_nPOT);
+	    break;
+	  }
+	}
+      }//end loop over the virtual-det hits
+    }
+  }
+
+  //--------------------------------------------------------------------------------
   void ReadTriggerInfo::analyze(const art::Event& event) {
 
     //get the number of POT
@@ -835,16 +968,20 @@ namespace mu2e {
     if (evtWeightH.isValid()){
       _nPOT  = (double)evtWeightH->intensity();
     }
+    _sumHist._hTrigInfo[19]->Fill(_nPOT);
 
-    //    std::vector<art::Handle<TriggerInfo> > hTrigInfoVec;
+    art::Handle<StepPointMCCollection> vdH;
+    event.getByLabel(_vdTag, vdH);
+    const mu2e::StepPointMCCollection*vdSteps(0);
+    if (vdH.isValid()){
+      vdSteps = vdH.product();
+    }
     
-    //    event.getManyByType(hTrigInfoVec);
-
     //get the TriggerResult
     art::InputTag const tag{Form("TriggerResults::%s", _processName.c_str())};  
     auto const trigResultsH   = event.getValidHandle<art::TriggerResults>(tag);
     const art::TriggerResults*trigResults = trigResultsH.product();
-    
+
     //fill the histogram with the trigger bits
     for (unsigned i=0; i<trigResults->size(); ++i){
       if (trigResults->accept(i)){
@@ -852,14 +989,45 @@ namespace mu2e {
       }
     }
 
-
     TriggerResultsNavigator   trigNavig(trigResults);
     
-    for (unsigned int i=0; i< _trigPaths.size(); ++i){
-      string&path = _trigPaths.at(i);
-      if (trigNavig.accepted(path)) _sumHist._hTrigInfo[15]->Fill((double)i);
+    for (unsigned int i=0; i< trigNavig.getTrigPaths().size(); ++i){
+      std::string path   = trigNavig.getTrigPathName(i);
+      size_t      pathID = trigNavig.findTrigPathID(path);
+      if (trigNavig.accepted(path)) _sumHist._hTrigInfo[15]->Fill(pathID);
     }
     
+    art::Handle<mu2e::HelixSeedCollection>  hsCprH;
+    event.getByLabel(_hsCprTag, hsCprH);
+    if (hsCprH.isValid()){
+      _hsCprCol = hsCprH.product();
+    }else {
+      _hsCprCol = NULL;
+    }
+
+    art::Handle<mu2e::HelixSeedCollection>  hsTprH;
+    event.getByLabel(_hsTprTag, hsTprH);
+    if (hsTprH.isValid()){
+      _hsTprCol = hsTprH.product();
+    }else {
+      _hsTprCol = NULL;
+    }
+
+    art::Handle<mu2e::KalSeedCollection>  ksH;
+    const mu2e::KalSeedCollection*        ksCol(0);
+    event.getByLabel(_ksTag, ksH);
+    if (ksH.isValid()){
+      ksCol = ksH.product();
+    }
+    art::Handle<mu2e::TrkQualCollection> trkQualH;
+    const mu2e::TrkQualCollection*       trkQualCol(0);
+    event.getByLabel(_trkQualTag, trkQualH);
+    if (trkQualH.isValid()) {
+      trkQualCol = trkQualH.product();
+    }
+
+    fillTrackEfficiencyHist(ksCol, trkQualCol, trigResults, vdSteps);
+
     //get the strawDigiMC truth if present
     art::Handle<mu2e::StrawDigiMCCollection> mcdH;
     event.getByLabel(_sdMCTag, mcdH);
@@ -918,7 +1086,6 @@ namespace mu2e {
 	    if (j==0) printf("[ReadTriggerInfo::analyze]      name      \n");
 	    printf("[ReadTriggerInfo::analyze] %10s\n", moduleLabel.c_str());
 	  }
-
 	  int          index_all(0);         
 	  int          index(0);         
 	  bool         passed(false);
@@ -946,9 +1113,9 @@ namespace mu2e {
 		  fillOccupancyInfo(_nTrackTrig+index, sdCol, cdCol, _occupancyHist);
 		}
 	      }
-	    }
+	    }//end loop over the helix-collection 
 	    _helHist._hHelInfo[i][120]->Fill(nTrigObj);
-	    
+
 	  }else if ( moduleLabel.find("TSFilter") != std::string::npos){
 	    findTrigIndex(_trigTrack, moduleLabel, index);
 	    _trigTrack[index].label  = moduleLabel;
@@ -964,10 +1131,10 @@ namespace mu2e {
 		  fillOccupancyInfo(index, sdCol, cdCol, _occupancyHist);
 		}
 	      }
-	    }
+	    }//end loop over the kaseed-collection
 	    _trkHist._hTrkInfo[i][40]->Fill(nTrigObj);
-
 	    trigFlag_index.push_back(index_all);
+
 	  }else if ( moduleLabel.find("EventPrescale") != std::string::npos){
 	    findTrigIndex(_trigEvtPS, moduleLabel, index);
 	    _trigEvtPS[index].label  = moduleLabel;
@@ -983,7 +1150,7 @@ namespace mu2e {
 		++nTrigObj;
 		fillCaloCalibTrigInfo(index, cluster.get(), _caloCalibHist);
 	      }
-	    }
+	    }//end loop over the cluster-collection
 	    trigFlag_index.push_back(index_all);
 	  }else if ( (moduleLabel.find("caloMVACEFilter") != std::string::npos) || (moduleLabel.find("caloLHCEFilter") != std::string::npos) ){
 	    findTrigIndex(_trigCaloOnly, moduleLabel, index);
@@ -997,18 +1164,18 @@ namespace mu2e {
 		fillCaloTrigSeedInfo(index, clseed.get(), _caloTSeedHist);
 		if (passed) {
 		  passed = false;
-		  // fillOccupancyInfo   (_nTrackTrig*2+index, sdCol, cdCol, _occupancyHist);
-		  fillOccupancyInfo   (_nTrackTrig + index, sdCol, cdCol, _occupancyHist);
+		  fillOccupancyInfo   (_nTrackTrig*2+index, sdCol, cdCol, _occupancyHist);
 		}
 	      }
-	    }
+	    }//end loop
 	    _caloTSeedHist._hCaloOnlyInfo[i][20]->Fill(nTrigObj);
 	    trigFlag_index.push_back(index_all);	    
 	  }
 	  
-
+	  bool isCosmicHelix = (moduleLabel.find("HSFilter")!= std::string::npos) && (moduleLabel.find("CosmicHelix")!= std::string::npos);
 	  if ( (moduleLabel.find("caloMVACEFilter")!= std::string::npos) || 
-	       (moduleLabel.find("TSFilter")       != std::string::npos) ){ 
+	       (moduleLabel.find("TSFilter")       != std::string::npos) ||
+	       isCosmicHelix ){ 
 	    findTrigIndex(_trigFinal, moduleLabel, index);
 	    _trigFinal[index].label    = moduleLabel;
 	    _trigFinal[index].counts   = _trigFinal[index].counts + 1;
@@ -1032,20 +1199,25 @@ namespace mu2e {
   
   void   ReadTriggerInfo::findTrigIndex(std::vector<trigInfo_> &Vec, std::string& ModuleLabel, int &Index){
     //reset the index value
-    Index = 0;
-    for (size_t i=0; i<Vec.size(); ++i){
-      if (Vec[i].label == ModuleLabel) { 
+    Index  = 0;
+    size_t offset = 0;
+    if ( ModuleLabel.find(std::string("tpr")) != std::string::npos) {
+      offset = 10;
+      Index  = 10; 
+    }
+    for (size_t i=offset; i<Vec.size(); ++i){
+      if ( (Vec[i].label == ModuleLabel) || (Vec[i].label == "") ) { 
 	Index = i;
 	break;
-      }else if (Vec[i].label != ""){
-	Index = i+1;
-      }
+      }// else if (Vec[i].label != ""){
+      // 	Index = i+1;
+      // }
     }
   }
 
   void   ReadTriggerInfo::fillTrackTrigInfo(int TrkTrigIndex, const KalSeed*KSeed, trackInfoHist_   &Hist){
     GlobalConstantsHandle<ParticleDataTable> pdt;
-//    HelixTool helTool(KSeed->helix().get(), _tracker);
+    //HelixTool helTool(KSeed->helix().get(), _tracker);
 
     int                nsh = (int)KSeed->hits().size();
     KalSegment const& fseg = KSeed->segments().front();
@@ -1057,7 +1229,7 @@ namespace mu2e {
     double     d0    = fseg.helix().d0();
     double     clE(-1.);
     if (KSeed->caloCluster()) clE = KSeed->caloCluster()->energyDep();
-//    double     nLoops    = helTool.nLoops();
+    //    double     nLoops    = helTool.nLoops();
 
     Hist._hTrkInfo[TrkTrigIndex][0]->Fill(p);
     Hist._hTrkInfo[TrkTrigIndex][1]->Fill(pt);
@@ -1065,7 +1237,7 @@ namespace mu2e {
     Hist._hTrkInfo[TrkTrigIndex][3]->Fill(d0);
     Hist._hTrkInfo[TrkTrigIndex][4]->Fill(chi2d);
     Hist._hTrkInfo[TrkTrigIndex][5]->Fill(clE);
-//    Hist._hTrkInfo[TrkTrigIndex][6]->Fill(nLoops);
+    //    Hist._hTrkInfo[TrkTrigIndex][6]->Fill(nLoops);
 
     //add the MC info if available
     if (_mcdigis) {
@@ -1115,45 +1287,45 @@ namespace mu2e {
     
       //finally, get the info of the first StrawDigi
       const mu2e::StrawDigiMC* sdmc = &_mcdigis->at(mostvalueindex);
-      art::Ptr<mu2e::SimParticle> const& simptr = sdmc->earlyStrawGasStep()->simParticle();
-      int     pdg   = simptr->pdgId();
-      art::Ptr<mu2e::SimParticle> mother = simptr;
+	art::Ptr<mu2e::SimParticle> const& simptr = sdmc->earlyStrawGasStep()->simParticle();
+	int     pdg   = simptr->pdgId();
+	art::Ptr<mu2e::SimParticle> mother = simptr;
 
-      while(mother->hasParent()) 
-	mother = mother->parent();
-      //sim = mother.operator->();
-      int      pdgM   = mother->pdgId();
-      double   pXMC   = simptr->startMomentum().x();
-      double   pYMC   = simptr->startMomentum().y();
-      double   pZMC   = simptr->startMomentum().z();
-      double   mass(-1.);//  = part->Mass();
-      double   energy(-1.);// = sqrt(px*px+py*py+pz*pz+mass*mass);
-      mass   = pdt->particle(pdg).ref().mass();
-      energy = sqrt(pXMC*pXMC+pYMC*pYMC+pZMC*pZMC+mass*mass);
+	while(mother->hasParent()) 
+	  mother = mother->parent();
+	//sim = mother.operator->();
+	int      pdgM   = mother->pdgId();
+	double   pXMC   = simptr->startMomentum().x();
+	double   pYMC   = simptr->startMomentum().y();
+	double   pZMC   = simptr->startMomentum().z();
+	double   mass(-1.);//  = part->Mass();
+	double   energy(-1.);// = sqrt(px*px+py*py+pz*pz+mass*mass);
+	mass   = pdt->particle(pdg).ref().mass();
+	energy = sqrt(pXMC*pXMC+pYMC*pYMC+pZMC*pZMC+mass*mass);
       
-      double   pTMC   = sqrt(pXMC*pXMC + pYMC*pYMC);
-      double   pMC    = sqrt(pZMC*pZMC + pTMC*pTMC);
+	double   pTMC   = sqrt(pXMC*pXMC + pYMC*pYMC);
+	double   pMC    = sqrt(pZMC*pZMC + pTMC*pTMC);
       
-      const CLHEP::Hep3Vector* sp = &simptr->startPosition();
-      XYZVec origin;
-      origin.SetX(sp->x()+3904);
-      origin.SetY(sp->y());
-      origin.SetZ(sp->z());
-      double origin_r = sqrt(origin.x()*origin.x() + origin.y()*origin.y());
-      double pz     = sqrt(p*p - pt*pt);
+	const CLHEP::Hep3Vector* sp = &simptr->startPosition();
+	XYZVec origin;
+	origin.SetX(sp->x()+3904);
+	origin.SetY(sp->y());
+	origin.SetZ(sp->z());
+	double origin_r = sqrt(origin.x()*origin.x() + origin.y()*origin.y());
+	double pz     = sqrt(p*p - pt*pt);
 
-      //now fill the MC histograms
-      Hist._hTrkInfo[TrkTrigIndex][10]->Fill(pMC);
-      Hist._hTrkInfo[TrkTrigIndex][11]->Fill(pTMC);
-      Hist._hTrkInfo[TrkTrigIndex][12]->Fill(pZMC);
-      Hist._hTrkInfo[TrkTrigIndex][13]->Fill(p - pMC);
-      Hist._hTrkInfo[TrkTrigIndex][14]->Fill(pt - pTMC);
-      Hist._hTrkInfo[TrkTrigIndex][15]->Fill(pz - pZMC);
-      Hist._hTrkInfo[TrkTrigIndex][16]->Fill(pdg);
-      Hist._hTrkInfo[TrkTrigIndex][17]->Fill(origin.z());
-      Hist._hTrkInfo[TrkTrigIndex][18]->Fill(origin_r);
-      Hist._hTrkInfo[TrkTrigIndex][19]->Fill(pdgM);
-      Hist._hTrkInfo[TrkTrigIndex][20]->Fill(energy);
+	//now fill the MC histograms
+	Hist._hTrkInfo[TrkTrigIndex][10]->Fill(pMC);
+	Hist._hTrkInfo[TrkTrigIndex][11]->Fill(pTMC);
+	Hist._hTrkInfo[TrkTrigIndex][12]->Fill(pZMC);
+	Hist._hTrkInfo[TrkTrigIndex][13]->Fill(p - pMC);
+	Hist._hTrkInfo[TrkTrigIndex][14]->Fill(pt - pTMC);
+	Hist._hTrkInfo[TrkTrigIndex][15]->Fill(pz - pZMC);
+	Hist._hTrkInfo[TrkTrigIndex][16]->Fill(pdg);
+	Hist._hTrkInfo[TrkTrigIndex][17]->Fill(origin.z());
+	Hist._hTrkInfo[TrkTrigIndex][18]->Fill(origin_r);
+	Hist._hTrkInfo[TrkTrigIndex][19]->Fill(pdgM);
+	Hist._hTrkInfo[TrkTrigIndex][20]->Fill(energy);
     }
   }
 
@@ -1205,7 +1377,7 @@ namespace mu2e {
     Hist._hHelInfo[HelTrigIndex][8]->Fill(nLoops);
     Hist._hHelInfo[HelTrigIndex][9]->Fill(helTool.hitRatio());
 
-    //add the MC info if available
+     //add the MC info if available
     if (_mcdigis) {
       //      const mu2e::ComboHit*    hit(0);
       std::vector<int>         hits_simp_id, hits_simp_index, hits_simp_z;
@@ -1218,13 +1390,13 @@ namespace mu2e {
 	for (size_t k=0; k<shids.size(); ++k) {
 	  const mu2e::StrawDigiMC* sdmc = &_mcdigis->at(shids[k]);
 	  auto const& spmcp = sdmc->earlyStrawGasStep();
-	  art::Ptr<mu2e::SimParticle> const& simptr = spmcp->simParticle(); 
-	  int sim_id        = simptr->id().asInt();
-	  float   dz        = spmcp->position().z();// - trackerZ0;
-	  hits_simp_id.push_back   (sim_id); 
-	  hits_simp_index.push_back(shids[k]);
-	  hits_simp_z.push_back(dz);
-	  break;
+	    art::Ptr<mu2e::SimParticle> const& simptr = spmcp->simParticle(); 
+	    int sim_id        = simptr->id().asInt();
+	    float   dz        = spmcp->position().z();// - trackerZ0;
+	    hits_simp_id.push_back   (sim_id); 
+	    hits_simp_index.push_back(shids[k]);
+	    hits_simp_z.push_back(dz);
+	    break;
 	}
       }//end loop over the hits
     
@@ -1246,114 +1418,114 @@ namespace mu2e {
       //finally, get the info of the first StrawDigi
       const mu2e::StrawDigiMC* sdmc = &_mcdigis->at(mostvalueindex);
       auto const& spmcp = sdmc->earlyStrawGasStep();
-      art::Ptr<mu2e::SimParticle> const& simptr = spmcp->simParticle(); 
-      int     pdg   = simptr->pdgId();
-      art::Ptr<mu2e::SimParticle> mother = simptr;
+	art::Ptr<mu2e::SimParticle> const& simptr = spmcp->simParticle(); 
+	int     pdg   = simptr->pdgId();
+	art::Ptr<mu2e::SimParticle> mother = simptr;
 
-      while(mother->hasParent()) mother = mother->parent();
-      int      pdgM   = mother->pdgId();
-      double   pXMC   = spmcp->momentum().x();
-      double   pYMC   = spmcp->momentum().y();
-      double   pZMC   = spmcp->momentum().z();
-      // double   mass(-1.);//  = part->Mass();
-      // double   energy(-1.);// = sqrt(px*px+py*py+pz*pz+mass*mass);
-      // mass   = pdt->particle(pdg).ref().mass();
-      // energy = sqrt(pXMC*pXMC+pYMC*pYMC+pZMC*pZMC+mass*mass);
+	while(mother->hasParent()) mother = mother->parent();
+	int      pdgM   = mother->pdgId();
+	double   pXMC   = spmcp->momentum().x();
+	double   pYMC   = spmcp->momentum().y();
+	double   pZMC   = spmcp->momentum().z();
+	// double   mass(-1.);//  = part->Mass();
+	// double   energy(-1.);// = sqrt(px*px+py*py+pz*pz+mass*mass);
+	// mass   = pdt->particle(pdg).ref().mass();
+	// energy = sqrt(pXMC*pXMC+pYMC*pYMC+pZMC*pZMC+mass*mass);
       
-      //need to check the mother of the particle
-      //the possible cases we are interested are:
-      // 1) IPA negative muon: 
-      // 2) atmospheric negative muon:
-      // 3) atmospheric positive muon:
-      // 4) photon
-      // 5) proton
-      // 6) neutron
+	//need to check the mother of the particle
+	//the possible cases we are interested are:
+	// 1) IPA negative muon: 
+	// 2) atmospheric negative muon:
+	// 3) atmospheric positive muon:
+	// 4) photon
+	// 5) proton
+	// 6) neutron
 
-      int   indexMother(-1);
+	int   indexMother(-1);
 
-      if (pdgM == 13){ //negative muon
-	XYZVec  mother_origin;
-	mother_origin.SetX(mother->startPosition().x()+3904);
-	mother_origin.SetY(mother->startPosition().y());
-	mother_origin.SetZ(mother->startPosition().z());
-	double mother_origin_r =  sqrt(mother_origin.x()*mother_origin.x() + mother_origin.y()*mother_origin.y());
-	double IPA_z(7400.), IPA_z_tolerance(600.);
-	// case 1: origin in the IPA and PDG-Id
-	if ( (fabs(mother_origin_r) <= 300.5) && 
-	     (fabs(mother_origin_r) >= 299.5) && 
-	     (fabs(mother_origin.z() - IPA_z) < IPA_z_tolerance) &&
-	     (mother->startMomentum().px() < 1e-10) &&
-	     (mother->startMomentum().py() < 1e-10) &&
-	     (mother->startMomentum().pz() < 1e-10)){
-	  indexMother = 40;
-	}else{//case 2: negative cosmic muon
-	  indexMother = 20;	  
+	if (pdgM == 13){ //negative muon
+	  XYZVec  mother_origin;
+	  mother_origin.SetX(mother->startPosition().x()+3904);
+	  mother_origin.SetY(mother->startPosition().y());
+	  mother_origin.SetZ(mother->startPosition().z());
+	  double mother_origin_r =  sqrt(mother_origin.x()*mother_origin.x() + mother_origin.y()*mother_origin.y());
+	  double IPA_z(7400.), IPA_z_tolerance(600.);
+	  // case 1: origin in the IPA and PDG-Id
+	  if ( (fabs(mother_origin_r) <= 300.5) && 
+	       (fabs(mother_origin_r) >= 299.5) && 
+	       (fabs(mother_origin.z() - IPA_z) < IPA_z_tolerance) &&
+	       (mother->startMomentum().px() < 1e-10) &&
+	       (mother->startMomentum().py() < 1e-10) &&
+	       (mother->startMomentum().pz() < 1e-10)){
+	    indexMother = 40;
+	  }else{//case 2: negative cosmic muon
+	    indexMother = 20;	  
+	  }
+	}else if (pdgM == -13){//case 3: positive muon
+	  indexMother = 30;
+	}else if (pdgM == 22){//case 4: photon
+	  indexMother = 50;
+	}else if (pdgM == 2212){//case 5: proton
+	  indexMother = 60;
+	}else if (pdgM == 2112){ //case 6: neutron
+	  indexMother = 70;
+	}else if (pdgM == -211){ //case 7: pi minus
+	  indexMother = 80;
+	}else if (pdgM == 211){ //case 8: pi plus
+	  indexMother = 90;
+	}else if (pdgM == PDGCode::e_minus){ //case 9: electrons
+	  indexMother = 100;
+	}else if (pdgM == PDGCode::e_plus){ //case 10: positrons
+	  indexMother = 110;
 	}
-      }else if (pdgM == PDGCode::mu_plus){//case 3: positive muon
-	indexMother = 30;
-      }else if (pdgM == PDGCode::gamma){//case 4: photon
-	indexMother = 50;
-      }else if (pdgM == PDGCode::proton){//case 5: proton
-	indexMother = 60;
-      }else if (pdgM == PDGCode::n0){ //case 6: neutron
-	indexMother = 70;
-      }else if (pdgM == PDGCode::pi_minus){ //case 7: pi minus
-	indexMother = 80;
-      }else if (pdgM == PDGCode::pi_plus){ //case 8: pi plus
-	indexMother = 90;
-      }else if (pdgM == PDGCode::e_minus){ //case 9: electrons
-	indexMother = 100;
-      }else if (pdgM == PDGCode::e_plus){ //case 10: positrons
-	indexMother = 110;
-      }
 
-      double   pTMC   = sqrt(pXMC*pXMC + pYMC*pYMC);
-      double   pMC    = sqrt(pZMC*pZMC + pTMC*pTMC);
+	double   pTMC   = sqrt(pXMC*pXMC + pYMC*pYMC);
+	double   pMC    = sqrt(pZMC*pZMC + pTMC*pTMC);
       
-      const CLHEP::Hep3Vector* sp = &simptr->startPosition();
-      XYZVec origin;
-      origin.SetX(sp->x()+3904);
-      origin.SetY(sp->y());
-      origin.SetZ(sp->z());
-      double origin_r = sqrt(origin.x()*origin.x() + origin.y()*origin.y());
-      // trackSeed->fOrigin1.SetXYZT(sp->x(),sp->y(),sp->z(),simptr->startGlobalTime());
-      double pz     = sqrt(p*p - pt*pt);
+	const CLHEP::Hep3Vector* sp = &simptr->startPosition();
+	XYZVec origin;
+	origin.SetX(sp->x()+3904);
+	origin.SetY(sp->y());
+	origin.SetZ(sp->z());
+	double origin_r = sqrt(origin.x()*origin.x() + origin.y()*origin.y());
+	// trackSeed->fOrigin1.SetXYZT(sp->x(),sp->y(),sp->z(),simptr->startGlobalTime());
+	double pz     = sqrt(p*p - pt*pt);
 
-      //now fill the MC histograms
-      Hist._hHelInfo[HelTrigIndex][10]->Fill(pMC);	   
-      Hist._hHelInfo[HelTrigIndex][11]->Fill(pTMC);	   
-      Hist._hHelInfo[HelTrigIndex][12]->Fill(pZMC);	   
-      Hist._hHelInfo[HelTrigIndex][13]->Fill(p - pMC);   
-      Hist._hHelInfo[HelTrigIndex][14]->Fill(pt - pTMC); 
-      Hist._hHelInfo[HelTrigIndex][15]->Fill(pz - pZMC); 
-      Hist._hHelInfo[HelTrigIndex][16]->Fill(pdg);	   
-      Hist._hHelInfo[HelTrigIndex][17]->Fill(origin.z());
-      Hist._hHelInfo[HelTrigIndex][18]->Fill(origin_r);  
-      Hist._hHelInfo[HelTrigIndex][19]->Fill(pdgM);      
+	//now fill the MC histograms
+	Hist._hHelInfo[HelTrigIndex][10]->Fill(pMC);	   
+	Hist._hHelInfo[HelTrigIndex][11]->Fill(pTMC);	   
+	Hist._hHelInfo[HelTrigIndex][12]->Fill(pZMC);	   
+	Hist._hHelInfo[HelTrigIndex][13]->Fill(p - pMC);   
+	Hist._hHelInfo[HelTrigIndex][14]->Fill(pt - pTMC); 
+	Hist._hHelInfo[HelTrigIndex][15]->Fill(pz - pZMC); 
+	Hist._hHelInfo[HelTrigIndex][16]->Fill(pdg);	   
+	Hist._hHelInfo[HelTrigIndex][17]->Fill(origin.z());
+	Hist._hHelInfo[HelTrigIndex][18]->Fill(origin_r);  
+	Hist._hHelInfo[HelTrigIndex][19]->Fill(pdgM);      
 
-      //fill the "add" info
-      if (indexMother>0){
-	MCInfo tmpMCInfo;
-	tmpMCInfo.pMC   = (pMC);	
-	tmpMCInfo.pTMC  = (pTMC);	
-	tmpMCInfo.pZMC  = (pZMC);	
-	tmpMCInfo.dpMC  = (p - pMC); 
-	tmpMCInfo.dpTMC = (pt - pTMC);
-	tmpMCInfo.dpZMC = (pz - pZMC);
-	tmpMCInfo.pdg   = (pdg);	 
-	tmpMCInfo.origZ = (origin.z());
-	tmpMCInfo.origR = (origin_r);  
-	tmpMCInfo.pdgM  = (pdgM);      
-	tmpMCInfo.lambda  = lambda;      
-	tmpMCInfo.d0    = d0;      
-	tmpMCInfo.p     = p;      
+	//fill the "add" info
+	if (indexMother>0){
+	  MCInfo tmpMCInfo;
+	  tmpMCInfo.pMC   = (pMC);	
+	  tmpMCInfo.pTMC  = (pTMC);	
+	  tmpMCInfo.pZMC  = (pZMC);	
+	  tmpMCInfo.dpMC  = (p - pMC); 
+	  tmpMCInfo.dpTMC = (pt - pTMC);
+	  tmpMCInfo.dpZMC = (pz - pZMC);
+	  tmpMCInfo.pdg   = (pdg);	 
+	  tmpMCInfo.origZ = (origin.z());
+	  tmpMCInfo.origR = (origin_r);  
+	  tmpMCInfo.pdgM  = (pdgM);      
+	  tmpMCInfo.lambda  = lambda;      
+	  tmpMCInfo.d0    = d0;      
+	  tmpMCInfo.p     = p;      
 	  
 
-	fillHelixTrigInfoAdd(HelTrigIndex, indexMother, HSeed, Hist, tmpMCInfo);
-      }
+	  fillHelixTrigInfoAdd(HelTrigIndex, indexMother, HSeed, Hist, tmpMCInfo);
+	}
 
-      // Hist._hHelInfo[HelTrigIndex][20]->Fill(energy);
-    }
+	// Hist._hHelInfo[HelTrigIndex][20]->Fill(energy);
+      }
     
   }
   //--------------------------------------------------------------------------------


### PR DESCRIPTION
- improvements to the Trigger Analyzer module
- now setting the paths ID in the Menu files
- update the TriggerResultsNavigator code to handle the labels of the `art::TriggerResults` object of the latest art version ("pathName" -> "id:pathName")
- temporary fix in the `CaloHitMakerFast` module (see comments in the code)
- fixed time offset for CalPatRec-trigger_mode (probably needs to be fixed also for the Offline_mode); it moved from `-41` to `-61`
- probably need to adjust the calorimeter-timeOffset also for TPR; I tried to apply the same correction I found for CPR, but it didn't play as expected (aka smaller eff); right now is `-20`, and I tried `-40` and `0`, but both tests were returning worst result than the default.