### PR TITLE
organize DbService verbose settings

### DIFF
--- a/DbService/src/DbEngine.cc
+++ b/DbService/src/DbEngine.cc
@@ -8,7 +8,7 @@ using namespace std;
 
 int mu2e::DbEngine::beginJob() {
 
-  if(_verbose>5) cout << "DbEngine::beginJob start" << endl;
+  if(_verbose>4) cout << "DbEngine::beginJob start" << endl;
   _initialized = true;  // true no matter when we return
 
   _gids.clear();
@@ -36,7 +36,7 @@ int mu2e::DbEngine::beginJob() {
     // assign nominal tid's to file-based tables
     for(auto& lt: _override) {
       if(_overrideTids.find(lt.table().name()) == _overrideTids.end()) {
-	if(_verbose>5) {
+	if(_verbose>4) {
 	  cout << "DbEngine::beginRun assigning TID "
 	       << fakeTid << " to " << lt.table().name() << endl;
 	}
@@ -44,7 +44,7 @@ int mu2e::DbEngine::beginJob() {
 	fakeTid++;
       }
       int mytid = _overrideTids[lt.table().name()];
-      if(_verbose>5) {
+      if(_verbose>4) {
 	cout << "DbEngine::beginRun assigning override CID "
 	     << fakeCid << " and TID " << mytid << " to " << lt.table().name() << endl;
       }
@@ -53,7 +53,7 @@ int mu2e::DbEngine::beginJob() {
       fakeCid++;
     }
     
-    if(_verbose>1) cout << "DbEngine::beginJob exit early, purpose=EMPTY" 
+    if(_verbose>2) cout << "DbEngine::beginJob exit early, purpose=EMPTY" 
 			<< endl;
     return 0;
   }
@@ -183,7 +183,7 @@ int mu2e::DbEngine::beginJob() {
 
   
   // make the list of tables in this purpose/version
-  if(_verbose>5) cout << "DbEngine::beginJob make table list" << endl;
+  if(_verbose>4) cout << "DbEngine::beginJob make table list" << endl;
   _lookup.clear();
   auto const& tls = vcache.valTableLists();
   for(auto const& r : tls.rows()) {
@@ -193,7 +193,7 @@ int mu2e::DbEngine::beginJob() {
   }
 
   // now fill the rows of _lookup
-  if(_verbose>5) cout << "DbEngine::beginJob make _lookup" << endl;
+  if(_verbose>4) cout << "DbEngine::beginJob make _lookup" << endl;
 
   // take the list of groups and loop over the grouplists
   // which gives IOVs for a group 
@@ -224,7 +224,7 @@ int mu2e::DbEngine::beginJob() {
     }
     if(mytid<0) {
       if(_overrideTids.find(lt.table().name()) == _overrideTids.end()) {
-	if(_verbose>5) {
+	if(_verbose>4) {
 	  cout << "DbEngine::beginRun assigning TID "
 	       << fakeTid << " to " << lt.table().name() << endl;
 	}
@@ -233,7 +233,7 @@ int mu2e::DbEngine::beginJob() {
       }
       mytid = _overrideTids[lt.table().name()];
     }
-    if(_verbose>5) {
+    if(_verbose>4) {
       cout << "DbEngine::beginRun assigning override CID "
 	   << fakeCid << " and TID " << mytid 
 	   << " to " << lt.table().name() << endl;
@@ -243,7 +243,7 @@ int mu2e::DbEngine::beginJob() {
     fakeCid++;
   }
 
-  if( _verbose>9 ) {
+  if( _verbose>4 ) {
     std::cout << "DbEngine::beginRun results of lookup" << std::endl;
     std::cout << "  tid       valid range        cid" << std::endl;
     for(auto const& p : _lookup) {
@@ -259,7 +259,7 @@ int mu2e::DbEngine::beginJob() {
   // this will be the current list of active, filled tables
   _last.clear();
 
-  if( _verbose>0 ) {
+  if( _verbose>1 ) {
     std::cout << "DbEngine confirmed purpose and version " 
 	      << _version.purpose() << " " << _version.major() 
 	      << "/" << _version.minor() 
@@ -275,12 +275,12 @@ int mu2e::DbEngine::beginJob() {
 
   auto end_time = std::chrono::high_resolution_clock::now();
   auto beginJobTime = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
-  if(_verbose>0) {
+  if(_verbose>1) {
     std::cout<<"DbEngine inclusive beginJob time was " 
 	     << beginJobTime.count()*1.0e-6<<" s" << std::endl;
   }
 
-  if(_verbose>5) cout << "DbEngine::beginJob end" << endl;
+  if(_verbose>4) cout << "DbEngine::beginJob end" << endl;
 
   return 0;
 }
@@ -291,7 +291,7 @@ mu2e::DbLiveTable mu2e::DbEngine::update(int tid, uint32_t run,
 
   lazyBeginJob(); // initialize if needed
 
-  if(_verbose>9) cout << "DbEngine::update call "
+  if(_verbose>5) cout << "DbEngine::update call "
 		      << tid << " " << run << " " << subrun << endl;
 
   // first look for table in override table list
@@ -303,7 +303,7 @@ mu2e::DbLiveTable mu2e::DbEngine::update(int tid, uint32_t run,
     if(oltab.tid()==tid) { // if override table is the right type
       if(oltab.iov().inInterval(run,subrun)) { // and in valid interval
 	auto dblt = oltab;
-	if(_verbose>9) cout << "DbEngine::update table found " 
+	if(_verbose>5) cout << "DbEngine::update table found " 
 			    << dblt.table().name() << " in overrides " << endl;
 	return dblt;
       }
@@ -484,7 +484,7 @@ void mu2e::DbEngine::lazyBeginJob() {
 
 int mu2e::DbEngine::endJob() {
   if(!_vcache) return 0;
-  if(_verbose>0) {
+  if(_verbose>1) {
     std::cout << "DbEngine::endJob" << std::endl;
     std::cout << "    Total time in reading DB: "<< _reader.totalTime() 
 	      <<" s" << std::endl;

--- a/DbService/src/DbReader.cc
+++ b/DbService/src/DbReader.cc
@@ -187,11 +187,11 @@ int mu2e::DbReader::fillValTables(DbValCache& vcache) {
   _lastTime = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
   _totalTime += _lastTime;
 
-  if(_timeVerbose>0) {
+  if(_timeVerbose>1) {
     std::cout<<"DbReader::fillValCache took " <<
       std::setprecision(6) << _lastTime.count()*1.0e-6 <<" s" << std::endl;
   }
-  if(_verbose>3) {
+  if(_verbose>2) {
     std::cout<<"DbReader::fillValCache results " << std::endl;
     vcache.print();
   }
@@ -274,7 +274,7 @@ int mu2e::DbReader::queryCore(std::string& csv,
     url.append(order);
   }
 
-  if(_verbose>3) {
+  if(_verbose>5) {
     std::string time = DbUtil::timeString();
     std::cout << "DbReader " << time 
 	      <<"  url="<<url << std::endl;
@@ -352,7 +352,7 @@ int mu2e::DbReader::queryCore(std::string& csv,
   _lastTime = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
   _totalTime += _lastTime;
 
-  if(_timeVerbose>3 || _verbose>3) {
+  if(_timeVerbose>5 || _verbose>5) {
     std::string time = DbUtil::timeString();
 
     std::cout<<"DbReader "<< time << " "

--- a/DbService/src/DbService_service.cc
+++ b/DbService/src/DbService_service.cc
@@ -18,27 +18,20 @@ namespace mu2e {
     iRegistry.sPostEndJob.watch (this, &DbService::postEndJob );
 
     if(_verbose>0) {
-      std::cout << "DbService: purpose = " 
-		<< _version.purpose() << std::endl;
-      std::cout << "DbService: version = " 
-		<< config().version() << std::endl;
-      std::cout << "DbService: interpreted version = " 
-		<< _version.major() <<"/"
-		<< _version.minor() <<"/"
-		<< _version.extension() 
-		<< std::endl;
-      std::cout << "DbService: dbName = " 
+      std::cout << "DbService  " 
+		<< config().purpose() << " " 
+		<< config().version() << "   "
 		<< config().dbName() << std::endl;
       std::vector<std::string> files;
       config().textFile(files);
-      std::cout << "DbService: textFile =" ;
+      std::cout << "DbService  textFiles: " ;
       for(auto const& s : files) std::cout << " " << s;
       std::cout << std::endl;
     }
 
 
 
-    if(_verbose>1) std::cout << "DbService::constructor " <<std::endl;
+    if(_verbose>2) std::cout << "DbService::constructor " <<std::endl;
 
     // the engine which will read db, hold calibrations, deliver them
     _engine.setVerbose(_verbose);
@@ -55,11 +48,11 @@ namespace mu2e {
    ConfigFileLookupPolicy configFile;
    std::string fn;
     for(auto ss : files ) {
-      if(_verbose>1) std::cout << "DbService::beginJob reading file "<<
+      if(_verbose>2) std::cout << "DbService::beginJob reading file "<<
 		       ss <<std::endl;
       fn = configFile(ss);
       auto coll = DbUtil::readFile(fn,_config.saveCsv());
-      if(_verbose>1) {
+      if(_verbose>2) {
 	for(auto const& lt : coll) {
 	  std::cout << "  read table " << lt.table().name() <<std::endl;
 	}
@@ -78,7 +71,7 @@ namespace mu2e {
     _config.fastStart(fastStart);
     if (fastStart) {
       // this prepares IOV infrastructure for efficient queries
-      if(_verbose>1) std::cout << "DbService::beginJob initializing engine "
+      if(_verbose>2) std::cout << "DbService::beginJob initializing engine "
 			       <<std::endl;
       _engine.beginJob();
     }

--- a/DbService/src/DbSql.cc
+++ b/DbService/src/DbSql.cc
@@ -28,7 +28,7 @@ int mu2e::DbSql::connect() {
 		 //sslmode=require  krbsrvname
 
   _conn = PQconnectdb(command.c_str());
-  if(_verbose>1) {
+  if(_verbose>2) {
     std::cout << "DbSql opened connection, status: " 
 	      << PQerrorMessage(_conn) << std::endl;
   }
@@ -48,7 +48,7 @@ int mu2e::DbSql::connect() {
 int mu2e::DbSql::disconnect() {
   if (_conn) {
     PQfinish(_conn);
-    if(_verbose>1) {
+    if(_verbose>2) {
       std::cout << "DbSql closed connection, status: " 
 		<< PQerrorMessage(_conn) << std::endl;
     }
@@ -62,7 +62,7 @@ int mu2e::DbSql::disconnect() {
 int mu2e::DbSql::execute(const std::string& command, std::string& result) {
   result.clear();
   PGresult* res = PQexec(_conn,command.c_str());
-  if(_verbose>1) {
+  if(_verbose>4) {
     std::cout << "\nDbSql execute command:\n" << command << "\n"
 	      << "status message: " << PQerrorMessage(_conn) << "\n";
   }
@@ -78,7 +78,7 @@ int mu2e::DbSql::execute(const std::string& command, std::string& result) {
 
   size_t nrow = PQntuples(res);
   size_t ncol = PQnfields(res);
-  if(_verbose>5) {
+  if(_verbose>4) {
     std::cout << "DbSql execute returned: " << nrow << " rows and "
 	      << ncol << " columns" << std::endl;
   }
@@ -91,7 +91,7 @@ int mu2e::DbSql::execute(const std::string& command, std::string& result) {
     result.append("\n");
   }
 
-  if(_verbose>5) {
+  if(_verbose>4) {
     std::cout << "DbSql execute result ("<< result.size()<<" char):\n" << result << std::endl;
   }
   return 0;


### PR DESCRIPTION
Organize debug prints a bit more:
1 will be on by default (when db is on by default)
  only echo the conditions set and override tables
2 good for validation and production, log total time and memory
5 log max about configuration and startup
6 start logging every table request and db read
9 print head and tail of each request/read
10 dump full content of each request/read
