### PR TITLE
Extracted no bfield

### DIFF
--- a/Mu2eG4/geom/bfgeom_no_field.txt
+++ b/Mu2eG4/geom/bfgeom_no_field.txt
@@ -1,0 +1,53 @@
+//
+// Variant of the BField system with zero magnetic field everywhere.
+//
+// BField information maintained as a separate file.
+//
+// Warning:
+//  There are multiple points of maintenance when you change bfield.innerMaps
+//  There are multiple points of maintenance when you change bfield.innerMaps
+//    - bfgeom_v01.txt           ( the base geometry  )
+//    - bfgeom_no_ds_v01.txt     ( DS map removed     )
+//    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
+//    - bfgeom_no_tsu_ps_v01.txt ( PS and TSu maps removed.
+//    - bfgeom_no_field.txt      ( Magnetic field is zero everywhere )
+//
+
+// Form of DS field: 0 is full field;
+//                   1 is full upstream, const downstream;
+//                   2 is const throughout
+int detSolFieldForm = 0;
+
+vector<string> bfield.innerMaps = {};
+
+// Value of the uniform magnetic field with the DS volume (only for
+// detSolFieldForm>0)
+double toyDS.bz            = 0.0;
+
+// Gradient of field in DS2 volume. Applied only in the case
+// of detSolFieldForm=1 or detSolFieldForm=2.
+double toyDS.gradient      = 0.0; // Tesla/m
+
+// This is recommended field map. See geom_mecofield.txt to use the meco field.
+string bfield.format  = "G4BL";
+
+// The other option is "meco"
+string bfield.interpolationStyle = trilinear;
+
+int  bfield.verbosityLevel =  0;
+bool bfield.writeG4BLBinaries     =  false;
+
+vector<string> bfield.outerMaps = {};
+
+// This scale factor is of limited use.
+// It can make approximate sense to scale the PS field to get a rough
+// answer; the answer will be wrong in detail.
+// It never makes sense to scale the TS field.
+// Not sure if it ever makes sense to scale the PS field.
+double bfield.scaleFactor = 0.0;
+
+//
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_extracted.txt
+++ b/Mu2eG4/geom/geom_common_extracted.txt
@@ -1,7 +1,10 @@
-// Top level geometry file for extracted detector cosmics running
+// Top level geometry file for extracted detector cosmics running with no magnetic field
 
 // Start from recent baseline geometry
 #include "Offline/Mu2eG4/geom/geom_common_current.txt"
+
+// Set the magnetic field to zero everywhere.
+#include "Offline/Mu2eG4/geom/bfgeom_no_field.txt"
 
 // Special - for garage position!
 bool inGaragePosition   = true;


### PR DESCRIPTION
For the extracted position, set the magnetic field to zero everywhere.

To implement this I created a bfgeom variant to do the work and included it in main extracted position geometry file.  If people want to set the field to zero in other cases, they should use the method of including this bfgeom variant.

