### PR TITLE
Hide fhicl::Sequence internals from ROOT where necessary

### DIFF
--- a/EventDisplay/src/EventDisplayFrame.h
+++ b/EventDisplay/src/EventDisplayFrame.h
@@ -10,12 +10,10 @@
 
 #include <iostream>
 #include <TGFrame.h>
-#ifndef __CINT__
 #include "art/Framework/Principal/Event.h"
 #include "boost/shared_ptr.hpp"
 #include "Offline/Mu2eUtilities/inc/SimParticleTimeOffset.hh"
 #include "TVirtualX.h"
-#endif
 
 class TBox;
 class TGCheckButton;
@@ -53,11 +51,9 @@ namespace mu2e_eventdisplay
     EventDisplayFrame(const TGWindow* p, UInt_t w, UInt_t h, fhicl::ParameterSet const &pset);
     virtual          ~EventDisplayFrame();
     void             fillGeometry();
-#ifndef __CINT__     //hide art::Event from ROOTCint
     void             setEvent(const art::Event& event, bool firstLoop=false);
     boost::shared_ptr<RootFileManager> getRootFileManager() {return _rootFileManager;}
     std::vector<boost::shared_ptr<HistDraw> > &getHistDrawVector(){return _histDrawVector;}
-#endif
     bool             isClosed() const;
     bool             getSelectedHitsName(std::string &className,
                                          std::string &moduleLabel,
@@ -94,13 +90,11 @@ namespace mu2e_eventdisplay
                                           //timer times out - knows about
                                           //this via TTimer::SetObject)
 
-#ifndef __CINT__    //hide boost from ROOTCint
     boost::shared_ptr<DataInterface>   _dataInterface;
     boost::shared_ptr<ContentSelector> _contentSelector;
     boost::shared_ptr<RootFileManager> _rootFileManager;
     boost::shared_ptr<RootFileManager> _rootFileManagerAnim;
     std::vector<boost::shared_ptr<HistDraw> > _histDrawVector;
-#endif
     double              _timeCurrent, _timeStart, _timeStop;
     int                 _minHits, _eventToFind;
     int                 _eventNumber, _subrunNumber, _runNumber;

--- a/EventDisplay/src/dict_classes/EventDisplayGeoVolumeBox.h
+++ b/EventDisplay/src/dict_classes/EventDisplayGeoVolumeBox.h
@@ -30,7 +30,6 @@ class EventDisplayGeoVolumeBox : public TGeoVolume, public ComponentInfoContaine
   EventDisplayGeoVolumeBox& operator=(const EventDisplayGeoVolumeBox &);
 
   public:
-#ifndef __CINT__
   EventDisplayGeoVolumeBox(double dx, double dy, double dz, EventDisplayFrame *mainframe, const boost::shared_ptr<ComponentInfo> info):TGeoVolume(),ComponentInfoContainer(info),_mainframe(mainframe)
   {
     //bare pointer needed since ROOT manages this object
@@ -38,7 +37,6 @@ class EventDisplayGeoVolumeBox : public TGeoVolume, public ComponentInfoContaine
     SetShape(box);
     SetNumber(GetGeoManager()->AddVolume(this)); //this is what happens in the base TGeoVolume constructor
   }
-#endif
 
   virtual ~EventDisplayGeoVolumeBox()
   {

--- a/Mu2eUtilities/inc/SimParticleTimeOffset.hh
+++ b/Mu2eUtilities/inc/SimParticleTimeOffset.hh
@@ -28,6 +28,7 @@ namespace mu2e {
   class SimParticleTimeOffset {
   public:
 
+#ifndef __ROOTCLING__
     struct Config {
       fhicl::Sequence<art::InputTag> inputs{
         fhicl::Name("inputs"),
@@ -37,6 +38,7 @@ namespace mu2e {
     };
 
     explicit SimParticleTimeOffset(const Config& conf);
+#endif
     explicit SimParticleTimeOffset(const fhicl::ParameterSet& pset); // legacy
     explicit SimParticleTimeOffset(const std::vector<art::InputTag>& tags);
 

--- a/Mu2eUtilities/src/SimParticleTimeOffsets.cc
+++ b/Mu2eUtilities/src/SimParticleTimeOffsets.cc
@@ -26,11 +26,13 @@
 
 namespace mu2e {
 
+#ifndef __ROOTCLING__
   SimParticleTimeOffset::SimParticleTimeOffset(const Config& conf) {
     for(const auto& i: conf.inputs()) {
       inputs_.emplace_back(i);
     }
   }
+#endif
 
   SimParticleTimeOffset::SimParticleTimeOffset(const fhicl::ParameterSet& pset) {
     // Do not add any offsets by default

--- a/RecoDataProducts/inc/ComboHit.hh
+++ b/RecoDataProducts/inc/ComboHit.hh
@@ -17,8 +17,10 @@
 // root includes
 #include "Rtypes.h"
 // art includes
+#ifndef __ROOTCLING__
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
+#endif
 // C++ includes
 #include <array>
 #include <vector>
@@ -95,6 +97,7 @@ namespace mu2e {
       typedef std::vector<ComboHitCollection::const_iterator> CHCIter;
       // fill a vector of indices to the underlying digis used in a given ComboHit
       // This function is called recursively, so the the vector must be empty on the top-most call
+#ifndef __ROOTCLING__
       void fillStrawDigiIndices(art::Event const& event, uint16_t chindex, std::vector<StrawHitIndex>& shids) const;
       // similarly fill to the StrawHit level
       void fillStrawHitIndices(art::Event const& event, uint16_t chindex, std::vector<StrawHitIndex>& shids) const;
@@ -110,6 +113,7 @@ namespace mu2e {
       // set the parent Id given a handle to the parent collection
       void setParent(art::Handle<ComboHitCollection> const& phandle);
       // or directly from the product ID
+#endif
       void setParent(art::ProductID const& par){ _parent = par; }
       // accessors
       art::ProductID const& parent() const { return _parent; }
@@ -128,5 +132,3 @@ namespace mu2e {
   }
 }
 #endif
-
-

--- a/RecoDataProducts/src/ComboHit.cc
+++ b/RecoDataProducts/src/ComboHit.cc
@@ -55,6 +55,7 @@ namespace mu2e {
       return false;
   }
 
+#ifndef __ROOTCLING__
   void ComboHitCollection::setParentHandle(art::Event const& event, art::Handle<ComboHitCollection>& phandle) const  {
     // set the handle to an invalid state in case we find no such
     phandle = art::Handle<ComboHitCollection>();
@@ -212,6 +213,7 @@ namespace mu2e {
     }
     return retval; 
   }
+#endif
 
   uint16_t ComboHitCollection::nStrawHits() const {
     uint16_t retval(0);
@@ -241,4 +243,3 @@ namespace mu2e {
 
   }
 }
-

--- a/TEveEventDisplay/src/Collection_Filler.cc
+++ b/TEveEventDisplay/src/Collection_Filler.cc
@@ -1,8 +1,8 @@
-
 #include "Offline/TEveEventDisplay/src/dict_classes/Collection_Filler.h"
 using namespace mu2e;
 namespace mu2e{
 
+#ifndef __ROOTCLING__
   Collection_Filler::Collection_Filler(const Config& conf) :
     chTag_(conf.chTag()),
     crvcoinTag_(conf.crvdigiTag()),
@@ -23,7 +23,7 @@ namespace mu2e{
     addMCTraj_(conf.addMCTraj()), 
     MCOnly_(conf.MCOnly())
   {}
-
+#endif
 
   /*------------Function to turn InputTag to string for track labels:-------------*/
   template <typename T>
@@ -90,6 +90,3 @@ namespace mu2e{
   }
 
 }
-
-
-

--- a/TEveEventDisplay/src/dict_classes/Collection_Filler.h
+++ b/TEveEventDisplay/src/dict_classes/Collection_Filler.h
@@ -28,9 +28,11 @@
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/SubRun.h"
+#ifndef __ROOTCLING__
 #include "fhiclcpp/types/Atom.h"
 #include "fhiclcpp/types/Sequence.h"
 #include "fhiclcpp/types/Table.h"
+#endif
 
 using namespace CLHEP;
 
@@ -44,6 +46,8 @@ namespace mu2e{
 	class Collection_Filler
 	{
   public:
+#ifndef __ROOTCLING__
+
     struct Config{
       using Name=fhicl::Name;
       using Comment=fhicl::Comment;
@@ -74,9 +78,8 @@ namespace mu2e{
       fhicl::Atom<bool> MCOnly{Name("MCOnly"), Comment("set to see only MC Data Products"), false};
     };
 
-    #ifndef __CINT__
-
     explicit Collection_Filler(const Config& conf);
+#endif
     Collection_Filler(const Collection_Filler &);
     Collection_Filler& operator=(const Collection_Filler &);
 
@@ -101,6 +104,7 @@ namespace mu2e{
     virtual ~Collection_Filler(){};
 
   private:
+#ifndef __ROOTCLING__
     Config _conf;
     #endif
   ClassDef(Collection_Filler,0);

--- a/TEveEventDisplay/src/dict_classes/Geom_Interface.h
+++ b/TEveEventDisplay/src/dict_classes/Geom_Interface.h
@@ -34,9 +34,6 @@
 #include "Offline/BFieldGeom/inc/BFieldManager.hh"
 #include "Offline/Mu2eUtilities/inc/SimParticleTimeOffset.hh"
 #include "Offline/TrkDiag/inc/TrkMCTools.hh"*/
-//ART
-#include "art/Framework/Principal/Event.h"
-#include "art/Framework/Principal/Run.h"
 //Geom:
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"


### PR DESCRIPTION
This PR is not imminently necessary.  However, once art 3.10 is released, it will contain the fix for [redmine issue #26137](https://cdcvs.fnal.gov/redmine/issues/26137), which uses an `std::variant` to optimize `fhicl::Sequence` validation.  This PR hides the `std::variant` usage from ROOT, which does not appear to uniformly support such a construct.