### PR TITLE
fix index issues and remove interpolation

### DIFF
--- a/Mu2eUtilities/inc/MedianCalculator.hh
+++ b/Mu2eUtilities/inc/MedianCalculator.hh
@@ -1,52 +1,59 @@
 #ifndef Mu2eUtilities_MedianCalculator_hh
 #define Mu2eUtilities_MedianCalculator_hh
 //
-// Original author G. Pezzullo
-//
-// this class is intended to be used for evaluaitng the median 
+// this class is intended to be used for evaluating the median
 // from a set of elements that are stored internally in a vector
 //
+// - intermediate answers can be retrieved before the full
+// set of elements have been pushed
+// - after clear(), it is ready for a new set of elements
+//
 
-#include <stddef.h>
 #include <functional>
-//#include <utility>
-#include <numeric>
 #include <vector>
 
-namespace mu2e { 
-  class MedianCalculator{
-    struct  MedianData {
-      MedianData(float Val, float Wg): val(Val), wg(Wg){}
-      float    val;
-      float    wg;
-    };
-    struct MedianDatacomp : public std::binary_function<MedianData,MedianData,bool> {
-      bool operator()(MedianData const& p1, MedianData const& p2) { return p1.val < p2.val; }
-    };
-   
-  public:
-    MedianCalculator(size_t nToReserve=0){
-      _vec.reserve(nToReserve);
-    }
-    
-    float  weightedMedian();
-    float  unweightedMedian();
-    
-    inline void     push(float  value, float   weight=1){
-      _vec.emplace_back(MedianData(value, weight));
-      _needsSorting = true;
-      _totalWeight  += weight;
-    }
-    
-    inline size_t   size(){ return _vec.size(); }
-  private:
-    
-    std::vector<MedianData>  _vec; 
-    bool                     _needsSorting     = true;
-    float                    _weightedMedian   = 0;
-    float                    _unweightedMedian = 0;
-    float                    _totalWeight      = 0;
+namespace mu2e {
+class MedianCalculator {
+
+  struct MedianData {
+    MedianData(float Val, float Wg) : val(Val), wg(Wg) {}
+    float val;
+    float wg;
   };
+  struct lessByValue : public std::binary_function<MedianData, MedianData, bool> {
+    bool operator()(MedianData const& p1, MedianData const& p2) { return p1.val < p2.val; }
+  };
+
+public:
+  MedianCalculator(size_t nToReserve = 0) {
+    clear();
+    _vec.reserve(nToReserve);
+  }
+
+  float weightedMedian() { return median(true); }
+  float unweightedMedian() { return median(false); }
+
+  inline void push(float value, float weight = 1) {
+    _vec.emplace_back(value, weight);
+    _needsSorting = true;
+    _totalWeight += weight;
+  }
+
+  inline size_t size() { return _vec.size(); }
+  void clear();
+
+private:
+  float median(bool useWeights);
+
+  std::vector<MedianData> _vec;
+  bool _needsSorting;
+  bool _goodWM;
+  bool _goodUWM;
+  float _weightedMedian;
+  float _unweightedMedian;
+  float _totalWeight;
+};
+
 } // namespace mu2e
 
 #endif /* Mu2eUtilities_MedianCalculator_hh */

--- a/Mu2eUtilities/src/MedianCalculator.cc
+++ b/Mu2eUtilities/src/MedianCalculator.cc
@@ -8,88 +8,76 @@
 
 namespace mu2e {
 
-  float    MedianCalculator::weightedMedian(){
-    //now, we need to loop over it and evaluate the median
-    size_t   v_size = _vec.size();
-    if (v_size ==0) {
-      throw cet::exception("MATH")<<"No entries in the vector: median undefined" << std::endl;
-    }
-    if (v_size == 1){
-      return _vec[0].val;
-    }
-    
-    if (_needsSorting){
-      std::sort(_vec.begin(), _vec.end(), MedianDatacomp());
-      _needsSorting = false;
-    }else {
-      return   _weightedMedian;
-    }
-  
-    float   sum(0);
-    size_t  id(0);
+//================================================================
 
-    sum = _totalWeight - _vec[0].wg;
-    while (sum > 0.5*_totalWeight){
-      ++id;
-      sum -= _vec[id].wg;
-    }
-
-    float   over((sum)/_totalWeight);
-    float   interpolation(0);
-    if (v_size %2 == 0) {
-      interpolation =  _vec[id].val * over + _vec[id+1].val * (1.-over);
-    }else {
-      float  w2     = (sum)/_totalWeight;
-      float  w1     = (sum + _vec[id].wg )/_totalWeight;
-      float  val1   = _vec[id-1].val*w1 + _vec[id].val*(1.-w1);
-      float  val2   = _vec[id].val*w2 + _vec[id+1].val*(1.-w2);
-      interpolation = 0.5*(val1 + val2);
-    }
-
-    //cache the result
-    _weightedMedian = interpolation;
-
-    return interpolation;
-  }
-	
-  float    MedianCalculator::unweightedMedian(){
-    //now, we need to loop over it and evaluate the median
-    size_t   v_size = _vec.size();
-    if (v_size ==0) {
-      throw cet::exception("MATH")<<"No entries in the vector: median undefined" << std::endl;
-    }
-    if (v_size == 1){
-      return _vec[0].val;
-    }
-
-    if (_needsSorting){
-      std::sort(_vec.begin(), _vec.end(), MedianDatacomp());
-      _needsSorting = false;
-    }else {
-      return   _unweightedMedian;
-    }
- 
-    float   totWg(_vec.size());
-    size_t  id(0);
-
-    float   interpolation(0);
-    if (v_size %2 == 0) {
-      id = v_size/2 - 1;
-      interpolation =  _vec[id].val * 0.5 + _vec[id+1].val * 0.5;
-    }else {
-      id = v_size/2;
-      float  sum(id);      
-      float  w2     = (sum)/totWg;
-      float  w1     = (sum + 1.)/totWg;
-      float  val1   = _vec[id-1].val*w1 + _vec[id].val  *(1.-w1);
-      float  val2   = _vec[id].val  *w2 + _vec[id+1].val*(1.-w2);
-      interpolation = 0.5*(val1 + val2);
-    }
-
-    //cache the result
-    _weightedMedian = interpolation;
-
-    return interpolation;
-  }
-  
+void MedianCalculator::clear() {
+  _vec.clear();
+  _needsSorting = true;
+  _goodWM = false;
+  _goodUWM = false;
+  _weightedMedian = 0;
+  _unweightedMedian = 0;
+  _totalWeight = 0;
 }
+
+//================================================================
+
+float MedianCalculator::median(bool useWeights) {
+
+  size_t v_size = _vec.size();
+  if (v_size == 0) {
+    throw cet::exception("MEDIANCALCULATOR_ZERO")
+        << "No entries in the vector: median undefined" << std::endl;
+  }
+
+  if (v_size == 1) {
+    return _vec[0].val;
+  }
+
+  if (_needsSorting) {
+    std::sort(_vec.begin(), _vec.end(), lessByValue());
+    _needsSorting = false;
+    _goodWM = false;
+    _goodUWM = false;
+  }
+
+  if (useWeights) {
+
+    if (!_goodWM) {
+
+      // integratng low to high, id will the first entry past the 50% point
+      // the entry at id then satisfies the definition of weighted median:
+      // the sum of weights above and below id (not including id)
+      // is less than 50%.  id can be the first or last entry.
+
+      size_t id = 0;
+      float sum = _vec[0].wg;
+      while (sum < 0.5 * _totalWeight) {
+        ++id;
+        sum += _vec[id].wg;
+      }
+
+      _weightedMedian = _vec[id].val;
+      _goodWM = true;
+    }
+
+    return _weightedMedian;
+
+  } else {
+
+    if (!_goodUWM) {
+
+      // v_size is >=2, so id >=1
+      size_t id = v_size / 2;
+      if (v_size % 2 == 0) {
+        _unweightedMedian = (_vec[id - 1].val + _vec[id].val) / 2.0;
+      } else {
+        _unweightedMedian = _vec[id].val;
+      }
+      _goodUWM = true;
+    }
+    return _unweightedMedian;
+  }
+}
+
+} // namespace mu2e


### PR DESCRIPTION
- fix some overrunning-by-one vector bounds 
- set flags so that both medians are protected
- remove interpolation since it is not mathematically well-defined
- add clear for re-use
- right now, it is reasonable general-purpose routine. If we decide it should be focused on use in the trigger, it can be further optimized.