### PR TITLE
Add products to NullPrimary so that Reco runs OOTB

### DIFF
--- a/CommonMC/src/NullMCPrimary_module.cc
+++ b/CommonMC/src/NullMCPrimary_module.cc
@@ -1,32 +1,43 @@
 //
 //  Trivial module to insert an empty PrimaryParticle object in the event, used for NoPrimary production
 //
-// mu2e
-#include "Offline/MCDataProducts/inc/PrimaryParticle.hh"
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Core/ModuleMacros.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "Offline/MCDataProducts/inc/PrimaryParticle.hh"
+#include "Offline/MCDataProducts/inc/StepPointMC.hh"
+#include <vector>
+#include <string>
 namespace mu2e {
   class NullMCPrimary : public art::EDProducer {
     public:
       struct Config {
+        fhicl::Sequence<std::string> extraSteps { fhicl::Name("ExtraSteps"), fhicl::Comment("2ndary keys of extra StepPointMC collections") };
       };
       using Parameters = art::EDProducer::Table<Config>;
       explicit NullMCPrimary(const Parameters& conf);
       void produce(art::Event& evt) override;
     private:
+    std::vector<std::string> extrasteps_;
   };
 
   NullMCPrimary::NullMCPrimary(const Parameters& config )  :
-    art::EDProducer{config}
+    art::EDProducer{config},
+    extrasteps_(config().extraSteps())
     {
       produces <PrimaryParticle>();
+      for(auto extrastep : extrasteps_)
+        produces <StepPointMCCollection>(extrastep);
     }
 
   void NullMCPrimary::produce(art::Event& event) {
     // create empty output object
     PrimaryParticle pp;
     event.put(std::make_unique<PrimaryParticle>(pp));
+    StepPointMCCollection empty;
+    for(auto extrastep : extrasteps_)
+      event.put(std::make_unique<StepPointMCCollection>(empty),extrastep);
   }
 }
 DEFINE_ART_MODULE(mu2e::NullMCPrimary)

--- a/CommonMC/src/NullMCPrimary_module.cc
+++ b/CommonMC/src/NullMCPrimary_module.cc
@@ -7,6 +7,7 @@
 #include "fhiclcpp/types/Sequence.h"
 #include "Offline/MCDataProducts/inc/PrimaryParticle.hh"
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
+#include "Offline/MCDataProducts/inc/MCTrajectoryCollection.hh"
 #include <vector>
 #include <string>
 namespace mu2e {
@@ -27,14 +28,17 @@ namespace mu2e {
     extrasteps_(config().extraSteps())
     {
       produces <PrimaryParticle>();
+      produces <MCTrajectoryCollection>();
       for(auto extrastep : extrasteps_)
         produces <StepPointMCCollection>(extrastep);
     }
 
   void NullMCPrimary::produce(art::Event& event) {
-    // create empty output object
+    // create empty output objects
     PrimaryParticle pp;
+    MCTrajectoryCollection mctc;
     event.put(std::make_unique<PrimaryParticle>(pp));
+    event.put(std::make_unique<MCTrajectoryCollection>(mctc));
     StepPointMCCollection empty;
     for(auto extrastep : extrasteps_)
       event.put(std::make_unique<StepPointMCCollection>(empty),extrastep);


### PR DESCRIPTION
Added more empty products required by Reco to NullMCPrimary producer.