### PR TITLE
Mixing CosmicLivetime at event level and store it at SubRun level

### DIFF
--- a/EventMixing/inc/Mu2eProductMixer.hh
+++ b/EventMixing/inc/Mu2eProductMixer.hh
@@ -111,6 +111,7 @@ namespace mu2e {
     Mu2eProductMixer(const Config& conf, art::MixHelper& helper);
 
     void startEvent(art::Event const& e);
+    void processEventIDs(const art::EventIDSequence& seq);
     void beginSubRun(const art::SubRun& sr);
     void endSubRun(art::SubRun& sr);
 
@@ -202,6 +203,10 @@ namespace mu2e {
     float highE_ = 0;
     float fluxConstant_ = 0;
     float livetime_ = 0;
+    // Merging cosmic livetime info from multiple subruns is not
+    // implemented.  Make sure we only see a single subrun in a job.
+    bool cosmicSubrunInitialized_;
+    art::SubRunID cosmicSubRun_;
 
   };
 

--- a/EventMixing/src/MixBackgroundFrames_module.cc
+++ b/EventMixing/src/MixBackgroundFrames_module.cc
@@ -232,6 +232,9 @@ namespace mu2e {
 
   //================================================================
   void MixBackgroundFramesDetail::processEventIDs(art::EventIDSequence const& seq) {
+
+    spm_.processEventIDs(seq);
+
     if(writeEventIDs_) {
       idseq_ = seq;
     }

--- a/EventMixing/src/Mu2eProductMixer.cc
+++ b/EventMixing/src/Mu2eProductMixer.cc
@@ -136,6 +136,7 @@ namespace mu2e {
 
   }
 
+  //================================================================
   void Mu2eProductMixer::startEvent(art::Event const& e) {
     if(applyTimeOffset_){
     // find the time offset in the event, and copy it locally
@@ -145,8 +146,31 @@ namespace mu2e {
     resampledEvents_++;
   }
 
+  //----------------------------------------------------------------
+  void Mu2eProductMixer::processEventIDs(const art::EventIDSequence& seq)  {
+    if(mixCosmicLivetimes_) {
 
-  //================================================================
+      if(seq.size() != 1) {
+        throw cet::exception("BADINPUT")<<"Mu2eProductMixer: can't mix CosmicLiveTime" << std::endl;
+      }
+
+      if(!cosmicSubrunInitialized_) {
+        cosmicSubrunInitialized_ = true;
+        cosmicSubRun_ = seq.at(0).subRunID();
+      }
+      else {
+        if(seq.at(0).subRunID() != cosmicSubRun_) {
+          throw cet::exception("BADINPUT")<<"Mu2eProductMixer: input from multiple subruns is not supported for CosmicLivetime. "
+                                          <<"Got SubRunIDs"<<cosmicSubRun_<<" and "<<seq.at(0).subRunID()
+                                          <<std::endl;
+
+        }
+      }
+
+    }
+  }
+
+  //----------------------------------------------------------------
   void Mu2eProductMixer::beginSubRun(const art::SubRun& s) {
     subrunVolumes_.clear();
     resampledEvents_ = 0;

--- a/EventMixing/src/ResamplingMixer_module.cc
+++ b/EventMixing/src/ResamplingMixer_module.cc
@@ -27,16 +27,12 @@ namespace mu2e {
   // Our "detail" class for art/Framework/Modules/MixFilter.h
   class ResamplingMixerDetail {
     Mu2eProductMixer spm_;
-    const bool resampleMultipleSubruns_;
     const int debugLevel_;
     const unsigned maxEventsToSkip_;
     bool writeEventIDs_;
     art::EventIDSequence idseq_;
     art::RandomNumberGenerator::base_engine_t& engine_;
     artURBG urbg_;
-
-    art::SubRunNumber_t firstSubrun_;
-    bool initialized_ = false;
 
   public:
 
@@ -64,12 +60,6 @@ namespace mu2e {
           Comment("Write out IDs of events on the secondary input stream."),
           true
           };
-
-      fhicl::Atom<bool> resampleMultipleSubruns { Name("resampleMultipleSubruns"),
-          Comment("Flag for resampling multiple subruns (to be set to false for cosmic resampling)"),
-          true
-          };
-
       fhicl::Atom<int> debugLevel { Name("debugLevel"),
           Comment("control the level of debug output"),
           0u
@@ -83,7 +73,7 @@ namespace mu2e {
     using Parameters = art::MixFilterTable<Config>;
     ResamplingMixerDetail(const Parameters& pset, art::MixHelper &helper);
 
-    size_t eventsToSkip() {
+    size_t eventsToSkip() { 
       static bool first(true);
       size_t result(0);
       if(first) {
@@ -109,7 +99,6 @@ namespace mu2e {
 
   ResamplingMixerDetail::ResamplingMixerDetail(const Parameters& pars, art::MixHelper& helper)
     : spm_{ pars().mu2e().products(), helper }
-    , resampleMultipleSubruns_{ pars().mu2e().resampleMultipleSubruns() }
     , debugLevel_{ pars().mu2e().debugLevel() }
     , maxEventsToSkip_{ pars().mu2e().maxEventsToSkip() }
     , writeEventIDs_{ pars().mu2e().writeEventIDs() }
@@ -122,20 +111,8 @@ namespace mu2e {
     }
 
   void ResamplingMixerDetail::processEventIDs(const art::EventIDSequence& seq) {
-    if (!resampleMultipleSubruns_) {
-      for(const auto& s: seq) {
-        if (!initialized_) {
-          initialized_ = true;
-          firstSubrun_ = s.subRun();
-        } else {
-          if (s.subRun() != firstSubrun_) {
-            throw cet::exception("BADINPUT")
-              << "ResamplingMixer: resampleMultipleSubruns is false, but the EventIDSequence "
-              << "contains " << s.subRun() << " and the first subrun was " << firstSubrun_ << ".\n";
-          }
-        }
-      }
-    }
+
+    spm_.processEventIDs(seq);
 
     if(writeEventIDs_) {
       idseq_ = seq;


### PR DESCRIPTION
This PR fixes the mixing of the `CosmicLivetime` data products. We store them at `art::Event` level in the Source module `FromCorsikaBinary`, which is then passed to the `CORSIKAEventGenerator` (our S1 stage). We resample these files with a `ResamplingMixer` (our S2 stage), which now stores the sum of the livetime of the mixed events as a `art::SubRun` data product.
