### PR TITLE
Mu2eII_SM21: Make tracker straws 8 um with no gold plating

### DIFF
--- a/Mu2eG4/geom/geom_Mu2eII_2020.txt
+++ b/Mu2eG4/geom/geom_Mu2eII_2020.txt
@@ -23,6 +23,27 @@ double building.tsArea.hatchblock.southTop.offsetFromFloorSurface.y = 7080.25;
 bool pbar.build = false;
 
 ///////////////////////////////////////
+//     Thinner tracker straws        //
+///////////////////////////////////////
+double tracker.strawOuterRadius     =     2.5;
+double tracker.strawWallThickness   =     0.008;
+double tracker.strawGap             =     1.25;
+double tracker.wireRadius           =     0.0125;
+string tracker.mat.strawgas  = "StrawGas";
+string tracker.mat.wire      = "G4_W";
+vector<string> tracker.strawMaterials = { "G4_MYLAR", "StrawGas", "G4_W" };
+// Define the parameters of the metal coatings on the straws and wires.
+// Remove the gold layer from the straw wall and wire plating
+double tracker.straw.wallOuterMetal.thickness  = 0.00005;
+string tracker.straw.wallOuterMetal.material   = "G4_Al";
+double tracker.straw.wallInnerMetal2.thickness = 0.00005; //switch the aluminum to being the innermost metal
+string tracker.straw.wallInnerMetal2.material  = "G4_Al";
+double tracker.straw.wallInnerMetal1.thickness = 0.00001;
+string tracker.straw.wallInnerMetal1.material  = "G4_MYLAR"; //same as straw material to ignore
+double tracker.straw.wirePlate.thickness       = 0.00001;
+string tracker.straw.wirePlate.material        = "G4_W"; //same as wire material to ignore
+
+///////////////////////////////////////
 //     Change production target      //
 ///////////////////////////////////////
 //Carbon conveyor target

--- a/Mu2eG4/geom/geom_Mu2eII_2020.txt
+++ b/Mu2eG4/geom/geom_Mu2eII_2020.txt
@@ -40,8 +40,8 @@ double tracker.straw.wallInnerMetal2.thickness = 0.00005; //switch the aluminum 
 string tracker.straw.wallInnerMetal2.material  = "G4_Al";
 double tracker.straw.wallInnerMetal1.thickness = 0.00001;
 string tracker.straw.wallInnerMetal1.material  = "G4_MYLAR"; //same as straw material to ignore
-double tracker.straw.wirePlate.thickness       = 0.00001;
-string tracker.straw.wirePlate.material        = "G4_W"; //same as wire material to ignore
+double tracker.straw.wirePlate.thickness       = 0.00025;
+string tracker.straw.wirePlate.material        = "G4_Au"; //keep the gold plating on the sense wires
 
 ///////////////////////////////////////
 //     Change production target      //


### PR DESCRIPTION
This update changes the tracker straws to have 8 um thick walls (instead of 15 um) with only the aluminum metal layers left in place. The gold layer in the straw wall and the sense wire have both been removed.

I ran the general Geant4 surface checking and a higher density check just on the tracker volumes with no issues.
General parameters:
```
/ /number of random points on the volume surface
int  g4.nSurfaceCheckPointsPercmsq =   2;
int  g4.minSurfaceCheckPoints     = 1000; // per volume
int  g4.maxSurfaceCheckPoints = 10000000; // per volume
```
Select parameters:
```
// number of random points on the volume surface
int  g4.nSurfaceCheckPointsPercmsq   = 10;
int  g4.minSurfaceCheckPoints     = 10000; // per volume
int  g4.maxSurfaceCheckPoints = 100000000; // per volume
bool tracker.doSurfaceCheck = true;
```
Let me know if any of the straw parameters aren't correct or any other changes are recommended along with these!

Best,
Michael