### PR TITLE
Extracted position configuration

### DIFF
--- a/EventGenerator/defaultConfigs/extractedCRYconfig.txt
+++ b/EventGenerator/defaultConfigs/extractedCRYconfig.txt
@@ -1,0 +1,48 @@
+// extracted config for CRY cosmic generator
+
+// Verbose
+int cosmicCRY.verbose = 0;
+
+string cosmicCRY.refPoint = "TRACKER";
+double cosmicCRY.refY0 = 20000; // 15.4 meter above nominal beam height - at the surface
+
+bool cosmicCRY.projectToTargetBox = true;
+
+double cosmicCRY.targetBoxXmin =-10000;
+double cosmicCRY.targetBoxXmax =  3000;
+
+double cosmicCRY.targetBoxYmin = -5000;
+double cosmicCRY.targetBoxYmax =  9880; // defined by CRV
+
+double cosmicCRY.targetBoxZmin = 17105; // defined by CRV
+double cosmicCRY.targetBoxZmax = 32220; // defined by Calo Z1
+
+// Enable all particles by default
+bool cosmicCRY.returnMuons = true;
+bool cosmicCRY.returnNeutrons = true;
+bool cosmicCRY.returnProtons = true;
+bool cosmicCRY.returnGammas = true;
+bool cosmicCRY.returnElectrons = true;
+bool cosmicCRY.returnPions = true;
+bool cosmicCRY.returnKaons = true;
+
+
+// Date
+int cosmicCRY.month = 6;
+int cosmicCRY.day = 21;
+int cosmicCRY.year = 2021;
+
+// Experiment site settings
+double cosmicCRY.latitude = 41.8;
+int cosmicCRY.altitude = 0; // meter, accepts either of 3 values: 0, 2100 or 11300
+double cosmicCRY.subboxLength = 300.; // meter
+double cosmicCRY.maxShowerEn  = 1e8; // MeV
+double cosmicCRY.minShowerEn  = 50; // MeV
+
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:
+// Similar stuff for vim
+// vim: ft=cpp


### PR DESCRIPTION
CRY configuration for extracted position of the detector. Needed by https://github.com/Mu2e/Production/pull/126.