### PR TITLE
make valCompare more sensitive

### DIFF
--- a/Validation/inc/TValHist.hh
+++ b/Validation/inc/TValHist.hh
@@ -23,6 +23,7 @@ public:
   TValPar&   GetPar()    { return fPar;}
   TString&   GetTag()    { return fTag;}
   Float_t    GetFontScale() { return fFontScale; }
+  Bool_t     GetEmpty()  { return fEmpty; }
 
   virtual const char* GetName() const=0;
   virtual const char* GetTitle() const=0;
@@ -51,6 +52,7 @@ protected:
   TString fTag;
 
   Float_t fFontScale;
+  Bool_t   fEmpty;    // true if eiher hist is empty
 
   ClassDef(TValHist,1)
 

--- a/Validation/root/TValCompare.cc
+++ b/Validation/root/TValCompare.cc
@@ -249,7 +249,7 @@ void TValCompare::Report(Option_t* Opt) {
 //_____________________________________________________________________________
 void TValCompare::Summary(Option_t* Opt) {
 
-  int n0=0,ns=0,n1=0,n2=0,n3=0,n10=0,n11=0,n100=0;
+  int n0=0,ns=0,ne=0,n1=0,n2=0,n3=0,n11=0,n100=0;
   TIter it(&fList);
   TValHist* hh;
 
@@ -266,9 +266,9 @@ void TValCompare::Summary(Option_t* Opt) {
       else if(hh->GetStatus()==1 ) n1++;
       else if(hh->GetStatus()==2 ) n2++;
       else if(hh->GetStatus()==3 ) n3++;
-      else if(hh->GetStatus()==10) n10++;
       else if(hh->GetStatus()==11) n11++;
       else n100++;
+      if(hh->GetEmpty()) ne++;
     } else {
       ns++;
     }
@@ -279,8 +279,8 @@ void TValCompare::Summary(Option_t* Opt) {
   printf("%5d marked to skip\n",ns);
   printf("%5d had unknown status\n",n100);
   printf("%5d could not be compared\n",n11);
-  printf("%5d had at least one histogram empty\n",n10);
-  printf("%5d failed loose comparison\n",n3);
+  printf("%5d had at least one histogram empty\n",ne);
+  printf("%5d failed loose comparison\n",n3+n11+n100);
   printf("%5d passed loose comparison, failed tight\n",n2);
   printf("%5d passed tight comparison, not perfect match\n",n1);
   printf("%5d had perfect match\n",n0);
@@ -499,7 +499,7 @@ void TValCompare::SaveAs(const char *filename, Option_t *option) const {
 	  float res = (io==0 ? hh->GetKsProb() : hh->GetFrProb());
 	  // if Fraction test and samples are independent
 	  bool frblack = (io==1 && fPar.GetIndependent()!=0);
-	  if(hh->GetStatus()<10 && ! frblack) {
+	  if( !frblack ) {
 	    color="Red";
 	    if(res>fPar.GetLoose()) color="Orange";
 	    if(res>fPar.GetTight()) color="Green";

--- a/Validation/root/TValHist.cc
+++ b/Validation/root/TValHist.cc
@@ -14,5 +14,6 @@ void TValHist::ClearB(Option_t* Opt) {
   fDiff = true;
   fStatus = 10;
   fFontScale = 1.0;
+  fEmpty = false;
 }
 

--- a/Validation/root/TValHistE.cc
+++ b/Validation/root/TValHistE.cc
@@ -60,56 +60,61 @@ Int_t TValHistE::Analyze(Option_t* Opt) {
     fSum2 += fEff2->GetTotalHistogram()->GetBinContent(ii);
   }
 
-  // can't compare if one is zero
-  if(fSum1==0 || fSum2==0) {
-    if(fSum1>0 || fSum2>0) {
-      // prob of observing zero event when expecting N
-      fKsProb = TMath::Exp( -TMath::Max(fSum1,fSum2) );
-      fFrProb = 0.0;
-    }
-    fStatus = 10;
+  // if both zero, they agree
+  if(fSum1==0 && fSum2==0) {
+    fEmpty = true;
+    fKsProb = 1.0;
+    fFrProb = 1.0;
+    fStatus = 0;
     return fStatus;
   }
   
   // no sensible meaning to fractional difference
   fFrProb = 1.0;
 
-  // KsProb is filled from a chi2 comparison
-  int ndof = 0;
-  double chi2 = 0.0;
-  double n1,n2,c1,c2,e1,e2;
-  for(uint ii=llim; ii<=ulim; ii++) {
-    n1 = fEff1->GetTotalHistogram()->GetBinContent(ii);
-    n2 = fEff2->GetTotalHistogram()->GetBinContent(ii);
-    c1 = fEff1->GetEfficiency(ii);
-    c2 = fEff2->GetEfficiency(ii);
-    e1 = (fEff1->GetEfficiencyErrorLow(ii) 
-	  + fEff1->GetEfficiencyErrorUp(ii))/2.0;
-    e2 = (fEff2->GetEfficiencyErrorLow(ii) 
-	  + fEff2->GetEfficiencyErrorUp(ii))/2.0;
-    if(n1>0 && n2>0) {
-      // both have entries, add to chi2
-      chi2 += pow(c1-c2,2)/(pow(e1,2)+pow(e2,2));
-      ndof++;
-    } else if(n1>0 || n2>0) {
-      // one has entries, the other doesn't, we need some penalty
-      // the idea is to add the Poisson probability of observing
-      // zero when expecting n to the likelihood, represented by 
-      // adding n to the chi2
-      chi2 += (n1>0 ? n1 : n2);
-      ndof++;
-    }
-    // if both effs have no entries, ignore this bin
-
-  } // loop over bins
-
-  if(ndof>0) {
-    fKsProb = TMath::Prob(chi2,ndof);
+  if(fSum1==0 || fSum2==0) {
+    fEmpty = true;
+    // prob of observing zero event when expecting N
+    fKsProb = TMath::Exp( -TMath::Max(fSum1,fSum2) );
+    fFrProb = 0.0;
   } else {
-    // shouldn't come here since we returned above if no entries
-    // in either plot.  If there were entries then ndof should be >0
-    fKsProb = 0.0;
-  }
+    // KsProb is filled from a chi2 comparison
+    int ndof = 0;
+    double chi2 = 0.0;
+    double n1,n2,c1,c2,e1,e2;
+    for(uint ii=llim; ii<=ulim; ii++) {
+      n1 = fEff1->GetTotalHistogram()->GetBinContent(ii);
+      n2 = fEff2->GetTotalHistogram()->GetBinContent(ii);
+      c1 = fEff1->GetEfficiency(ii);
+      c2 = fEff2->GetEfficiency(ii);
+      e1 = (fEff1->GetEfficiencyErrorLow(ii) 
+	    + fEff1->GetEfficiencyErrorUp(ii))/2.0;
+      e2 = (fEff2->GetEfficiencyErrorLow(ii) 
+	    + fEff2->GetEfficiencyErrorUp(ii))/2.0;
+      if(n1>0 && n2>0) {
+	// both have entries, add to chi2
+	chi2 += pow(c1-c2,2)/(pow(e1,2)+pow(e2,2));
+	ndof++;
+      } else if(n1>0 || n2>0) {
+	// one has entries, the other doesn't, we need some penalty
+	// the idea is to add the Poisson probability of observing
+	// zero when expecting n to the likelihood, represented by 
+	// adding n to the chi2
+	chi2 += (n1>0 ? n1 : n2);
+	ndof++;
+      }
+      // if both effs have no entries, ignore this bin
+
+    } // loop over bins
+
+    if(ndof>0) {
+      fKsProb = TMath::Prob(chi2,ndof);
+    } else {
+      // shouldn't come here since we returned above if no entries
+      // in either plot.  If there were entries then ndof should be >0
+      fKsProb = 0.0;
+    }
+  } // end if a sum is zero
 
   fStatus = 3;
   if(fKsProb>fPar.GetLoose()) fStatus = 2;
@@ -212,14 +217,10 @@ void TValHistE::Draw(Option_t* Opt) {
   char tstring[200];
   int color;
 
-  color=kBlack;
-  //printf("ks %f  loose %f\n",GetKsProb(),fPar.GetLoose());
-  if(GetStatus()<10) {
-    color=kRed;
-    if(GetKsProb()>fPar.GetLoose()) color=kOrange;
-    if(GetKsProb()>fPar.GetTight()) color=kGreen;
-    if(GetStatus()==0) color=kGreen+2;
-  }
+  color=kRed;
+  if(GetKsProb()>fPar.GetLoose()) color=kOrange;
+  if(GetKsProb()>fPar.GetTight()) color=kGreen;
+  if(GetStatus()==0) color=kGreen+2;
   sprintf(tstring,"KS=%8.6f",GetKsProb());
   TText* t1 = new TText();
   t1->SetNDC();
@@ -229,14 +230,10 @@ void TValHistE::Draw(Option_t* Opt) {
   t1->SetTextColor(color);
   t1->Draw();
 
-  color=kBlack;
-  // if samples are independant, then don't flag the fraction result
-  if(GetStatus()<10 && fPar.GetIndependent()==0) {
-    color=kRed;
-    if(GetFrProb()>fPar.GetLoose()) color=kOrange;
-    if(GetFrProb()>fPar.GetTight()) color=kGreen;
-    if(GetStatus()==0) color=kGreen+2;
-  }
+  color=kRed;
+  if(GetFrProb()>fPar.GetLoose()) color=kOrange;
+  if(GetFrProb()>fPar.GetTight()) color=kGreen;
+  if(GetStatus()==0) color=kGreen+2;
   sprintf(tstring,"FR=%8.6f",GetFrProb());
   TText* t2 = new TText();
   t2->SetNDC();

--- a/Validation/src/valCompare_main.cc
+++ b/Validation/src/valCompare_main.cc
@@ -27,7 +27,6 @@ void valCompare_usage() {
 "  0 = perfect match\n"
 "  1 = matches > 99.9% in K-S or fractional test\n"
 "  2 = matches > 99% in K-S or fractional test\n"
-"  10 = one or both histograms is empty\n"
 "  11 = can't compare\n"
 "  \n"
 "  Examples:\n"


### PR DESCRIPTION
- if both histograms are empty, was special category, no alarm, now perfect agreement
- if one histogram empty and the other not, was special category, no alarm, now use Poisson prob in KS, and fraction tests fails
- if the two histograms have inconsistent binning, was special category, no alarm,  now an alarm
- in addition, still note if one or both histograms are empty in the summary

This pattern is better suited for how we use valCompare today, when we are asking "are these files the same?"  In the future, if we use it for asking "are the files consistent?", we will probably want to add tuning for that.  In any case, it is now set to alarm on special cases of diffs, which is the most conservative.