### PR TITLE
fixed EventDisplay bug

### DIFF
--- a/CRVResponse/src/MakeCrvSiPMCharges.cc
+++ b/CRVResponse/src/MakeCrvSiPMCharges.cc
@@ -247,9 +247,9 @@ int main()
   CLHEP::RandFlat randFlat(engine);
   CLHEP::RandPoissonQ randPoissonQ(engine);
   mu2eCrv::MakeCrvSiPMCharges sim(randFlat,randPoissonQ,"/cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/photonMap.root");
-  sim.SetSiPMConstants(40, 40, 3.0, 500, 1695, 12.0, 8.84e-14, probabilities, inactivePixels);
+  sim.SetSiPMConstants(40, 40, 3.0, 13.3, 8.84e-14, probabilities, inactivePixels);
 
-  sim.Simulate(photonTimes, SiPMresponseVector);
+  sim.Simulate(photonTimes, SiPMresponseVector, 500, 1695);
 
   for(unsigned int i=0; i<SiPMresponseVector.size(); i++)
   {

--- a/EventDisplay/src/ContentSelector.cc
+++ b/EventDisplay/src/ContentSelector.cc
@@ -414,6 +414,11 @@ const mu2e::PhysicalVolumeInfoMultiCollection* ContentSelector::getPhysicalVolum
 
 const double ContentSelector::getTDC0time() const
 {
+  if(!_protonBunchTime.isValid())
+  {
+    std::cout<<"ProtonBunchTime not found! Setting it to 0."<<std::endl;
+    return 0;
+  }
   double TDC0time = -_protonBunchTime->pbtime_;
   return TDC0time;
 }

--- a/EventDisplay/src/DataInterface.cc
+++ b/EventDisplay/src/DataInterface.cc
@@ -1486,7 +1486,8 @@ void DataInterface::findTrajectory(boost::shared_ptr<ContentSelector> const &con
     std::map<art::Ptr<mu2e::SimParticle>,mu2e::MCTrajectory>::const_iterator traj_iter;
     for(traj_iter=mcTrajectories->begin(); traj_iter!=mcTrajectories->end(); traj_iter++)
     {
-      if(traj_iter->first->id()==id)
+      if(traj_iter->first.key()==id.asUint())
+//      if(traj_iter->first->id()==id)
 //      if(traj_iter->second.sim()->id()==id)
       {
         const auto& points = traj_iter->second.points();
@@ -1499,7 +1500,6 @@ void DataInterface::findTrajectory(boost::shared_ptr<ContentSelector> const &con
         }
       }
     }
-    return;
   }
 }
 


### PR DESCRIPTION
-Bug fix in EventDisplay for the case of missing protonBunchTimes.
-Use art::Ptr::key() instead of art::Ptr<SimParticle>->id() to identify the correct trajectory in the trajectory collection. This change made it possible to read art files, where access to the art::Ptr<SimParticle> from the trajectory collection was not possible.
-Updated the standalone part of MakeCrvSiPMCharges.cc, which is used for testing purposes. It has no impact on the simulation.