### PR TITLE
Mu2eII_SM21: Add option to not build the IPA

### DIFF
--- a/GeometryService/src/MECOStyleProtonAbsorberMaker.cc
+++ b/GeometryService/src/MECOStyleProtonAbsorberMaker.cc
@@ -132,21 +132,22 @@ namespace mu2e {
     // Decide which pabs will be turned on
     //////////////////////////////////////
 
-    bool pabs1 = true;
-    bool pabs2 = true;
+    bool pabs1 = _config.getBool("protonabsorber.buildIPA", true);
+    bool pabs2 = _config.getBool("protonabsorber.buildIPA", true);
     bool opa1 = _config.getBool("protonabsorber.outerPA", false);
     bool opa2 = true;
 
     // if pabs starts from DS3 region
-    if (distFromTargetEnd > targetEndToDS2End) {
+    if (pabs1 && distFromTargetEnd > targetEndToDS2End) {
       pabs1 = false;
     }
 
     // if pabs is short enouhg to locate at DS2 region only
-    if (distFromTargetEnd + pabsZHalfLen*2.< targetEndToDS2End) {
+    if (pabs2 && distFromTargetEnd + pabsZHalfLen*2.< targetEndToDS2End) {
       pabs2 = false;
     }
-    if (!pabs1 && !pabs2) {
+
+    if (!pabs1 && !pabs2 && _config.getBool("protonabsorber.buildIPA", true)) {
       return;
     }
 

--- a/Mu2eG4/geom/geom_Mu2eTrackerStraws_common.txt
+++ b/Mu2eG4/geom/geom_Mu2eTrackerStraws_common.txt
@@ -1,25 +1,6 @@
 // Geometry using the Mu2e era tracker straws
 #include "Offline/Mu2eG4/geom/geom_common.txt"
-
-// Mu2e era straw parameters taken from tracker_v6.txt
-double tracker.strawOuterRadius     =     2.5;
-double tracker.strawWallThickness   =     0.015;
-double tracker.strawGap             =     1.25;
-double tracker.wireRadius           =     0.0125;
-string tracker.mat.strawgas  = "StrawGas";
-string tracker.mat.wire      = "G4_W";
-vector<string> tracker.strawMaterials = { "G4_MYLAR", "StrawGas", "G4_W" };
-// define an inactive length at each end of every straw
-double tracker.passivationMargin = -4.;
-// Define the parameters of the metal coatings on the straws and wires.
-double tracker.straw.wallOuterMetal.thickness  = 0.00005;
-string tracker.straw.wallOuterMetal.material   = "G4_Al";
-double tracker.straw.wallInnerMetal1.thickness = 0.00005;
-string tracker.straw.wallInnerMetal1.material  = "G4_Al";
-double tracker.straw.wallInnerMetal2.thickness = 0.00002;
-string tracker.straw.wallInnerMetal2.material  = "G4_Au";
-double tracker.straw.wirePlate.thickness       = 0.00025;
-string tracker.straw.wirePlate.material        = "G4_Au";
+#include "Offline/Mu2eG4/geom/tracker_straw_params_v01.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/geom_Mu2eTrackerStraws_common.txt
+++ b/Mu2eG4/geom/geom_Mu2eTrackerStraws_common.txt
@@ -1,0 +1,27 @@
+// Geometry using the Mu2e era tracker straws
+#include "Offline/Mu2eG4/geom/geom_common.txt"
+
+// Mu2e era straw parameters taken from tracker_v6.txt
+double tracker.strawOuterRadius     =     2.5;
+double tracker.strawWallThickness   =     0.015;
+double tracker.strawGap             =     1.25;
+double tracker.wireRadius           =     0.0125;
+string tracker.mat.strawgas  = "StrawGas";
+string tracker.mat.wire      = "G4_W";
+vector<string> tracker.strawMaterials = { "G4_MYLAR", "StrawGas", "G4_W" };
+// define an inactive length at each end of every straw
+double tracker.passivationMargin = -4.;
+// Define the parameters of the metal coatings on the straws and wires.
+double tracker.straw.wallOuterMetal.thickness  = 0.00005;
+string tracker.straw.wallOuterMetal.material   = "G4_Al";
+double tracker.straw.wallInnerMetal1.thickness = 0.00005;
+string tracker.straw.wallInnerMetal1.material  = "G4_Al";
+double tracker.straw.wallInnerMetal2.thickness = 0.00002;
+string tracker.straw.wallInnerMetal2.material  = "G4_Au";
+double tracker.straw.wirePlate.thickness       = 0.00025;
+string tracker.straw.wirePlate.material        = "G4_Au";
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_noIPA_common.txt
+++ b/Mu2eG4/geom/geom_noIPA_common.txt
@@ -1,0 +1,9 @@
+// Geometry without the IPA
+#include "Offline/Mu2eG4/geom/geom_common.txt"
+bool protonabsorber.buildIPA = false;
+bool protonabsorber.ipa.buildSupports = false;
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/tracker_straw_params_v01.txt
+++ b/Mu2eG4/geom/tracker_straw_params_v01.txt
@@ -1,0 +1,25 @@
+// Mu2e era straw parameters taken from tracker_v6.txt
+
+double tracker.strawOuterRadius     =     2.5;
+double tracker.strawWallThickness   =     0.015;
+double tracker.strawGap             =     1.25;
+double tracker.wireRadius           =     0.0125;
+string tracker.mat.strawgas  = "StrawGas";
+string tracker.mat.wire      = "G4_W";
+vector<string> tracker.strawMaterials = { "G4_MYLAR", "StrawGas", "G4_W" };
+// define an inactive length at each end of every straw
+double tracker.passivationMargin = -4.;
+// Define the parameters of the metal coatings on the straws and wires.
+double tracker.straw.wallOuterMetal.thickness  = 0.00005;
+string tracker.straw.wallOuterMetal.material   = "G4_Al";
+double tracker.straw.wallInnerMetal1.thickness = 0.00005;
+string tracker.straw.wallInnerMetal1.material  = "G4_Al";
+double tracker.straw.wallInnerMetal2.thickness = 0.00002;
+string tracker.straw.wallInnerMetal2.material  = "G4_Au";
+double tracker.straw.wirePlate.thickness       = 0.00025;
+string tracker.straw.wirePlate.material        = "G4_Au";
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:


### PR DESCRIPTION
Added the option to not build the IPA and an example configuration file for this.
I also added a configuration file with the Mu2e era tracker straw parameters for studies
interested in this effect.

The only validation I did was building it and writing out the no IPA gdml file and inspecting it to see the IPA was gone.
I don't expect any overlap issues as an element was simple removed.

Best,
Michael