### PR TITLE
STM trolley and upstream elements geometry update

### DIFF
--- a/GeometryService/inc/STMMaker.hh
+++ b/GeometryService/inc/STMMaker.hh
@@ -52,7 +52,10 @@ namespace mu2e {
     double       _magnetHoleHalfLength;
     double       _magnetHoleHalfWidth;
     double       _magnetHoleHalfHeight;
+    double       _magnetHoleXOffset;
+    double       _magnetHoleYOffset;
     std::string  _magnetMaterial;
+    bool         _magnetHasLiner;
     double       _magnetField;
     bool         _magnetFieldVisible;
     
@@ -166,15 +169,23 @@ namespace mu2e {
     
     bool         _shieldBuild;
     double       _shieldRadiusIn;
+    bool         _shieldHasLiner;
     double       _shieldLinerWidth;
     double       _shieldRadiusOut;
     double       _shieldPipeHalfLength;
     std::string  _shieldMaterialLiner;
     std::string  _shieldMaterial;
+    bool         _shieldMatchPipeBlock;
     double       _shieldUpStrSpace;
     double       _shieldDnStrSpace;
     double       _shieldDnStrWallHalfLength;
-    
+    double       _shieldDnStrWallHoleRadius;
+    double       _shieldDnStrWallHalfHeight;
+    double       _shieldDnStrWallHalfWidth;
+    double       _shieldDnStrWallGap;
+    double       _shieldUpStrWallGap;
+    std::string  _shieldDnStrWallMaterial;
+
   };
 
 }  //namespace mu2e

--- a/Mu2eG4/geom/STM_v05.txt
+++ b/Mu2eG4/geom/STM_v05.txt
@@ -1,0 +1,73 @@
+// (Muon) Stoping Target Monitor (STM)
+// v05 Updates: increase shielding outer radius
+
+#include "Mu2eG4/geom/STM_v04.txt"
+
+string stm.magnet.material             = "StainlessSteel"; //FIXME: Should be just steel, need new material
+double stm.magnet.halfLength           =  584.2;
+double stm.magnet.halfWidth            =  197.485;
+double stm.magnet.halfHeight           =  244.475;
+double stm.magnet.holeHalfHeight       =  203.0;  // 12 inch high hole
+double stm.magnet.holeHalfWidth        =  105.0;  // this must be larger than stm.pipe.rOut
+double stm.magnet.holeXOffset          =  0.0;
+double stm.magnet.holeYOffset          = -2.921; //-20.835; //top of the yoke is thicker than the bottom
+bool   stm.magnet.hasLiner             =  false; //turn off the poly liner
+bool   stm.magnet.usePipeAsOrigin      =  true; //place magnet based on pipe wrt shield wall
+bool   stm.magnet.centerHole           =  true; //place the hole center along viewing axis
+
+//turn off the support table material
+string stm.magnet.stand.material       = "G4_AIR";
+
+//add a poly absorber downstream of the IFB window
+bool   stm.ifbPoly.build               = true;
+double stm.ifbPoly.rIn                 =   0.0;
+double stm.ifbPoly.rOut                = 110.0;
+double stm.ifbPoly.halfLength          =   3.0; //z half length
+double stm.ifbPoly.gap                 =  10.0; //gap between poly and IFB window
+string stm.ifbPoly.material            = "Polyethylene094";
+
+//add a poly absorber in the shielding hole upstream of trolly
+bool   stm.shieldingHolePoly.build               = true;
+double stm.shieldingHolePoly.rIn                 =   0.0;
+double stm.shieldingHolePoly.rOut                = 110.0;
+double stm.shieldingHolePoly.halfLength          =  25.0; //z half length
+double stm.shieldingHolePoly.gap                 = 215.0; //gap between poly and IFB window, to put into shielding hole
+string stm.shieldingHolePoly.material            = "Polyethylene094";
+
+//update FOV collimator
+bool   stm.FOVcollimator.liner.build            = false;
+double stm.FOVcollimator.liner.cutOutHalfLength = 0.;
+double stm.FOVcollimator.UpStrSpace             = 3.0; //gap between magnet and FOV collimator
+double stm.FOVcollimator.halfWidth              =  197.485;
+double stm.FOVcollimator.halfHeight             =  244.475;
+double stm.FOVcollimator.halfLength             =   63.5;
+double stm.FOVcollimator.hole1.radiusUpStr      =   71.0;
+double stm.FOVcollimator.hole1.radiusDnStr      =   71.0;
+string stm.FOVcollimator.material               = "G4_Pb";
+
+//poly plug in the FOV collimator
+bool   stm.FOVcollimator.plug.build      = true;
+double stm.FOVcollimator.plug.radius     = 70.99;
+double stm.FOVcollimator.plug.halfLength = 50.;
+double stm.FOVcollimator.plug.offset     = 0.; //offset from downstream end of hole
+string stm.FOVcollimator.plug.material   = "Polyethylene094";
+
+double stm.shield.rIn                  = 139.70;
+double stm.shield.rOut                 = 184.20;
+bool   stm.shield.hasLiner             = false; //don't build the poly liner in the CRV shield pipe
+double stm.shield.widthLiner           = 0.0;
+string stm.shield.material             = "StainlessSteel"; //FIXME: Should be just steel, need new material
+double stm.shield.pipe.halfLength      = 254.0;
+bool   stm.shield.matchPipeBlock       = true;
+double stm.shield.DnStrWall.holeRadius = 184.21; //added 10um to prevent an overlap with the shield pipe
+double stm.shield.DnStrWall.halfLength =  25.40;
+double stm.shield.DnStrWall.halfHeight = 244.475;
+double stm.shield.DnStrWall.halfWidth  = 197.485;
+double stm.shield.DnStrWall.gap        = 0.10; //add small gap between the mating block and the magnet
+double stm.shield.UpStrWall.gap        = -223.75; //position is based on CRV, not shielding, so correct by adjusting the gap so the gap is ~50 +-20 um (measured in ROOT viewer)
+string stm.shield.DnStrWall.material   = "StainlessSteel"; //Stainless steel, not steel like the other components
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_2021_PhaseI.txt
+++ b/Mu2eG4/geom/geom_2021_PhaseI.txt
@@ -60,7 +60,7 @@ double mu2e.detectorSystemZ0 = 10171.;   // mm  G4BL: (17730-7292=9801 mm)
 #include "Mu2eG4/geom/TSdA_v02.txt"
 #include "Mu2eG4/geom/muonBeamStop_v08.txt"
 
-#include "Mu2eG4/geom/STM_v04.txt" // (muon) stopping target monitor
+#include "Mu2eG4/geom/STM_v05.txt" // (muon) stopping target monitor
 
 // Proton Absorber
 #include "Mu2eG4/geom/protonAbsorber_cylindrical_v04.txt"

--- a/Mu2eG4/src/constructDS.cc
+++ b/Mu2eG4/src/constructDS.cc
@@ -480,7 +480,8 @@ namespace mu2e {
       dss->getVPSPendFlange()->zEnd(),
       dss->getIFBmain()->zEnd(),
       dss->getIFBendPlug()->zBegin(),
-      dss->getIFBendPlug()->zEnd() };
+      dss->getIFBendPlug()->zEnd()
+    };
 
     vector<double> tmp_rOuterDs3  = {
       ds->rIn1(),
@@ -495,8 +496,6 @@ namespace mu2e {
       dss->getIFBmain()->outerRadius(),
       dss->getIFBendPlug()->outerRadius(),
       dss->getIFBendPlug()->outerRadius()
-      // (ds->cableRunVersion() > 2) ? ds->calR2CableRunIFB() : dss->getIFBendPlug()->outerRadius(),
-      // (ds->cableRunVersion() > 2) ? ds->calR2CableRunIFB() : dss->getIFBendPlug()->outerRadius()
     };
 
     assert( tmp_zPlanesDs3.size() == tmp_rOuterDs3.size() );

--- a/Mu2eG4/src/constructSTM.cc
+++ b/Mu2eG4/src/constructSTM.cc
@@ -562,10 +562,11 @@ namespace mu2e {
     //and in the pipe, and pipe gas, that goes through the magnet
     //Note the local values for the stepper etc...
     //Geant4 should take ownership of the objects created here
-
+    double stmMagnetFieldZHalfLength = pSTMMagnetParams.zHalfLength();
+    if(pSTMMagnetParams.hasLiner()) stmMagnetFieldZHalfLength -= pSTMShieldPipeParams.linerWidth();
     const double stmMagnetFieldHalfLengths[3] = {pSTMMagnetParams.xHoleHalfLength(),
                                                  pSTMMagnetParams.yHoleHalfLength(),
-                                                 pSTMMagnetParams.zHalfLength()-pSTMMagnetParams.hasLiner()*pSTMShieldPipeParams.linerWidth()};
+                                                 stmMagnetFieldZHalfLength};
 
     VolumeInfo stmMagneticFieldBoxInfo;
     stmMagneticFieldBoxInfo.name = "stmMagneticField";

--- a/Mu2eG4/src/constructSTM.cc
+++ b/Mu2eG4/src/constructSTM.cc
@@ -19,6 +19,7 @@
 
 #include "Mu2eG4/inc/constructSTM.hh"
 #include "DetectorSolenoidGeom/inc/DetectorSolenoid.hh"
+#include "DetectorSolenoidGeom/inc/DetectorSolenoidShielding.hh"
 #include "CosmicRayShieldGeom/inc/CosmicRayShield.hh"
 #include "StoppingTargetGeom/inc/StoppingTarget.hh"
 #include "Mu2eG4Helper/inc/VolumeInfo.hh"
@@ -125,33 +126,55 @@ namespace mu2e {
     G4ThreeVector stmMagnetPositionInParent = pSTMMagnetParams.originInMu2e() - parentCenterInMu2e;
 
     // Make the magnet
-    G4Box* boxMagnet     = new G4Box("boxMagnet",     pSTMMagnetParams.xHalfLength(),     pSTMMagnetParams.yHalfLength(),     pSTMMagnetParams.zHalfLength());
+    G4Box* boxMagnet     = new G4Box("boxMagnet",
+                                     pSTMMagnetParams.xHalfLength(),
+                                     pSTMMagnetParams.yHalfLength(),
+                                     pSTMMagnetParams.zHalfLength());
 
     // Make the rectangular window (make the box that gets subtracted just a bit longer to be sure there are no edge effects)
     const double stmMagnetHoleHalfLengths[3] = {pSTMMagnetParams.xHoleHalfLength(),
                                                 pSTMMagnetParams.yHoleHalfLength(),
                                                 pSTMMagnetParams.zHalfLength()     };
-    G4Box* boxMagnetHole = new G4Box("boxMagnetHole", stmMagnetHoleHalfLengths[0]+pSTMShieldPipeParams.linerWidth(), stmMagnetHoleHalfLengths[1]+pSTMShieldPipeParams.linerWidth(), stmMagnetHoleHalfLengths[2]+1.0);
+    G4Box* boxMagnetHole = new G4Box("boxMagnetHole",
+                                     stmMagnetHoleHalfLengths[0]+pSTMShieldPipeParams.linerWidth(),
+                                     stmMagnetHoleHalfLengths[1]+pSTMShieldPipeParams.linerWidth(),
+                                     stmMagnetHoleHalfLengths[2]+1.0);
+
     VolumeInfo stmMagnet;
     stmMagnet.name = "stmMagnet";
-    stmMagnet.solid = new G4SubtractionSolid(stmMagnet.name,boxMagnet,boxMagnetHole,0,zeroVector);
+    stmMagnet.solid = new G4SubtractionSolid(stmMagnet.name,boxMagnet,boxMagnetHole,0,pSTMMagnetParams.holeOffset());
 
     // Make the poly-liner
-    G4Box* boxMagnetPLine = new G4Box("boxMagnetPLine", stmMagnetHoleHalfLengths[0]+pSTMShieldPipeParams.linerWidth(), stmMagnetHoleHalfLengths[1]+pSTMShieldPipeParams.linerWidth(), pSTMMagnetParams.zHalfLength()-pSTMShieldPipeParams.linerWidth());
-    G4Box* boxPolyHole = new G4Box("boxPolyHole", stmMagnetHoleHalfLengths[0], stmMagnetHoleHalfLengths[1], stmMagnetHoleHalfLengths[2]+1.0);
-
+    G4Box* boxMagnetPLine;
+    G4Box* boxPolyHole;
     VolumeInfo stmMagnetPLine;
     stmMagnetPLine.name = "stmMagnetPLine";
-    stmMagnetPLine.solid = new G4SubtractionSolid(stmMagnetPLine.name,boxMagnetPLine,boxPolyHole,0,zeroVector);
+    if(pSTMMagnetParams.hasLiner()) {
+      boxMagnetPLine = new G4Box("boxMagnetPLine",
+                                 stmMagnetHoleHalfLengths[0]+pSTMShieldPipeParams.linerWidth(),
+                                 stmMagnetHoleHalfLengths[1]+pSTMShieldPipeParams.linerWidth(),
+                                 pSTMMagnetParams.zHalfLength()-pSTMShieldPipeParams.linerWidth());
+      boxPolyHole = new G4Box("boxPolyHole",
+                              stmMagnetHoleHalfLengths[0],
+                              stmMagnetHoleHalfLengths[1],
+                              stmMagnetHoleHalfLengths[2]+1.0);
 
+      stmMagnetPLine.solid = new G4SubtractionSolid(stmMagnetPLine.name,boxMagnetPLine,boxPolyHole,0,zeroVector);
+    }
 
 
     if (pSTMMagnetParams.build()){
+      G4ThreeVector magnetOffset(0., 0., 0.);
+      //if the goal is the magnet hole is centered on FOV line, add offset
+      if(_config.getBool("stm.magnet.centerHole", false)) {
+        magnetOffset -= pSTMMagnetParams.holeOffset();
+        magnetOffset.setZ(0.); //ensure it doesn't move in z
+      }
       finishNesting(stmMagnet,
                     findMaterialOrThrow(pSTMMagnetParams.materialName()),
                     0,
-                    stmMagnetPositionInParent, //mstmMagnetPositionInMother,
-                    parentInfo.logical, //parentInfo.logical, //mstmMotherInfo.logical,
+                    stmMagnetPositionInParent + magnetOffset,
+                    parentInfo.logical,
                     0,
                     STMisVisible,
                     G4Colour::Gray(),
@@ -159,19 +182,20 @@ namespace mu2e {
                     forceAuxEdgeVisible,
                     placePV,
                     doSurfaceCheck);
-
-      finishNesting(stmMagnetPLine,
-                    findMaterialOrThrow(pSTMShieldPipeParams.materialLiner()),
-                    0,
-                    stmMagnetPositionInParent, //mstmMagnetPositionInMother,
-                    parentInfo.logical, //parentInfo.logical, //mstmMotherInfo.logical,
-                    0,
-                    STMisVisible,
-                    G4Colour::Gray(),
-                    STMisSolid,
-                    forceAuxEdgeVisible,
-                    placePV,
-                    doSurfaceCheck);
+      if(pSTMMagnetParams.hasLiner()) {
+        finishNesting(stmMagnetPLine,
+                      findMaterialOrThrow(pSTMShieldPipeParams.materialLiner()),
+                      0,
+                      stmMagnetPositionInParent, //mstmMagnetPositionInMother,
+                      parentInfo.logical, //parentInfo.logical, //mstmMotherInfo.logical,
+                      0,
+                      STMisVisible,
+                      G4Colour::Gray(),
+                      STMisSolid,
+                      forceAuxEdgeVisible,
+                      placePV,
+                      doSurfaceCheck);
+      }
 
 
     }
@@ -183,6 +207,54 @@ namespace mu2e {
        cout << __func__ << " Sweeper magnet hole opening yHalfLength : "<< stmMagnetHoleHalfLengths[1] << endl;
     }
 
+
+    //=================== Upstream absorbers=========================
+    //absorber by IFB window
+    GeomHandle<DetectorSolenoidShielding> dss;
+    if(_config.getBool("stm.ifbPoly.build", false)) {
+      const auto ifb_window = dss->getIFBendWindow();
+      const auto ifb_poly_location = ifb_window->originInMu2e() + CLHEP::Hep3Vector(0., 0.,
+                                                                                    (ifb_window->zHalfLength() +
+                                                                                     _config.getDouble("stm.ifbPoly.gap") +
+                                                                                     _config.getDouble("stm.ifbPoly.halfLength")));
+      const double ifb_poly_params[] = {_config.getDouble("stm.ifbPoly.rIn"),
+                                        _config.getDouble("stm.ifbPoly.rOut"),
+                                        _config.getDouble("stm.ifbPoly.halfLength"),
+                                        0., CLHEP::twopi};
+      nestTubs("IFB_Window_Poly",
+               ifb_poly_params,
+               findMaterialOrThrow(_config.getString("stm.ifbPoly.material")),
+               0, //no rotation
+               ifb_poly_location - parentInfo.centerInMu2e(),
+               parentInfo,
+               0,
+               G4Colour::Blue(),
+               "dsShielding"
+               );
+    }
+
+    //absorber in the shielding block hole
+    if(_config.getBool("stm.shieldingHolePoly.build", false)) {
+      const auto ifb_window = dss->getIFBendWindow();
+      const auto poly_location = ifb_window->originInMu2e() + CLHEP::Hep3Vector(0., 0.,
+                                                                                    (ifb_window->zHalfLength() +
+                                                                                     _config.getDouble("stm.shieldingHolePoly.gap") +
+                                                                                     _config.getDouble("stm.shieldingHolePoly.halfLength")));
+      const double poly_params[] = {_config.getDouble("stm.shieldingHolePoly.rIn"),
+                                    _config.getDouble("stm.shieldingHolePoly.rOut"),
+                                    _config.getDouble("stm.shieldingHolePoly.halfLength"),
+                                    0., CLHEP::twopi};
+      nestTubs("STM_ShieldingHole_Poly",
+               poly_params,
+               findMaterialOrThrow(_config.getString("stm.shieldingHolePoly.material")),
+               0, //no rotation
+               poly_location - parentInfo.centerInMu2e(),
+               parentInfo,
+               0,
+               G4Colour::Blue(),
+               "dsShielding"
+               );
+    }
 
     //===================== Transport Pipe ==========================
 
@@ -492,8 +564,8 @@ namespace mu2e {
     //Geant4 should take ownership of the objects created here
 
     const double stmMagnetFieldHalfLengths[3] = {pSTMMagnetParams.xHoleHalfLength(),
-                                                pSTMMagnetParams.yHoleHalfLength(),
-                                                pSTMMagnetParams.zHalfLength()-pSTMShieldPipeParams.linerWidth()};
+                                                 pSTMMagnetParams.yHoleHalfLength(),
+                                                 pSTMMagnetParams.zHalfLength()-pSTMMagnetParams.hasLiner()*pSTMShieldPipeParams.linerWidth()};
 
     VolumeInfo stmMagneticFieldBoxInfo;
     stmMagneticFieldBoxInfo.name = "stmMagneticField";
@@ -581,35 +653,65 @@ namespace mu2e {
     //Make the tube for the hole
     G4Tubs *tubFOVColl1 = new G4Tubs("tubFOVColl1", 0.0, pSTMFOVCollimatorParams.hole1RadiusUpStr(), stmFOVCollHalfLength1+1.0, 0.0, CLHEP::twopi );
     //Make a box to subtract so liner can fit inside
-    G4Box* boxFOVCollLinerToSubt = new G4Box("boxFOVCollLinerToSubt",stmFOVCollHalfWidth2+1.0,stmFOVCollHalfHeight2+1.0,pSTMFOVCollimatorParams.linerCutOutHalfLength()+1.0);
+    double buffer = 1.0;
+    G4Box* boxFOVCollLinerToSubt = nullptr;
+    bool hasLinerCutout = pSTMFOVCollimatorParams.linerCutOutHalfLength() > 0.001; //if < 1um, ignore
+    if(hasLinerCutout) {
+      boxFOVCollLinerToSubt = new G4Box("boxFOVCollLinerToSubt",
+                                        stmFOVCollHalfWidth2+buffer,
+                                        stmFOVCollHalfHeight2+buffer,
+                                        pSTMFOVCollimatorParams.linerCutOutHalfLength()+buffer);
+    }
     // Combine into the collimator with the liner cutout and collimation hole
     VolumeInfo collimatorFOV;
     collimatorFOV.name = "collimatorFOV";
-    collimatorFOV.solid = new G4SubtractionSolid(collimatorFOV.name,boxFOVColl,         tubFOVColl1,0,G4ThreeVector(0.0,0.0,0.0));
-    collimatorFOV.solid = new G4SubtractionSolid(collimatorFOV.name,collimatorFOV.solid,boxFOVCollLinerToSubt,0,G4ThreeVector(0.0,0.0,-1.0*(stmFOVCollHalfLength1-pSTMFOVCollimatorParams.linerCutOutHalfLength() )));
-
+    collimatorFOV.solid = new G4SubtractionSolid(collimatorFOV.name,
+                                                 boxFOVColl,
+                                                 tubFOVColl1,
+                                                 0,
+                                                 G4ThreeVector(0.0,0.0,0.0));
+    if(hasLinerCutout) {
+      collimatorFOV.solid = new G4SubtractionSolid(collimatorFOV.name,
+                                                   collimatorFOV.solid,
+                                                   boxFOVCollLinerToSubt,
+                                                   0,
+                                                   G4ThreeVector(0.0,0.0,-1.0*(stmFOVCollHalfLength1-pSTMFOVCollimatorParams.linerCutOutHalfLength())));
+    }
     //position of liner
     G4ThreeVector stmFOVCollPositionInMu2e2   = stmFOVCollPositionInMu2e1   + G4ThreeVector(0.0,0.0, -stmFOVCollHalfLength1+2.0*pSTMFOVCollimatorParams.linerCutOutHalfLength()-stmFOVCollHalfLength2);
     G4ThreeVector stmFOVCollPositionInParent2 = stmFOVCollPositionInParent1 + G4ThreeVector(0.0,0.0, -stmFOVCollHalfLength1+2.0*pSTMFOVCollimatorParams.linerCutOutHalfLength()-stmFOVCollHalfLength2);
-    // make the box for the liner
-    G4Box* boxFOVCollLiner = new G4Box("boxFOVCollLiner",stmFOVCollHalfWidth2,stmFOVCollHalfHeight2,stmFOVCollHalfLength2);
-    //Make the tube for the hole
-    G4Tubs *tubFOVCollLiner1 = new G4Tubs("tubFOVCollLiner1", 0.0, pSTMFOVCollimatorParams.hole1RadiusUpStr(), stmFOVCollHalfLength2+1.0, 0.0, CLHEP::twopi );
-    // Combine into the liner with hole
+
     VolumeInfo collimatorFOVliner;
     collimatorFOVliner.name = "collimatorFOVliner";
-    collimatorFOVliner.solid = new G4SubtractionSolid(collimatorFOVliner.name,boxFOVCollLiner,tubFOVCollLiner1,0,G4ThreeVector(0.0,0.0,0.0));
+    if(hasLinerCutout) {
+      // make the box for the liner
+      G4Box* boxFOVCollLiner = new G4Box("boxFOVCollLiner",stmFOVCollHalfWidth2,stmFOVCollHalfHeight2,stmFOVCollHalfLength2);
+      //Make the tube for the hole
+      G4Tubs *tubFOVCollLiner1 = new G4Tubs("tubFOVCollLiner1", 0.0, pSTMFOVCollimatorParams.hole1RadiusUpStr(), stmFOVCollHalfLength2+1.0, 0.0, CLHEP::twopi );
+      // Combine into the liner with hole
+      collimatorFOVliner.solid = new G4SubtractionSolid(collimatorFOVliner.name,boxFOVCollLiner,tubFOVCollLiner1,0,G4ThreeVector(0.0,0.0,0.0));
+    }
 
     // Liner sheets to cover the upstream corner of FOV collimator
     VolumeInfo FOVlinerH;
     FOVlinerH.name = "FOVlinerH";
-    FOVlinerH.solid = new G4Box(FOVlinerH.name,stmFOVCollHalfWidth2, pSTMShieldPipeParams.linerWidth()/2.0, pSTMFOVCollimatorParams.linerCutOutHalfLength()-stmFOVCollHalfLength2);
+    if(pSTMFOVCollimatorParams.linerBuild()) {
+      FOVlinerH.solid = new G4Box(FOVlinerH.name,
+                                  stmFOVCollHalfWidth2,
+                                  pSTMShieldPipeParams.linerWidth()/2.0,
+                                  pSTMFOVCollimatorParams.linerCutOutHalfLength()-stmFOVCollHalfLength2);
+    }
     G4ThreeVector stmFOVCollPositionInParent3 = stmFOVCollPositionInParent1 + G4ThreeVector(0.0,-stmFOVCollHalfHeight2+pSTMShieldPipeParams.linerWidth()/2.0, -2*stmFOVCollHalfLength2);
 
     VolumeInfo FOVlinerW;
     FOVlinerW.name = "FOVlinerW";
     double cornerHeight = (stmFOVCollHalfLength1-stmFOVCollHalfLength2)/2.0;
-    FOVlinerW.solid = new G4Box(FOVlinerW.name,stmFOVCollHalfWidth2, cornerHeight/2.0, pSTMShieldPipeParams.linerWidth()/2.0);
+    if(pSTMFOVCollimatorParams.linerBuild()) {
+      FOVlinerW.solid = new G4Box(FOVlinerW.name,
+                                  stmFOVCollHalfWidth2,
+                                  cornerHeight/2.0,
+                                  pSTMShieldPipeParams.linerWidth()/2.0);
+    }
     G4ThreeVector stmFOVCollPositionInParent4 = stmFOVCollPositionInParent1 + G4ThreeVector(0.0,-stmFOVCollHalfHeight2-cornerHeight/2.0, -stmFOVCollHalfLength1-pSTMShieldPipeParams.linerWidth()/2.0);
 
     if (pSTMFOVCollimatorParams.build()){
@@ -625,44 +727,67 @@ namespace mu2e {
                     forceAuxEdgeVisible,
                     placePV,
                     doSurfaceCheck);
-      finishNesting(collimatorFOVliner,
-                    findMaterialOrThrow(pSTMFOVCollimatorParams.linerMaterial()),
-                    0,
-                    stmFOVCollPositionInParent2,
-                    parentInfo.logical,
-                    0,
-                    STMisVisible,
-                    G4Colour::Magenta(),
-                    STMisSolid,
-                    forceAuxEdgeVisible,
-                    placePV,
-                    doSurfaceCheck);
-      finishNesting(FOVlinerH,
-                    findMaterialOrThrow(pSTMFOVCollimatorParams.linerMaterial()),
-                    0,
-                    stmFOVCollPositionInParent3,
-                    parentInfo.logical,
-                    0,
-                    STMisVisible,
-                    G4Colour::Magenta(),
-                    STMisSolid,
-                    forceAuxEdgeVisible,
-                    placePV,
-                    doSurfaceCheck);
+      if(pSTMFOVCollimatorParams.linerBuild()) {
+        finishNesting(collimatorFOVliner,
+                      findMaterialOrThrow(pSTMFOVCollimatorParams.linerMaterial()),
+                      0,
+                      stmFOVCollPositionInParent2,
+                      parentInfo.logical,
+                      0,
+                      STMisVisible,
+                      G4Colour::Magenta(),
+                      STMisSolid,
+                      forceAuxEdgeVisible,
+                      placePV,
+                      doSurfaceCheck);
+        finishNesting(FOVlinerH,
+                      findMaterialOrThrow(pSTMFOVCollimatorParams.linerMaterial()),
+                      0,
+                      stmFOVCollPositionInParent3,
+                      parentInfo.logical,
+                      0,
+                      STMisVisible,
+                      G4Colour::Magenta(),
+                      STMisSolid,
+                      forceAuxEdgeVisible,
+                      placePV,
+                      doSurfaceCheck);
 
-      finishNesting(FOVlinerW,
-                    findMaterialOrThrow(pSTMFOVCollimatorParams.linerMaterial()),
-                    0,
-                    stmFOVCollPositionInParent4,
-                    parentInfo.logical,
-                    0,
-                    STMisVisible,
-                    G4Colour::Magenta(),
-                    STMisSolid,
-                    forceAuxEdgeVisible,
-                    placePV,
-                    doSurfaceCheck);
-
+        finishNesting(FOVlinerW,
+                      findMaterialOrThrow(pSTMFOVCollimatorParams.linerMaterial()),
+                      0,
+                      stmFOVCollPositionInParent4,
+                      parentInfo.logical,
+                      0,
+                      STMisVisible,
+                      G4Colour::Magenta(),
+                      STMisSolid,
+                      forceAuxEdgeVisible,
+                      placePV,
+                      doSurfaceCheck);
+      }
+      //build poly plug in FOV collimator if asked for
+      if(_config.getBool("stm.FOVcollimator.plug.build", false)) {
+        const double FOVPlugParams[] = {0.,
+                                        _config.getDouble("stm.FOVcollimator.plug.radius"),
+                                        _config.getDouble("stm.FOVcollimator.plug.halfLength"),
+                                        0.,
+                                        CLHEP::twopi};
+        const double FOVPlugZOffset = stmFOVCollHalfLength1 + _config.getDouble("stm.FOVcollimator.plug.offset") - FOVPlugParams[2];
+        nestTubs("STM_FOVCollimatorPlug",
+                 FOVPlugParams,
+                 findMaterialOrThrow(_config.getString("stm.FOVcollimator.plug.material")),
+                 0, //no rotation
+                 G4ThreeVector(0., 0., FOVPlugZOffset) + stmFOVCollPositionInParent1,
+                 parentInfo.logical,
+                 0,
+                 STMisVisible,
+                 G4Color::Gray(),
+                 STMisSolid,
+                 forceAuxEdgeVisible,
+                 placePV,
+                 doSurfaceCheck);
+      }
     }
 
     G4Tubs *tubFOVCollAbsorber = new G4Tubs("tubFOVCollAbsorber", 0.0, pSTMFOVCollimatorParams.hole1RadiusUpStr()-0.01, _config.getDouble("stm.FOVcollimator.absorber.halfLength"), 0.0, CLHEP::twopi );
@@ -1279,18 +1404,35 @@ namespace mu2e {
 
     //===================== Shield Pipe/Wall to prevent michel electrons from causing deadtime in the CRV  ==========================
 
-    const double mstmCRVShieldDnStrSpace     =  pSTMShieldPipeParams.dnStrSpace();
-    const double mstmCRVShieldHalfLength     =  pSTMShieldPipeParams.dnStrWallHalflength();
-    const double mstmCRVShieldHalfWidth      =  pSTMMagnetParams.xHalfLength();
-    const double mstmCRVShieldHalfHeight     =  pSTMMagnetParams.yHalfLength();
+    const double mstmCRVShieldDnStrSpace  =  pSTMShieldPipeParams.dnStrSpace();
+    const double mstmCRVShieldHalfLength  =  pSTMShieldPipeParams.dnStrWallHalflength();
+    double mstmCRVShieldHalfWidth         =  pSTMShieldPipeParams.dnStrWallHalfWidth();
+    double mstmCRVShieldHalfHeight        =  pSTMShieldPipeParams.dnStrWallHalfHeight();
 
-    G4ThreeVector mstmCRVShieldPositionInMu2e   = stmMagnetPositionInMu2e + G4ThreeVector(0.0,0.0, -pSTMMagnetParams.zHalfLength()-mstmCRVShieldDnStrSpace-mstmCRVShieldHalfLength);
+    //if mating block parameters aren't defined, default to the magnet dimensions for backwards compatibility
+    if(mstmCRVShieldHalfWidth < 0.) {
+      mstmCRVShieldHalfWidth = pSTMMagnetParams.xHalfLength();
+    }
+    if(mstmCRVShieldHalfHeight < 0.) {
+      mstmCRVShieldHalfHeight = pSTMMagnetParams.yHalfLength();
+    }
+
+    double mstmCRVShieldZOffset = -pSTMMagnetParams.zHalfLength()-mstmCRVShieldDnStrSpace-mstmCRVShieldHalfLength-pSTMShieldPipeParams.dnStrWallGap();
+    G4ThreeVector mstmCRVShieldPositionInMu2e   = stmMagnetPositionInMu2e + G4ThreeVector(0.0,0.0, mstmCRVShieldZOffset);
     G4ThreeVector mstmCRVShieldPositionInParent = mstmCRVShieldPositionInMu2e - parentCenterInMu2e;
 
     // Make the box for the collimator wall
     G4Box* crvShieldBox = new G4Box("crvShieldBox",mstmCRVShieldHalfWidth,mstmCRVShieldHalfHeight,mstmCRVShieldHalfLength);
     //Make the tube for the hole
-    G4Tubs *crvShieldHole = new G4Tubs( "crvShieldHole", 0.0, pSTMShieldPipeParams.radiusIn()+pSTMShieldPipeParams.linerWidth(), mstmCRVShieldHalfLength+1.0, 0.0, CLHEP::twopi );
+    const double matingBlockHoleRadius = ((pSTMShieldPipeParams.dnStrWallHoleRadius() < 0.) ?
+                                          pSTMShieldPipeParams.radiusIn() + pSTMShieldPipeParams.linerWidth() :
+                                          pSTMShieldPipeParams.dnStrWallHoleRadius());
+
+    G4Tubs *crvShieldHole = new G4Tubs( "crvShieldHole",
+                                        0.0,
+                                        matingBlockHoleRadius,
+                                        mstmCRVShieldHalfLength+10.0, //add extra length to ensure the hole punches through both sides
+                                        0.0, CLHEP::twopi );
 
     // create wall with hole
     VolumeInfo crvshield;
@@ -1299,28 +1441,55 @@ namespace mu2e {
 
     //Make the tube to shield CRV
     const double crvShieldTubeHalfLength = pSTMShieldPipeParams.pipeHalfLength();
-    G4Tubs *crvShieldTubeTemp = new G4Tubs( "crvShieldTubeTemp", pSTMShieldPipeParams.radiusIn(), pSTMShieldPipeParams.radiusIn()+pSTMShieldPipeParams.linerWidth(), crvShieldTubeHalfLength+mstmCRVShieldHalfLength, 0.0, CLHEP::twopi );
-
-    G4ThreeVector mstmCRVShieldTubePositionInMu2e      = mstmCRVShieldPositionInMu2e + G4ThreeVector(0.0,0.0,-mstmCRVShieldHalfLength-crvShieldTubeHalfLength-0.1);
-    G4ThreeVector mstmCRVShieldTubeInPositionInParent  = mstmCRVShieldPositionInParent + G4ThreeVector(0.0,0.0,-crvShieldTubeHalfLength-0.1);
-    G4ThreeVector mstmCRVShieldTubePositionInParent    = mstmCRVShieldPositionInParent + G4ThreeVector(0.0,0.0,-mstmCRVShieldHalfLength-crvShieldTubeHalfLength-0.1);
+    G4Tubs *crvShieldTubeTemp = nullptr;
+    if(pSTMShieldPipeParams.hasLiner()) {
+      crvShieldTubeTemp = new G4Tubs( "crvShieldTubeTemp",
+                                      pSTMShieldPipeParams.radiusIn(),
+                                      pSTMShieldPipeParams.radiusIn()+pSTMShieldPipeParams.linerWidth(),
+                                      crvShieldTubeHalfLength+mstmCRVShieldHalfLength,
+                                      0.0, CLHEP::twopi );
+    }
+    double zOffsetBuffer = 0.1;
+    double mstmCRVShieldTubeZOffset = -mstmCRVShieldHalfLength-crvShieldTubeHalfLength-zOffsetBuffer;
+    if(pSTMShieldPipeParams.matchPipeBlock()) { //match the pipe to the downstream end of the mating block
+      //remove the buffer added in previous versions to prevent overlap as well as mating block half length, then add another half length
+      mstmCRVShieldTubeZOffset += zOffsetBuffer + 2.*mstmCRVShieldHalfLength;
+      zOffsetBuffer = 0.; //remove from other position offsets
+    }
+    G4ThreeVector mstmCRVShieldTubePositionInMu2e      = mstmCRVShieldPositionInMu2e + G4ThreeVector(0.0,0.0,mstmCRVShieldTubeZOffset);
+    G4ThreeVector mstmCRVShieldTubeInPositionInParent  = mstmCRVShieldPositionInParent + G4ThreeVector(0.0,0.0,mstmCRVShieldTubeZOffset + mstmCRVShieldHalfLength);
+    G4ThreeVector mstmCRVShieldTubePositionInParent    = mstmCRVShieldPositionInParent + G4ThreeVector(0.0,0.0,mstmCRVShieldTubeZOffset);
 
     CLHEP::Hep3Vector vdSTM_UpStrPositionWRTcrvShieldTube           = vdSTM_UpStrPositionInMu2e           - mstmCRVShieldTubePositionInMu2e;
     CLHEP::Hep3Vector vdDSNeutronShieldExitPositionWRTcrvShieldTube = vdDSNeutronShieldExitPositionInMu2e - mstmCRVShieldTubePositionInMu2e;
 
-    G4SubtractionSolid *crvShieldTubeTemp2 = new G4SubtractionSolid("crvShieldTubeTemp2",crvShieldTubeTemp, aDiskVDDSNeutronShieldExitTub, 0, vdDSNeutronShieldExitPositionWRTcrvShieldTube);
 
     VolumeInfo crvlinershieldtube;
-    crvlinershieldtube.name = "crvlinershieldtube";
-    crvlinershieldtube.solid = new G4SubtractionSolid(crvlinershieldtube.name,crvShieldTubeTemp2, aDiskVDSTM_UpStrTub, 0, vdSTM_UpStrPositionWRTcrvShieldTube);
+    crvlinershieldtube.name = "STM_CRVShieldPipeLiner";
+    if(pSTMShieldPipeParams.hasLiner()) {
+      G4SubtractionSolid *crvShieldTubeTemp2 = new G4SubtractionSolid("crvShieldTubeTemp2",
+                                                                      crvShieldTubeTemp,
+                                                                      aDiskVDDSNeutronShieldExitTub,
+                                                                      0,
+                                                                      vdDSNeutronShieldExitPositionWRTcrvShieldTube);
+      crvlinershieldtube.solid = new G4SubtractionSolid(crvlinershieldtube.name,
+                                                        crvShieldTubeTemp2,
+                                                        aDiskVDSTM_UpStrTub,
+                                                        0,
+                                                        vdSTM_UpStrPositionWRTcrvShieldTube);
+    }
 
     VolumeInfo crvsteelshieldtube;
-    crvsteelshieldtube.name = "crvsteelshieldtube";
-    crvsteelshieldtube.solid = new G4Tubs(crvsteelshieldtube.name , pSTMShieldPipeParams.radiusIn()+pSTMShieldPipeParams.linerWidth(),  pSTMShieldPipeParams.radiusOut(), crvShieldTubeHalfLength, 0.0, CLHEP::twopi );
+    crvsteelshieldtube.name = "STM_CRVShieldPipe";
+    crvsteelshieldtube.solid = new G4Tubs(crvsteelshieldtube.name,
+                                          pSTMShieldPipeParams.radiusIn()+pSTMShieldPipeParams.linerWidth(),
+                                          pSTMShieldPipeParams.radiusOut(),
+                                          crvShieldTubeHalfLength,
+                                          0.0, CLHEP::twopi );
 
     if (pSTMShieldPipeParams.build()){
       finishNesting(crvshield,
-                    findMaterialOrThrow(pSTMShieldPipeParams.material()),
+                    findMaterialOrThrow(pSTMShieldPipeParams.dnStrWallMaterial()),
                     0,
                     mstmCRVShieldPositionInParent,
                     parentInfo.logical,
@@ -1331,18 +1500,20 @@ namespace mu2e {
                     forceAuxEdgeVisible,
                     placePV,
                     doSurfaceCheck);
-      finishNesting(crvlinershieldtube,
-                    findMaterialOrThrow(pSTMShieldPipeParams.materialLiner()),
-                    0,
-                    mstmCRVShieldTubeInPositionInParent,
-                    parentInfo.logical,
-                    0,
-                    STMisVisible,
-                    G4Colour::Magenta(),
-                    STMisSolid,
-                    forceAuxEdgeVisible,
-                    placePV,
-                    doSurfaceCheck);
+      if(pSTMShieldPipeParams.hasLiner()) {
+        finishNesting(crvlinershieldtube,
+                      findMaterialOrThrow(pSTMShieldPipeParams.materialLiner()),
+                      0,
+                      mstmCRVShieldTubeInPositionInParent,
+                      parentInfo.logical,
+                      0,
+                      STMisVisible,
+                      G4Colour::Magenta(),
+                      STMisSolid,
+                      forceAuxEdgeVisible,
+                      placePV,
+                      doSurfaceCheck);
+      }
       finishNesting(crvsteelshieldtube,
                     findMaterialOrThrow(pSTMShieldPipeParams.material()),
                     0,

--- a/STMGeom/inc/PermanentMagnet.hh
+++ b/STMGeom/inc/PermanentMagnet.hh
@@ -20,7 +20,9 @@ namespace mu2e {
                     double holeHalfX, double holeHalfY, 
                     CLHEP::Hep3Vector const & originInMu2e = CLHEP::Hep3Vector(),
                     CLHEP::HepRotation const & rotation = CLHEP::HepRotation(), 
-                    std::string const & materialName = "", double field=0.0,
+                    CLHEP::Hep3Vector const & holeOffset = CLHEP::Hep3Vector(),
+                    std::string const & materialName = "",
+                    bool hasLiner = true, double field=0.0,
                     bool fieldVisible=false
                    ) :
       _build( build),
@@ -31,12 +33,15 @@ namespace mu2e {
       _holeyhl( holeHalfY ),
       _originInMu2e( originInMu2e ),
       _rotation    ( rotation     ),
+      _holeOffset( holeOffset ),
       _materialName( materialName ),
+      _hasLiner( hasLiner ),
       _field( field ),
       _fieldVisible ( fieldVisible )
     {}
 
     bool   build()           const { return _build; }
+    bool   hasLiner()        const { return _hasLiner; }
     double xHalfLength()     const { return _xhl; }
     double yHalfLength()     const { return _yhl; }
     double zHalfLength()     const { return _zhl; }
@@ -49,6 +54,7 @@ namespace mu2e {
    
     CLHEP::Hep3Vector const &  originInMu2e() const { return _originInMu2e; }
     CLHEP::HepRotation const & rotation()     const { return _rotation; }
+    CLHEP::Hep3Vector const &  holeOffset()   const { return _holeOffset; }
     std::string const &        materialName() const { return _materialName; }    
 
     // Genreflex can't do persistency of vector<PermanentMagnet> without a default constructor
@@ -63,7 +69,9 @@ namespace mu2e {
     double _holeyhl;
     CLHEP::Hep3Vector  _originInMu2e;
     CLHEP::HepRotation _rotation; // wrt to parent volume
+    CLHEP::Hep3Vector  _holeOffset;
     std::string        _materialName;
+    bool               _hasLiner;
     double _field;
     bool   _fieldVisible;
 

--- a/STMGeom/inc/ShieldPipe.hh
+++ b/STMGeom/inc/ShieldPipe.hh
@@ -15,36 +15,53 @@ namespace mu2e {
 
   class ShieldPipe {
   public:
-    ShieldPipe(bool build, double radiusIn, double linerWidth, double radiusOut, double pipeHalfLength,
+    ShieldPipe(bool build, double radiusIn, bool hasLiner, double linerWidth, double radiusOut, double pipeHalfLength,
                std::string materialLiner, std::string material,
-               double upStrSpace, double dnStrSpace, 
-               double dnStrWallHalflength,
+               bool matchPipeBlock,
+               double upStrSpace, double dnStrSpace,
+               double dnStrWallHalflength, double dnStrWallHoleRadius,
+               double dnStrWallHalfHeight, double dnStrWallHalfWidth,
+               double dnStrWallGap, std::string dnStrWallMaterial,
                CLHEP::Hep3Vector originInMu2e, CLHEP::HepRotation rotation
               ) :
-      _build( build ),   
+      _build( build ),
       _radiusIn( radiusIn ),
+      _hasLiner( hasLiner ),
       _linerWidth( linerWidth ),
       _radiusOut( radiusOut ),
       _pipeHalfLength( pipeHalfLength ),
       _materialLiner( materialLiner ),
       _material( material ),
+      _matchPipeBlock( matchPipeBlock ),
       _upStrSpace( upStrSpace ),
       _dnStrSpace( dnStrSpace ),
       _dnStrWallHalflength( dnStrWallHalflength ),
+      _dnStrWallHoleRadius( dnStrWallHoleRadius ),
+      _dnStrWallHalfHeight( dnStrWallHalfHeight ),
+      _dnStrWallHalfWidth( dnStrWallHalfWidth ),
+      _dnStrWallGap( dnStrWallGap ),
+      _dnStrWallMaterial( dnStrWallMaterial ),
       _originInMu2e( originInMu2e ),
       _rotation    ( rotation     )
     {}
 
     bool   build()                            const { return _build; }
+    bool   hasLiner()                         const { return _hasLiner; }
     double radiusIn()                         const { return _radiusIn; }
     double linerWidth()                       const { return _linerWidth; }
     double radiusOut()                        const { return _radiusOut; }
     double pipeHalfLength()                   const { return _pipeHalfLength; }
     std::string const & materialLiner()       const { return _materialLiner; }
-    std::string const & material()            const { return _material; }      
+    std::string const & material()            const { return _material; }
+    bool   matchPipeBlock()                   const { return _matchPipeBlock; }
     double upStrSpace()                       const { return _upStrSpace; }
     double dnStrSpace()                       const { return _dnStrSpace; }
     double dnStrWallHalflength()              const { return _dnStrWallHalflength; }
+    double dnStrWallHoleRadius()              const { return _dnStrWallHoleRadius; }
+    double dnStrWallHalfHeight()              const { return _dnStrWallHalfHeight; }
+    double dnStrWallHalfWidth()               const { return _dnStrWallHalfWidth; }
+    double dnStrWallGap()                     const { return _dnStrWallGap; }
+    std::string const & dnStrWallMaterial()   const { return _dnStrWallMaterial; }
     CLHEP::Hep3Vector const &  originInMu2e() const { return _originInMu2e; }
     CLHEP::HepRotation const & rotation()     const { return _rotation; }
     //double zBegin()          const { return _originInMu2e.z() - zTabletopHalflength(); }
@@ -56,14 +73,21 @@ namespace mu2e {
 
     bool               _build;
     double             _radiusIn;
+    bool               _hasLiner;
     double             _linerWidth;
     double             _radiusOut;
     double             _pipeHalfLength;
     std::string        _materialLiner;
     std::string        _material;
+    bool               _matchPipeBlock;
     double             _upStrSpace;
     double             _dnStrSpace;
     double             _dnStrWallHalflength;
+    double             _dnStrWallHoleRadius;
+    double             _dnStrWallHalfHeight;
+    double             _dnStrWallHalfWidth;
+    double             _dnStrWallGap; //between mating block/shield pipe and magnet
+    std::string        _dnStrWallMaterial;
     CLHEP::Hep3Vector  _originInMu2e;
     CLHEP::HepRotation _rotation; // wrt to parent volume
 


### PR DESCRIPTION
Updates to the STM trolley and sweeper magnet geometry as well as upstream absorbers.
Validation performed:
Geant4 surface checking using old and new geometry configuration
ROOT overlap check using old and new geometry configuration

Summary of the geometry changes with validation images can be found here:
https://mu2e-docdb.fnal.gov/cgi-bin/private/ShowDocument?docid=38804