### PR TITLE
removed cut on t0 in the TimeClusterFilter module

### DIFF
--- a/Trigger/data/cprCosmicHelixDeM/main_cprCosmicHelixDeMTCFilter.fcl
+++ b/Trigger/data/cprCosmicHelixDeM/main_cprCosmicHelixDeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.cprCosmicHelixDeMTCFilter.requireCaloCluster : false
 physics.filters.cprCosmicHelixDeMTCFilter.minNHits : 10.0
-physics.filters.cprCosmicHelixDeMTCFilter.minTime : 0.0
-physics.filters.cprCosmicHelixDeMTCFilter.maxTime : 1695.0

--- a/Trigger/data/cprCosmicHelixDeP/main_cprCosmicHelixDePTCFilter.fcl
+++ b/Trigger/data/cprCosmicHelixDeP/main_cprCosmicHelixDePTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.cprCosmicHelixDePTCFilter.requireCaloCluster : false
 physics.filters.cprCosmicHelixDePTCFilter.minNHits : 10.0
-physics.filters.cprCosmicHelixDePTCFilter.minTime : 0.0
-physics.filters.cprCosmicHelixDePTCFilter.maxTime : 1695.0

--- a/Trigger/data/cprCosmicHelixUeM/main_cprCosmicHelixUeMTCFilter.fcl
+++ b/Trigger/data/cprCosmicHelixUeM/main_cprCosmicHelixUeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.cprCosmicHelixUeMTCFilter.requireCaloCluster : false
 physics.filters.cprCosmicHelixUeMTCFilter.minNHits : 10.0
-physics.filters.cprCosmicHelixUeMTCFilter.minTime : 0.0
-physics.filters.cprCosmicHelixUeMTCFilter.maxTime : 1695.0

--- a/Trigger/data/cprCosmicHelixUeP/main_cprCosmicHelixUePTCFilter.fcl
+++ b/Trigger/data/cprCosmicHelixUeP/main_cprCosmicHelixUePTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.cprCosmicHelixUePTCFilter.requireCaloCluster : false
 physics.filters.cprCosmicHelixUePTCFilter.minNHits : 10.0
-physics.filters.cprCosmicHelixUePTCFilter.minTime : 0.0
-physics.filters.cprCosmicHelixUePTCFilter.maxTime : 1695.0

--- a/Trigger/data/cprCosmicSeedDeM/main_cprCosmicSeedDeMTCFilter.fcl
+++ b/Trigger/data/cprCosmicSeedDeM/main_cprCosmicSeedDeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.cprCosmicSeedDeMTCFilter.requireCaloCluster : false
 physics.filters.cprCosmicSeedDeMTCFilter.minNHits : 10.0
-physics.filters.cprCosmicSeedDeMTCFilter.minTime : 0.0
-physics.filters.cprCosmicSeedDeMTCFilter.maxTime : 1695.0

--- a/Trigger/data/cprCosmicSeedDeP/main_cprCosmicSeedDePTCFilter.fcl
+++ b/Trigger/data/cprCosmicSeedDeP/main_cprCosmicSeedDePTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.cprCosmicSeedDePTCFilter.requireCaloCluster : false
 physics.filters.cprCosmicSeedDePTCFilter.minNHits : 10.0
-physics.filters.cprCosmicSeedDePTCFilter.minTime : 0.0
-physics.filters.cprCosmicSeedDePTCFilter.maxTime : 1695.0

--- a/Trigger/data/cprLowPSeedDeM/main_cprLowPSeedDeMTCFilter.fcl
+++ b/Trigger/data/cprLowPSeedDeM/main_cprLowPSeedDeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.cprLowPSeedDeMTCFilter.requireCaloCluster : false
 physics.filters.cprLowPSeedDeMTCFilter.minNHits           : 10.0
-physics.filters.cprLowPSeedDeMTCFilter.minTime            : 500.0
-physics.filters.cprLowPSeedDeMTCFilter.maxTime            : 1695.0

--- a/Trigger/data/cprLowPSeedDeP/main_cprLowPSeedDePTCFilter.fcl
+++ b/Trigger/data/cprLowPSeedDeP/main_cprLowPSeedDePTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.cprLowPSeedDePTCFilter.requireCaloCluster : false
 physics.filters.cprLowPSeedDePTCFilter.minNHits : 10.0
-physics.filters.cprLowPSeedDePTCFilter.minTime : 500.0
-physics.filters.cprLowPSeedDePTCFilter.maxTime : 1695.0

--- a/Trigger/data/cprSeedDeM/main_cprSeedDeMTCFilter.fcl
+++ b/Trigger/data/cprSeedDeM/main_cprSeedDeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.cprSeedDeMTCFilter.requireCaloCluster : true
 physics.filters.cprSeedDeMTCFilter.minNHits           : 10.0
-physics.filters.cprSeedDeMTCFilter.minTime            : 500.0
-physics.filters.cprSeedDeMTCFilter.maxTime            : 1695.0

--- a/Trigger/data/cprSeedDeP/main_cprSeedDePTCFilter.fcl
+++ b/Trigger/data/cprSeedDeP/main_cprSeedDePTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.cprSeedDePTCFilter.requireCaloCluster : false
 physics.filters.cprSeedDePTCFilter.minNHits : 10.0
-physics.filters.cprSeedDePTCFilter.minTime : 500.0
-physics.filters.cprSeedDePTCFilter.maxTime : 1695.0

--- a/Trigger/data/cstSeed/main_cstSeedTCFilter.fcl
+++ b/Trigger/data/cstSeed/main_cstSeedTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.cstSeedTCFilter.requireCaloCluster : false
 physics.filters.cstSeedTCFilter.minNHits           : 8
-physics.filters.cstSeedTCFilter.minTime            : 0.0
-physics.filters.cstSeedTCFilter.maxTime            : 1695.0

--- a/Trigger/data/tprCosmicHelixDeM/main_tprCosmicHelixDeMTCFilter.fcl
+++ b/Trigger/data/tprCosmicHelixDeM/main_tprCosmicHelixDeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprCosmicHelixDeMTCFilter.requireCaloCluster : false
 physics.filters.tprCosmicHelixDeMTCFilter.minNHits : 10.0
-physics.filters.tprCosmicHelixDeMTCFilter.minTime : 0.0
-physics.filters.tprCosmicHelixDeMTCFilter.maxTime : 1695.0

--- a/Trigger/data/tprCosmicHelixDeP/main_tprCosmicHelixDePTCFilter.fcl
+++ b/Trigger/data/tprCosmicHelixDeP/main_tprCosmicHelixDePTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprCosmicHelixDePTCFilter.requireCaloCluster : false
 physics.filters.tprCosmicHelixDePTCFilter.minNHits : 10.0
-physics.filters.tprCosmicHelixDePTCFilter.minTime : 0.0
-physics.filters.tprCosmicHelixDePTCFilter.maxTime : 1695.0

--- a/Trigger/data/tprCosmicHelixUeM/main_tprCosmicHelixUeMTCFilter.fcl
+++ b/Trigger/data/tprCosmicHelixUeM/main_tprCosmicHelixUeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprCosmicHelixUeMTCFilter.requireCaloCluster : false
 physics.filters.tprCosmicHelixUeMTCFilter.minNHits : 10.0
-physics.filters.tprCosmicHelixUeMTCFilter.minTime : 0.0
-physics.filters.tprCosmicHelixUeMTCFilter.maxTime : 1695.0

--- a/Trigger/data/tprCosmicHelixUeP/main_tprCosmicHelixUePTCFilter.fcl
+++ b/Trigger/data/tprCosmicHelixUeP/main_tprCosmicHelixUePTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprCosmicHelixUePTCFilter.requireCaloCluster : false
 physics.filters.tprCosmicHelixUePTCFilter.minNHits : 10.0
-physics.filters.tprCosmicHelixUePTCFilter.minTime : 0.0
-physics.filters.tprCosmicHelixUePTCFilter.maxTime : 1695.0

--- a/Trigger/data/tprCosmicSeedDeM/main_tprCosmicSeedDeMTCFilter.fcl
+++ b/Trigger/data/tprCosmicSeedDeM/main_tprCosmicSeedDeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprCosmicSeedDeMTCFilter.requireCaloCluster : false
 physics.filters.tprCosmicSeedDeMTCFilter.minNHits : 10.0
-physics.filters.tprCosmicSeedDeMTCFilter.minTime : 0.0
-physics.filters.tprCosmicSeedDeMTCFilter.maxTime : 1695.0

--- a/Trigger/data/tprCosmicSeedDeP/main_tprCosmicSeedDePTCFilter.fcl
+++ b/Trigger/data/tprCosmicSeedDeP/main_tprCosmicSeedDePTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprCosmicSeedDePTCFilter.requireCaloCluster : false
 physics.filters.tprCosmicSeedDePTCFilter.minNHits : 10.0
-physics.filters.tprCosmicSeedDePTCFilter.minTime : 0.0
-physics.filters.tprCosmicSeedDePTCFilter.maxTime : 1695.0

--- a/Trigger/data/tprHelixCalibIPADeM/main_tprHelixCalibIPADeMTCFilter.fcl
+++ b/Trigger/data/tprHelixCalibIPADeM/main_tprHelixCalibIPADeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprHelixCalibIPADeMTCFilter.requireCaloCluster : false
 physics.filters.tprHelixCalibIPADeMTCFilter.minNHits           : 10.0
-physics.filters.tprHelixCalibIPADeMTCFilter.minTime            : 500.0
-physics.filters.tprHelixCalibIPADeMTCFilter.maxTime            : 1695.0

--- a/Trigger/data/tprHelixIPADeM/main_tprHelixIPADeMTCFilter.fcl
+++ b/Trigger/data/tprHelixIPADeM/main_tprHelixIPADeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprHelixIPADeMTCFilter.requireCaloCluster : false
 physics.filters.tprHelixIPADeMTCFilter.minNHits           : 10.0
-physics.filters.tprHelixIPADeMTCFilter.minTime            : 500.0
-physics.filters.tprHelixIPADeMTCFilter.maxTime            : 1695.0

--- a/Trigger/data/tprLowPSeedDeM/main_tprLowPSeedDeMTCFilter.fcl
+++ b/Trigger/data/tprLowPSeedDeM/main_tprLowPSeedDeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprLowPSeedDeMTCFilter.requireCaloCluster : false
 physics.filters.tprLowPSeedDeMTCFilter.minNHits : 10.0
-physics.filters.tprLowPSeedDeMTCFilter.minTime : 500.0
-physics.filters.tprLowPSeedDeMTCFilter.maxTime : 1695.0

--- a/Trigger/data/tprLowPSeedDeP/main_tprLowPSeedDePTCFilter.fcl
+++ b/Trigger/data/tprLowPSeedDeP/main_tprLowPSeedDePTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprLowPSeedDePTCFilter.requireCaloCluster : false
 physics.filters.tprLowPSeedDePTCFilter.minNHits : 10.0
-physics.filters.tprLowPSeedDePTCFilter.minTime : 500.0
-physics.filters.tprLowPSeedDePTCFilter.maxTime : 1695.0

--- a/Trigger/data/tprSeedDeM/main_tprSeedDeMTCFilter.fcl
+++ b/Trigger/data/tprSeedDeM/main_tprSeedDeMTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprSeedDeMTCFilter.requireCaloCluster : false
 physics.filters.tprSeedDeMTCFilter.minNHits : 10.0
-physics.filters.tprSeedDeMTCFilter.minTime : 500.0
-physics.filters.tprSeedDeMTCFilter.maxTime : 1695.0

--- a/Trigger/data/tprSeedDeP/main_tprSeedDePTCFilter.fcl
+++ b/Trigger/data/tprSeedDeP/main_tprSeedDePTCFilter.fcl
@@ -1,4 +1,2 @@
 physics.filters.tprSeedDePTCFilter.requireCaloCluster : false
 physics.filters.tprSeedDePTCFilter.minNHits : 10.0
-physics.filters.tprSeedDePTCFilter.minTime : 500.0
-physics.filters.tprSeedDePTCFilter.maxTime : 1695.0

--- a/TrkFilters/src/TimeClusterFilter_module.cc
+++ b/TrkFilters/src/TimeClusterFilter_module.cc
@@ -29,7 +29,6 @@ namespace mu2e
     art::InputTag _tcTag;
     bool          _hascc; // Calo Cluster
     unsigned      _minnhits;
-    double        _mintime, _maxtime;
     int           _debug;
     // counters
     unsigned _nevt, _npass;
@@ -40,8 +39,6 @@ namespace mu2e
     _tcTag(pset.get<art::InputTag>("timeClusterCollection","TimeClusterFinder")),
     _hascc(pset.get<bool>("requireCaloCluster",false)),
     _minnhits(pset.get<unsigned>("minNHits",11)),
-    _mintime(pset.get<double>("minTime",500.0)),
-    _maxtime(pset.get<double>("maxTime",1695.0)) ,
     _debug(pset.get<int>("debugLevel",0)),
     _nevt(0), _npass(0)
   {
@@ -63,8 +60,7 @@ namespace mu2e
         std::cout << moduleDescription().moduleLabel() << " nhits = " << tc.hits().size() << " t0 = " << tc.t0().t0() << std::endl;
       }
       if( (!_hascc || tc.caloCluster().isNonnull()) &&
-          tc.hits().size() >= _minnhits &&
-          tc.t0().t0() > _mintime && tc.t0().t0() < _maxtime) {
+          tc.hits().size() >= _minnhits) {
         retval = true;
         ++_npass;
         // Fill the trigger info object


### PR DESCRIPTION
removed a useless cut in the TimeClusterFilter module. 
- it was not needed as the DAQ acceptance window will be encoded in the firmware of the ROCs
- it was creating configuration issues for running the OnSpillMenu track sequences also in the OffSpill events