### PR TITLE
dbTool updates

### DIFF
--- a/DbService/inc/DbTool.hh
+++ b/DbService/inc/DbTool.hh
@@ -38,8 +38,8 @@ namespace mu2e {
     int run();
     int init();
 
+    int printContent();
     int printCalibration();
-    int printTable();
     int printIov();
     int printGroup();
     int printExtension();

--- a/DbService/inc/DbTool.hh
+++ b/DbService/inc/DbTool.hh
@@ -58,10 +58,11 @@ namespace mu2e {
     int commitCalibration();
     int commitCalibrationTable(DbTable::cptr_t const& ptr, 
 			       bool qdr=false, bool admin=false);
-    int commitCalibrationList(DbTableCollection const& coll,
+    int commitCalibrationList(DbTableCollection& coll,
+			      bool qai=false, bool qag=false,
 			      bool qdr=false, bool admin=false);
-    int commitIov(int cid=0, std::string iovtext="");
-    int commitGroup(std::vector<int> iids=std::vector<int>());
+    int commitIov(int& iid, int cid=0, std::string iovtext="");
+    int commitGroup(int& gid, std::vector<int> iids=std::vector<int>());
     int commitExtension();
     int commitTable();
     int commitList();
@@ -85,6 +86,7 @@ namespace mu2e {
     bool _pretty;
     std::string _database;
     bool _admin;
+    bool _dryrun;
 
     DbId _id;
     DbReader _reader;

--- a/DbTables/inc/DbIoV.hh
+++ b/DbTables/inc/DbIoV.hh
@@ -56,6 +56,14 @@ namespace mu2e {
       return true;
     }
 
+    bool isOverlapping(DbIoV const& iov) const {
+      if(iov.endRun()<_startRun) return false;
+      if(iov.endRun()==_startRun and iov.endSubrun()<_startSubrun) return false;
+      if(iov.startRun()>_endRun) return false;
+      if(iov.startRun()==_endRun and iov.startSubrun()>_endSubrun) return false;
+      return true;
+    }
+
     uint32_t startRun() const {return _startRun;}
     uint32_t startSubrun() const {return _startSubrun;}
     uint32_t endRun() const {return _endRun;}


### PR DESCRIPTION
- rename print-calibration to print-content and print-table to print-calibration
- add protection against committing extensions with overlapping IOV
- allow committing IOV with calibration data