### PR TITLE
Enabling the use of G4TDormandPrince45 stepper

### DIFF
--- a/Mu2eG4/fcl/prolog.fcl
+++ b/Mu2eG4/fcl/prolog.fcl
@@ -35,7 +35,10 @@ mu2eg4DefaultPhysics: {
 
     // current G4 stepper choices in Mu2eWorld.cc are shown below
     // G4DormandPrince745 Geant4 10.4+
+    // G4TDormandPrince45 Geant4 10.7+
     // G4DormandPrince745WSpin
+    // G4TDormandPrince45WSpin
+    // G4BogackiShampine23 10.4+
     // G4ClassicalRK4
     // G4ClassicalRK4WSpin
     // G4ImplicitEuler

--- a/Mu2eG4/src/Mu2eWorld.cc
+++ b/Mu2eG4/src/Mu2eWorld.cc
@@ -129,6 +129,9 @@
 #include "Geant4/G4DormandPrince745.hh"
 #include "Geant4/G4BogackiShampine23.hh"
 #endif
+#if G4VERSION>4106
+#include "Geant4/G4TDormandPrince45.hh"
+#endif
 #include "Geant4/G4GDMLParser.hh"
 #include "Geant4/G4ProductionCuts.hh"
 #include "Geant4/G4Region.hh"
@@ -457,6 +460,16 @@ namespace mu2e {
                << "and used G4DormandPrince745 with Spin" << G4endl;
       }
 #endif
+#if G4VERSION>4106
+    } else if ( g4stepperName_  == "G4TDormandPrince45WSpin" ) {
+      delete _rhs; // consider avoiding the delete once we really start tracking with spin
+      _rhs  = new G4Mag_SpinEqRhs(_field);
+      _stepper = new G4TDormandPrince45(_rhs, 12);
+      if ( _g4VerbosityLevel > 0) {
+        G4cout << __func__ << " Replaced G4Mag_UsualEqRhs with G4TDormandPrince45WSpin "
+               << "and used G4TDormandPrince45 with Spin" << G4endl;
+      }
+#endif
     } else if ( g4stepperName_  == "G4ImplicitEuler" ) {
       _stepper = new G4ImplicitEuler(_rhs);
     } else if ( g4stepperName_  == "G4ExplicitEuler" ) {
@@ -472,6 +485,10 @@ namespace mu2e {
       _stepper = new G4DormandPrince745(_rhs);
     } else if ( g4stepperName_  == "G4BogackiShampine23" ) {
       _stepper = new G4BogackiShampine23(_rhs);
+#endif
+#if G4VERSION>4106
+    } else if ( g4stepperName_  == "G4TDormandPrince45" ) {
+      _stepper = new G4TDormandPrince45(_rhs);
 #endif
     } else if ( g4stepperName_  == "G4SimpleRunge" ) {
       _stepper = new G4SimpleRunge(_rhs);

--- a/Mu2eG4/src/physicsListDecider.cc
+++ b/Mu2eG4/src/physicsListDecider.cc
@@ -148,9 +148,10 @@ namespace mu2e{
     // Muon Spin and Radiative decays plus pion muons with spin
     if ( phys.decayMuonsWithSpin() ) {
 
-      // requires spin tracking: G4ClassicalRK4WSpin
+      // requires spin tracking
       if ( phys.stepper() != "G4ClassicalRK4WSpin" &&
-           phys.stepper() != "G4DormandPrince745WSpin" ) {
+           phys.stepper() != "G4DormandPrince745WSpin" &&
+           phys.stepper() != "G4TDormandPrince45WSpin" ) {
         mf::LogError("Config") << "Inconsistent config";
         G4cout << "Error: Mu2eG4DecayMuonsWithSpinPhysicsConstructor requires enabling spin tracking" << G4endl;
         throw cet::exception("BADINPUT")<<" Mu2eG4DecayMuonsWithSpinPhysicsConstructor requires enabling spin tracking\n";


### PR DESCRIPTION
Enabling the use of the templated G4TDormandPrince45 stepper, the current Geant4 default.
As per release notes: "A speedup is expected. Instead a slowdown can occur if a large fraction of 'long' steps propagating in a vacuum or gas volume with a strong-enough magnetic field." as compared with the equivalent 
previous default G4DormandPrince745