### PR TITLE
Fixes for Offpill digitization

### DIFF
--- a/CalPatRec/fcl/prolog.fcl
+++ b/CalPatRec/fcl/prolog.fcl
@@ -11,25 +11,25 @@
 #include "Offline/fcl/TrkCaloDt.fcl"
 BEGIN_PROLOG
 #------------------------------------------------------------------------------
-# there seems to be a circular dependence between MakeStrawHitPositions and 
+# there seems to be a circular dependence between MakeStrawHitPositions and
 # FlagStrawHits ... FlagBkgHits ?
 # MakeStrawHitPositions stores the hit flag in StrawHitPosition object
 # for that, an existing StrawHitFlagCollection is required
 #
-# in its turn, the FlagStrawHits module flags if the corresponding hit 
+# in its turn, the FlagStrawHits module flags if the corresponding hit
 # position 'stereo' and also sets radial selection flag
 # it also sets 'timesel' and 'energysel' flags
-# if, however, the StrawHitPosition doesnt exist, the 'stereo' and 'radsel' 
+# if, however, the StrawHitPosition doesnt exist, the 'stereo' and 'radsel'
 # flags are not set
 #
-# FlagBkgHits produces yet another hit flag collection, copying flags set by 
-# the OR of FlagStrawHits and flags stored in StrawHitPositions, and potentially adding 
+# FlagBkgHits produces yet another hit flag collection, copying flags set by
+# the OR of FlagStrawHits and flags stored in StrawHitPositions, and potentially adding
 # a 'delta' and 'isolated' flags
 # in principle, FlagBkgHits also uses StereoHitCollection, but that is not a must
 #
 # yes, there is a circular dependence between the data products.
 # Dave runs several instances of the hit flagging modules for a reason
-#------------------------------------------------------------------------------ 
+#------------------------------------------------------------------------------
 #-----------------------------------------------------------------------------
 # new format
 #------------------------------------------------------------------------------
@@ -48,11 +48,9 @@ CalPatRec : { @table::CalPatRec
 	debugLevel2                             : 0
 	smartTag                                : 1
 	diagLevel                               : 0
-	HelixFitSelectionBits                   : [] 
+	HelixFitSelectionBits                   : []
 	BackgroundSelectionBits                 : ["Background"]
 	maxElectronHitEnergy                    : 0.005           # 5 KeV, in MeV
-	minimumTime                             : 500.    #ns
-	maximumTime                             : 2000.   #ns
 	minNHit                                 : @local::CalPatRec.minNStrawHits       # minimal number of hits on found helix
 	hitChi2Max                              : @local::CalPatRec.chi2HitCut
 	mostProbableDfDz                        : 0.00475
@@ -60,19 +58,19 @@ CalPatRec : { @table::CalPatRec
 #	minNActiveStationPairs                  : 10
 	dzOverHelPitchCut                       : 0.7
 	maxDfDz                                 : 0.01
-	minDfDz                                 : 0.002    
+	minDfDz                                 : 0.002
 	sigmaPhi                                : 0.1636  # radians
 	targetconsistent                        : 0
 	weightXY                                : 1.11      #0.4527
-	weightZPhi                              : 0.75      #0.15      #0.29      #0.4423    
+	weightZPhi                              : 0.75      #0.15      #0.29      #0.4423
 	weight3D                                : 0.12      #1
 	maxXDPhi                                : 5         #
 	maxPanelToHelixDPhi                     : 1.309     # 75 degrees
 	distPatRec                              : 100.      # mm
 	minDeltaNShPatRec                       : 2
 	mindist                                 : 500.      # mm
-	minP                                    :  50.      # 
-	maxP                                    : 150.      # 
+	minP                                    :  50.      #
+	maxP                                    : 150.      #
 	minAbsTanDip                            : 0.3
 	maxAbsTanDip                            : 2.0
 	xyWeights                               : false
@@ -82,14 +80,14 @@ CalPatRec : { @table::CalPatRec
 	usetarget                               : true
 	maxZTripletSearch                       : 2000.    # mm
 	nHitsMaxPerPanel                        : 1
-	chi2xyMax                               : 5.0    
-	chi2zphiMax                             : 5.0    
+	chi2xyMax                               : 5.0
+	chi2zphiMax                             : 5.0
 	chi2hel3DMax                            : @local::CalPatRec.chi2hel3DMax
 	dfdzErr                                 : 0.1
 	minArea                                 : 5000.
     }
 #------------------------------------------------------------------------------
-# KalFitHack configuration for the KFF fits 
+# KalFitHack configuration for the KFF fits
 # I don't think it is used, CalTrkFit is using CPRKFFinal
 # first comment out, one month later - remove
 #------------------------------------------------------------------------------
@@ -101,7 +99,7 @@ CalPatRec : { @table::CalPatRec
 # 	hiterr 					: [ 80.  , 24.  , 8.   , 4.  , 2.   , 0.8  , 0.0  , 0.0 , 0.0  ]
 # 	t0Tolerance				: [ 2.0  , 1.0  , 1.0  , 1.0 , 0.5  , 0.5  , 0.2  , 0.2 , 0.1  ]
 # 	weedhits                                : [ true , true , true , true, true , true , true , true, true ]
-# 	# did Dave mean that? 
+# 	# did Dave mean that?
 # 	AddMaterial		                : [ false, false, false, true, false, false, false, true, true ]
 # 	initT0					: true
 # 	updateT0				: [ false, true, true, true, true, true, true, true, true ]
@@ -146,7 +144,7 @@ CalPatRec : { @table::CalPatRec
 	minnstraws                        : 10
 	maxhitchi                         : 5.0
 	maxDriftPull                      : 10.
-	minT0DOCA                         : -0.2               # 
+	minT0DOCA                         : -0.2               #
 	t0window                          : 2.5
 	MaxIterations                     : 3
 	fieldCorrection	      	          : false
@@ -163,18 +161,18 @@ CalPatRec : { @table::CalPatRec
 	ResolveAfterWeeding		  : false
 	AddMaterial			  : [ false, false ]
 	#  initT0			  : true
-	initT0   			  : false 
+	initT0   			  : false
 	useTrkCaloHit                     : false
 	updateT0			  : [ false, false, false, false, false, false, false, false, false ]
 	dtOffset                          : @local::TrackCaloMatching.DtOffset
 	strawHitT0Weight                  : 1
 	caloHitT0Weight                   : 10
-        caloHitError                    : 15.0 # mm 
-		
+        caloHitError                    : 15.0 # mm
+
 	DivergeFlt                        : 1000.            #  default: 1000.
         T0Calculator : @local::TimeCalculator
 #------------------------------------------------------------------------------
-#  parameters of KalContext 
+#  parameters of KalContext
 #------------------------------------------------------------------------------
 	MinNDOF                                 : 10
 #------------------------------------------------------------------------------
@@ -209,14 +207,14 @@ CalPatRec : { @table::CalPatRec
 	hiterr 		                        : [ 80.  , 24.  , 8.   , 4.  , 2.   , 0.8  , 0.0  , 0.0 , 0.0  ]
 	t0Tolerance			        : [ 2.0  , 1.0  , 1.0  , 1.0 , 0.5  , 0.5  , 0.2  , 0.2 , 0.1  ]
 	# not used t0ErrorFactor                           : 1.2                # scale ?
-	minT0DOCA                               : -0.2               # 
+	minT0DOCA                               : -0.2               #
 	t0window                                : 2.5
 	dtOffset                                : @local::TrackCaloMatching.DtOffset
-	# did Dave mean that? 
+	# did Dave mean that?
 	useTrkCaloHit                           : true
 	strawHitT0Weight                        : 1
 	caloHitT0Weight                         : 10
-	caloHitError				: 15.0 # mm 
+	caloHitError				: 15.0 # mm
 	updateT0				: [ false, true, true, true, true, true, true, true, true ]
 	updateT0Mode                            : 1 # 0: always use cluster time, if available;  1: use cluster time just once
 	DivergeFlt                              : 1000.
@@ -263,10 +261,10 @@ CalPatRec : { @table::CalPatRec
 	hiterr 					: [ 80.  , 24.  , 8.   , 4.  , 2.   , 0.8  , 0.0  , 0.0 , 0.0  ]
 	t0Tolerance				: [ 2.0  , 1.0  , 1.0  , 1.0 , 0.5  , 0.5  , 0.2  , 0.2 , 0.1  ]
 	# not used t0ErrorFactor                           : 1.2                # scale ?
-	minT0DOCA                               : -0.2               # 
+	minT0DOCA                               : -0.2               #
 	t0window                                : 2.5
 	dtOffset                                : @local::TrackCaloMatching.DtOffset
-	# did Dave mean that? 
+	# did Dave mean that?
 	updateT0				: [ false, true, true, true, true, true, true, true, true ]
 	updateT0Mode                            : 1 # 0: always use cluster time, if available;  1: use cluster time just once
 	HitAmbigPenalty 			: false
@@ -297,17 +295,17 @@ CalPatRec : { @table::CalPatRec
 	deltaDriftDoublet                       : 0.3
 	maxDoubletChi2                          : 9
 	sigmaSlope                              : 0.025
-	caloHitError                            : 15.0 # mm 
+	caloHitError                            : 15.0 # mm
 	printUtils                              : { @table::TrkReco.PrintUtils }
     }
 }
 #------------------------------------------------------------------------------
 #  module
 #------------------------------------------------------------------------------
-CalPatRec : { @table::CalPatRec 
+CalPatRec : { @table::CalPatRec
 
-    producers : { 
-	
+    producers : {
+
 	CalTrkFit          : {   module_type : KalFinalFit
 	    diagLevel                                   : 0
 	    debugLevel                                  : 0
@@ -328,13 +326,13 @@ CalPatRec : { @table::CalPatRec
 	    fitdirection                                : @local::FitDir.downstream
 	    KalFit                                      : { @table::CalPatRec.CprKFFinal }
 	    TimeOffsets                                 : { inputs : [ "protonTimeMap", "muonTimeMap" ] }
-	    diagPlugin : { tool_type  : "KalFinalFitDiag" 
+	    diagPlugin : { tool_type  : "KalFinalFitDiag"
 		mcTruth       : 0
 		mcUtils       : { @table::TrkReco.McUtils }
 	    }
 	}
-	
-	MergeHelixFinder : { module_type:MergeHelixFinder	
+
+	MergeHelixFinder : { module_type:MergeHelixFinder
 	    diagLevel                    : 0
 	    debugLevel                   : 0
 	    tprHelixCollTag    : "HelixFinderDe:Positive"
@@ -349,14 +347,14 @@ CalPatRec : { @table::CalPatRec
 	    # strawHitPositionCollectionTag : makePH                # input coll
 	    timePeakCollectionTag         : CalTimePeakFinder
 	    useTimePeaks                  : 1
-	                                                          # +/-70 to provide 100% efficiency for delta tagging + +/- 5 
+	                                                          # +/-70 to provide 100% efficiency for delta tagging + +/- 5
                                                                   # accounting for the drift time of a delta electron
 	    minCaloDt                     : -75.
 	    maxCaloDt                     :  75.
 	    particleMeanPitchAngle        : 0.67                  # mean pitch for CE
 	    strawDigiMCCollectionTag      : makeSD                # input coll
 	    minHitTime                    : 450.                  # ns
-	    minNFacesWithHits             : 2                     # 
+	    minNFacesWithHits             : 2                     #
 	    minNSeeds                     : 2                     #
 	    maxElectronHitEnergy          : 0.0200                # means: use all hits
 	    minimumTime                   : 500.                  # ns
@@ -377,11 +375,11 @@ CalPatRec : { @table::CalPatRec
 	    testOrder                     : 0
 	    debugLevel                    : 0
 	    diagLevel                     : 0
-	    diagPlugin : { tool_type : "DeltaFinderDiag" 
+	    diagPlugin : { tool_type : "DeltaFinderDiag"
 		stepPointMcCollTag        : makeSD
 		debugLevel                : 0
 		mcDiag                    : false
-		mcTruth                   : 0 
+		mcTruth                   : 0
 		printElectrons            : 0
 		printElectronsHits        : 0
 		printElectronsMinNHits    : 0
@@ -393,7 +391,7 @@ CalPatRec : { @table::CalPatRec
 		printOTracker             : 0                     #
 		printShcol                : 0                     #
 		testOrder                 : 0                     #
-		mcUtils                   : { tool_type : "TrkPatRecMcUtils" 
+		mcUtils                   : { tool_type : "TrkPatRecMcUtils"
 		    strawDigiMCCollTag : "compressDigiMCs"
 		}
 	    }
@@ -415,7 +413,7 @@ CalPatRec : { @table::CalPatRec
 #------------------------------------------------------------------------------
 # producers
 #------------------------------------------------------------------------------
-CalPatRec : { @table::CalPatRec 
+CalPatRec : { @table::CalPatRec
 
     producers : { @table::CalPatRec.producers
 
@@ -440,12 +438,12 @@ CalPatRec : { @table::CalPatRec
 
 #------------------------------------------------------------------------------
 # default configuration: DEM
-# CalPatRec, so far, has been validated only for e- 
+# CalPatRec, so far, has been validated only for e-
 #------------------------------------------------------------------------------
-	CalSeedFit : { module_type:KalSeedFit   
+	CalSeedFit : { module_type:KalSeedFit
 	    debugLevel                                  : 0
 	    printFrequency                              : 100
-	    ComboHitCollection                          : makeSH			 
+	    ComboHitCollection                          : makeSH
 	    SeedCollection                              : "CalHelixFinder:Positive"
 	    MinNHits                                    : 10
 	    MaxDoca                                     : 40.
@@ -460,10 +458,10 @@ CalPatRec : { @table::CalPatRec
 	    KalFit                                      : { @table::CalPatRec.KalSeedFitter }
 	}
 
-	MHSeedFit : { module_type:KalSeedFit   
+	MHSeedFit : { module_type:KalSeedFit
 	    debugLevel                                  : 0
 	    printFrequency                              : 100
-	    ComboHitCollection                          : makeSH			 
+	    ComboHitCollection                          : makeSH
 	    SeedCollection                              : MergeHelixFinder
 	    MinNHits                                    : 10
 	    MaxDoca                                     : 40.
@@ -478,38 +476,38 @@ CalPatRec : { @table::CalPatRec
 	    KalFit                                      : { @table::CalPatRec.KalSeedFitter }
 	}
 
-	MHFinderTprDe : { @table::CalPatRec.producers.MergeHelixFinder 
+	MHFinderTprDe : { @table::CalPatRec.producers.MergeHelixFinder
 	    tprHelixCollTag : "HelixFinderDe:Positive"
 	    cprHelixCollTag : "HelixFinderDe:Negative"
 	}
 
-	MHFinderCprDe : { @table::CalPatRec.producers.MergeHelixFinder 
+	MHFinderCprDe : { @table::CalPatRec.producers.MergeHelixFinder
 	    tprHelixCollTag : "CalHelixFinderDe:Positive"
 	    cprHelixCollTag : "CalHelixFinderDe:Negative"
 	}
 
-	MHFinderDe   : { @table::CalPatRec.producers.MergeHelixFinder 
+	MHFinderDe   : { @table::CalPatRec.producers.MergeHelixFinder
 	    tprHelixCollTag : MHFinderTprDe
 	    cprHelixCollTag : MHFinderCprDe
 	}
 
-	MHFinderTprDmu : { @table::CalPatRec.producers.MergeHelixFinder 
+	MHFinderTprDmu : { @table::CalPatRec.producers.MergeHelixFinder
 	    tprHelixCollTag : "HelixFinderMu:Positive"
 	    cprHelixCollTag : "HelixFinderMu:Negative"
 	}
 
-	MHFinderCprDmu : { @table::CalPatRec.producers.MergeHelixFinder 
+	MHFinderCprDmu : { @table::CalPatRec.producers.MergeHelixFinder
 	    tprHelixCollTag : "CalHelixFinderDmu:Positive"
 	    cprHelixCollTag : "CalHelixFinderDmu:Negative"
 	}
 
-	MHFinderDmu   : { @table::CalPatRec.producers.MergeHelixFinder 
+	MHFinderDmu   : { @table::CalPatRec.producers.MergeHelixFinder
 	    tprHelixCollTag : MHFinderTprDmu
 	    cprHelixCollTag : MHFinderCprDmu
 	}
     }
 
-    filters : { 
+    filters : {
 #------------------------------------------------------------------------------
 # new modules
 #------------------------------------------------------------------------------
@@ -521,9 +519,9 @@ CalPatRec : { @table::CalPatRec
 	    StrawHitCollectionLabel                     : makePH            # CalTimePeakFinder uses ComboHits
 	    StrawHitFlagCollectionLabel                 : ShouldNotBeUsed
 	    caloClusterModuleLabel                      : CaloClusterMaker
-	    HitSelectionBits                            : [] 
-	    BackgroundSelectionBits                     : [] 
-	    MinNHits                                    : @local::CalPatRec.minNStrawHits  
+	    HitSelectionBits                            : []
+	    BackgroundSelectionBits                     : []
+	    MinNHits                                    : @local::CalPatRec.minNStrawHits
 	    DtMin                                       : -30.   # value before 2017-11-17 was -40. ns
 	    DtMax                                       :  30.   # 2018-07-29 P.M.: DtMax=20ns was cutting out a few percent of hits
 	    minClusterEnergy                            : 50.    # MeV
@@ -532,9 +530,9 @@ CalPatRec : { @table::CalPatRec
 	    pitchAngle                                  : 0.67   # mean pitch for CE
 	    beta                                        : 1.0    # for muon reco needs to be changed
 	    dtOffset                                    : @local::TrackCaloMatching.DtOffset
-	    diagPlugin : { tool_type                    : "CalTimePeakFinderDiag" 
-		mcTruth                                 : 0 
-		mcUtils                                 : { tool_type : "TrkPatRecMcUtils" 
+	    diagPlugin : { tool_type                    : "CalTimePeakFinderDiag"
+		mcTruth                                 : 0
+		mcUtils                                 : { tool_type : "TrkPatRecMcUtils"
 		    strawDigiMCCollTag : "compressDigiMCs"
 		}
 	    }
@@ -548,7 +546,7 @@ CalPatRec : { @table::CalPatRec
 	    StrawHitCollectionLabel                     : makePH
 	    StrawHitFlagCollectionLabel                 : "DeltaFinder:ComboHits"
 	    TimeClusterCollectionLabel                  : CalTimePeakFinder
-	    minNHitsTimeCluster                         : @local::CalPatRec.minNStrawHits  
+	    minNHitsTimeCluster                         : @local::CalPatRec.minNStrawHits
 	    fitparticle                                 : @local::Particle.eminus
 	    fitdirection                                : @local::FitDir.downstream
 
@@ -556,7 +554,7 @@ CalPatRec : { @table::CalPatRec
 	    HelixFinderAlg                              : { @table::CalPatRec.HelixFinderAlg }
 	    diagPlugin : { tool_type                    : "CalHelixFinderDiag"
 		mcTruth                                 : 0
-		mcUtils                                 : { tool_type : "TrkPatRecMcUtils" 
+		mcUtils                                 : { tool_type : "TrkPatRecMcUtils"
 		    strawDigiMCCollTag : "compressDigiMCs"
 		}
 	    }
@@ -567,10 +565,10 @@ CalPatRec : { @table::CalPatRec
 #------------------------------------------------------------------------------
 # calorimeter-seeded tracking makes sense only for downstream particles
 #------------------------------------------------------------------------------
-CalPatRec: { @table::CalPatRec 
+CalPatRec: { @table::CalPatRec
     producers : { @table::CalPatRec.producers
 
-	DeltaFinderUe : { @table::CalPatRec.producers.DeltaFinder 
+	DeltaFinderUe : { @table::CalPatRec.producers.DeltaFinder
 	    timePeakCollectionTag         : CalTimePeakFinderUe
 
 	}
@@ -578,94 +576,94 @@ CalPatRec: { @table::CalPatRec
 	DeltaFinderMu                  : { @table::CalPatRec.producers.DeltaFinder
 	    timePeakCollectionTag      : CalTimePeakFinderMu
 	}
-	CalSeedFitDem                  : { @table::CalPatRec.producers.CalSeedFit        
+	CalSeedFitDem                  : { @table::CalPatRec.producers.CalSeedFit
 	    SeedCollection             : "CalHelixFinderDe:Positive"
 	}
-	CalSeedFitUem                  : { @table::CalPatRec.producers.CalSeedFit        
+	CalSeedFitUem                  : { @table::CalPatRec.producers.CalSeedFit
 	    SeedCollection             : "CalHelixFinderUe:Positive"
 	}
-	CalSeedFitDmm                  : { @table::CalPatRec.producers.CalSeedFit 
+	CalSeedFitDmm                  : { @table::CalPatRec.producers.CalSeedFit
 	    fitparticle                : @local::Particle.muminus
 	    SeedCollection             : "CalHelixFinderDmu:Positive"
 	}
-	CalSeedFitUmm                  : { @table::CalPatRec.producers.CalSeedFit 
+	CalSeedFitUmm                  : { @table::CalPatRec.producers.CalSeedFit
 	    fitparticle                : @local::Particle.muminus
 	    SeedCollection             : "CalHelixFinderUmu:Positive"
 	}
-	CalSeedFitDep                  : { @table::CalPatRec.producers.CalSeedFit 
-	    fitparticle                : @local::Particle.eplus  
+	CalSeedFitDep                  : { @table::CalPatRec.producers.CalSeedFit
+	    fitparticle                : @local::Particle.eplus
 	    SeedCollection             : "CalHelixFinderDe:Negative"
 	}
-	CalSeedFitDmp                  : { @table::CalPatRec.producers.CalSeedFit 
+	CalSeedFitDmp                  : { @table::CalPatRec.producers.CalSeedFit
 	    fitparticle                : @local::Particle.muplus
 	    SeedCollection             : "CalHelixFinderDmu:Negative"
 	}
-	
-	MHSeedFitDem                  : { @table::CalPatRec.producers.MHSeedFit        
+
+	MHSeedFitDem                  : { @table::CalPatRec.producers.MHSeedFit
 	    SeedCollection             : MergeHelixFinderDem
 	}
-	MHSeedFitDmm                  : { @table::CalPatRec.producers.MHSeedFit 
+	MHSeedFitDmm                  : { @table::CalPatRec.producers.MHSeedFit
 	    fitparticle                : @local::Particle.muminus
 	    SeedCollection             : MergeHelixFinderDmm
 	}
-	MHSeedFitDep                  : { @table::CalPatRec.producers.MHSeedFit 
-	    fitparticle                : @local::Particle.eplus  
+	MHSeedFitDep                  : { @table::CalPatRec.producers.MHSeedFit
+	    fitparticle                : @local::Particle.eplus
 	    SeedCollection             : MergeHelixFinderDep
 	}
-	MHSeedFitDmp                  : { @table::CalPatRec.producers.MHSeedFit 
+	MHSeedFitDmp                  : { @table::CalPatRec.producers.MHSeedFit
 	    fitparticle                : @local::Particle.muplus
 	    SeedCollection             : MergeHelixFinderDmp
 	}
-	
-	CalTrkFitDem                   : { @table::CalPatRec.producers.CalTrkFit         
+
+	CalTrkFitDem                   : { @table::CalPatRec.producers.CalTrkFit
 	    SeedCollection             : CalSeedFitDem
 	    CalTimePeakModuleLabel     : CalTimePeakFinder
 	}
-	CalTrkFitUem                   : { @table::CalPatRec.producers.CalTrkFit         
+	CalTrkFitUem                   : { @table::CalPatRec.producers.CalTrkFit
 	    SeedCollection             : CalSeedFitUem
 	    CalTimePeakModuleLabel     : CalTimePeakFinder
 	}
-	CalTrkFitDmm                   : { @table::CalPatRec.producers.CalTrkFit 
-	    fitparticle                : @local::Particle.muminus 
+	CalTrkFitDmm                   : { @table::CalPatRec.producers.CalTrkFit
+	    fitparticle                : @local::Particle.muminus
 	    SeedCollection             : CalSeedFitDmm
 	    CalTimePeakModuleLabel     : CalTimePeakFinderMu
 	    StrawHitFlagCollection     : "DeltaFinderMu:StrawHits"
 	}
-	CalTrkFitUmm                   : { @table::CalPatRec.producers.CalTrkFit         
+	CalTrkFitUmm                   : { @table::CalPatRec.producers.CalTrkFit
 	    SeedCollection             : CalSeedFitUmm
 	    CalTimePeakModuleLabel     : CalTimePeakFinder
 	}
-	CalTrkFitDep                   : { @table::CalPatRec.producers.CalTrkFit 
-	    fitparticle                : @local::Particle.eplus  
+	CalTrkFitDep                   : { @table::CalPatRec.producers.CalTrkFit
+	    fitparticle                : @local::Particle.eplus
 	    SeedCollection             : CalSeedFitDep
 	    CalTimePeakModuleLabel     : CalTimePeakFinder
 	}
-	CalTrkFitDmp                   : { @table::CalPatRec.producers.CalTrkFit 
-	    fitparticle                : @local::Particle.muplus 
+	CalTrkFitDmp                   : { @table::CalPatRec.producers.CalTrkFit
+	    fitparticle                : @local::Particle.muplus
 	    SeedCollection             : CalSeedFitDmp
 	    CalTimePeakModuleLabel     : CalTimePeakFinderMu
 	    StrawHitFlagCollection     : "DeltaFinderMu:StrawHits"
 	}
     }
-    
+
     filters : { @table::CalPatRec.filters
 	CalTimePeakFinderUe            : { @table::CalPatRec.filters.CalTimePeakFinder   pitchAngle: -0.67                }
-	CalTimePeakFinderMu            : { @table::CalPatRec.filters.CalTimePeakFinder   beta: 0.7                        } 
+	CalTimePeakFinderMu            : { @table::CalPatRec.filters.CalTimePeakFinder   beta: 0.7                        }
 	CalHelixFinderDe               : { @table::CalPatRec.filters.CalHelixFinder fitparticle: @local::Particle.eminus  }
 	CalHelixFinderUe               : { @table::CalPatRec.filters.CalHelixFinder
-	    fitparticle                : @local::Particle.eminus  
+	    fitparticle                : @local::Particle.eminus
 	    StrawHitFlagCollectionLabel: "DeltaFinderUe:ComboHits"
 	    TimeClusterCollectionLabel : CalTimePeakFinderUe
 	}
-	CalHelixFinderDmu              : { @table::CalPatRec.filters.CalHelixFinder 
-	    fitparticle                   : @local::Particle.muminus 
+	CalHelixFinderDmu              : { @table::CalPatRec.filters.CalHelixFinder
+	    fitparticle                   : @local::Particle.muminus
 	    StrawHitFlagCollectionLabel   : "DeltaFinderMu:ComboHits"
 	    TimeClusterCollectionLabel    : CalTimePeakFinderMu
 	}
 	# CalHelixFinderDeP              : { @table::CalPatRec.filters.CalHelixFinder fitparticle: @local::Particle.eplus   }
-	# CalHelixFinderDmuP             : { @table::CalPatRec.filters.CalHelixFinder 
-	#     fitparticle                   : @local::Particle.muplus 
-	#     StrawHitFlagCollectionLabel   : "DeltaFinderMu:ComboHits" 
+	# CalHelixFinderDmuP             : { @table::CalPatRec.filters.CalHelixFinder
+	#     fitparticle                   : @local::Particle.muplus
+	#     StrawHitFlagCollectionLabel   : "DeltaFinderMu:ComboHits"
 	#     TimeClusterCollectionLabel    : CalTimePeakFinderMu
 	# }
     }

--- a/CommonMC/src/SelectRecoMC_module.cc
+++ b/CommonMC/src/SelectRecoMC_module.cc
@@ -25,6 +25,7 @@
 #include "Offline/MCDataProducts/inc/CaloMCTruthAssns.hh"
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
+#include "Offline/RecoDataProducts/inc/HelixSeed.hh"
 #include "Offline/RecoDataProducts/inc/CaloCluster.hh"
 #include "Offline/RecoDataProducts/inc/CaloDigi.hh"
 #include "Offline/RecoDataProducts/inc/StrawDigi.hh"
@@ -77,7 +78,7 @@ namespace mu2e {
    using Parameters = art::EDProducer::Table<Config>;
    explicit SelectRecoMC(const Parameters& conf);
    void produce(art::Event& evt) override;
-        
+
   private:
    typedef std::vector<TrkMCTools::spcount>SPCC;
    typedef std::set<StrawHitIndex> SHIS;
@@ -102,7 +103,7 @@ namespace mu2e {
 
   };
 
-  SelectRecoMC::SelectRecoMC(const Parameters& config )  : 
+  SelectRecoMC::SelectRecoMC(const Parameters& config )  :
     art::EDProducer{config},
     _debug(config().debug()),
     _saveallenergy(config().saveEnergySteps()),
@@ -136,11 +137,11 @@ namespace mu2e {
     consumes<PrimaryParticle>(_pp);
     consumes<StrawDigiMCCollection>(_sdmcc);
     consumes<CrvDigiMCCollection>(_crvdmcc);
-    produces <IndexMap>("StrawDigiMap"); 
-    produces <IndexMap>("CrvDigiMap"); 
-    produces <KalSeedMCCollection>(); 
-    produces <KalSeedMCAssns>();    
-    produces <CaloDigiCollection>();    
+    produces <IndexMap>("StrawDigiMap");
+    produces <IndexMap>("CrvDigiMap");
+    produces <KalSeedMCCollection>();
+    produces <KalSeedMCAssns>();
+    produces <CaloDigiCollection>();
     produces <StrawDigiCollection>();
     produces <StrawDigiADCWaveformCollection>();
     produces <StrawHitFlagCollection>();
@@ -148,12 +149,12 @@ namespace mu2e {
     produces <CrvRecoPulseCollection>();
     produces <CrvCoincidenceClusterCollection>();
     produces <RecoCount>();
-    
+
     if (_debug > 0)
     {
        std::cout << "Using KalSeed collections from ";
        for (auto const& kff : _kscs) std::cout << kff << " " << std::endl;
-      
+
        std::cout << "Using HelixSeed collections from ";
        for (auto const& hsc : _hscs) std::cout << hsc << " " << std::endl;
     }
@@ -203,7 +204,7 @@ namespace mu2e {
       }
     }
   }
-  
+
   void SelectRecoMC::fillTSHMC(KalSeed const& seed, SPCC const& spcc,
       StrawDigiMCCollection const& sdmcc, KalSeedMC& mcseed) {
     for(auto const& hit : seed.hits() ) {
@@ -282,8 +283,8 @@ namespace mu2e {
     // for the primary particle
     for(auto const& vdsp : vdspc ) {
       if(vdsp.simParticle() == psp){
-	if(_debug > 1) std::cout << "Found matching VD StepPoint position" 
-	  << vdsp.position() << " momentum " << vdsp.momentum() 
+	if(_debug > 1) std::cout << "Found matching VD StepPoint position"
+	  << vdsp.position() << " momentum " << vdsp.momentum()
 	    << " time " << vdsp.time() << " VDID = " << vdsp.virtualDetectorId() << std::endl;
 	VDStep vds(det->toDetector(vdsp.position()),
 	    vdsp.momentum() ,
@@ -297,7 +298,7 @@ namespace mu2e {
   void SelectRecoMC::fillStrawHitCounts(ComboHitCollection const& chc, StrawHitFlagCollection const& shfc, RecoCount& nrec) {
 // test
     if(chc.size() != shfc.size())
-      throw cet::exception("Reco")<<"mu2e::SelectRecoMC: inconsistent collections"<< std::endl; 
+      throw cet::exception("Reco")<<"mu2e::SelectRecoMC: inconsistent collections"<< std::endl;
     for(const auto& shf : shfc) {
       if(shf.hasAllProperties(StrawHitFlag::energysel))++nrec._nshfesel;
       if(shf.hasAllProperties(StrawHitFlag::radsel))++nrec._nshfrsel;
@@ -382,9 +383,9 @@ namespace mu2e {
 	  ksmca->addSingle(seedp,mcseedp);
 	  // record the CaloCluster associated with this seed (if any)
 	  if(seed.hasCaloCluster())ccptrs.insert(seed.caloCluster());
-	  if(_debug > 2) std::cout << "KalSeedMC has " << mcseed._tshmcs.size() 
+	  if(_debug > 2) std::cout << "KalSeedMC has " << mcseed._tshmcs.size()
 	    << " MCHits , KalSeed has " << seed.hits().size() << " TrkStrawHits" << std::endl;
-	} 
+	}
       }
     }
     // get straw indices from all helices too
@@ -432,7 +433,7 @@ namespace mu2e {
     event.put(std::move(ksmca));
   }
 
-  void SelectRecoMC::fillCrv(art::Event& event, 
+  void SelectRecoMC::fillCrv(art::Event& event,
       PrimaryParticle const& pp, RecoCount& nrec) {
 // find Crv data in event
     auto crvccch = event.getValidHandle<CrvCoincidenceClusterCollection>(_crvccc);
@@ -499,7 +500,7 @@ namespace mu2e {
     event.put(std::move(crvdmcim),"CrvDigiMap");
   }
 
-  void SelectRecoMC::fillCalo(art::Event& event, std::set<art::Ptr<CaloCluster> >& ccptrs, 
+  void SelectRecoMC::fillCalo(art::Event& event, std::set<art::Ptr<CaloCluster> >& ccptrs,
                               PrimaryParticle const& pp, RecoCount& nrec)
   {
 
@@ -507,7 +508,7 @@ namespace mu2e {
     auto const& cdc = *cdch;
     auto ccch = event.getValidHandle<CaloClusterCollection>(_ccc);
     auto const& ccc = *ccch;
-    
+
     std::unique_ptr<CaloDigiCollection> scdc(new CaloDigiCollection);
     // reco count
     nrec._ncalodigi = cdc.size();

--- a/RecoDataProducts/inc/KalSeed.hh
+++ b/RecoDataProducts/inc/KalSeed.hh
@@ -6,7 +6,6 @@
 #define RecoDataProducts_KalSeed_HH
 // mu2e
 #include "Offline/DataProducts/inc/PDGCode.hh"
-#include "Offline/RecoDataProducts/inc/HelixSeed.hh"
 #include "Offline/RecoDataProducts/inc/HitT0.hh"
 #include "Offline/RecoDataProducts/inc/TrkFitDirection.hh"
 #include "Offline/RecoDataProducts/inc/TrkStrawHitSeed.hh"
@@ -43,26 +42,26 @@ namespace mu2e {
     std::vector<KalSegment>::const_iterator nearestSeg(double time)  const;
 
     // global information about the track
-    PDGCode::type		    _tpart; // particle assumed for this fit
-    TrkFitDirection	      	    _fdir; // direction in which this particle was fit
-    TrkFitFlag			    _status; // status of this fit: includes alglorithm information
-    Float_t			    _chisq; // fit chisquared value
-    Float_t			    _fitcon; // fit consistency
-    UInt_t			    _nseg; // # of fit trajectory segments 
+    PDGCode::type       _tpart; // particle assumed for this fit
+    TrkFitDirection             _fdir; // direction in which this particle was fit
+    TrkFitFlag          _status; // status of this fit: includes alglorithm information
+    Float_t         _chisq; // fit chisquared value
+    Float_t         _fitcon; // fit consistency
+    UInt_t          _nseg; // # of fit trajectory segments
     //
     // contained content substructure.
     //
-    std::vector<KalSegment>	    _segments; // segments of the Kalman filter fit result
+    std::vector<KalSegment>     _segments; // segments of the Kalman filter fit result
     std::vector<TrkStrawHitSeed>    _hits; // hit seeds for all the hits used in this fit
-    std::vector<TrkStraw>	    _straws; // straws interesected by this fit
-    TrkCaloHitSeed		    _chit;  // CaloCluster-based hit.  If it has no CaloCluster, this has no content
-    // 
+    std::vector<TrkStraw>     _straws; // straws interesected by this fit
+    TrkCaloHitSeed        _chit;  // CaloCluster-based hit.  If it has no CaloCluster, this has no content
+    //
     // deprecated BTrk legacy content, DO NOT write any new code which depends on these functions
     // find the nearest segment to a given GLOBAL flightlength
     std::vector<KalSegment>::const_iterator nearestSegment(float fltlen)  const;
     std::vector<KalSegment>::const_iterator nearestSegment(const XYZVectorF& pos)  const; // find nearest segment to a GLOBAL position
     Float_t flt0() const { return _flt0; }
-    Float_t			    _flt0; // flight distance where the track crosses the tracker midplane (z=0).  Redundant with t0 in KinKal fits, and in the wrong unit
+    Float_t         _flt0; // flight distance where the track crosses the tracker midplane (z=0).  Redundant with t0 in KinKal fits, and in the wrong unit
   };
   typedef std::vector<mu2e::KalSeed> KalSeedCollection;
 }

--- a/RecoDataProducts/inc/TrkStrawHitSeed.hh
+++ b/RecoDataProducts/inc/TrkStrawHitSeed.hh
@@ -14,62 +14,62 @@
 namespace mu2e {
   struct TrkStrawHitSeed {
     TrkStrawHitSeed() : _index(0), _trklen(0), _hitlen(0), _rdrift(0), _dtime(0), _stime(0), _htime(0),
-      _wdoca(0), _rerr(0), _ambig(0), _edep(0), _wdist(0), _werr(0) {}
+    _wdoca(0), _rerr(0), _ambig(0), _edep(0), _wdist(0), _werr(0) {}
     // construct from the information
     TrkStrawHitSeed(StrawHitIndex index, HitT0 const& t0, Float_t trklen, Float_t hitlen, Float_t rdrift,
-	Float_t stime,
-	Float_t wdoca, Int_t ambig, Float_t rerr, StrawHitFlag const& flag, ComboHit const& chit) :
+        Float_t stime,
+        Float_t wdoca, Int_t ambig, Float_t rerr, StrawHitFlag const& flag, ComboHit const& chit) :
       _index(index), _sid(chit.strawId()), _t0(t0), _trklen(trklen),
       _hitlen(hitlen), _rdrift(rdrift),
       _dtime(chit.driftTime()), _stime(stime),_htime(chit.time()),
-      _wdoca(wdoca), _rerr(rerr), _ambig(ambig), 
-      _edep(chit.energyDep()),_wdist(chit.wireDist()), _werr(chit.wireRes()), _end(chit.driftEnd()), 
+      _wdoca(wdoca), _rerr(rerr), _ambig(ambig),
+      _edep(chit.energyDep()),_wdist(chit.wireDist()), _werr(chit.wireRes()), _end(chit.driftEnd()),
       _flag(flag)  {}
     TrkStrawHitSeed(StrawHitIndex index, TrkT0 const& t0, Float_t trklen, Float_t hitlen, Float_t rdrift,
-	Float_t stime,
-	Float_t wdoca, Int_t ambig, Float_t rerr, StrawHitFlag const& flag, ComboHit const& chit) :
+        Float_t stime,
+        Float_t wdoca, Int_t ambig, Float_t rerr, StrawHitFlag const& flag, ComboHit const& chit) :
       _index(index), _sid(chit.strawId()), _t0(t0), _trklen(trklen),
       _hitlen(hitlen), _rdrift(rdrift),
       _dtime(chit.driftTime()), _stime(stime),_htime(chit.time()),
-      _wdoca(wdoca), _rerr(rerr), _ambig(ambig), 
-      _edep(chit.energyDep()),_wdist(chit.wireDist()), _werr(chit.wireRes()), _end(chit.driftEnd()), 
+      _wdoca(wdoca), _rerr(rerr), _ambig(ambig),
+      _edep(chit.energyDep()),_wdist(chit.wireDist()), _werr(chit.wireRes()), _end(chit.driftEnd()),
       _flag(flag)  {}
     // accessors
     StrawHitIndex index() const { return _index; }
-    StrawId const&	strawId() const { return _sid; }
+    StrawId const&  strawId() const { return _sid; }
     HitT0 const&  t0() const { return _t0; }
-    Float_t	trkLen() const { return _trklen; }
-    Float_t	hitLen() const { return _hitlen; }
-    Float_t	driftRadius() const { return _rdrift; }
-    Float_t	signalTime() const { return _stime; }
-    Float_t	hitTime() const { return _htime; }
-    Float_t	TOTDriftTime() const { return _dtime; }
-    Float_t	wireDOCA() const { return _wdoca; }
-    Float_t	radialErr() const { return _rerr; }
+    Float_t trkLen() const { return _trklen; }
+    Float_t hitLen() const { return _hitlen; }
+    Float_t driftRadius() const { return _rdrift; }
+    Float_t signalTime() const { return _stime; }
+    Float_t hitTime() const { return _htime; }
+    Float_t TOTDriftTime() const { return _dtime; }
+    Float_t wireDOCA() const { return _wdoca; }
+    Float_t radialErr() const { return _rerr; }
     Float_t     wireDist() const { return _wdist; }
     Float_t     wireRes() const { return _werr; }
     Float_t     energyDep() const { return _edep; }
     StrawEnd    driftEnd() const { return _end; }
-    Int_t	ambig() const { return _ambig; }
+    Int_t ambig() const { return _ambig; }
     StrawHitFlag const& flag() const { return _flag; }
     //
     StrawHitIndex   _index;       // index to the original straw (Combo) hit, and (for MC) MCDigi
-    StrawId	    _sid;	  // which straw has the hit
-    HitT0	    _t0;	  // time origin for this hit = track t0 + particle propagation time to this straw
-    Float_t	    _trklen;	  // Length from the nominal track start to the POCA of this hit
-    Float_t	    _hitlen;	  // Length from the straw center to the POCA of this hit
-    Float_t	    _rdrift;	  // drift radius for this hit
-    Float_t	    _dtime;	  // drift time from TOT for this hit
-    Float_t	    _stime;	  // signal propagation time for this hit, to the nearest end
-    Float_t	    _htime;	  // measured time for this hit 
-    Float_t	    _wdoca;	  // DOCA from the track to the wire, signed by the angular momentum WRT the wire
-    Float_t	    _rerr;	  // intrinsic radial error
-    Int_t	    _ambig;	  // LR ambiguity assigned to this hit
+    StrawId     _sid;   // which straw has the hit
+    HitT0     _t0;    // time origin for this hit = track t0 + particle propagation time to this straw
+    Float_t     _trklen;    // Length from the nominal track start to the POCA of this hit
+    Float_t     _hitlen;    // Length from the straw center to the POCA of this hit
+    Float_t     _rdrift;    // drift radius for this hit
+    Float_t     _dtime;   // drift time from TOT for this hit
+    Float_t     _stime;   // signal propagation time for this hit, to the nearest end
+    Float_t     _htime;   // measured time for this hit
+    Float_t     _wdoca;   // DOCA from the track to the wire, signed by the angular momentum WRT the wire
+    Float_t     _rerr;    // intrinsic radial error
+    Int_t     _ambig;   // LR ambiguity assigned to this hit
     Float_t         _edep;        // reco energy deposition
     Float_t         _wdist;       // wire distance
     Float_t         _werr;        // wire distance error estimate
-    StrawEnd	    _end;         // straw end used for hit time measurement
-    StrawHitFlag    _flag;	  // flag describing the status of this hit (active, ....)
+    StrawEnd      _end;         // straw end used for hit time measurement
+    StrawHitFlag    _flag;    // flag describing the status of this hit (active, ....)
   };
   // binary functor to sort TrkStrawHits by StrawHit index
   struct indexcompseed : public std::binary_function<TrkStrawHitSeed,TrkStrawHitSeed, bool> {

--- a/TEveEventDisplay/src/dict_classes/Collection_Filler.h
+++ b/TEveEventDisplay/src/dict_classes/Collection_Filler.h
@@ -17,6 +17,7 @@
 #include "Offline/MCDataProducts/inc/MCTrajectoryCollection.hh"
 //Kalman Tracks
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
+#include "Offline/RecoDataProducts/inc/HelixSeed.hh"
 #include "Offline/RecoDataProducts/inc/KalRepCollection.hh"
 #include "Offline/RecoDataProducts/inc/TrkExtTraj.hh"
 //Tracker Hits:
@@ -68,7 +69,7 @@ namespace mu2e{
       fhicl::Atom<bool> addHits{Name("addHits"), Comment("set to add the hits"),false};
       fhicl::Atom<bool> addTracks{Name("addTracks"), Comment("set to add tracks"),false};
       fhicl::Atom<bool> addClusters{Name("addClusters"), Comment("set to add calo lusters"),false};
-      fhicl::Atom<bool> addCrvHits{Name("addCrvHits"), Comment("set to add crv hits"),false};	
+      fhicl::Atom<bool> addCrvHits{Name("addCrvHits"), Comment("set to add crv hits"),false};
       fhicl::Atom<bool> addCrystallHits{Name("addCrystalHits"), Comment("for calo cry hits"), false};
       fhicl::Atom<bool> addCosmicSeedFit{Name("addCosmicSeedFit"), Comment("for fitted cosmic track"), false};
       fhicl::Atom<bool> addTrkExtTrajs{Name("addTrkExtTrajs"), Comment("set to add track exit trajectories"), false};
@@ -83,7 +84,7 @@ namespace mu2e{
     Collection_Filler(const Collection_Filler &);
     Collection_Filler& operator=(const Collection_Filler &);
 
-    //RecoDataProducts: 
+    //RecoDataProducts:
     art::InputTag chTag_;
     art::InputTag crvcoinTag_;
     art::InputTag cosmicTag_;
@@ -92,7 +93,7 @@ namespace mu2e{
     art::InputTag hseedTag_;
     std::vector<art::InputTag> kalseedTag_;
     art::InputTag trkexttrajTag_;
-    
+
     //MCDataProdutcs:
     art::InputTag mctrajTag_;
 
@@ -112,4 +113,4 @@ namespace mu2e{
 
 }
 
-#endif 
+#endif

--- a/TEveEventDisplay/src/dict_classes/Data_Collections.h
+++ b/TEveEventDisplay/src/dict_classes/Data_Collections.h
@@ -8,6 +8,7 @@
 #include "Offline/MCDataProducts/inc/MCTrajectoryCollection.hh"
 //Kalman Tracks
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
+#include "Offline/RecoDataProducts/inc/HelixSeed.hh"
 #include "Offline/RecoDataProducts/inc/KalRepCollection.hh"
 #include "Offline/RecoDataProducts/inc/TrkExtTraj.hh"
 //Tracker Hits:
@@ -52,7 +53,7 @@ namespace mu2e{
       std::vector<const KalSeedCollection*> track_list;
       std::vector<std::string> track_labels;
       std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple;
-      
+
       //MCDataProducts:
       const MCTrajectoryCollection *mctrajcol = 0;
 
@@ -63,4 +64,4 @@ namespace mu2e{
 
 }
 
-#endif 
+#endif

--- a/TrkHitReco/fcl/prolog.fcl
+++ b/TrkHitReco/fcl/prolog.fcl
@@ -9,6 +9,8 @@ PBTFSD : {
 
 makeSH : {
   module_type             : StrawHitReco
+  minimumTime             : 0.0 # accept all digis
+  maximumTime             : 100.0e3 # allow offspill events
   FitType                 : 1
   FilterHits              : false
   WriteStrawHitCollection : true
@@ -24,7 +26,7 @@ makePH : {
   TestFlag              : true
   TestRadius            : true
   ComboHitCollection    : makeSH
-  StrawHitSelectionBits : ["EnergySelection","TimeSelection"] 
+  StrawHitSelectionBits : ["EnergySelection","TimeSelection"]
   StrawHitMask          : []
   MaxDt                 : 40
   UseTOT                : false
@@ -46,7 +48,7 @@ makeSTH : {
 
 # flag hits from low-energy electrons (Compton electrons, delta rays, ...)
 # First, configure the clusters
-TNTClusterer : { 
+TNTClusterer : {
     HitDistance      : 5.0
     SeedDistance     : 20.0
     ClusterDiameter  : 5.0
@@ -74,13 +76,13 @@ TNTClusterer : {
 ScanClusterer: {
     Pbin             : 0.08
     Tbin             : 20
-    Rbin             : 50 
+    Rbin             : 50
     Rmin             : 350
     Rmax             : 650
     MinPeakHit       : 3
     MinSeedHit       : 2
     MinRadHit        : 50
-    FilterAlgo       : 1   
+    FilterAlgo       : 1
     TestFlag         : true
     BackgroundMask   : []
     SignalMask       : ["TimeSelection", "EnergySelection","RadiusSelection"]
@@ -114,7 +116,7 @@ SflagBkgHits : {
 
 # combine together
 TrkHitReco : {
-    producers : { 
+    producers : {
 	# normal reco
 	PBTFSD       : { @table::PBTFSD       }
 	makeSH        : { @table::makeSH       }

--- a/TrkHitReco/fcl/prolog_trigger.fcl
+++ b/TrkHitReco/fcl/prolog_trigger.fcl
@@ -11,6 +11,8 @@ TTPBTFSD : {
 
 TTmakeSH : {
     module_type             : StrawHitReco
+    minimumTime             : 0.0 # accept all digis
+    maximumTime             : 100.0e3 # allow offspill events
     FitType                 : 5
     FilterHits              : true
     WriteStrawHitCollection : false
@@ -25,7 +27,7 @@ TTmakePH : {
     TestFlag                : false
     TestRadius              : true
     ComboHitCollection      : "TTmakeSH"
-    StrawHitSelectionBits : ["EnergySelection","TimeSelection"] 
+    StrawHitSelectionBits : ["EnergySelection","TimeSelection"]
     StrawHitMask          : []
     MaxDt                 : 40
     UseTOT                : false
@@ -53,7 +55,7 @@ TTmakePHUCC : {
     TestFlag                : false
     TestRadius              : true
     ComboHitCollection      : "TTmakeSHUCC"
-    StrawHitSelectionBits : ["EnergySelection","TimeSelection"] 
+    StrawHitSelectionBits : ["EnergySelection","TimeSelection"]
     StrawHitMask          : []
     MaxDt                 : 40
     UseTOT                : false
@@ -91,8 +93,8 @@ TTSflagBkgHits : {
 }
 
 # combine together
-TrkHitRecoTrigger : { 
-    producers : { 
+TrkHitRecoTrigger : {
+    producers : {
 	TTPBTFSD            : { @table::TTPBTFSD             }
 	TTmakeSH            : { @table::TTmakeSH             }
 	TTmakePH            : { @table::TTmakePH             }
@@ -101,10 +103,10 @@ TrkHitRecoTrigger : {
 	TTmakeSTH           : { @table::TTmakeSTH            }
 	TTflagBkgHits	    : { @table::TTflagBkgHits        }
 	TTflagBkgHitsUCC    : { @table::TTflagBkgHits
-	        ComboHitCollection : TTmakePHUCC		
+	        ComboHitCollection : TTmakePHUCC
 	}
     }
-    
+
     # SEQUENCES
     # production sequence to prepare hits for tracking
     sequences: {

--- a/TrkHitReco/src/StrawHitReco_module.cc
+++ b/TrkHitReco/src/StrawHitReco_module.cc
@@ -63,8 +63,8 @@ namespace mu2e {
 	fhicl::Atom<float>ctE{ Name("crossTalkEnergy"), Comment("Energy to filter cross-talk in adajcent straws (MeV)"),0.007};
 	fhicl::Atom<float>ctMinT{ Name("crossTalkMinimumTime"), Comment("Earliest time for cross-talk filter (nsec)"),-1};
 	fhicl::Atom<float>ctMaxT{ Name("crossTalkMaximumTime"), Comment("Latest time for cross-talk filter (nsec)"),100};
-	fhicl::Atom<float>minT{ Name("minimumTime"), Comment("Earliest StrawDigi time to process (nsec)"),500};
-	fhicl::Atom<float>maxT{ Name("maximumTime"), Comment("Latest StrawDigi time to process (nsec)"),2000};
+	fhicl::Atom<float>minT{ Name("minimumTime"), Comment("Earliest StrawDigi time to process (nsec)")};
+	fhicl::Atom<float>maxT{ Name("maximumTime"), Comment("Latest StrawDigi time to process (nsec)")};
 	fhicl::Atom<bool>filter{ Name("FilterHits"), Comment("Filter hits (alternative is to just flag)") };
 	fhicl::Atom<bool>writesh{ Name("WriteStrawHitCollection"), Comment("Save StrawHitCollection")};
 	fhicl::Atom<bool>flagXT{ Name("FlagCrossTalk"), Comment("Search for cross-talk"),false};

--- a/TrkPatRec/fcl/prolog.fcl
+++ b/TrkPatRec/fcl/prolog.fcl
@@ -3,7 +3,7 @@
 # this file is included by fcl/standardProducers.fcl inside the PROLOG section
 #------------------------------------------------------------------------------
 #include "Offline/TrkPatRec/fcl/Particle.fcl"
-#include "Offline/TrkPatRec/fcl/PanelAmbigResolver.fcl" 
+#include "Offline/TrkPatRec/fcl/PanelAmbigResolver.fcl"
 #include "Offline/fcl/TrkCaloDt.fcl"
 BEGIN_PROLOG
 
@@ -21,7 +21,7 @@ TimeCalculator : {
 
 TimeClusterFinder : {
   module_type            : TimeClusterFinder
-  
+
   ComboHitCollection     : "makePH"
   StrawHitFlagCollection : "FlagBkgHits:ComboHits"
   CaloClusterCollection  : "CaloClusterMaker"
@@ -41,8 +41,8 @@ TimeClusterFinder : {
   MinKeepHitMVA          : 0.2
   MinAddHitMVA           : 0.2
   MaxdPhi                : 1.5
-  Tmin                   : 450.0
-  Tmax                   : 1700.0
+  Tmin                   : 0.0
+  Tmax                   : 100000.0
   Tbin                   : 15.0
   AveragePitch           : 0.6
   Ymin                   : 5.0
@@ -55,7 +55,7 @@ TimeClusterFinder : {
 
 
 
-# time clustering is the 1st stage of track finding 
+# time clustering is the 1st stage of track finding
 TimeClusterFinderNew : {
   module_type            : TimeAndPhiClusterFinder
   ComboHitCollection     : "makePH"
@@ -85,7 +85,7 @@ TimeClusterFinderNew : {
   Recover                : true
   DphiMaxReco            : 1.2
 
-  DiagPlugin : { 
+  DiagPlugin : {
     tool_type             : "TimeAndPhiClusterFinderDiag"
     MCDiag                : false
     StrawDigiMCCollection : "compressDigiMCs"
@@ -153,7 +153,7 @@ RobustHelixFinder : {
     ComboHitCollection     : "makePH"
     HelixStereoHitMVA      : { MVAWeights : "Offline/TrkPatRec/data/HelixStereoHitMVA.weights.xml" }
     HelixNonStereoHitMVA   : { MVAWeights : "Offline/TrkPatRec/data/HelixNonStereoHitMVA.weights.xml" }
-    DiagPlugin : { 
+    DiagPlugin : {
 	diagLevel                    : 0
 	tool_type                    : "RobustHelixFinderDiag"
 	mcTruth                      : 0
@@ -193,8 +193,8 @@ RobustHelixFinder : {
     HitSelectionBits : ["TimeDivision"]
     HitBackgroundBits : ["Background"]
     Helicities : [-1,1]
-    
-    
+
+
 }
 RobustHelixFinderDe : {
   @table::RobustHelixFinder
@@ -238,13 +238,13 @@ KFSeed : {
   ResolveAfterWeeding		  : false
   AddMaterial			  : [ false, false ]
 #  initT0			  : true
-  initT0			  : false 
+  initT0			  : false
   useTrkCaloHit                   : false
   updateT0			  : [false, false ]
   dtOffset                        : @local::TrackCaloMatching.DtOffset
   strawHitT0Weight                : 1
   caloHitT0Weight                 : 10
-  caloHitError                    : 15.0 # mm 
+  caloHitError                    : 15.0 # mm
   T0Calculator			  : @local::TimeCalculator
   mcTruth                         : 0
   printUtils                      : { @table::TrkReco.PrintUtils}
@@ -272,12 +272,12 @@ KFFinal : {
   dtOffset                    : @local::TrackCaloMatching.DtOffset
   strawHitT0Weight            : 1 # unused? FIXME!
   caloHitT0Weight             : 10 # unused? FIXME!
-  caloHitError                : 15.0 # mm 
+  caloHitError                : 15.0 # mm
   T0Calculator		      : @local::TimeCalculator
   useTrkCaloHit               : true
   t0window                    : 4.0
   mcTruth                     : 0
-  printUtils                  : { @table::TrkReco.PrintUtils } 
+  printUtils                  : { @table::TrkReco.PrintUtils }
 }
 
 # KalFit (Kalman fiter)  configuration for Doublet Ambig Resolver
@@ -296,10 +296,10 @@ CprKFFinal : {
     hiterr 		                    : [ 80.  , 24.  , 8.   , 4.  , 2.   , 0.8  , 0.0  , 0.0 , 0.0  ]
     t0Tolerance				    : [ 2.0  , 1.0  , 1.0  , 1.0 , 0.5  , 0.5  , 0.2  , 0.2 , 0.1  ]
     # not used t0ErrorFactor                           : 1.2                # scale ?
-    minT0DOCA                               : -0.2               # 
+    minT0DOCA                               : -0.2               #
     t0window                                : 2.5
     dtOffset                                : @local::TrackCaloMatching.DtOffset
-    # did Dave mean that? 
+    # did Dave mean that?
     updateT0			            : [ false, true, true, true, true, true, true, true, true ]
     DivergeFlt                              : 1000.
     #------------------------------------------------------------------------------
@@ -357,77 +357,77 @@ KSFDeM	: {
   @table::KSF
   SeedCollection      : "HelixFinderDe:Positive"
   fitparticle	      : @local::Particle.eminus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 # upstream electrons
 KSFUeM	: {
   @table::KSF
   SeedCollection      : "HelixFinderUe:Negative"
   fitparticle	      : @local::Particle.eminus
-  fitdirection	      : @local::FitDir.upstream 
+  fitdirection	      : @local::FitDir.upstream
 }
 #  downstream positrons
 KSFDeP	: {
   @table::KSF
   SeedCollection      : "HelixFinderDe:Negative"
   fitparticle	      : @local::Particle.eplus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 # upstream positrons
 KSFUeP	: {
   @table::KSF
   SeedCollection      : "HelixFinderUe:Positive"
   fitparticle	      : @local::Particle.eplus
-  fitdirection	      : @local::FitDir.upstream 
+  fitdirection	      : @local::FitDir.upstream
 }
 # downstream mu minus
-KSFDmuM	: { 
+KSFDmuM	: {
   @table::KSF
   SeedCollection     : "HelixFinderDmu:Positive"
   fitparticle	      : @local::Particle.muminus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 # upstream mu minus
 KSFUmuM	: {
   @table::KSF
   SeedCollection     : "HelixFinderUmu:Negative"
   fitparticle	      : @local::Particle.muminus
-  fitdirection	      : @local::FitDir.upstream 
+  fitdirection	      : @local::FitDir.upstream
 }
 # downstream mu plus
 KSFDmuP	: {
   @table::KSF
   SeedCollection     : "HelixFinderDmu:Negative"
   fitparticle	      : @local::Particle.muplus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 # upstream mu plus
 KSFUmuP	: {
   @table::KSF
   SeedCollection     : "HelixFinderUmu:Positive"
   fitparticle	      : @local::Particle.muplus
-  fitdirection	      : @local::FitDir.upstream 
+  fitdirection	      : @local::FitDir.upstream
 }
 # downstream pi minus
 KSFDpiM	: {
   @table::KSF
   SeedCollection     : "HelixFinderDpi:Positive"
   fitparticle	      : @local::Particle.piminus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 # upstream pi minus
 KSFUpiM	: {
   @table::KSF
   SeedCollection     : "HelixFinderUpi:Negative"
   fitparticle	      : @local::Particle.piminus
-  fitdirection	      : @local::FitDir.upstream 
+  fitdirection	      : @local::FitDir.upstream
 }
 # downstream pi plus
 KSFDpiP	: {
   @table::KSF
   SeedCollection     : "HelixFinderDpi:Negative"
   fitparticle	      : @local::Particle.piplus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 # upstream pi plus
 KSFUpiP	: {
@@ -438,62 +438,62 @@ KSFUpiP	: {
 }
 # Final Fit configuration for specific particles
 #  First, downstream electrons
-KFFDeM			      : { 
+KFFDeM			      : {
   @table::KFF
   SeedCollection      : "KSFDeM"
   fitparticle	      : @local::Particle.eminus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 
 # upstream electrons
-  KFFUeM			      : { 
+  KFFUeM			      : {
   @table::KFF
   SeedCollection      : "KSFUeM"
   fitparticle	      : @local::Particle.eminus
-  fitdirection	      : @local::FitDir.upstream 
+  fitdirection	      : @local::FitDir.upstream
 }
 
 #  downstream positrons
-KFFDeP			      : { 
+KFFDeP			      : {
   @table::KFF
   SeedCollection      : "KSFDeP"
   fitparticle	      : @local::Particle.eplus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 # upstream positrons
-KFFUeP			      : { 
+KFFUeP			      : {
   @table::KFF
   SeedCollection      : "KSFUeP"
   fitparticle	      : @local::Particle.eplus
-  fitdirection	      : @local::FitDir.upstream 
+  fitdirection	      : @local::FitDir.upstream
 }
 
 # downstream mu minus
-KFFDmuM			      : { 
+KFFDmuM			      : {
   @table::KFF
   SeedCollection     : "KSFDmuM"
   fitparticle	      : @local::Particle.muminus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 
 # upstream mu minus
-KFFUmuM			      : { 
+KFFUmuM			      : {
   @table::KFF
   SeedCollection     : "KSFUmuM"
   fitparticle	      : @local::Particle.muminus
-  fitdirection	      : @local::FitDir.upstream 
+  fitdirection	      : @local::FitDir.upstream
 }
 
 # downstream mu plus
-KFFDmuP			      : { 
+KFFDmuP			      : {
   @table::KFF
   SeedCollection     : "KSFDmuP"
   fitparticle	      : @local::Particle.muplus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 
 # upstream mu plus
-KFFUmuP			      : { 
+KFFUmuP			      : {
   @table::KFF
   SeedCollection     : "KSFUmuP"
   fitparticle	      : @local::Particle.muplus
@@ -501,31 +501,31 @@ KFFUmuP			      : {
 }
 
 # downstream pi minus
-KFFDpiM			      : { 
+KFFDpiM			      : {
   @table::KFF
   SeedCollection     : "KSFDpiM"
   fitparticle	      : @local::Particle.piminus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 
 # upstream pi minus
-KFFUpiM			      : { 
+KFFUpiM			      : {
   @table::KFF
   SeedCollection     : "KSFUpiM"
   fitparticle	      : @local::Particle.piminus
-  fitdirection	      : @local::FitDir.upstream 
+  fitdirection	      : @local::FitDir.upstream
 }
 
 # downstream pi plus
-KFFDpiP			      : { 
+KFFDpiP			      : {
   @table::KFF
   SeedCollection     : "KSFDpiP"
   fitparticle	      : @local::Particle.piplus
-  fitdirection	      : @local::FitDir.downstream 
+  fitdirection	      : @local::FitDir.downstream
 }
 
 # upstream pi plus
-KFFUpiP			      : { 
+KFFUpiP			      : {
   @table::KFF
   SeedCollection     : "KSFUpiP"
   fitparticle	      : @local::Particle.piplus
@@ -534,7 +534,7 @@ KFFUpiP			      : {
 
 # Final fit of merged Helices : these depend on CalPatRec
 
-MHFinalFitDeM                : { 
+MHFinalFitDeM                : {
   @table::KFFDeM
   SeedCollection : MHSeedFitDem
 }
@@ -544,7 +544,7 @@ MHFinalFitDeP                :  {
   SeedCollection : MHSeedFitDep
 }
 
-MHFinalFitDmuM               : { 
+MHFinalFitDmuM               : {
   @table::KFFDmuM
   SeedCollection : MHSeedFitDmm
 }
@@ -603,10 +603,10 @@ Tracking : {
     MHFinalFitDeP	  : @local::MHFinalFitDeP
     MHFinalFitDmuM        : @local::MHFinalFitDmuM
     MHFinalFitDmuP	  : @local::MHFinalFitDmuP
-    
+
   }
 
-# define standard outputs 
+# define standard outputs
   Output : {
     Digis : [ "keep mu2e::StrawDigis_*_*_*" ]
     Hits : [ "keep mu2e::StrawHitFlagDetailmu2e::BitMaps_FlagBkgHits_*_*",

--- a/Validation/inc/ValCaloDigi.hh
+++ b/Validation/inc/ValCaloDigi.hh
@@ -20,12 +20,13 @@ namespace mu2e {
 
   private:
     std::string _name;
-    
+
     TH1D* _hVer;
     TH1D* _hN;
     TH1D* _hN2;
     TH1D* _hI;
     TH1D* _ht;
+    TH1D* _ht2;
     TH1D* _hm;
     TH1D* _hE;
   };

--- a/Validation/inc/ValCaloShowerStep.hh
+++ b/Validation/inc/ValCaloShowerStep.hh
@@ -20,11 +20,12 @@ namespace mu2e {
 
   private:
     std::string _name;
-    
+
     TH1D* _hVer;
     TH1D* _hN;
     TH1D* _hN2;
     TH1D* _ht;
+    TH1D* _ht2;
     TH1D* _hE;
     TH1D* _hE2;
     TH1D* _hposx;

--- a/Validation/inc/ValCrvDigi.hh
+++ b/Validation/inc/ValCrvDigi.hh
@@ -20,13 +20,14 @@ namespace mu2e {
 
   private:
     std::string _name;
-    
+
     TH1D* _hVer;
     TH1D* _hN;
     TH1D* _hN2;
     TH1D* _hI;
     TH1D* _hIS;
     TH1D* _ht;
+    TH1D* _ht2;
     TH1D* _hA;
   };
 }

--- a/Validation/inc/ValStrawDigi.hh
+++ b/Validation/inc/ValStrawDigi.hh
@@ -20,7 +20,7 @@ namespace mu2e {
 
   private:
     std::string _name;
-    
+
     TH1D* _hVer;
     TH1D* _hN;
     TH1D* _hN2;

--- a/Validation/inc/ValStrawGasStep.hh
+++ b/Validation/inc/ValStrawGasStep.hh
@@ -20,11 +20,12 @@ namespace mu2e {
 
   private:
     std::string _name;
-    
+
     TH1D* _hVer;
     TH1D* _hN;
     TH1D* _hN2;
     TH1D* _ht;
+    TH1D* _ht2;
     TH1D* _hE;
     TH1D* _hlE;
     TH1D* _hlen;

--- a/Validation/src/ValCaloDigi.cc
+++ b/Validation/src/ValCaloDigi.cc
@@ -8,6 +8,7 @@ int mu2e::ValCaloDigi::declare(art::TFileDirectory tfs) {
   _hN2= tfs.make<TH1D>( "NDigis2", "N Digis", 100, -0.5, 4999.5);
   _hI = tfs.make<TH1D>( "SiPMID", "SiPM ID",100, 0.0, 3000.0);
   _ht = tfs.make<TH1D>( "t", "time", 100, 0.0, 2000.0);
+  _ht2 = tfs.make<TH1D>( "t2", "time", 100, 0.0, 100.0e3);
   _hm = tfs.make<TH1D>( "Nwave", "N points in waveform",81, -0.5, 80.5);
   _hE = tfs.make<TH1D>( "EMax", "E max in waveform",100, 0.0, 1500.0);
 
@@ -17,7 +18,7 @@ int mu2e::ValCaloDigi::declare(art::TFileDirectory tfs) {
 int mu2e::ValCaloDigi::fill(const mu2e::CaloDigiCollection & coll,
 				art::Event const& event) {
 
-  // increment this by 1 any time the defnitions of the histograms or the 
+  // increment this by 1 any time the defnitions of the histograms or the
   // histogram contents change, and will not match previous versions
   _hVer->Fill(0.0);
 
@@ -26,6 +27,7 @@ int mu2e::ValCaloDigi::fill(const mu2e::CaloDigiCollection & coll,
   for(auto dg : coll) {
     _hI->Fill(dg.SiPMID());
     _ht->Fill(dg.t0());
+    _ht2->Fill(dg.t0());
     double emax = 0.0;
     _hm->Fill(double(dg.waveform().size()));
     for (auto e: dg.waveform()) { if(e>emax) emax = e; }

--- a/Validation/src/ValCaloShowerStep.cc
+++ b/Validation/src/ValCaloShowerStep.cc
@@ -7,6 +7,7 @@ int mu2e::ValCaloShowerStep::declare(art::TFileDirectory tfs) {
   _hN = tfs.make<TH1D>( "NStep", "N Steps", 51, -0.5, 50.5);
   _hN2 = tfs.make<TH1D>( "NStep2", "N Steps", 101, -9.5, 1000.5);
   _ht = tfs.make<TH1D>( "t", "time", 100, 0.0, 4000.0);
+  _ht2 = tfs.make<TH1D>( "t2", "time", 100, 0.0, 100.0e3);
   _hE = tfs.make<TH1D>( "E", "Energy",50, 0.0, 10.0);
   _hE2 = tfs.make<TH1D>( "E2", "Energy",50, 0.0, 200.0);
   _hposx = tfs.make<TH1D>( "posx", "Position X",50, -20.0, 20.0);
@@ -28,6 +29,7 @@ int mu2e::ValCaloShowerStep::fill(const mu2e::CaloShowerStepCollection & coll,
   _hN2->Fill(coll.size());
   for(auto ss : coll) {
     _ht->Fill(ss.time());
+    _ht2->Fill(ss.time());
     _hE->Fill(ss.energyDepG4());
     _hE2->Fill(ss.energyDepG4());
     _hposx->Fill(ss.position().x());

--- a/Validation/src/ValCrvDigi.cc
+++ b/Validation/src/ValCrvDigi.cc
@@ -9,7 +9,7 @@ int mu2e::ValCrvDigi::declare(art::TFileDirectory tfs) {
   _hI = tfs.make<TH1D>( "BarId", "Bar ID",200, -0.5, 5503.5);
   _hIS= tfs.make<TH1D>( "SiPM", "SiPM",4, -0.5, 3.5);
   _ht = tfs.make<TH1D>( "t", "TDC", 100, 0.0, 250.0);
-  _ht2 = tfs.make<TH1D>( "t2", "TDC", 100, 0.0, 100.0e3);
+  _ht2 = tfs.make<TH1D>( "t2", "TDC", 100, 0.0, 1.5e4);
   _hA = tfs.make<TH1D>( "ADC", "ADC in waveform",100, 0.0, 3000.0);
 
   return 0;

--- a/Validation/src/ValCrvDigi.cc
+++ b/Validation/src/ValCrvDigi.cc
@@ -9,6 +9,7 @@ int mu2e::ValCrvDigi::declare(art::TFileDirectory tfs) {
   _hI = tfs.make<TH1D>( "BarId", "Bar ID",200, -0.5, 5503.5);
   _hIS= tfs.make<TH1D>( "SiPM", "SiPM",4, -0.5, 3.5);
   _ht = tfs.make<TH1D>( "t", "TDC", 100, 0.0, 250.0);
+  _ht2 = tfs.make<TH1D>( "t2", "TDC", 100, 0.0, 100.0e3);
   _hA = tfs.make<TH1D>( "ADC", "ADC in waveform",100, 0.0, 3000.0);
 
   return 0;
@@ -17,7 +18,7 @@ int mu2e::ValCrvDigi::declare(art::TFileDirectory tfs) {
 int mu2e::ValCrvDigi::fill(const mu2e::CrvDigiCollection & coll,
 				art::Event const& event) {
 
-  // increment this by 1 any time the defnitions of the histograms or the 
+  // increment this by 1 any time the defnitions of the histograms or the
   // histogram contents change, and will not match previous versions
   _hVer->Fill(0.0);
 
@@ -27,6 +28,7 @@ int mu2e::ValCrvDigi::fill(const mu2e::CrvDigiCollection & coll,
     _hI->Fill(dg.GetScintillatorBarIndex().asInt());
     _hIS->Fill(dg.GetSiPMNumber());
     _ht->Fill(dg.GetStartTDC());
+    _ht2->Fill(dg.GetStartTDC());
     for (auto a: dg.GetADCs()) _hA->Fill(a);
   }
   return 0;

--- a/Validation/src/ValStrawDigi.cc
+++ b/Validation/src/ValStrawDigi.cc
@@ -6,8 +6,8 @@ int mu2e::ValStrawDigi::declare(art::TFileDirectory tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NHit", "N Straw Hits", 101, -0.5, 100.0);
   _hN2 = tfs.make<TH1D>( "NHit2", "N Straw Hits", 100, -0.5, 9999.5);
-  _htdc = tfs.make<TH1D>( "TDC", "TDC", 100, 0.0, 120000.0);
-  _htdc2= tfs.make<TH1D>( "TDC2", "TDC2", 100, 0.0, 1400000.0);
+  _htdc = tfs.make<TH1D>( "TDC", "TDC", 100, 0.0, 80.0e3);
+  _htdc2= tfs.make<TH1D>( "TDC2", "TDC2", 100, 0.0, 5.0e6);
   _htot = tfs.make<TH1D>( "TOT", "TOT", 21, -0.5, 20.5);
   _hpmp = tfs.make<TH1D>( "PMP", "PMP",50, -0.5, 1000.0);
   _hSI = tfs.make<TH1D>( "Straw", "Straw Index",100, -0.5, StrawId::_maxval);
@@ -18,12 +18,12 @@ int mu2e::ValStrawDigi::declare(art::TFileDirectory tfs) {
 int mu2e::ValStrawDigi::fill(const mu2e::StrawDigiCollection & coll,
 				art::Event const& event) {
 
-  // increment this by 1 any time the defnitions of the histograms or the 
+  // increment this by 1 any time the defnitions of the histograms or the
   // histogram contents change, and will not match previous versions
   _hVer->Fill(2.0);
 
-  _hN->Fill(coll.size()); 
-  _hN2->Fill(coll.size()); 
+  _hN->Fill(coll.size());
+  _hN2->Fill(coll.size());
   for(auto sd : coll) {
     for (size_t ie=0; ie<StrawEnd::nends; ie++) {  // for the two straw ends
       _htdc->Fill(sd.TDC()[ie]);

--- a/Validation/src/ValStrawGasStep.cc
+++ b/Validation/src/ValStrawGasStep.cc
@@ -7,6 +7,7 @@ int mu2e::ValStrawGasStep::declare(art::TFileDirectory tfs) {
   _hN = tfs.make<TH1D>( "NHit", "N Straw Hits", 101, -0.5, 100.0);
   _hN2 = tfs.make<TH1D>( "NHit2", "N Straw Hits", 100, -0.5, 9999.5);
   _ht = tfs.make<TH1D>( "t", "time", 100, -100.0, 2000.0);
+  _ht2 = tfs.make<TH1D>( "t2", "time", 100, -100.0, 100.0e3);
   _hE = tfs.make<TH1D>( "E", "Energy",50, 0.0, 0.01);
   _hlE = tfs.make<TH1D>( "lE", "log10(Energy)",100, -6.0, 1.0);
   _hlen = tfs.make<TH1D>( "Length", "steplength",100, 0.0, 10.0);
@@ -22,14 +23,15 @@ int mu2e::ValStrawGasStep::declare(art::TFileDirectory tfs) {
 int mu2e::ValStrawGasStep::fill(const mu2e::StrawGasStepCollection & coll,
 				art::Event const& event) {
 
-  // increment this by 1 any time the defnitions of the histograms or the 
+  // increment this by 1 any time the defnitions of the histograms or the
   // histogram contents change, and will not match previous versions
   _hVer->Fill(2.0);
 
-  _hN->Fill(coll.size()); 
-  _hN2->Fill(coll.size()); 
+  _hN->Fill(coll.size());
+  _hN2->Fill(coll.size());
   for(auto gs : coll) {
     _ht->Fill(gs.time());
+    _ht2->Fill(gs.time());
     _hE->Fill(gs.ionizingEdep());
     _hlE->Fill(  ( gs.ionizingEdep()>0.0 ? log10(gs.ionizingEdep()) : -10 ) );
     _hlen->Fill(gs.stepLength());


### PR DESCRIPTION
Loosen or remove cuts on the digitization window.  Extend TrkPatRec (time cluster finder) in trigger and reco to support up to  100usec long events.  Remove some spurious, misleading parameters set in CalPatRec config.  Extend validation plots to cover OffSpill timing window.  Cleanup of HelixSeed dependencies got mixed in.