### PR TITLE
add example code

### DIFF
--- a/DbService/test/dbBin_main.cc
+++ b/DbService/test/dbBin_main.cc
@@ -3,8 +3,8 @@
 // conditions sets can be accessed in a stand-alone bin
 // 
 // To build this, copy it to an apropriate repo src dir
-// You can see what you need in your SConstruct by looking at
-// the build for dbTool in DbService/src
+// You can see what you need in your SConscript by looking at
+// the build for dbTool in Offline/DbService/src
 //
 // arguments are 
 // PURPOSE: the conditions set purpose


### PR DESCRIPTION
As requested by tracker VST group, here is an example of how to use the DbEngine to access run-dependent conditions sets outside of art and DbService.