### PR TITLE
Cosmic offset at generator level

### DIFF
--- a/EventGenerator/src/CORSIKAEventGenerator_module.cc
+++ b/EventGenerator/src/CORSIKAEventGenerator_module.cc
@@ -118,8 +118,8 @@ namespace mu2e {
                                                                          _refPointChoice(_conf.refPointChoice()),
                                                                          _intDist(_conf.intDist()),
                                                                          _applyTimeOffset(!_conf.simTimeOffset().empty()),
-                                                                         _timeOffsetTag(conf.simTimeOffset()),
-                                                                         _stoff(0.0))
+                                                                         _timeOffsetTag(_conf.simTimeOffset()),
+                                                                         _stoff(0.0)
   {
     produces<GenParticleCollection>();
     produces<CosmicLivetime,art::InSubRun>();
@@ -142,8 +142,8 @@ namespace mu2e {
 
     if (_applyTimeOffset) {
       // find the time offset in the event, and copy it locally
-      const auto& stoH = e.getValidHandle<SimTimeOffset>(_timeOffsetTag);
-      stoff_ = *stoH;
+      const auto& stoH = evt.getValidHandle<SimTimeOffset>(_timeOffsetTag);
+      _stoff = *stoH;
     }
 
     if (!_geomInfoObtained) {
@@ -259,7 +259,7 @@ namespace mu2e {
 
           genParticles->push_back(GenParticle(static_cast<PDGCode::type>(particle.pdgId()),
                                               GenId::cosmicCORSIKA, projectedPos, mom4,
-                                              particle.time() + _stoff));
+                                              particle.time() + _stoff.timeOffset_));
         } else {
           _worldIntersections.clear();
           VectorVolume particleWorld(position, particle.momentum().vect(),
@@ -272,13 +272,13 @@ namespace mu2e {
             const Hep3Vector projectedPos = _worldIntersections.at(0);
             genParticles->push_back(GenParticle(static_cast<PDGCode::type>(particle.pdgId()),
                                                 GenId::cosmicCORSIKA, projectedPos, mom4,
-                                                particle.time() + _stoff));
+                                                particle.time() + _stoff.timeOffset_));
           }
         }
       } else {
         genParticles->push_back(GenParticle(static_cast<PDGCode::type>(particle.pdgId()),
                   GenId::cosmicCORSIKA, position, mom4,
-                  particle.time() + _stoff));
+                  particle.time() + _stoff.timeOffset_));
       }
     }
 

--- a/EventMixing/inc/Mu2eProductMixer.hh
+++ b/EventMixing/inc/Mu2eProductMixer.hh
@@ -96,7 +96,7 @@ namespace mu2e {
       fhicl::Table<CollectionMixerConfig> cosmicLivetimeMixer { fhicl::Name("cosmicLivetimeMixer") };
       fhicl::Table<CollectionMixerConfig> eventIDMixer { fhicl::Name("eventIDMixer") };
       fhicl::OptionalTable<VolumeInfoMixerConfig> volumeInfoMixer { fhicl::Name("volumeInfoMixer") };
-      fhicl::Atom<art::InputTag> simTimeOffset { fhicl::Name("simTimeOffset"), fhicl::Comment("Simulation time offset to apply (optional)"), art::InputTag() };
+      fhicl::OptionalAtom<art::InputTag> simTimeOffset { fhicl::Name("simTimeOffset"), fhicl::Comment("Simulation time offset to apply (optional)") };
     };
 
     Mu2eProductMixer(const Config& conf, art::MixHelper& helper);

--- a/EventMixing/src/Mu2eProductMixer.cc
+++ b/EventMixing/src/Mu2eProductMixer.cc
@@ -43,11 +43,11 @@ namespace mu2e {
   //----------------------------------------------------------------
   Mu2eProductMixer::Mu2eProductMixer(const Config& conf, art::MixHelper& helper)
     : mixVolumes_(false)
-      , applyTimeOffset_{! conf.simTimeOffset().empty() }
-      , timeOffsetTag_{ conf.simTimeOffset() }
+      , applyTimeOffset_(conf.simTimeOffset.hasValue())
       , stoff_(0.0)
   {
     if(applyTimeOffset_){
+      timeOffsetTag_ = conf.simTimeOffset().value();
       std::cout << "Mu2eProductMixer: Applying time offsets from " << timeOffsetTag_ << std::endl;
     }
 
@@ -163,8 +163,8 @@ namespace mu2e {
     art::flattenCollections(in, out, genOffsets_);
     if(applyTimeOffset_){
       for(auto& particle : out){
-	particle.time() += stoff_.timeOffset_;
-	// proper times are WRT the particles own internal clock, can't shift them
+        particle.time() += stoff_.timeOffset_;
+        // proper times are WRT the particles own internal clock, can't shift them
       }
     }
 
@@ -237,7 +237,7 @@ namespace mu2e {
       auto& step = out[i];
       step.simParticle() = remap(step.simParticle(), simOffsets_[ie]);
       if(applyTimeOffset_){
-	step.time() += stoff_.timeOffset_;
+        step.time() += stoff_.timeOffset_;
       }
     }
     return true;
@@ -351,7 +351,7 @@ namespace mu2e {
                                                  art::PtrRemapper const& remap)
   {
     if(in.size() > 1)
-      throw cet::exception("BADINPUT")<<"Mu2eProductMixer/evt: can't mix CosmicLiveTime" << std::endl; 
+      throw cet::exception("BADINPUT")<<"Mu2eProductMixer/evt: can't mix CosmicLiveTime" << std::endl;
     for(const auto& x: in) {
       out = *x;
     }


### PR DESCRIPTION
This PR adds the possibility to add a time offset to the cosmic `GenParticles` at generator level, without resampling. 