### PR TITLE
Import optimized pbar absorber from SU2020

### DIFF
--- a/Mu2eG4/geom/TransportSolenoid_v08.txt
+++ b/Mu2eG4/geom/TransportSolenoid_v08.txt
@@ -1,0 +1,23 @@
+//titanium pbar window and updated wedge to match, used first in SU2020
+#include "Offline/Mu2eG4/geom/TransportSolenoid_v07.txt"
+
+//-----------------------------------------------------------------------------
+// TS3 window: 150 um Ti
+//-----------------------------------------------------------------------------
+string pbar.materialName                  = "G4_Ti";
+double pbar.halfLength                    = 0.075;   // 150 um thick
+
+//-----------------------------------------------------------------------------
+// TS3 pbar wedge : 2 strips 127 um starting from 50 mm
+//                  heights 90mm and 140 mm
+//-----------------------------------------------------------------------------
+string         pbar.Type                  = "wedge";
+string         pbarwedge.wedgeMaterial    = "A1100";
+int            pbarwedge.nStrips          = 2;
+vector<double> pbarwedge.stripThicknesses = { 0.127, 0.127 };  // mm
+vector<double> pbarwedge.stripHeights     = {  90.0, 140.0 };  // mm
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_2021_PhaseI.txt
+++ b/Mu2eG4/geom/geom_2021_PhaseI.txt
@@ -45,7 +45,7 @@ double mu2e.detectorSystemZ0 = 10171.;   // mm  G4BL: (17730-7292=9801 mm)
 #include "Offline/Mu2eG4/geom/psEnclosure_v04.txt"
 #include "Offline/Mu2eG4/geom/PSShield_v06.txt"
 #include "Offline/Mu2eG4/geom/PSExternalShielding_v01.txt"
-#include "Offline/Mu2eG4/geom/TransportSolenoid_v07.txt"
+#include "Offline/Mu2eG4/geom/TransportSolenoid_v08.txt"
 
 // External Shielding
 #include "Offline/Mu2eG4/geom/ExtShieldUpstream_v06.txt"


### PR DESCRIPTION
Importing the pbar window and wedge optimized by Pasha from SU2020. This was validated in SU2020,
and I ran a simple POT job  a Geant4 overlap check without any issues, and by eye it looked correct in
the ROOT geometry viewer. Both geom_common and geom_common_current are updated by updating
the underlying main geometry file.