### PR TITLE
row order review

### DIFF
--- a/DbService/src/DbReader.cc
+++ b/DbService/src/DbReader.cc
@@ -105,26 +105,47 @@ int mu2e::DbReader::fillValTables(DbValCache& vcache) {
   // load up the queries
   qfv[0].select = tables.query();
   qfv[0].table = tables.dbname();
+  qfv[0].order = tables.orderBy();
+
   qfv[1].select = calibrations.query();
   qfv[1].table = calibrations.dbname();
+  qfv[1].order = calibrations.orderBy();
+
   qfv[2].select = iovs.query();
   qfv[2].table = iovs.dbname();
+  qfv[2].order = iovs.orderBy();
+
   qfv[3].select = groups.query();
   qfv[3].table = groups.dbname();
+  qfv[3].order = groups.orderBy();
+
   qfv[4].select = grouplists.query();
   qfv[4].table = grouplists.dbname();
+  qfv[4].order = grouplists.orderBy();
+
   qfv[5].select = purposes.query();
   qfv[5].table = purposes.dbname();
+  qfv[5].order = purposes.orderBy();
+
   qfv[6].select = lists.query();
   qfv[6].table = lists.dbname();
+  qfv[6].order = lists.orderBy();
+
   qfv[7].select = tablelists.query();
   qfv[7].table = tablelists.dbname();
+  qfv[7].order = tablelists.orderBy();
+
   qfv[8].select = versions.query();
   qfv[8].table = versions.dbname();
+  qfv[8].order = versions.orderBy();
+
   qfv[9].select = extensions.query();
   qfv[9].table = extensions.dbname();
+  qfv[9].order = extensions.orderBy();
+
   qfv[10].select = extensionlists.query();
   qfv[10].table = extensionlists.dbname();
+  qfv[10].order = extensionlists.orderBy();
 
   rc = multiQuery(qfv);
   if(rc!=0) return rc;

--- a/DbTables/inc/MVAToolDb.hh
+++ b/DbTables/inc/MVAToolDb.hh
@@ -50,6 +50,7 @@ namespace mu2e {
     std::size_t nrow() const override { return _rows.size(); };
     size_t size() const override { return baseSize() + 
 	+ nrow()*nrow()/2 + nrow()*sizeof(Row); };
+    const std::string orderBy() const {return std::string("idx");}
 
     void addRow(const std::vector<std::string>& columns) override {
       int idx = std::stoi(columns[0]);

--- a/DbTables/inc/TrkAlignElement.hh
+++ b/DbTables/inc/TrkAlignElement.hh
@@ -30,7 +30,15 @@ namespace mu2e {
     const std::string orderBy() const {return std::string("index");}
 
     void addRow(const std::vector<std::string>& columns) override {
-      _rows.emplace_back(std::stoi(columns[0]),
+      int index = std::stoi(columns[0]);
+      // enforce a strict sequential order
+      if(index!=int(_rows.size())) {
+	throw cet::exception("TRKALIGNELEMENT_BAD_INDEX") 
+	  << "TrkAlignElement::addRow found index out of order: " 
+	  <<index << " != " << _rows.size() <<"\n";
+      }
+
+      _rows.emplace_back(index,
 			 StrawId(columns[1]),
 			 std::stof(columns[2]),
 			 std::stof(columns[3]),

--- a/DbTables/inc/TrkAlignStraw.hh
+++ b/DbTables/inc/TrkAlignStraw.hh
@@ -29,8 +29,16 @@ namespace mu2e {
     const std::string orderBy() const {return std::string("index");}
 
     void addRow(const std::vector<std::string>& columns) override {
+      int index = std::stoi(columns[0]);
+      // enforce a strict sequential order
+      if(index!=int(_rows.size())) {
+	throw cet::exception("TRKALIGNSTRAW_BAD_INDEX") 
+	  << "TrkAlignStraw::addRow found index out of order: " 
+	  <<index << " != " << _rows.size() <<"\n";
+      }
+
       _rows.emplace_back(
-	  std::stoi(columns[0]),
+	  index,
 	  StrawId(columns[1]),
 	  std::stof(columns[2]),
 	  std::stof(columns[3]),

--- a/DbTables/inc/TrkDelayPanel.hh
+++ b/DbTables/inc/TrkDelayPanel.hh
@@ -35,9 +35,17 @@ namespace mu2e {
     std::size_t nrow() const override { return _rows.size(); };
     virtual std::size_t nrowFix() const override { return 216; }; 
     size_t size() const override { return baseSize() + nrow()*sizeof(Row); };
+    const std::string orderBy() const {return std::string("index");}
 
     void addRow(const std::vector<std::string>& columns) override {
-      _rows.emplace_back(std::stoi(columns[0]),
+      int index = std::stoi(columns[0]);
+      // enforce a strict sequential order
+      if(index!=int(_rows.size())) {
+	throw cet::exception("TRKDELAYPANEL_BAD_INDEX") 
+	  << "TrkDelayPanel::addRow found index out of order: " 
+	  <<index << " != " << _rows.size() <<"\n";
+      }
+      _rows.emplace_back(index,
 			 std::stof(columns[1]) );
     }
 

--- a/DbTables/inc/TrkDelayRStraw.hh
+++ b/DbTables/inc/TrkDelayRStraw.hh
@@ -38,6 +38,7 @@ namespace mu2e {
     std::size_t nrow() const override { return _rows.size(); };
     virtual std::size_t nrowFix() const override { return 96; }; 
     size_t size() const override { return baseSize() + nrow()*sizeof(Row); };
+    const std::string orderBy() const {return std::string("straw");}
 
     void addRow(const std::vector<std::string>& columns) override {
       int straw = std::stoi(columns[0]);

--- a/DbTables/inc/TrkPreampRStraw.hh
+++ b/DbTables/inc/TrkPreampRStraw.hh
@@ -47,9 +47,18 @@ namespace mu2e {
     std::size_t nrow() const override { return _rows.size(); };
     virtual std::size_t nrowFix() const override { return 96; }; 
     size_t size() const override { return baseSize() + nrow()*sizeof(Row); };
+    const std::string orderBy() const {return std::string("index");}
 
     void addRow(const std::vector<std::string>& columns) override {
-      _rows.emplace_back(std::stoi(columns[0]),
+      int index = std::stoi(columns[0]);
+      // enforce a strict sequential order
+      if(index!=int(_rows.size())) {
+	throw cet::exception("TRKPREAMPRSTRAW_BAD_INDEX") 
+	  << "TrkPreampRStraw::addRow found index out of order: " 
+	  <<index << " != " << _rows.size() <<"\n";
+      }
+
+      _rows.emplace_back(index,
 			 std::stof(columns[1]),
 			 std::stof(columns[2]),
 			 std::stof(columns[3]),

--- a/DbTables/inc/TrkPreampStraw.hh
+++ b/DbTables/inc/TrkPreampStraw.hh
@@ -47,9 +47,17 @@ namespace mu2e {
     std::size_t nrow() const override { return _rows.size(); };
     virtual std::size_t nrowFix() const override { return 20736; }; 
     size_t size() const override { return baseSize() + nrow()*sizeof(Row); };
+    const std::string orderBy() const {return std::string("index");}
 
     void addRow(const std::vector<std::string>& columns) override {
-      _rows.emplace_back(std::stoi(columns[0]),
+      int index = std::stoi(columns[0]);
+      // enforce a strict sequential order
+      if(index!=int(_rows.size())) {
+	throw cet::exception("TRKPREAMPSTRAW_BAD_INDEX") 
+	  << "TrkPreampStraw::addRow found index out of order: " 
+	  <<index << " != " << _rows.size() <<"\n";
+      }
+      _rows.emplace_back(index,
 			 std::stof(columns[1]),
 			 std::stof(columns[2]),
 			 std::stof(columns[3]),

--- a/DbTables/inc/TrkThresholdRStraw.hh
+++ b/DbTables/inc/TrkThresholdRStraw.hh
@@ -39,9 +39,17 @@ namespace mu2e {
     std::size_t nrow() const override { return _rows.size(); };
     virtual std::size_t nrowFix() const override { return 96; }; 
     size_t size() const override { return baseSize() + nrow()*sizeof(Row); };
+    const std::string orderBy() const {return std::string("index");}
 
     void addRow(const std::vector<std::string>& columns) override {
-      _rows.emplace_back(std::stoi(columns[0]),
+      int index = std::stoi(columns[0]);
+      // enforce a strict sequential order
+      if(index!=int(_rows.size())) {
+	throw cet::exception("TRKTHRESHOLDRSTRAW_BAD_INDEX") 
+	  << "TrkThresholdRStraw::addRow found index out of order: " 
+	  <<index << " != " << _rows.size() <<"\n";
+      }
+      _rows.emplace_back(index,
 			 std::stof(columns[1]),
 			 std::stof(columns[2]) );
     }

--- a/DbTables/inc/ValCalibrations.hh
+++ b/DbTables/inc/ValCalibrations.hh
@@ -40,6 +40,7 @@ namespace mu2e {
     std::size_t nrow() const override { return _rows.size(); };
     size_t size() const override { return baseSize() + sizeof(this)  
 	+ nrow()*nrow()/2 + nrow()*48; };
+    const std::string orderBy() const {return std::string("cid");}
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),std::stoi(columns[1]),

--- a/DbTables/inc/ValExtensionLists.hh
+++ b/DbTables/inc/ValExtensionLists.hh
@@ -33,6 +33,8 @@ namespace mu2e {
     std::vector<Row> const& rows() const {return _rows;}
     std::size_t nrow() const override { return _rows.size(); };
     size_t size() const override { return baseSize() + sizeof(this) + nrow()*8; };
+    const std::string orderBy() const {return std::string("eid,gid");}
+
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),std::stoi(columns[1]));

--- a/DbTables/inc/ValExtensions.hh
+++ b/DbTables/inc/ValExtensions.hh
@@ -42,6 +42,7 @@ namespace mu2e {
     std::vector<Row> const& rows() const {return _rows;}
     std::size_t nrow() const override { return _rows.size(); };
     size_t size() const override { return baseSize() + sizeof(this) + nrow()*52; };
+    const std::string orderBy() const {return std::string("eid");}
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),std::stoi(columns[1]),

--- a/DbTables/inc/ValGroupLists.hh
+++ b/DbTables/inc/ValGroupLists.hh
@@ -32,6 +32,7 @@ namespace mu2e {
     std::vector<Row> const& rows() const {return _rows;}
     std::size_t nrow() const override { return _rows.size(); };
     size_t size() const override { return baseSize() + sizeof(this) + nrow()*8; };
+    const std::string orderBy() const {return std::string("gid,iid");}
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),std::stoi(columns[1]));

--- a/DbTables/inc/ValGroups.hh
+++ b/DbTables/inc/ValGroups.hh
@@ -37,6 +37,8 @@ namespace mu2e {
     std::size_t nrow() const override { return _rows.size(); };
     size_t size() const override { return baseSize() + sizeof(this) 
 	+ nrow()*44; };
+    const std::string orderBy() const {return std::string("gid");}
+
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),

--- a/DbTables/inc/ValIovs.hh
+++ b/DbTables/inc/ValIovs.hh
@@ -55,6 +55,7 @@ namespace mu2e {
     std::size_t nrow() const override { return _rows.size(); };
     size_t size() const override { return baseSize() + sizeof(this) 
 	+ nrow()*nrow()/2 + nrow()*64; };
+    const std::string orderBy() const {return std::string("iid");}
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),std::stoi(columns[1]),

--- a/DbTables/inc/ValLists.hh
+++ b/DbTables/inc/ValLists.hh
@@ -46,6 +46,7 @@ namespace mu2e {
       for (auto const& r : _rows) b += r.name().capacity() + r.comment().capacity();
       return b;
     };
+    const std::string orderBy() const {return std::string("lid");}
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),columns[1],

--- a/DbTables/inc/ValPurposes.hh
+++ b/DbTables/inc/ValPurposes.hh
@@ -46,6 +46,7 @@ namespace mu2e {
       for (auto const& r : _rows) b += r.name().capacity() + r.comment().capacity();
       return b;
     };
+    const std::string orderBy() const {return std::string("pid");}
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),columns[1],columns[2],

--- a/DbTables/inc/ValTableLists.hh
+++ b/DbTables/inc/ValTableLists.hh
@@ -32,6 +32,7 @@ namespace mu2e {
     std::vector<Row> const& rows() const {return _rows;}
     std::size_t nrow() const override { return _rows.size(); };
     size_t size() const override { return baseSize() + sizeof(this) + nrow()*8; };
+    const std::string orderBy() const {return std::string("lid,tid");}
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),std::stoi(columns[1]));

--- a/DbTables/inc/ValTables.hh
+++ b/DbTables/inc/ValTables.hh
@@ -46,6 +46,7 @@ namespace mu2e {
       for (auto const& r : _rows) b += r.name().capacity() + r.dbname().capacity();
       return b;
     };
+    const std::string orderBy() const {return std::string("tid");}
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),columns[1],

--- a/DbTables/inc/ValVersions.hh
+++ b/DbTables/inc/ValVersions.hh
@@ -54,6 +54,7 @@ namespace mu2e {
       for (auto const& r : _rows) b += r.comment().capacity();
       return b;
     };
+    const std::string orderBy() const {return std::string("vid");}
 
     void addRow(const std::vector<std::string>& columns) override {
       _rows.emplace_back(std::stoi(columns[0]),std::stoi(columns[1]),


### PR DESCRIPTION
We were not fully prepared for postgres to return rows in arbitrary order.  This commit is the result of reviewing the tables we have
- val* tables were not vulnerable, but adding these sorts makes the results more readable and prepared for future optimizations
- trk tables were vulnerable and are now prepared
- MVAToolDb was protected, but now won't need to throw
- SimEfficiencies, TrkElelmentStatus do not assume an order
- CalRoIDMap* are vulnerable, but I need to understand better how the indices work before I can fix it.  There are also other aspects of these tables I'd like improve.  I vaguely recall they are not complete. They do not exist in the database yet.

Nothing has to be done by any users of the code - the previously built-in assumptions of the code are now enforced.