### PR TITLE
order on query

### DIFF
--- a/DbService/src/DbReader.cc
+++ b/DbService/src/DbReader.cc
@@ -73,7 +73,7 @@ int mu2e::DbReader::multiQuery(std::vector<QueryForm>& qfv) {
 int mu2e::DbReader::fillTableByCid(DbTable::ptr_t ptr, int cid) {
   std::string csv;
   std::string where="cid:eq:"+std::to_string(cid);
-  int rc = query(csv,ptr->query(),ptr->dbname(),where);
+  int rc = query(csv,ptr->query(),ptr->dbname(),where,ptr->orderBy());
   if(rc!=0) return rc;
   ptr->fill(csv,_saveCsv);
   return 0;

--- a/DbTables/inc/DbTable.hh
+++ b/DbTables/inc/DbTable.hh
@@ -38,6 +38,8 @@ namespace mu2e {
     // approx size in bytes - overridden by derived class
     virtual std::size_t size() const =0;
     std::size_t baseSize() const { return _csv.capacity(); }
+    // if table needs to be sorted
+    virtual const std::string orderBy() const {return std::string();}
 
     // take the cvs text from a query and build out the table contents
     int fill(const std::string& csv, bool saveCsv=true);

--- a/DbTables/inc/TrkAlignElement.hh
+++ b/DbTables/inc/TrkAlignElement.hh
@@ -27,6 +27,7 @@ namespace mu2e {
     std::size_t nrow() const override { return _rows.size(); };
     std::size_t nrowFix() const override { return _nrows; };
     size_t size() const override { return baseSize() + nrow()*sizeof(TrkAlignParams); };
+    const std::string orderBy() const {return std::string("index");}
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),

--- a/DbTables/inc/TrkAlignStraw.hh
+++ b/DbTables/inc/TrkAlignStraw.hh
@@ -26,6 +26,7 @@ namespace mu2e {
     size_t nrow() const override { return _rows.size(); };
     size_t nrowFix() const override { return StrawId::_nustraws; };
     size_t size() const override { return baseSize() + nrow()*sizeof(TrkStrawEndAlign); };
+    const std::string orderBy() const {return std::string("index");}
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(


### PR DESCRIPTION
The straw alignment table assumed the delivery order of rows, but that is not guaranteed by postgres and postgres recently reminded us of this policy.  I have not been checking for this issue and I can't recall my original thinking or plans on it.  I will have to check the other tables to make sure they are not relying on the same assumption.