### PR TITLE
fix vector lengths

### DIFF
--- a/Mu2eUtilities/src/CaloPulseShape.cc
+++ b/Mu2eUtilities/src/CaloPulseShape.cc
@@ -34,12 +34,12 @@ namespace mu2e {
        // Adjust binning to match digitizer sampling period, shift to zero and normalize
        int nbins = int((pshape->GetXaxis()->GetXmax()-pshape->GetXaxis()->GetXmin())/digiStep_);
        TH1F pulseShape("ps","ps", nbins, 0.0, pshape->GetXaxis()->GetXmax()-pshape->GetXaxis()->GetXmin());
-       for (int i=1;i<nbins;++i) pulseShape.SetBinContent(i,pshape->Interpolate(pulseShape.GetBinCenter(i)+pshape->GetXaxis()->GetXmin()));
+       for (int i=1;i<=nbins;++i) pulseShape.SetBinContent(i,pshape->Interpolate(pulseShape.GetBinCenter(i)));
        pulseShape.Scale(1.0/pulseShape.GetMaximum(),"nosw2");
 
        // Cache histogram content into vector and shift waveform (see note), 
        // calculate the number of bins for the digitized waveform
-       for (int j=1;j<nbins-1;++j)pulseVec_.push_back((j>nSteps_) ? pulseShape.GetBinContent(j-nSteps_) : 0.0);
+       for (int j=1;j<=(nbins+nSteps_);++j)pulseVec_.push_back((j>nSteps_) ? pulseShape.GetBinContent(j-nSteps_) : 0.0);
        nBinShape_      = int(nbins/nSteps_);
        digitizedPulse_ = std::vector<double>(nBinShape_,0);
 

--- a/Mu2eUtilities/src/CaloPulseShape.cc
+++ b/Mu2eUtilities/src/CaloPulseShape.cc
@@ -17,6 +17,9 @@ namespace mu2e {
    //----------------------------------------------------------------------------------------------------------------------
    void CaloPulseShape::buildShapes()
    {
+
+       pulseVec_.clear();
+
        // Get the pulse shape histogram
        ConditionsHandle<CalorimeterCalibrations> calorimeterCalibrations("ignored");
        std::string fileName = calorimeterCalibrations->pulseFileName();


### PR DESCRIPTION
In investigating the nightly validation instability, I was able to establish that at 
[this line](https://github.com/Mu2e/Offline/blob/21740f2317c5234d9207e87204e92e256c252fe3/CaloMC/src/CaloHitTruthMatch_module.cc#L134) the value of wfBinMax_ was changing because the last entry of the vector wf_ was changing.  This commit is my attempt to fix the last entry.  In limited tests, it seems to remove the instability.   This commit should be reviewed carefully because the code is complex and I do not know, for example, the possible values and conceptual uses of some variables.
