### PR TITLE
Remove turncated process code from compression

### DIFF
--- a/Compression/src/CompressDetStepMCs_module.cc
+++ b/Compression/src/CompressDetStepMCs_module.cc
@@ -171,6 +171,7 @@ private:
 
   // record the SimParticles that we are keeping so we can use compressSimParticleCollection to do all the work for us
   std::map<art::ProductID, mu2e::SimParticleSet> _simParticlesToKeep;
+  std::map<art::ProductID, mu2e::SimParticleSet> _simParticlesToTruncate;
   SimParticleRemapping _simPtrRemap;
 };
 
@@ -231,6 +232,7 @@ void mu2e::CompressDetStepMCs::produce(art::Event & event)
   _newMCTrajectories = std::unique_ptr<MCTrajectoryCollection>(new MCTrajectoryCollection);
 
   _simParticlesToKeep.clear();
+  _simParticlesToTruncate.clear();
   _simPtrRemap.clear();
 
   // Compress detector steps and record which SimParticles we want to keep
@@ -433,7 +435,7 @@ void mu2e::CompressDetStepMCs::compressSimParticles(const art::Event& event) {
             std::cout << "SimParticle " << i_parentPtr << " will not be in output collection because it has been compressed away by genealogy compression" << std::endl;
           }
 
-          (*_newSimParticles)[i_childPtr->id()].parent() = art::Ptr<SimParticle>(); // remove the parent so that we can see that it is truncated later
+          _simParticlesToTruncate[i_childPtr.id()].insert(i_childPtr);
           break; // don't go further up the genealogy tree otherwise we will be adding particles
         }
         else {
@@ -447,35 +449,35 @@ void mu2e::CompressDetStepMCs::compressSimParticles(const art::Event& event) {
       }
     }
 
-    // We might have truncated some SimParticles so go through the output SimParticleCollection and fix the parent/child links
-    for (auto& i_simParticle : *_newSimParticles) {
-      mu2e::SimParticle& newsim = i_simParticle.second;
-      if (newsim.isTruncated()) {
-        // go up genealogy to get the next ancestor that is in the output
-        art::Ptr<mu2e::SimParticle> i_ancestorPtr = newsim.parent();
-        if (_debugLevel>0) {
-          std::cout << "Look for a new parent for particle id " << newsim.id() << " (current parent = " << i_ancestorPtr << ")" << std::endl;
+    // Go through the truncated SimParticles and fix the parent/child links
+    for (const auto& i_truncatedSimPart : _simParticlesToTruncate[i_product_id]) {
+      //    for (auto& i_simParticle : *_newSimParticles) {
+      mu2e::SimParticle& newsim = (*_newSimParticles)[i_truncatedSimPart->id()];//_newSimParticles->at(i_truncatedSimPart.second);//i_simParticle.second;
+      // go up genealogy to get the next ancestor that is in the output
+      art::Ptr<mu2e::SimParticle> i_ancestorPtr = newsim.parent();
+      if (_debugLevel>0) {
+        std::cout << "Look for a new parent for particle id " << newsim.id() << " (current parent = " << i_ancestorPtr << ")" << std::endl;
+      }
+      while (i_ancestorPtr) {
+        const auto& findIter = _simPtrRemap.find(i_ancestorPtr);
+        if (findIter != _simPtrRemap.end()) {
+          newsim.parent() = findIter->second;
+          art::Ptr<mu2e::SimParticle> newChildPtr = art::Ptr<mu2e::SimParticle>(_newSimParticlesPID, newsim.id().asUint(), _newSimParticleGetter);
+          (*_newSimParticles)[i_ancestorPtr->id()].addDaughter(newChildPtr);
+          if (_debugLevel > 0) {
+            std::cout << "Because of truncation setting SimParticle (" << newsim.id() << ")'s parent to " << findIter->second << " and adding daughter " << newChildPtr << std::endl;
+          }
+          break; // don't need to go any further
         }
-        while (i_ancestorPtr) {
-          const auto& findIter = _simPtrRemap.find(i_ancestorPtr);
-          if (findIter != _simPtrRemap.end()) {
-            newsim.parent() = findIter->second;
-            art::Ptr<mu2e::SimParticle> newChildPtr = art::Ptr<mu2e::SimParticle>(_newSimParticlesPID, newsim.id().asUint(), _newSimParticleGetter);
-            (*_newSimParticles)[i_ancestorPtr->id()].addDaughter(newChildPtr);
-            if (_debugLevel > 0) {
-              std::cout << "Because of truncation setting SimParticle (" << newsim.id() << ")'s parent to " << findIter->second << " and adding daughter " << newChildPtr << std::endl;
-            }
+        else {
+          // If we have got to the very first SimParticle (i.e. the one that points to the GenParticle)
+          if (i_ancestorPtr->isPrimary()) {
+            newsim.genParticle() = i_ancestorPtr->genParticle();// set this particle's GenParticlePtr
+            newsim.parent() = art::Ptr<SimParticle>(); // remove the parent
             break; // don't need to go any further
           }
-          else {
-            // If we have got to the very first SimParticle (i.e. the one that points to the GenParticle)
-            if (i_ancestorPtr->isPrimary()) {
-              newsim.genParticle() = i_ancestorPtr->genParticle();// set this particle's GenParticlePtr
-              break; // don't need to go any further
-            }
-            else { // this is just another step in the genealogy
-              i_ancestorPtr = i_ancestorPtr->parent();
-            }
+          else { // this is just another step in the genealogy
+            i_ancestorPtr = i_ancestorPtr->parent();
           }
         }
       }

--- a/Compression/src/CompressDetStepMCs_module.cc
+++ b/Compression/src/CompressDetStepMCs_module.cc
@@ -14,7 +14,7 @@
 // There is also the concept of "genealogy" compression, which uses the fhicl parameter
 // keepNGenerations and takes an integer corresponding to the
 // number of generations back you want to keep. The "oldest" SimParticle remaining
-// has a status code of "truncated" to identify that a truncation has occured
+// can be identified as "truncated" with the SimParticle::isTruncated() function
 // - Note 1: N = -1 means keep all generations (i.e. no compression)
 //
 // Dec 2020, Andy Edmonds
@@ -433,7 +433,7 @@ void mu2e::CompressDetStepMCs::compressSimParticles(const art::Event& event) {
             std::cout << "SimParticle " << i_parentPtr << " will not be in output collection because it has been compressed away by genealogy compression" << std::endl;
           }
 
-          (*_newSimParticles)[i_childPtr->id()].setCreationCode(ProcessCode::truncated);
+          (*_newSimParticles)[i_childPtr->id()].parent() = art::Ptr<SimParticle>(); // remove the parent so that we can see that it is truncated later
           break; // don't go further up the genealogy tree otherwise we will be adding particles
         }
         else {
@@ -468,10 +468,9 @@ void mu2e::CompressDetStepMCs::compressSimParticles(const art::Event& event) {
             break; // don't need to go any further
           }
           else {
-            // If we have got to the very SimParticle (i.e. the one that points to the GenParticle)
+            // If we have got to the very first SimParticle (i.e. the one that points to the GenParticle)
             if (i_ancestorPtr->isPrimary()) {
               newsim.genParticle() = i_ancestorPtr->genParticle();// set this particle's GenParticlePtr
-              newsim.parent() = art::Ptr<SimParticle>(); // remove the parent
               break; // don't need to go any further
             }
             else { // this is just another step in the genealogy

--- a/MCDataProducts/inc/SimParticle.hh
+++ b/MCDataProducts/inc/SimParticle.hh
@@ -181,7 +181,7 @@ namespace mu2e {
 
     // Where was this particle created: in the event generator or in G4?
     bool isSecondary()   const { return _parentSim.isNonnull(); }
-    bool isPrimary()     const { return _genParticle.isNonnull(); }
+    bool isPrimary()     const { return _genParticle.isNonnull() && _creationCode == ProcessCode::mu2ePrimary; }
     bool selfParent()    const { return _parentSim.isNonnull() && _creationCode == ProcessCode::mu2ePrimary; }
 
     // Some synonyms for the previous two accessors.
@@ -198,8 +198,7 @@ namespace mu2e {
     unsigned    startVolumeIndex() const { return _startVolumeIndex;}
     unsigned    startG4Status()    const { return _startG4Status;}
     ProcessCode creationCode()     const { return _creationCode;   }
-    void setCreationCode(ProcessCode newCode) { _creationCode = newCode;   }
-    bool isTruncated() { return (_creationCode == ProcessCode::truncated);}
+    bool isTruncated() { return (_parentSim.isNull() && _creationCode != ProcessCode::mu2ePrimary); }
 
     // the following is for excited ions
     IonDetail const& ion()                      const { return _ion; }

--- a/MCDataProducts/inc/SimParticle.hh
+++ b/MCDataProducts/inc/SimParticle.hh
@@ -198,7 +198,7 @@ namespace mu2e {
     unsigned    startVolumeIndex() const { return _startVolumeIndex;}
     unsigned    startG4Status()    const { return _startG4Status;}
     ProcessCode creationCode()     const { return _creationCode;   }
-    bool isTruncated() { return (_parentSim.isNull() && _creationCode != ProcessCode::mu2ePrimary); }
+    bool isTruncated() const { return (_parentSim.isNull() && _creationCode != ProcessCode::mu2ePrimary); }
 
     // the following is for excited ions
     IonDetail const& ion()                      const { return _ion; }


### PR DESCRIPTION
When compressing the genealogy in CompressDetStepMCs, the final "truncated" particle has a creation code of `truncated`. However, as of PR #553, the truncated particle has an invalid parent ptr (and a valid GenParticlePtr). This means we can identify genealogy trnucation without the need for a special ProcessCode.

In this PR, I have removed the "truncated" ProcessCode from the truncated SimParticles. Instead the `SimParticle::isTruncated()` function now checks whether the SimParticle has a valid parentPtr and does not have creation code mu2ePrimary.

I have also corrected a logical bug in `SimParticle::isPrimary` which would return `true` for truncated particles.

One possible open question is whether we want to change `truncated` to `obsolete` or similar in the `ProcessCode` enum. Let me know if there's something I should do here.

I have tested this PR locally with ceSteps.fcl, muDauSteps.fcl and ceMix.fcl. I will see if the CI tests show any other issues.