### PR TITLE
Add trivial module to create empty MCPrimary object

### DIFF
--- a/CommonMC/src/NullMCPrimary_module.cc
+++ b/CommonMC/src/NullMCPrimary_module.cc
@@ -1,0 +1,32 @@
+//
+//  Trivial module to insert an empty PrimaryParticle object in the event, used for NoPrimary production
+//
+// mu2e
+#include "Offline/MCDataProducts/inc/PrimaryParticle.hh"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Core/ModuleMacros.h"
+namespace mu2e {
+  class NullMCPrimary : public art::EDProducer {
+    public:
+      struct Config {
+      };
+      using Parameters = art::EDProducer::Table<Config>;
+      explicit NullMCPrimary(const Parameters& conf);
+      void produce(art::Event& evt) override;
+    private:
+  };
+
+  NullMCPrimary::NullMCPrimary(const Parameters& config )  :
+    art::EDProducer{config}
+    {
+      produces <PrimaryParticle>();
+    }
+
+  void NullMCPrimary::produce(art::Event& event) {
+    // create empty output object
+    PrimaryParticle pp;
+    event.put(std::make_unique<PrimaryParticle>(pp));
+  }
+}
+DEFINE_ART_MODULE(mu2e::NullMCPrimary)

--- a/Filters/src/ParticleCodeFilter_module.cc
+++ b/Filters/src/ParticleCodeFilter_module.cc
@@ -20,26 +20,26 @@
 
 namespace mu2e {
   class ParticleCodeFilter : public art::EDFilter {
-    public: 
+    public:
       using ParticleCodeConfig = fhicl::Sequence<fhicl::Tuple<int,std::string,std::string>>;
 
       struct ModuleConfig {
-	using Name=fhicl::Name;
-	using Comment=fhicl::Comment;
-	fhicl::Atom<int> printLevel { Name("PrintLevel"), Comment ("Printout Level"), 0 };
-	fhicl::Atom<art::InputTag> simParticles { Name("SimParticles"), Comment("SimParticle collection") };
-	ParticleCodeConfig codeConfig { Name("ParticleCodes"), Comment("particle code to select: PDG, creation, and termination code \n"
-	"(select 'uninitialized' to disable testing creation and/or termination codes)") };
+        using Name=fhicl::Name;
+        using Comment=fhicl::Comment;
+        fhicl::Atom<int> printLevel { Name("PrintLevel"), Comment ("Printout Level"), 0 };
+        fhicl::Atom<art::InputTag> simParticles { Name("SimParticles"), Comment("SimParticle collection") };
+        ParticleCodeConfig codeConfig { Name("ParticleCodes"), Comment("particle code to select: PDG, creation, and termination code \n"
+            "(select 'uninitialized' to disable testing creation and/or termination codes)") };
       };
 
       struct ParticleCodeSelector {
-	PDGCode::type pdgCode_;
-	ProcessCode::enum_type creationCode_, terminationCode_;
-	bool select(SimParticle const& part) const {
-	  return part.pdgId() == pdgCode_
-	    && ( creationCode_ == ProcessCode::uninitialized || part.creationCode() == creationCode_) 
-	    && ( terminationCode_ == ProcessCode::uninitialized || part.stoppingCode() == terminationCode_);
-	}
+        PDGCode::type pdgCode_;
+        ProcessCode::enum_type creationCode_, terminationCode_;
+        bool select(SimParticle const& part) const {
+          return part.pdgId() == pdgCode_
+            && ( creationCode_ == ProcessCode::uninitialized || part.creationCode() == creationCode_)
+            && ( terminationCode_ == ProcessCode::uninitialized || part.stoppingCode() == terminationCode_);
+        }
       };
 
       using Parameters = art::EDFilter::Table<ModuleConfig>;
@@ -54,18 +54,18 @@ namespace mu2e {
 
   ParticleCodeFilter::ParticleCodeFilter(const Parameters& conf) : art::EDFilter{conf}
   , printLevel_(conf().printLevel())
-  , simParticles_(consumes<SimParticleCollection>(conf().simParticles())) {
-    for(auto const& pconfig : conf().codeConfig()) {
-      ParticleCodeSelector pselector;
-      pselector.pdgCode_ = static_cast<PDGCode::type>(std::get<0>(pconfig));
-      pselector.creationCode_ = ProcessCode::findByName(std::get<1>(pconfig));
-      pselector.terminationCode_ = ProcessCode::findByName(std::get<2>(pconfig));
-      if(printLevel_ > 0) std::cout << "Creating selector of PDGcode " << pselector.pdgCode_ 
-      << " creation code " << pselector.creationCode_
-      << " termination code " << pselector.terminationCode_ << std::endl;
-      selectors_.push_back(pselector);
+    , simParticles_(consumes<SimParticleCollection>(conf().simParticles())) {
+      for(auto const& pconfig : conf().codeConfig()) {
+        ParticleCodeSelector pselector;
+        pselector.pdgCode_ = static_cast<PDGCode::type>(std::get<0>(pconfig));
+        pselector.creationCode_ = ProcessCode::findByName(std::get<1>(pconfig));
+        pselector.terminationCode_ = ProcessCode::findByName(std::get<2>(pconfig));
+        if(printLevel_ > 0) std::cout << "Creating selector of PDGcode " << pselector.pdgCode_
+          << " creation code " << pselector.creationCode_
+            << " termination code " << pselector.terminationCode_ << std::endl;
+        selectors_.push_back(pselector);
+      }
     }
-  }
 
   bool ParticleCodeFilter::filter(art::Event& event) {
     bool retval(false);
@@ -73,14 +73,14 @@ namespace mu2e {
     auto const& simps = *simH;
     for (auto const& simp : simps) {
       if(printLevel_ > 1) std::cout << "Testing particle PDGcode " << simp.second.pdgId()
-	<< " creationcode =" << simp.second.creationCode()
-	  << " termination code =" << simp.second.stoppingCode() << std::endl;
+        << " creationcode =" << simp.second.creationCode()
+          << " termination code =" << simp.second.stoppingCode() << std::endl;
       for( auto const& selector : selectors_ ){
-	if(selector.select(simp.second)){
-	  if(printLevel_ > 0) std::cout << "Found matching particle " << std::endl;
-	  retval = true;
-	  break;
-	}
+        if(selector.select(simp.second)){
+          if(printLevel_ > 0) std::cout << "Found matching particle " << std::endl;
+          retval = true;
+          break;
+        }
       }
     }
     return retval;


### PR DESCRIPTION
This module will be used in the NoPrimary sequence, so the output will be compatible with downstream (reco) processing.