### PR TITLE
Remove very first SimParticle when compressing genealogy

### DIFF
--- a/Compression/src/CompressDetStepMCs_module.cc
+++ b/Compression/src/CompressDetStepMCs_module.cc
@@ -13,8 +13,8 @@
 //
 // There is also the concept of "genealogy" compression, which uses the fhicl parameter
 // keepNGenerations and takes an integer corresponding to the
-// number of generations back you want to keep. All missing generations are
-// replaced with a new SimParticle to identify that a truncation has occured
+// number of generations back you want to keep. The "oldest" SimParticle remaining
+// has a status code of "truncated" to identify that a truncation has occured
 // - Note 1: N = -1 means keep all generations (i.e. no compression)
 // - Note 2: the very first SimParticle (i.e. the one that has a valid Ptr to a GenParticle) is always kept
 //

--- a/Compression/src/CompressDetStepMCs_module.cc
+++ b/Compression/src/CompressDetStepMCs_module.cc
@@ -471,6 +471,7 @@ void mu2e::CompressDetStepMCs::compressSimParticles(const art::Event& event) {
             // If we have got to the very SimParticle (i.e. the one that points to the GenParticle)
             if (i_ancestorPtr->isPrimary()) {
               newsim.genParticle() = i_ancestorPtr->genParticle();// set this particle's GenParticlePtr
+              newsim.parent() = art::Ptr<SimParticle>(); // remove the parent
               break; // don't need to go any further
             }
             else { // this is just another step in the genealogy

--- a/Compression/src/CompressDetStepMCs_module.cc
+++ b/Compression/src/CompressDetStepMCs_module.cc
@@ -498,6 +498,9 @@ void mu2e::CompressDetStepMCs::compressGenParticles() {
       // Copy GenParticle to the new collection
       _newGenParticles->emplace_back(*newsim.genParticle());
       newsim.genParticle() = art::Ptr<mu2e::GenParticle>(_newGenParticlesPID, _newGenParticles->size()-1, _newGenParticleGetter);
+      if (_debugLevel > 0) {
+        std::cout << "Keeping GenParticle with Ptr " << newsim.genParticle() << std::endl;
+      }
     }
   }
 }


### PR DESCRIPTION
In CompressDetStepMCs, we were keeping the very first SimParticle (i.e. the one that points to a GenParticle and has no parent SimParticle) even when we were compressing the genealogy. However, it is not necessary to keep this SimParticle since most of the important information is in the GenParticle. Also, mixing jobs are going over the memory limit in MDC2020, and we can reduce the memory footprint by removing these SimParticles.

With this PR, we now treat the very first SimParticle like all the others. To maintain a link to the GenParticle, the oldest surviving SimParticle now contains the GenParticlePtr.

I have left the code that was treating this very first SimParticle differently commented out. This is just in case we want to either put this back in, or (more likely) add something similar for important SimParticles (e.g. a stopped muon).

I have tested this with 100 MuStopPileup events and checked the verbose output makes sense. I will also see if the CI tests show any issues I may have missed.