### PR TITLE
Update PS endcap model

### DIFF
--- a/GeomPrimitives/inc/Polycone.hh
+++ b/GeomPrimitives/inc/Polycone.hh
@@ -31,6 +31,8 @@ namespace mu2e {
 
   public:
 
+    Polycone();
+
     Polycone(const std::vector<double>& zPlanes,
              const std::vector<double>& rInner,
              const std::vector<double>& rOuter,

--- a/GeomPrimitives/inc/Tube.hh
+++ b/GeomPrimitives/inc/Tube.hh
@@ -70,6 +70,7 @@ namespace mu2e {
 
   };
 
+  std::ostream& operator<<(std::ostream& os, const Tube& t);
 }
 
 #endif/*GeomPrimitives_Tube_hh*/

--- a/GeomPrimitives/src/Polycone.cc
+++ b/GeomPrimitives/src/Polycone.cc
@@ -14,6 +14,7 @@
 
 namespace mu2e {
 
+  Polycone::Polycone() : Polycone(std::vector<double>(), std::vector<double>(), std::vector<double>(), CLHEP::Hep3Vector(), "", 0., CLHEP::twopi) {};
   Polycone::Polycone(const std::vector<double>& zPlanes,
                      const std::vector<double>& rInner,
                      const std::vector<double>& rOuter,

--- a/GeomPrimitives/src/Tube.cc
+++ b/GeomPrimitives/src/Tube.cc
@@ -53,4 +53,14 @@ namespace mu2e {
     _rotation(rotation)
   {};
 
+  std::ostream& operator<<(std::ostream& os, const Tube& t) {
+    os<<"Tube: " << t.getTubsParams()
+      <<", originInMu2e="<<t.originInMu2e()
+      <<", phi0="<<t.phi0()
+      <<", phiMax="<<t.phiMax()
+      <<", rotation="<<t.rotation()
+      <<", materialName="<<t.materialName();
+    return os;
+  }
+
 }

--- a/GeometryService/inc/PSEnclosureMaker.hh
+++ b/GeometryService/inc/PSEnclosureMaker.hh
@@ -24,8 +24,10 @@ namespace mu2e {
 
                                             // The center of the downstream surface of the PS
                                             const CLHEP::Hep3Vector& psEndRefPoint);
-  };
+  private:
+    static void readWindow(int i, const SimpleConfig& c, const CLHEP::Hep3Vector& winRefPoint, std::unique_ptr<PSEnclosure>& res);
 
+  };
 }  //namespace mu2e
 
 #endif /* ProductionSolenoidGeom_PSEnclosureMaker_hh */

--- a/GeometryService/src/PSEnclosureMaker.cc
+++ b/GeometryService/src/PSEnclosureMaker.cc
@@ -109,18 +109,17 @@ namespace mu2e {
                      CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY),
                      shellMaterialName);
       if(vers == 2) {
-        res = std::unique_ptr<PSEnclosure>
-          (new PSEnclosure(
-                           shellCone,
-                           // end plate
-                           Tube(shellMaterialName,
-                                // The vacuum volume is flush to the PS surface
-                                psEndRefPoint + CLHEP::Hep3Vector(0,0, -shellLength - 0.5*endPlateThickness),
-                                0.,
-                                0.5*shellODWest,
-                                0.5*endPlateThickness
-                                )
-                           )
+        res = std::make_unique<PSEnclosure>
+          (
+           shellCone,
+           // end plate
+           Tube(shellMaterialName,
+                // The vacuum volume is flush to the PS surface
+                psEndRefPoint + CLHEP::Hep3Vector(0,0, -shellLength - 0.5*endPlateThickness),
+                0.,
+                0.5*shellODWest,
+                0.5*endPlateThickness
+                )
            );
       } else {
         std::vector<double> zPlanes; c.getVectorDouble("PSEnclosure.endPlate.zPlanes", zPlanes);
@@ -130,17 +129,16 @@ namespace mu2e {
         // if(zPlanes.size() > 0 ) {
         //   zlength = abs(zPlanes[0] - zPlanes[zPlanes.size() - 1]); //planes should be ordered
         // }
-        res = std::unique_ptr<PSEnclosure>
-          (new PSEnclosure(shellCone,
-                           // end plate
-                           Polycone(zPlanes,
-                                    rIns,
-                                    rOuts,
-                                    // The vacuum volume is flush to the PS surface
-                                    psEndRefPoint + CLHEP::Hep3Vector(0,0, -shellLength),
-                                    shellMaterialName
-                                    )
-                           )
+        res = std::make_unique<PSEnclosure>
+          (shellCone,
+           // end plate
+           Polycone(zPlanes,
+                    rIns,
+                    rOuts,
+                    // The vacuum volume is flush to the PS surface
+                    psEndRefPoint + CLHEP::Hep3Vector(0,0, -shellLength),
+                    shellMaterialName
+                    )
            );
       }
 
@@ -159,24 +157,24 @@ namespace mu2e {
 
       const CLHEP::Hep3Vector shellOriginInMu2e(psEndRefPoint + CLHEP::Hep3Vector(0,0, -0.5*shellLength));
 
-      res = std::unique_ptr<PSEnclosure> (new PSEnclosure(
-                            // cylindrical shell
-                            Tube(shellMaterialName,
-                                 shellOriginInMu2e,
-                                 0.5*(shellOD - 2*shellThickness),
-                                 0.5*shellOD,
-                                 0.5*shellLength),
+      res = std::make_unique<PSEnclosure>
+        (
+         // cylindrical shell
+         Tube(shellMaterialName,
+              shellOriginInMu2e,
+              0.5*(shellOD - 2*shellThickness),
+              0.5*shellOD,
+              0.5*shellLength),
 
-                            // end plate
-                            Tube(shellMaterialName,
-                                 // The vacuum volume is flush to the PS surface
-                                 psEndRefPoint + CLHEP::Hep3Vector(0,0, -shellLength - 0.5*endPlateThickness),
-                                 0.,
-                                 0.5*shellOD,
-                                 0.5*endPlateThickness
-                                 )
-                                                          )
-                            );
+         // end plate
+         Tube(shellMaterialName,
+              // The vacuum volume is flush to the PS surface
+              psEndRefPoint + CLHEP::Hep3Vector(0,0, -shellLength - 0.5*endPlateThickness),
+              0.,
+              0.5*shellOD,
+              0.5*endPlateThickness
+              )
+         );
     }
 
     //----------------------------------------------------------------

--- a/GeometryService/src/PSEnclosureMaker.cc
+++ b/GeometryService/src/PSEnclosureMaker.cc
@@ -22,24 +22,27 @@ namespace mu2e {
       const double yoff = c.getDouble(prefix+"y"   )*CLHEP::mm;
       const double zoff = c.getDouble(prefix+"z",0.)*CLHEP::mm;
       const double halfThick = 0.5*c.getDouble(prefix+"thickness")*CLHEP::mm;
+      const CLHEP::Hep3Vector windowCenterInMu2e = winRefPoint + CLHEP::Hep3Vector(xoff, yoff, zoff-halfThick);
 
       const bool windHasFrame = c.getBool(prefix+"hasFrame",false);
       res->hasFrames_.push_back(windHasFrame);
 
-      const double fWid = c.getDouble(prefix+"frameRadialWidth")*CLHEP::mm;
-      const double fHalfThick = 0.5*c.getDouble(prefix+"frameThickness")*CLHEP::mm;
-      const double rFin = c.getDouble(prefix+"r")*CLHEP::mm;//Same as rad of window
-      const double rFout = rFin+fWid;
+      if(windHasFrame) {
+        const double fWid = c.getDouble(prefix+"frameRadialWidth")*CLHEP::mm;
+        const double fHalfThick = 0.5*c.getDouble(prefix+"frameThickness")*CLHEP::mm;
+        const double rFin = c.getDouble(prefix+"r")*CLHEP::mm;//Same as rad of window
+        const double rFout = rFin+fWid;
 
-      const CLHEP::Hep3Vector windowCenterInMu2e = winRefPoint + CLHEP::Hep3Vector(xoff, yoff, zoff-fHalfThick);
+        //center the frame on the window, but pushed in z to avoid overlaps with the pipe
+        const CLHEP::Hep3Vector frameCenterInMu2e = winRefPoint + CLHEP::Hep3Vector(xoff, yoff, zoff-2.*fHalfThick);
 
-      res->wFrames_.push_back( Tube(c.getString(prefix+"frameMaterialName"),
-                                    windowCenterInMu2e,
-                                    rFin, // rIn
-                                    rFout,
-                                    fHalfThick
-                                    ));
-
+        res->wFrames_.push_back( Tube(c.getString(prefix+"frameMaterialName"),
+                                      frameCenterInMu2e,
+                                      rFin, // rIn
+                                      rFout,
+                                      fHalfThick
+                                      ));
+      }
 
       //retrieve the window pipe information
       if(res->version() > 2) {
@@ -48,9 +51,9 @@ namespace mu2e {
         const double thetax = c.getDouble(prefix+"pipe.thetaX")*CLHEP::degree;
         const double thetay = c.getDouble(prefix+"pipe.thetaY")*CLHEP::degree;
         const double zplate = abs(res->endPlatePolycone().zPlanes()[0] - res->endPlatePolycone().zPlanes().back());
-        const CLHEP::Hep3Vector origin = windowCenterInMu2e; //set at the same 
+        const CLHEP::Hep3Vector origin = windowCenterInMu2e; //set at the same
         //origin to ensure it intersects it.
-        //Set the pipe to be long enough to intersect both the 
+        //Set the pipe to be long enough to intersect both the
         //plate and the window.
         double zlength = abs(res->endPlatePolycone().originInMu2e().z() - windowCenterInMu2e.z()) + zplate;
         zlength /= abs(std::cos(thetax)*std::cos(thetay));

--- a/GeometryService/src/PSEnclosureMaker.cc
+++ b/GeometryService/src/PSEnclosureMaker.cc
@@ -13,27 +13,45 @@
 
 namespace mu2e {
 
-  namespace {
-    Tube readWindow(int i, const SimpleConfig& c, const CLHEP::Hep3Vector& winRefPoint) {
+  void PSEnclosureMaker::readWindow(int i, const SimpleConfig& c, const CLHEP::Hep3Vector& winRefPoint, std::unique_ptr<PSEnclosure>& res) {
       std::ostringstream sprefix;
       sprefix<<"PSEnclosure.window"<<1+i<<".";
       const std::string prefix(sprefix.str());
 
-      const double xoff = c.getDouble(prefix+"x")*CLHEP::mm;
-      const double yoff = c.getDouble(prefix+"y")*CLHEP::mm;
+      const double xoff = c.getDouble(prefix+"x"   )*CLHEP::mm;
+      const double yoff = c.getDouble(prefix+"y"   )*CLHEP::mm;
+      const double zoff = c.getDouble(prefix+"z",0.)*CLHEP::mm;
       const double halfThick = 0.5*c.getDouble(prefix+"thickness")*CLHEP::mm;
 
-      const CLHEP::Hep3Vector windowCenterInMu2e = winRefPoint + CLHEP::Hep3Vector(xoff, yoff, -halfThick);
+      const CLHEP::Hep3Vector windowCenterInMu2e = winRefPoint + CLHEP::Hep3Vector(xoff, yoff, zoff-halfThick);
 
-      return Tube(c.getString(prefix+"materialName"),
-                  windowCenterInMu2e,
-                  0., // rIn
-                  c.getDouble(prefix+"r")*CLHEP::mm,
-                  halfThick
-                  );
+      //retrieve the window pipe information
+      if(res->version() > 2) {
+        const double rin   = c.getDouble(prefix+"pipe.rin")*CLHEP::mm;
+        const double rout  = c.getDouble(prefix+"pipe.rout")*CLHEP::mm;
+        const double thetax = c.getDouble(prefix+"pipe.thetaX")*CLHEP::degree;
+        const double thetay = c.getDouble(prefix+"pipe.thetaY")*CLHEP::degree;
+        const double zplate = abs(res->endPlatePolycone().zPlanes()[0] - res->endPlatePolycone().zPlanes().back());
+        const CLHEP::Hep3Vector origin = windowCenterInMu2e; //set at the same origin to ensure it intersects it
+        //set the pipe to be long enough to intersect both the plate and the window
+        double zlength = abs(res->endPlatePolycone().originInMu2e().z() - windowCenterInMu2e.z()) + zplate;
+        zlength /= abs(std::cos(thetax)*std::cos(thetay));
+        // CLHEP::Hep3Vector origin(0.,0.,1.);
+        CLHEP::HepRotation matrix = CLHEP::HepRotation();
+        matrix.rotateX(thetax);
+        matrix.rotateY(thetay);
+        // origin = matrix*origin;
+        // origin *= zlength/2.;
+        // origin = windowCenterInMu2e - origin;
+        res->windowPipes_.push_back(Tube(rin, rout, zlength, origin, matrix));
+      }
+      res->windows_.push_back(Tube(c.getString(prefix+"materialName"),
+                                   windowCenterInMu2e,
+                                   0., // rIn
+                                   c.getDouble(prefix+"r")*CLHEP::mm, //rOut
+                                   halfThick
+                                   ));
     }
-  }
-
 
   std::unique_ptr<PSEnclosure>  PSEnclosureMaker::make(const SimpleConfig& c,
                                                      const CLHEP::Hep3Vector& psEndRefPoint)
@@ -54,30 +72,49 @@ namespace mu2e {
       const double shellLength = totalLength - endPlateThickness;
 
       const CLHEP::Hep3Vector shellOriginInMu2e(psEndRefPoint + CLHEP::Hep3Vector(0,0, -0.5*shellLength));
-
-      res = std::unique_ptr<PSEnclosure>(new PSEnclosure(
-			    // conical frustrum
-			    Cone(0.5*(shellODWest - 2*shellThickness),
-				 0.5*shellODWest,
-				 0.5*(shellODEast - 2*shellThickness),
-				 0.5*shellODEast,
-				 0.5*shellLength,
-				 0., CLHEP::twopi,
-				 shellOriginInMu2e,
-				 CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY),
-				 shellMaterialName),
-
-			    // end plate
-			    Tube(shellMaterialName,
-				 // The vacuum volume is flush to the PS surface
-				 psEndRefPoint + CLHEP::Hep3Vector(0,0, -shellLength - 0.5*endPlateThickness),
-				 0.,
-				 0.5*shellODWest,
-				 0.5*endPlateThickness
-				 )                              
-							 )
-			    );
-
+                            // conical frustrum
+      Cone shellCone(0.5*(shellODWest - 2*shellThickness),
+                     0.5*shellODWest,
+                     0.5*(shellODEast - 2*shellThickness),
+                     0.5*shellODEast,
+                     0.5*shellLength,
+                     0., CLHEP::twopi,
+                     shellOriginInMu2e,
+                     CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY),
+                     shellMaterialName);
+      if(vers == 2) {
+        res = std::unique_ptr<PSEnclosure>(new PSEnclosure(
+                                                           shellCone,
+                                                           // end plate
+                                                           Tube(shellMaterialName,
+                                                                // The vacuum volume is flush to the PS surface
+                                                                psEndRefPoint + CLHEP::Hep3Vector(0,0, -shellLength - 0.5*endPlateThickness),
+                                                                0.,
+                                                                0.5*shellODWest,
+                                                                0.5*endPlateThickness
+                                                                )
+                                                           )
+                                           );
+      } else {
+        std::vector<double> zPlanes; c.getVectorDouble("PSEnclosure.endPlate.zPlanes", zPlanes);
+        std::vector<double> rIns   ; c.getVectorDouble("PSEnclosure.endPlate.rIns"   , rIns   );
+        std::vector<double> rOuts  ; c.getVectorDouble("PSEnclosure.endPlate.rOuts"  , rOuts  );
+        // double zlength = 0.;
+        // if(zPlanes.size() > 0 ) {
+        //   zlength = abs(zPlanes[0] - zPlanes[zPlanes.size() - 1]); //planes should be ordered
+        // }
+        res = std::unique_ptr<PSEnclosure>(new PSEnclosure(shellCone,
+                                                           // end plate
+                                                           Polycone(zPlanes,
+                                                                    rIns,
+                                                                    rOuts,
+                                                                    // The vacuum volume is flush to the PS surface
+                                                                    psEndRefPoint + CLHEP::Hep3Vector(0,0, -shellLength),
+                                                                    shellMaterialName
+                                                                    )
+                                                           )
+                                           );
+      }
       res->setExtraOffset ( c.getDouble("PSEnclosure.v2.extraZOffset",0.0) );
 
     } else {
@@ -87,30 +124,30 @@ namespace mu2e {
       const CLHEP::Hep3Vector shellOriginInMu2e(psEndRefPoint + CLHEP::Hep3Vector(0,0, -0.5*shellLength));
 
       res = std::unique_ptr<PSEnclosure> (new PSEnclosure(
-			    // cylindrical shell
-			    Tube(shellMaterialName,
-				 shellOriginInMu2e,
-				 0.5*(shellOD - 2*shellThickness),
-				 0.5*shellOD,
-				 0.5*shellLength),
+                            // cylindrical shell
+                            Tube(shellMaterialName,
+                                 shellOriginInMu2e,
+                                 0.5*(shellOD - 2*shellThickness),
+                                 0.5*shellOD,
+                                 0.5*shellLength),
 
-			    // end plate
-			    Tube(shellMaterialName,
-				 // The vacuum volume is flush to the PS surface
-				 psEndRefPoint + CLHEP::Hep3Vector(0,0, -shellLength - 0.5*endPlateThickness),
-				 0.,
-				 0.5*shellOD,
-				 0.5*endPlateThickness
-				 )                              
-							  )
-			    );
+                            // end plate
+                            Tube(shellMaterialName,
+                                 // The vacuum volume is flush to the PS surface
+                                 psEndRefPoint + CLHEP::Hep3Vector(0,0, -shellLength - 0.5*endPlateThickness),
+                                 0.,
+                                 0.5*shellOD,
+                                 0.5*endPlateThickness
+                                 )
+                                                          )
+                            );
     }
     //----------------------------------------------------------------
     const CLHEP::Hep3Vector winRefPoint = psEndRefPoint + CLHEP::Hep3Vector(0, 0, -totalLength);
 
     const int nwin = c.getInt("PSEnclosure.nWindows");
     for(int i=0; i<nwin; ++i) {
-      res->windows_.push_back(readWindow(i, c, winRefPoint));
+      readWindow(i, c, winRefPoint, res);
     }
 
     //----------------------------------------------------------------

--- a/GeometryService/src/PSEnclosureMaker.cc
+++ b/GeometryService/src/PSEnclosureMaker.cc
@@ -56,7 +56,7 @@ namespace mu2e {
         //Set the pipe to be long enough to intersect both the
         //plate and the window.
         double zlength = abs(res->endPlatePolycone().originInMu2e().z() - windowCenterInMu2e.z()) + zplate;
-        zlength /= abs(std::cos(thetax)*std::cos(thetay));
+        zlength /= 0.9*abs(std::cos(thetax)*std::cos(thetay));
 
         CLHEP::HepRotation matrix = CLHEP::HepRotation();
         matrix.rotateX(thetax);

--- a/GeometryService/src/PSEnclosureMaker.cc
+++ b/GeometryService/src/PSEnclosureMaker.cc
@@ -34,7 +34,7 @@ namespace mu2e {
         const double rFout = rFin+fWid;
 
         //center the frame on the window, but pushed in z to avoid overlaps with the pipe
-        const CLHEP::Hep3Vector frameCenterInMu2e = winRefPoint + CLHEP::Hep3Vector(xoff, yoff, zoff-2.*fHalfThick);
+        const CLHEP::Hep3Vector frameCenterInMu2e = windowCenterInMu2e + CLHEP::Hep3Vector(0., 0., halfThick-fHalfThick);
 
         res->wFrames_.push_back( Tube(c.getString(prefix+"frameMaterialName"),
                                       frameCenterInMu2e,

--- a/Mu2eG4/geom/geom_2021_PhaseI.txt
+++ b/Mu2eG4/geom/geom_2021_PhaseI.txt
@@ -43,7 +43,7 @@ double mu2e.detectorSystemZ0 = 10171.;   // mm  G4BL: (17730-7292=9801 mm)
 #include "Offline/Mu2eG4/geom/DetectorSolenoid_v05.txt"
 #include "Offline/Mu2eG4/geom/DSShielding_v03.txt"
 #include "Offline/Mu2eG4/geom/ProductionSolenoid_v02.txt"
-#include "Offline/Mu2eG4/geom/psEnclosure_v04.txt"
+#include "Offline/Mu2eG4/geom/psEnclosure_v05.txt"
 #include "Offline/Mu2eG4/geom/PSShield_v06.txt"
 #include "Offline/Mu2eG4/geom/PSExternalShielding_v01.txt"
 #include "Offline/Mu2eG4/geom/TransportSolenoid_v08.txt"

--- a/Mu2eG4/geom/geom_2021_PhaseI_v02.txt
+++ b/Mu2eG4/geom/geom_2021_PhaseI_v02.txt
@@ -1,5 +1,5 @@
-// Updated to be used in the MDC2020 simulation campaign, based off Mu2eG4/geom/geom_2019_PhaseI_hayman_v2.txt
-// updates the OPA support structures to remove overlaps
+// Updated to be used in the MDC2020 simulation campaign, based off Mu2eG4/geom/geom_2021_PhaseI.txt
+// Updates made to improve the PS endcap implementation
 
 string detector.name  = "g4geom_v00";
 

--- a/Mu2eG4/geom/geom_2021_PhaseI_v02.txt
+++ b/Mu2eG4/geom/geom_2021_PhaseI_v02.txt
@@ -43,7 +43,7 @@ double mu2e.detectorSystemZ0 = 10171.;   // mm  G4BL: (17730-7292=9801 mm)
 #include "Offline/Mu2eG4/geom/DetectorSolenoid_v05.txt"
 #include "Offline/Mu2eG4/geom/DSShielding_v03.txt"
 #include "Offline/Mu2eG4/geom/ProductionSolenoid_v02.txt"
-#include "Offline/Mu2eG4/geom/psEnclosure_v04.txt"
+#include "Offline/Mu2eG4/geom/psEnclosure_v05.txt"
 #include "Offline/Mu2eG4/geom/PSShield_v06.txt"
 #include "Offline/Mu2eG4/geom/PSExternalShielding_v01.txt"
 #include "Offline/Mu2eG4/geom/TransportSolenoid_v08.txt"

--- a/Mu2eG4/geom/geom_common_current.txt
+++ b/Mu2eG4/geom/geom_common_current.txt
@@ -2,7 +2,7 @@
 // and features that will eventually become default -
 // the latest for testing..
 
-#include "Offline/Mu2eG4/geom/geom_2021_PhaseI.txt"
+#include "Offline/Mu2eG4/geom/geom_2021_PhaseI_v02.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/psEnclosure_v05.txt
+++ b/Mu2eG4/geom/psEnclosure_v05.txt
@@ -1,0 +1,76 @@
+// The configuration to be used with the as-built design, reflected
+// in docdb 8047.  The PSEnclosureShell is part F10031354 in TeamCenter
+
+// Original author Andrei Gaponenko
+// Latest updates by David Norvil Brown (Lou), Dec 2017.
+
+int PSEnclosure.version   = 3;
+
+double PSEnclosure.length = 958.9; // mm
+double PSEnclosure.shell.outerDiameterEast = 1526.6; // mm
+double PSEnclosure.shell.outerDiameterWest = 2217.7; // mm
+double PSEnclosure.shell.thickness = 9.53; // mm
+double PSEnclosure.endPlate.thickness = 6.35; // mm
+double PSEnclosure.v2.extraZOffset = -101.4; // mm
+
+vector<double> PSEnclosure.endPlate.zPlanes = {     0.,    6.34,    6.35, 250.00, 400.00, 405.00}; // mm
+vector<double> PSEnclosure.endPlate.rIns    = {1050.00, 1050.00, 1050.00, 550.00,  50.00,   0.00}; // mm
+vector<double> PSEnclosure.endPlate.rOuts   = {1108.84, 1108.84, 1056.35, 556.35,  56.35,   6.35}; // mm
+
+string PSEnclosure.shell.materialName  = "StainlessSteel316L";
+
+int  PSEnclosure.nWindows = 3;
+//IMPORTANT: Windows must be sorted in increasing z due to plane cuts on pipes at the given z
+
+// ExtMonFNAL window
+string PSEnclosure.window1.materialName = "G4_Ti";
+double PSEnclosure.window1.thickness = 2.84;
+double PSEnclosure.window1.r =  87.54;
+double PSEnclosure.window1.x = -602.8; // relative to PS center
+double PSEnclosure.window1.y =  465; // relative to PS center
+double PSEnclosure.window1.z = -248.41; // relative to PS endplate end
+// ExtMonFNAL window pipe
+double PSEnclosure.window1.pipe.rin  =   84.14.;
+double PSEnclosure.window1.pipe.rout =   87.54;
+double PSEnclosure.window1.pipe.thetaX =  -9.59; //degrees
+double PSEnclosure.window1.pipe.thetaY = -12.26; //degrees
+
+// Primary beam window
+string PSEnclosure.window2.materialName = "G4_Ti";
+double PSEnclosure.window2.thickness = 2.84;
+double PSEnclosure.window2.r =  166.50;
+double PSEnclosure.window2.x = -674.4; // relative to PS center
+double PSEnclosure.window2.y =  102.24; // relative to PS center
+double PSEnclosure.window2.z = -350.01; // relative to PS endplate end
+// Primary beam window pipe
+double PSEnclosure.window2.pipe.rin  =  161.93;
+double PSEnclosure.window2.pipe.rout =  166.50;
+double PSEnclosure.window2.pipe.thetaX =  -2.18.; //degrees
+double PSEnclosure.window2.pipe.thetaY = -13.73; //degrees
+
+// Central axis target access window
+string PSEnclosure.window3.materialName = "G4_Ti";
+double PSEnclosure.window3.thickness = 2.84;
+double PSEnclosure.window3.r =  254;
+double PSEnclosure.window3.x =  0.; // relative to PS center
+double PSEnclosure.window3.y =  0.; // relative to PS center
+double PSEnclosure.window3.z = -350.01; // relative to PS endplate end
+
+// Central axis target access window pipe
+double PSEnclosure.window3.pipe.rin  =  249.17.;
+double PSEnclosure.window3.pipe.rout =  254.;
+double PSEnclosure.window3.pipe.thetaX = 0.; //degrees
+double PSEnclosure.window3.pipe.thetaY = 0.; //degrees
+
+bool  PSEnclosure.visible = true;
+bool  PSEnclosure.solid = false;
+
+bool  PSEnclosure.vacuum.visible = true;
+bool  PSEnclosure.vacuum.solid = false;
+
+int   PSEnclosure.verbosityLevel = 1;
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/psEnclosure_v05.txt
+++ b/Mu2eG4/geom/psEnclosure_v05.txt
@@ -5,9 +5,8 @@
 // Original author Andrei Gaponenko
 // Latest updates by Michael MacKenzie and David Norvil Brown (WKU), Sept 2021.
 
-int   PSEnclosure.version   = 3;
+int   PSEnclosure.version        = 3;
 int   PSEnclosure.verbosityLevel = 0;
-
 
 double PSEnclosure.length = 955.5; // mm
 double PSEnclosure.shell.outerDiameterEast = 1526.6; // mm
@@ -20,14 +19,18 @@ double PSEnclosure.endPlate.inset  = 500.0; // mm to East of shell end
 double PSEnclosure.endPlate.radius = 550.0; // mm total approximation
 
 // Flange on the shell
-double PSEnclosure.flange.rInner  = 1035.0; //mm
-double PSEnclosure.flange.rOuter  = 1123.95; //mm
-double PSEnclosure.flange.thickness = 50.8; // mm (2 in) in z-direction
+double PSEnclosure.flange.rInner  = 1035.05; //mm
+double PSEnclosure.flange.rOuter  = 1123.95; //mm 3.5" wide
+double PSEnclosure.flange.thickness = 50.8; // mm 2 in thick in z
 string PSEnclosure.flange.materialName = "StainlessSteel316L";
 
-vector<double> PSEnclosure.endPlate.zPlanes = {     0.,    6.34,    6.35, 250.00, 400.00, 405.00}; // mm
-vector<double> PSEnclosure.endPlate.rIns    = {1050.00, 1050.00, 1050.00, 550.00,  50.00,   0.00}; // mm
-vector<double> PSEnclosure.endPlate.rOuts   = {1108.84, 1108.84, 1056.35, 556.35,  56.35,   6.35}; // mm
+//end plate curves in 21.98 inches into the PS, including the 2" flange
+//starts with an inner diameter of 81.5 inches and is 1/4" thick
+//approximate the curve with a few points by eye
+//add a final plane with near 0 radius to ensure cleaning off tube ends cuts through all tubes
+vector<double> PSEnclosure.endPlate.zPlanes = {     0.,    6.35,  130.00, 260.00, 501.13, 501.14, 507.49, 507.491}; // mm
+vector<double> PSEnclosure.endPlate.rIns    = {1035.05, 1035.05, 1009.65, 860.00, 350.00,   0.00,   0.00,   0.000}; // mm
+vector<double> PSEnclosure.endPlate.rOuts   = {1041.40, 1041.40, 1016.00, 866.35, 356.35, 356.35, 356.35,   0.001}; // mm
 
 
 string PSEnclosure.shell.materialName  = "StainlessSteel316L";
@@ -40,16 +43,16 @@ int  PSEnclosure.nWindows = 3;
 string PSEnclosure.window1.materialName = "G4_Ti";
 double PSEnclosure.window1.thickness = 2.84;
 double PSEnclosure.window1.r =  87.54;
-double PSEnclosure.window1.x = -602.8; // relative to PS center
-double PSEnclosure.window1.y =  465; // relative to PS center
-double PSEnclosure.window1.z = -248.41; // relative to PS endplate end
+double PSEnclosure.window1.x = -683.23; // relative to PS center
+double PSEnclosure.window1.y =  520.37; // relative to PS center
+double PSEnclosure.window1.z = -197.61; // 9.78" past endplate, z is relative to PS endplate end
 bool   PSEnclosure.window1.hasFrame = true;
-double PSEnclosure.window1.frameThickness = 25.4;//mm
+double PSEnclosure.window1.frameThickness = 22.23;//mm 0.875" thick
 double PSEnclosure.window1.frameRadialWidth = 50.8;//mm
 string PSEnclosure.window1.frameMaterialName = "StainlessSteel316L";
 // ExtMonFNAL window pipe
-double PSEnclosure.window1.pipe.rin  =   84.14.;
-double PSEnclosure.window1.pipe.rout =   87.54;
+double PSEnclosure.window1.pipe.rin  =   80.73; //0.134" thick
+double PSEnclosure.window1.pipe.rout =   84.14; //6.625" outer diameter
 double PSEnclosure.window1.pipe.thetaX =  -9.59; //degrees
 double PSEnclosure.window1.pipe.thetaY = -12.26; //degrees
 
@@ -57,16 +60,16 @@ double PSEnclosure.window1.pipe.thetaY = -12.26; //degrees
 string PSEnclosure.window2.materialName = "G4_Ti";
 double PSEnclosure.window2.thickness = 2.84;
 double PSEnclosure.window2.r =  166.50;
-double PSEnclosure.window2.x = -674.4; // relative to PS center
-double PSEnclosure.window2.y =  102.24; // relative to PS center
-double PSEnclosure.window2.z = -350.01; // relative to PS endplate end
+double PSEnclosure.window2.x = -786.05; // relative to PS center
+double PSEnclosure.window2.y =  122.76; // relative to PS center
+double PSEnclosure.window2.z = -282.96; // 13.14" past endplate, z is relative to PS endplate end without 2" frame
 bool   PSEnclosure.window2.hasFrame = true;
-double PSEnclosure.window2.frameThickness = 25.4;//mm
+double PSEnclosure.window2.frameThickness = 22.23;//mm 0.875" thick
 double PSEnclosure.window2.frameRadialWidth = 50.8;//mm
 string PSEnclosure.window2.frameMaterialName = "StainlessSteel316L";
 // Primary beam window pipe
-double PSEnclosure.window2.pipe.rin  =  161.93;
-double PSEnclosure.window2.pipe.rout =  166.50;
+double PSEnclosure.window2.pipe.rin  =  157.353; //0.18" thick wall
+double PSEnclosure.window2.pipe.rout =  161.925; //12.75" outer diameter
 double PSEnclosure.window2.pipe.thetaX =  -2.18.; //degrees
 double PSEnclosure.window2.pipe.thetaY = -13.73; //degrees
 
@@ -76,13 +79,12 @@ double PSEnclosure.window3.thickness = 2.84;
 double PSEnclosure.window3.r =  254;
 double PSEnclosure.window3.x =  0.; // relative to PS center
 double PSEnclosure.window3.y =  0.; // relative to PS center
-double PSEnclosure.window3.z = -350.01; // relative to PS endplate end
+double PSEnclosure.window3.z = -289.82; // 35.14" long, 13.78" past endplate, z is relative to PS endplate end
 bool   PSEnclosure.window3.hasFrame = true;
-double PSEnclosure.window3.frameThickness = 25.4;//mm
-double PSEnclosure.window3.frameRadialWidth = 50.8;//mm
+double PSEnclosure.window3.frameThickness = 22.23;//mm 0.875" thick
+double PSEnclosure.window3.frameRadialWidth = 50.8;//mm 2" wide
 string PSEnclosure.window3.frameMaterialName = "StainlessSteel316L";
-// Central axis target access window pipe
-double PSEnclosure.window3.pipe.rin  =  249.17.;
+double PSEnclosure.window3.pipe.rin  =  249.17.; //use the radius in the west end
 double PSEnclosure.window3.pipe.rout =  254.;
 double PSEnclosure.window3.pipe.thetaX = 0.; //degrees
 double PSEnclosure.window3.pipe.thetaY = 0.; //degrees

--- a/Mu2eG4/geom/psEnclosure_v05.txt
+++ b/Mu2eG4/geom/psEnclosure_v05.txt
@@ -1,25 +1,37 @@
 // The configuration to be used with the as-built design, reflected
+// The configuration to be used with the as-built design, reflected
 // in docdb 8047.  The PSEnclosureShell is part F10031354 in TeamCenter
 
 // Original author Andrei Gaponenko
-// Latest updates by David Norvil Brown (Lou), Dec 2017.
+// Latest updates by Michael MacKenzie and David Norvil Brown (WKU), Sept 2021.
 
 int PSEnclosure.version   = 3;
 
-double PSEnclosure.length = 958.9; // mm
+double PSEnclosure.length = 955.5; // mm
 double PSEnclosure.shell.outerDiameterEast = 1526.6; // mm
 double PSEnclosure.shell.outerDiameterWest = 2217.7; // mm
-double PSEnclosure.shell.thickness = 9.53; // mm
-double PSEnclosure.endPlate.thickness = 6.35; // mm
+double PSEnclosure.shell.thickness = 9.53; // mm  (3/8 inch)
+double PSEnclosure.endPlate.thickness = 6.35; // mm (1/4 inch)
 double PSEnclosure.v2.extraZOffset = -101.4; // mm
+
+double PSEnclosure.endPlate.inset  = 500.0; // mm to East of shell end
+double PSEnclosure.endPlate.radius = 550.0; // mm total approximation
+
+// Flange on the shell
+double PSEnclosure.flange.rInner  = 1035.0; //mm
+double PSEnclosure.flange.rOuter  = 1123.95; //mm
+double PSEnclosure.flange.thickness = 50.8; // mm (2 in) in z-direction
+string PSEnclosure.flange.materialName = "StainlessSteel316L";
 
 vector<double> PSEnclosure.endPlate.zPlanes = {     0.,    6.34,    6.35, 250.00, 400.00, 405.00}; // mm
 vector<double> PSEnclosure.endPlate.rIns    = {1050.00, 1050.00, 1050.00, 550.00,  50.00,   0.00}; // mm
 vector<double> PSEnclosure.endPlate.rOuts   = {1108.84, 1108.84, 1056.35, 556.35,  56.35,   6.35}; // mm
 
+
 string PSEnclosure.shell.materialName  = "StainlessSteel316L";
 
 int  PSEnclosure.nWindows = 3;
+
 //IMPORTANT: Windows must be sorted in increasing z due to plane cuts on pipes at the given z
 
 // ExtMonFNAL window
@@ -29,6 +41,10 @@ double PSEnclosure.window1.r =  87.54;
 double PSEnclosure.window1.x = -602.8; // relative to PS center
 double PSEnclosure.window1.y =  465; // relative to PS center
 double PSEnclosure.window1.z = -248.41; // relative to PS endplate end
+bool   PSEnclosure.window1.hasFrame = true;
+double PSEnclosure.window1.frameThickness = 25.4;//mm
+double PSEnclosure.window1.frameRadialWidth = 50.8;//mm
+string PSEnclosure.window1.frameMaterialName = "StainlessSteel316L";
 // ExtMonFNAL window pipe
 double PSEnclosure.window1.pipe.rin  =   84.14.;
 double PSEnclosure.window1.pipe.rout =   87.54;
@@ -42,6 +58,10 @@ double PSEnclosure.window2.r =  166.50;
 double PSEnclosure.window2.x = -674.4; // relative to PS center
 double PSEnclosure.window2.y =  102.24; // relative to PS center
 double PSEnclosure.window2.z = -350.01; // relative to PS endplate end
+bool   PSEnclosure.window2.hasFrame = true;
+double PSEnclosure.window2.frameThickness = 25.4;//mm
+double PSEnclosure.window2.frameRadialWidth = 50.8;//mm
+string PSEnclosure.window2.frameMaterialName = "StainlessSteel316L";
 // Primary beam window pipe
 double PSEnclosure.window2.pipe.rin  =  161.93;
 double PSEnclosure.window2.pipe.rout =  166.50;
@@ -55,7 +75,10 @@ double PSEnclosure.window3.r =  254;
 double PSEnclosure.window3.x =  0.; // relative to PS center
 double PSEnclosure.window3.y =  0.; // relative to PS center
 double PSEnclosure.window3.z = -350.01; // relative to PS endplate end
-
+bool   PSEnclosure.window3.hasFrame = true;
+double PSEnclosure.window3.frameThickness = 25.4;//mm
+double PSEnclosure.window3.frameRadialWidth = 50.8;//mm
+string PSEnclosure.window3.frameMaterialName = "StainlessSteel316L";
 // Central axis target access window pipe
 double PSEnclosure.window3.pipe.rin  =  249.17.;
 double PSEnclosure.window3.pipe.rout =  254.;
@@ -69,6 +92,7 @@ bool  PSEnclosure.vacuum.visible = true;
 bool  PSEnclosure.vacuum.solid = false;
 
 int   PSEnclosure.verbosityLevel = 1;
+
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/psEnclosure_v05.txt
+++ b/Mu2eG4/geom/psEnclosure_v05.txt
@@ -5,7 +5,9 @@
 // Original author Andrei Gaponenko
 // Latest updates by Michael MacKenzie and David Norvil Brown (WKU), Sept 2021.
 
-int PSEnclosure.version   = 3;
+int   PSEnclosure.version   = 3;
+int   PSEnclosure.verbosityLevel = 0;
+
 
 double PSEnclosure.length = 955.5; // mm
 double PSEnclosure.shell.outerDiameterEast = 1526.6; // mm
@@ -90,8 +92,6 @@ bool  PSEnclosure.solid = false;
 
 bool  PSEnclosure.vacuum.visible = true;
 bool  PSEnclosure.vacuum.solid = false;
-
-int   PSEnclosure.verbosityLevel = 1;
 
 
 // This tells emacs to view this file in c++ mode.

--- a/Mu2eG4/geom/psEnclosure_v05.txt
+++ b/Mu2eG4/geom/psEnclosure_v05.txt
@@ -1,6 +1,6 @@
 // The configuration to be used with the as-built design, reflected
-// The configuration to be used with the as-built design, reflected
 // in docdb 8047.  The PSEnclosureShell is part F10031354 in TeamCenter
+// Description of version 5 updates are given in docdb-39987
 
 // Original author Andrei Gaponenko
 // Latest updates by Michael MacKenzie and David Norvil Brown (WKU), Sept 2021.
@@ -42,7 +42,7 @@ int  PSEnclosure.nWindows = 3;
 // ExtMonFNAL window
 string PSEnclosure.window1.materialName = "G4_Ti";
 double PSEnclosure.window1.thickness = 2.84;
-double PSEnclosure.window1.r =  87.54;
+double PSEnclosure.window1.r =  84.14;
 double PSEnclosure.window1.x = -683.23; // relative to PS center
 double PSEnclosure.window1.y =  520.37; // relative to PS center
 double PSEnclosure.window1.z = -197.61; // 9.78" past endplate, z is relative to PS endplate end
@@ -59,7 +59,7 @@ double PSEnclosure.window1.pipe.thetaY = -12.26; //degrees
 // Primary beam window
 string PSEnclosure.window2.materialName = "G4_Ti";
 double PSEnclosure.window2.thickness = 2.84;
-double PSEnclosure.window2.r =  166.50;
+double PSEnclosure.window2.r =  161.925;
 double PSEnclosure.window2.x = -786.05; // relative to PS center
 double PSEnclosure.window2.y =  122.76; // relative to PS center
 double PSEnclosure.window2.z = -282.96; // 13.14" past endplate, z is relative to PS endplate end without 2" frame

--- a/Mu2eG4/src/constructPS.cc
+++ b/Mu2eG4/src/constructPS.cc
@@ -19,6 +19,7 @@
 #include "Offline/GeometryService/inc/G4GeometryOptions.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/ProductionTargetGeom/inc/ProductionTarget.hh"
+#include "Offline/ProductionSolenoidGeom/inc/PSEnclosure.hh"
 #include "Offline/Mu2eG4/inc/findMaterialOrThrow.hh"
 #include "Offline/Mu2eG4/inc/constructPS.hh"
 #include "Offline/Mu2eG4/inc/constructPSShield.hh"
@@ -39,6 +40,8 @@
 #include "Geant4/G4Polycone.hh"
 #include "Geant4/G4SDManager.hh"
 #include "Geant4/G4LogicalVolume.hh"
+#include "Geant4/G4Tubs.hh"
+#include "Geant4/G4SubtractionSolid.hh"
 
 #include "cetlib_except/exception.h"
 #include "CLHEP/Units/SystemOfUnits.h"
@@ -292,17 +295,56 @@ namespace mu2e {
 
 
     Tube const & psVacuumParams  = GeomHandle<PSVacuum>()->vacuum();
-
-    VolumeInfo psVacuumInfo   = nestTubs( "PSVacuum",
-                                          psVacuumParams.getTubsParams(),
-                                          findMaterialOrThrow(psVacuumParams.materialName()),
-                                          0,
-                                          psVacuumParams.originInMu2e()-_hallOriginInMu2e,
-                                          parent,
-                                          0,
-                                          G4Colour::Blue(),
-					  "PS"
-                                          );
+    GeomHandle<PSEnclosure> pse;
+    VolumeInfo psVacuumInfo("PSVacuum", psVacuumParams.originInMu2e() - _hallOriginInMu2e, parent.centerInWorld);
+    if(pse->version() < 3) {
+      psVacuumInfo = nestTubs( "PSVacuum",
+                               psVacuumParams.getTubsParams(),
+                               findMaterialOrThrow(psVacuumParams.materialName()),
+                               0,
+                               psVacuumParams.originInMu2e()-_hallOriginInMu2e,
+                               parent,
+                               0,
+                               G4Colour::Blue(),
+                               "PS"
+                               );
+    } else { //remove any of the PS vacuum from the PS end cap region
+      CLHEP::Hep3Vector extraOffset(0.,0.,pse->getExtraOffset());
+      const TubsParams& psVacuumTubsParams = psVacuumParams.getTubsParams();
+      G4Tubs* psVacuumTubs = new G4Tubs("PSVacuumTube",
+                                        psVacuumTubsParams.innerRadius(),
+                                        psVacuumTubsParams.outerRadius(),
+                                        psVacuumTubsParams.zHalfLength(),
+                                        0., CLHEP::twopi);
+      auto polycone = pse->endPlatePolycone();
+      std::vector<double> rInners, rOuters(polycone.rOuter()), zPlanes(polycone.zPlanes());
+      for(unsigned iplane = 0; iplane <= polycone.numZPlanes(); ++iplane) {
+        rInners.push_back(0.); //clear from center to outer radius
+      }
+      rOuters.insert(rOuters.begin(), rOuters.front());
+      zPlanes.insert(zPlanes.begin(), zPlanes.front()-2.e3); //clear beyond the endcap as well
+      G4Polycone* basecone = new G4Polycone("PSEnclosureEndplateBaseCone_FromPS",
+                                            polycone.phi0(),
+                                            polycone.phiTotal(),
+                                            zPlanes.size(),
+                                            &zPlanes[0],
+                                            &rInners[0],
+                                            &rOuters[0]
+                                            );
+      G4SubtractionSolid* psVacuumSolid = new G4SubtractionSolid("PSVacuum", psVacuumTubs, basecone,
+                                                                 nullptr, //assume no relative rotation
+                                                                 polycone.originInMu2e() - psVacuumParams.originInMu2e() + extraOffset);
+      psVacuumInfo.solid = psVacuumSolid;
+      finishNesting(psVacuumInfo,
+                    findMaterialOrThrow(psVacuumParams.materialName()),
+                    nullptr,
+                    psVacuumParams.originInMu2e()-_hallOriginInMu2e,
+                    parent.logical,
+                    0,
+                    G4Colour::Blue(),
+                    "PS"
+                    );
+    }
     //    std::cout << "inside " << __func__ << psVacuumParams.originInMu2e() << " " << _hallOriginInMu2e << std::endl;
 
     // Build the production target.

--- a/Mu2eG4/src/constructPS.cc
+++ b/Mu2eG4/src/constructPS.cc
@@ -323,10 +323,8 @@ namespace mu2e {
       }
       for(unsigned iplane = 0; iplane <= polycone.numZPlanes(); ++iplane) {
         rInners.push_back(0.); //clear from center to outer radius
-        if(iplane < polycone.numZPlanes()) {
-          rOuters[iplane] = rOuters[iplane] + 0.01; //add an extra 10 um gap
-          zPlanes[iplane] = zPlanes[iplane] + 0.01; //add an extra 10 um gap
-          if( verbosityLevel > 1) {
+        if( verbosityLevel > 1) {
+          if(iplane < polycone.numZPlanes()) {
             cout << " (r1, r2, z) = (" << rInners[iplane] << ", " << rOuters[iplane]
                  << ", " << zPlanes[iplane] << ")\n";
           }

--- a/Mu2eG4/src/constructPS.cc
+++ b/Mu2eG4/src/constructPS.cc
@@ -318,11 +318,22 @@ namespace mu2e {
                                         0., CLHEP::twopi);
       auto polycone = pse->endPlatePolycone();
       std::vector<double> rInners, rOuters(polycone.rOuter()), zPlanes(polycone.zPlanes());
+      if ( verbosityLevel > 1) {
+        cout << __func__ << " printing PS enclosure planes to subtract from PS vacuum:\n";
+      }
       for(unsigned iplane = 0; iplane <= polycone.numZPlanes(); ++iplane) {
         rInners.push_back(0.); //clear from center to outer radius
+        if(iplane < polycone.numZPlanes()) {
+          rOuters[iplane] = rOuters[iplane] + 0.01; //add an extra 10 um gap
+          zPlanes[iplane] = zPlanes[iplane] + 0.01; //add an extra 10 um gap
+          if( verbosityLevel > 1) {
+            cout << " (r1, r2, z) = (" << rInners[iplane] << ", " << rOuters[iplane]
+                 << ", " << zPlanes[iplane] << ")\n";
+          }
+        }
       }
       rOuters.insert(rOuters.begin(), rOuters.front());
-      zPlanes.insert(zPlanes.begin(), zPlanes.front()-2.e3); //clear beyond the endcap as well
+      zPlanes.insert(zPlanes.begin(), zPlanes.front()-1.e3); //clear beyond the endcap as well
       G4Polycone* basecone = new G4Polycone("PSEnclosureEndplateBaseCone_FromPS",
                                             polycone.phi0(),
                                             polycone.phiTotal(),

--- a/Mu2eG4/src/constructPSEnclosure.cc
+++ b/Mu2eG4/src/constructPSEnclosure.cc
@@ -13,15 +13,25 @@
 #include "Offline/GeometryService/inc/G4GeometryOptions.hh"
 #include "Offline/GeomPrimitives/inc/Tube.hh"
 #include "Offline/GeomPrimitives/inc/Cone.hh"
+#include "Offline/GeomPrimitives/inc/Polycone.hh"
 #include "Offline/GeomPrimitives/inc/TubsParams.hh"
 #include "Offline/Mu2eG4/inc/findMaterialOrThrow.hh"
+#include "Offline/Mu2eG4/inc/finishNesting.hh"
 #include "Offline/Mu2eG4/inc/nestTubs.hh"
 #include "Offline/Mu2eG4/inc/nestCons.hh"
 #include "Offline/Mu2eG4Helper/inc/VolumeInfo.hh"
 #include "Offline/ConfigTools/inc/SimpleConfig.hh"
 #include "Offline/Mu2eG4Helper/inc/Mu2eG4Helper.hh"
 
+#include "Geant4/G4RotationMatrix.hh"
 #include "Geant4/G4LogicalVolume.hh"
+#include "Geant4/G4VSolid.hh"
+#include "Geant4/G4Polycone.hh"
+#include "Geant4/G4Cons.hh"
+#include "Geant4/G4Tubs.hh"
+#include "Geant4/G4Box.hh"
+#include "Geant4/G4SubtractionSolid.hh"
+#include "Geant4/G4UnionSolid.hh"
 
 namespace mu2e {
 
@@ -38,13 +48,13 @@ namespace mu2e {
     geomOptions->loadEntry( config, "psEnclosure", "psEnclosure");
     geomOptions->loadEntry( config, "psEnclosureVacuum", "psEnclosure.vacuum");
 
-    const bool PSIsVisible         = geomOptions->isVisible("psEnclosure"); 
-    const bool PSVacuumIsVisible   = geomOptions->isVisible("psEnclosureVacuum"); 
-    const bool PSIsSolid           = geomOptions->isSolid("psEnclosure"); 
-    const bool PSVacuumIsSolid     = geomOptions->isSolid("psEnclosureVacuum"); 
-    const bool forceAuxEdgeVisible = geomOptions->forceAuxEdgeVisible("psEnclosure"); 
-    const bool doSurfaceCheck      = geomOptions->doSurfaceCheck("psEnclosure"); 
-    const bool placePV             = geomOptions->placePV("psEnclosure"); 
+    const bool PSIsVisible         = geomOptions->isVisible("psEnclosure");
+    const bool PSVacuumIsVisible   = geomOptions->isVisible("psEnclosureVacuum");
+    const bool PSIsSolid           = geomOptions->isSolid("psEnclosure");
+    const bool PSVacuumIsSolid     = geomOptions->isSolid("psEnclosureVacuum");
+    const bool forceAuxEdgeVisible = geomOptions->forceAuxEdgeVisible("psEnclosure");
+    const bool doSurfaceCheck      = geomOptions->doSurfaceCheck("psEnclosure");
+    const bool placePV             = geomOptions->placePV("psEnclosure");
     const int  verbosityLevel      = config.getInt("PSEnclosure.verbosityLevel",0);
 
 
@@ -53,123 +63,22 @@ namespace mu2e {
     std::string sName = "PSEnclosureShell";
     if ( pse->version() > 1 ) {
       double consParams[7] = { pse->shellCone().innerRadius1(),
-			       pse->shellCone().outerRadius1(),
-			       pse->shellCone().innerRadius2(),
-			       pse->shellCone().outerRadius2(),
-			       pse->shellCone().halfLength(),
-			       pse->shellCone().phi0(),
-			       pse->shellCone().deltaPhi() };
+                               pse->shellCone().outerRadius1(),
+                               pse->shellCone().innerRadius2(),
+                               pse->shellCone().outerRadius2(),
+                               pse->shellCone().halfLength(),
+                               pse->shellCone().phi0(),
+                               pse->shellCone().deltaPhi() };
       nestCons( sName,
-		consParams,
-		findMaterialOrThrow(pse->shellCone().materialName()),
-		0,
-		pse->shellCone().originInMu2e() - parent.centerInMu2e()
-		+ extraOffset,
-		parent,
-		0,
-	       PSIsVisible,
-	       G4Colour::Blue(),
-	       PSIsSolid,
-	       forceAuxEdgeVisible,
-	       placePV,
-	       doSurfaceCheck
-	       );
-		
-
-    } else {
-      nestTubs(sName,
-	       pse->shell().getTubsParams(),
-	       findMaterialOrThrow(pse->shell().materialName()),
-	       0,
-	       pse->shell().originInMu2e() - parent.centerInMu2e(),
-	       parent,
-	       0,
-	       PSIsVisible,
-	       G4Colour::Blue(),
-	       PSIsSolid,
-	       forceAuxEdgeVisible,
-	       placePV,
-	       doSurfaceCheck
-	       );
-    }
-
-    // get the mass of the Shell
-    Mu2eG4Helper* _helper = &(*art::ServiceHandle<Mu2eG4Helper>());
-    verbosityLevel 
-      && std::cout << __func__ << " " << sName << " Mass in kg: " 
-                   << _helper->locateVolInfo(sName).logical->GetMass()/CLHEP::kg 
-                   << std::endl;
-
-    sName = "PSEnclosureEndPlate";
-    const VolumeInfo endPlate = nestTubs(sName,
-                                         pse->endPlate().getTubsParams(),
-                                         findMaterialOrThrow(pse->endPlate().materialName()),
-                                         0,
-                                         pse->endPlate().originInMu2e() - parent.centerInMu2e() + extraOffset,
-                                         parent,
-                                         0,
-                                         PSIsVisible,
-                                         G4Colour::Blue(),
-                                         PSIsSolid,
-                                         forceAuxEdgeVisible,
-                                         placePV,
-                                         doSurfaceCheck
-                                         );
-
-
-    verbosityLevel 
-      && std::cout << __func__ << " " << sName << " Mass in kg: " 
-                   << _helper->locateVolInfo(sName).logical->GetMass()/CLHEP::kg 
-                   << std::endl;
-    //----------------------------------------------------------------
-    // Install the windows
-
-    for(unsigned i=0; i<pse->nWindows(); ++i) {
-
-      CLHEP::Hep3Vector windOff(0,0,pse->windows()[i].halfLength());
-
-      // Hole in the endPlate for the window
-      const CLHEP::Hep3Vector vacCenter =
-        pse->windows()[i].originInMu2e() +
-        CLHEP::Hep3Vector(0,0, pse->endPlate().halfLength())   + extraOffset
-	+ windOff;
-			  
-
-      const TubsParams vacTubs(pse->windows()[i].innerRadius(),
-                               pse->windows()[i].outerRadius(),
-                               pse->endPlate().halfLength()
-                               );
-
-      std::ostringstream vname;
-      vname<<"PSEnclosureWindowVac"<<i;
-      nestTubs(vname.str(),
-               vacTubs,
-               findMaterialOrThrow(psv->vacuum().materialName()),
-               0,
-               vacCenter - endPlate.centerInMu2e(),
-               endPlate,
-               0,
-               PSVacuumIsVisible,
-               G4Colour::Black(),
-               PSVacuumIsSolid,
-               forceAuxEdgeVisible,
-               placePV,
-               doSurfaceCheck
-               );
-
-      // The window itself
-      std::ostringstream wname;
-      wname<<"PSEnclosureWindow"<<i;
-
-      nestTubs(wname.str(),
-               pse->windows()[i].getTubsParams(),
-               findMaterialOrThrow(pse->windows()[i].materialName()),
-               0,
-               pse->windows()[i].originInMu2e() - parent.centerInMu2e() + extraOffset,
-               parent,
-               0,
+                consParams,
+                findMaterialOrThrow(pse->shellCone().materialName()),
+                0,
+                pse->shellCone().originInMu2e() - parent.centerInMu2e()
+                + extraOffset,
+                parent,
+                0,
                PSIsVisible,
-               G4Colour::Grey(),
+               G4Colour::Blue(),
                PSIsSolid,
                forceAuxEdgeVisible,
                placePV,
@@ -177,15 +86,238 @@ namespace mu2e {
                );
 
 
-      verbosityLevel
-        && std::cout << __func__ << " " << wname.str() << " center in Mu2e: "
-                     <<pse->windows()[i].originInMu2e()
-                     << std::endl;
+    } else {
+      nestTubs(sName,
+               pse->shell().getTubsParams(),
+               findMaterialOrThrow(pse->shell().materialName()),
+               0,
+               pse->shell().originInMu2e() - parent.centerInMu2e(),
+               parent,
+               0,
+               PSIsVisible,
+               G4Colour::Blue(),
+               PSIsSolid,
+               forceAuxEdgeVisible,
+               placePV,
+               doSurfaceCheck
+               );
     }
 
-    verbosityLevel 
-      && std::cout << __func__ << " " << sName << " with windows Mass in kg: " 
-                   << _helper->locateVolInfo(sName).logical->GetMass()/CLHEP::kg 
+    // get the mass of the Shell
+    Mu2eG4Helper* _helper = &(*art::ServiceHandle<Mu2eG4Helper>());
+    verbosityLevel
+      && std::cout << __func__ << " " << sName << " Mass in kg: "
+                   << _helper->locateVolInfo(sName).logical->GetMass()/CLHEP::kg
+                   << std::endl;
+
+    if(pse->version() < 3) {
+      sName = "PSEnclosureEndPlate";
+      const VolumeInfo endPlate = nestTubs(sName,
+                                           pse->endPlate().getTubsParams(),
+                                           findMaterialOrThrow(pse->endPlate().materialName()),
+                                           nullptr,
+                                           pse->endPlate().originInMu2e() - parent.centerInMu2e() + extraOffset,
+                                           parent,
+                                           0,
+                                           PSIsVisible,
+                                           G4Colour::Blue(),
+                                           PSIsSolid,
+                                           forceAuxEdgeVisible,
+                                           placePV,
+                                           doSurfaceCheck
+                                           );
+
+
+      verbosityLevel
+        && std::cout << __func__ << " " << sName << " Mass in kg: "
+                     << _helper->locateVolInfo(sName).logical->GetMass()/CLHEP::kg
+                     << std::endl;
+      //----------------------------------------------------------------
+      // Install the windows
+
+      for(unsigned i=0; i<pse->nWindows(); ++i) {
+
+        CLHEP::Hep3Vector windOff(0,0,pse->windows()[i].halfLength());
+
+        // Hole in the endPlate for the window
+        const CLHEP::Hep3Vector vacCenter =
+          pse->windows()[i].originInMu2e() +
+          CLHEP::Hep3Vector(0,0, pse->endPlate().halfLength())   + extraOffset
+          + windOff;
+
+
+        const TubsParams vacTubs(pse->windows()[i].innerRadius(),
+                                 pse->windows()[i].outerRadius(),
+                                 pse->endPlate().halfLength()
+                                 );
+
+        std::ostringstream vname;
+        vname<<"PSEnclosureWindowVac"<<i;
+        nestTubs(vname.str(),
+                 vacTubs,
+                 findMaterialOrThrow(psv->vacuum().materialName()),
+                 0,
+                 vacCenter - endPlate.centerInMu2e(),
+                 endPlate,
+                 0,
+                 PSVacuumIsVisible,
+                 G4Colour::Black(),
+                 PSVacuumIsSolid,
+                 forceAuxEdgeVisible,
+                 placePV,
+                 doSurfaceCheck
+                 );
+
+        // The window itself
+        std::ostringstream wname;
+        wname<<"PSEnclosureWindow"<<i;
+
+        nestTubs(wname.str(),
+                 pse->windows()[i].getTubsParams(),
+                 findMaterialOrThrow(pse->windows()[i].materialName()),
+                 0,
+                 pse->windows()[i].originInMu2e() - parent.centerInMu2e() + extraOffset,
+                 parent,
+                 0,
+                 PSIsVisible,
+                 G4Colour::Grey(),
+                 PSIsSolid,
+                 forceAuxEdgeVisible,
+                 placePV,
+                 doSurfaceCheck
+                 );
+
+
+        verbosityLevel
+          && std::cout << __func__ << " " << wname.str() << " center in Mu2e: "
+                       <<pse->windows()[i].originInMu2e()
+                       << std::endl;
+      } //end window for loop
+    } //end version < 3 endplate construction
+    else { //build version >= 3 endcap
+      auto polycone = pse->endPlatePolycone();
+      verbosityLevel
+        && std::cout << __func__ << ": PSEndPlate polycone: "
+                     << polycone
+                     << std::endl;
+      G4Polycone* basecone = new G4Polycone("PSEnclosureEndplateBaseCone",
+                                            polycone.phi0(),
+                                            polycone.phiTotal(),
+                                            polycone.numZPlanes(),
+                                            &polycone.zPlanes()[0],
+                                            &polycone.rInner()[0],
+                                            &polycone.rOuter()[0]
+                                            );
+      G4VSolid* solid = basecone;
+      // double zlength = 0.;
+      // if(polycone.zPlanes().size() > 0 ) {
+      //   zlength = abs(polycone.zPlanes()[0] - polycone.zPlanes()[polycone.zPlanes().size() - 1]); //planes should be ordered
+      // }
+      CLHEP::Hep3Vector coneOrigin = polycone.originInMu2e();
+      // coneOrigin.setZ(coneOrigin.z());
+      //punch a hole in the endcap for each window
+      for(unsigned iwindow = 0; iwindow<pse->nWindows(); ++iwindow) {
+        Tube pipe = pse->windowPipes()[iwindow];
+        std::ostringstream pipename, solidname, windowname, boxname;
+        pipename << "PSEnclosurePipeHole_" << iwindow+1;
+        solidname << "PSEnclosurePlateTmp_" << iwindow+1;
+        boxname   << "PSEnclosurePlateBox_" << iwindow+1;
+        windowname   << "PSEnclosureWindow_" << iwindow+1;
+        //make a solid pipe that is the hole in the pipe, to make a hole in the endplate
+        G4Tubs* pipetube = new G4Tubs(pipename.str(), 0., pipe.innerRadius(), pipe.halfLength(), 0., CLHEP::twopi);
+        G4RotationMatrix* matrix = new G4RotationMatrix(pipe.rotation());
+        CLHEP::Hep3Vector tubeOrigin = pipe.originInMu2e() - coneOrigin;
+        verbosityLevel
+          && std::cout << __func__ << ": PSEndPlate tube " << iwindow << ": "
+                       << pipe << " origin from end plate: " << tubeOrigin
+                       << std::endl;
+        solid = new G4SubtractionSolid(solidname.str(), solid, pipetube,
+                                       matrix, tubeOrigin );
+        //next fuse the pipe to the endplate
+        pipetube = new G4Tubs(windowname.str()+"_2", pipe.innerRadius(), pipe.outerRadius(), pipe.halfLength(), 0., CLHEP::twopi);
+        solid = new G4UnionSolid(solidname.str()+"_2", solid, pipetube,
+                                 matrix, tubeOrigin);
+        //next cut off a z-plane face for the window
+        CLHEP::Hep3Vector pipeaxis(0.,.0,1.);
+        pipeaxis = pipe.rotation()*pipeaxis;
+        const double boxside = abs(pipe.outerRadius()/pipeaxis.z())*10.; //cut off everything in this plane essentially
+        const double boxlength = pipe.halfLength()*10.;
+        G4Box* box = new G4Box(boxname.str(), boxside, boxside, boxlength);
+        CLHEP::Hep3Vector windowOrigin = pse->windows()[iwindow].originInMu2e() - coneOrigin;
+        CLHEP::Hep3Vector boxOrigin = windowOrigin - CLHEP::Hep3Vector(0.,0.,boxlength-pse->windows()[iwindow].getTubsParams().zHalfLength());
+        solid = new G4SubtractionSolid(solidname.str()+"_3", solid, box, nullptr, boxOrigin);
+        //now add the window
+        nestTubs(windowname.str(),
+                 pse->windows()[iwindow].getTubsParams(),
+                 findMaterialOrThrow(pse->windows()[iwindow].materialName()),
+                 nullptr,
+                 pse->windows()[iwindow].originInMu2e() - parent.centerInMu2e() + extraOffset,
+                 parent,
+                 0,
+                 PSIsVisible,
+                 G4Colour::Grey(),
+                 PSIsSolid,
+                 forceAuxEdgeVisible,
+                 placePV,
+                 doSurfaceCheck
+                 );
+        verbosityLevel
+          && std::cout << __func__ << ": PSEndPlate window " << iwindow << ": "
+                       << pse->windows()[iwindow]
+                       << std::endl;
+      }
+      //ensure no pipes extrude into the PS
+      std::vector<double> zplanes(polycone.zPlanes()), rins(polycone.rOuter()), routs;
+      for(unsigned iplane = 0; iplane <= polycone.numZPlanes(); ++iplane) {
+        routs.push_back(5.e3); //large outer radius to capture everything
+      }
+      zplanes.push_back(zplanes.back()+5.e3); //add another plane far into the detector
+      rins.push_back(0.); //clean everything within this last step
+      G4Polycone* outsidecone = new G4Polycone("PSEnclosureEndplateOutline",
+                                               polycone.phi0(),
+                                               polycone.phiTotal(),
+                                               zplanes.size(),
+                                               &zplanes[0],
+                                               &rins[0],
+                                               &routs[0]);
+      solid = new G4SubtractionSolid("PSEnclosureEndPlateCleaned", solid, outsidecone);
+
+      VolumeInfo endcap;
+      endcap.name = "PSEnclosureEndPlate";
+      sName = endcap.name;
+      verbosityLevel && std::cout << __func__ << ": Created PS endcap volume, now nesting it...\n";
+      endcap.solid = solid;
+      finishNesting(endcap,
+                    findMaterialOrThrow(pse->endPlatePolycone().materialName()),
+                    nullptr,
+                    polycone.originInMu2e() - parent.centerInMu2e() + extraOffset,
+                    parent.logical,
+                    0,
+                    PSIsVisible,
+                    G4Colour::Blue(),
+                    PSIsSolid,
+                    forceAuxEdgeVisible,
+                    placePV,
+                    doSurfaceCheck);
+      // const VolumeInfo endPlate = nestTubs(sName,
+      //                                      pse->endPlate().getTubsParams(),
+      //                                      findMaterialOrThrow(pse->endPlate().materialName()),
+      //                                      nullptr,
+      //                                      pse->endPlate().originInMu2e() - parent.centerInMu2e() + extraOffset,
+      //                                      parent,
+      //                                      0,
+      //                                      PSIsVisible,
+      //                                      G4Colour::Blue(),
+      //                                      PSIsSolid,
+      //                                      forceAuxEdgeVisible,
+      //                                      placePV,
+      //                                      doSurfaceCheck
+      //                                      );
+
+    }
+    verbosityLevel
+      && std::cout << __func__ << " " << sName << " with windows Mass in kg: "
+                   << _helper->locateVolInfo(sName).logical->GetMass()/CLHEP::kg
                    << std::endl;
 
     //----------------------------------------------------------------

--- a/Mu2eG4/src/constructPSEnclosure.cc
+++ b/Mu2eG4/src/constructPSEnclosure.cc
@@ -121,19 +121,19 @@ namespace mu2e {
     sName = "PSEnclosureFlange";
     const VolumeInfo flange =
       nestTubs(sName,
-	       pse->flange().getTubsParams(),
-	       findMaterialOrThrow(pse->flange().materialName()),
-	       0,
-	       pse->flange().originInMu2e() - parent.centerInMu2e() + extraOffset,
-	       parent,
-	       0,
-	       PSIsVisible,
-	       G4Colour::Blue(),
-	       PSIsSolid,
-	       forceAuxEdgeVisible,
-	       placePV,
-	       doSurfaceCheck
-	       );
+               pse->flange().getTubsParams(),
+               findMaterialOrThrow(pse->flange().materialName()),
+               0,
+               pse->flange().originInMu2e() - parent.centerInMu2e() + extraOffset,
+               parent,
+               0,
+               PSIsVisible,
+               G4Colour::Blue(),
+               PSIsSolid,
+               forceAuxEdgeVisible,
+               placePV,
+               doSurfaceCheck
+               );
 
 
     verbosityLevel

--- a/Mu2eG4/src/constructPSEnclosure.cc
+++ b/Mu2eG4/src/constructPSEnclosure.cc
@@ -19,6 +19,7 @@
 #include "Offline/Mu2eG4/inc/finishNesting.hh"
 #include "Offline/Mu2eG4/inc/nestTubs.hh"
 #include "Offline/Mu2eG4/inc/nestCons.hh"
+#include "Offline/Mu2eG4Helper/inc/AntiLeakRegistry.hh"
 #include "Offline/Mu2eG4Helper/inc/VolumeInfo.hh"
 #include "Offline/ConfigTools/inc/SimpleConfig.hh"
 #include "Offline/Mu2eG4Helper/inc/Mu2eG4Helper.hh"
@@ -269,7 +270,8 @@ namespace mu2e {
         windowname   << "PSEnclosureWindow_" << iwindow+1;
         //make a solid pipe that is the hole in the pipe, to make a hole in the endplate
         G4Tubs* pipetube = new G4Tubs(pipename.str(), 0., pipe.innerRadius(), pipe.halfLength(), 0., CLHEP::twopi);
-        G4RotationMatrix* matrix = new G4RotationMatrix(pipe.rotation());
+        AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
+        CLHEP::HepRotation* matrix = reg.add(CLHEP::HepRotation(pipe.rotation()));
         CLHEP::Hep3Vector tubeOrigin = pipe.originInMu2e() - coneOrigin;
         verbosityLevel
           && std::cout << __func__ << ": PSEndPlate tube " << iwindow << ": "

--- a/Mu2eG4/src/constructVirtualDetectors.cc
+++ b/Mu2eG4/src/constructVirtualDetectors.cc
@@ -1031,7 +1031,7 @@ namespace mu2e {
         if(pse->version() > 2) { //move the detector away from the PS endcap
           auto polycone = pse->endPlatePolycone();
           double pseZOffset = pse->getExtraOffset();
-          double pseMaxZ = polycone.zPlanes().back();
+          double pseMaxZ = polycone.zPlanes().back() + 0.01; //add an extra 10 um gap
           zoffset += std::max(0., (pseMaxZ + (polycone.originInMu2e().z() + pseZOffset) - (psevac.originInMu2e().z() - psevac.halfLength())));
         }
         TubsParams vdParams(0., psevac.outerRadius(), vdg->getHalfLength());

--- a/Mu2eG4/src/constructVirtualDetectors.cc
+++ b/Mu2eG4/src/constructVirtualDetectors.cc
@@ -33,6 +33,7 @@
 #include "Offline/Mu2eG4/inc/nestTubs.hh"
 #include "Offline/Mu2eG4/inc/nestBox.hh"
 #include "Offline/ProductionSolenoidGeom/inc/PSVacuum.hh"
+#include "Offline/ProductionSolenoidGeom/inc/PSEnclosure.hh"
 #include "Offline/ProtonBeamDumpGeom/inc/ProtonBeamDump.hh"
 #include "Offline/ProductionTargetGeom/inc/ProductionTarget.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
@@ -1025,11 +1026,23 @@ namespace mu2e {
         const VolumeInfo& parent = _helper->locateVolInfo("PSVacuum");
 
         const Tube& psevac = GeomHandle<PSVacuum>()->vacuum();
-
+        GeomHandle<PSEnclosure> pse;
+        double zoffset = -psevac.halfLength();
+        if(pse->version() > 2) { //move the detector away from the PS endcap
+          auto polycone = pse->endPlatePolycone();
+          double pseZOffset = pse->getExtraOffset();
+          double pseMaxZ = polycone.zPlanes().back();
+          zoffset += std::max(0., (pseMaxZ + (polycone.originInMu2e().z() + pseZOffset) - (psevac.originInMu2e().z() - psevac.halfLength())));
+        }
         TubsParams vdParams(0., psevac.outerRadius(), vdg->getHalfLength());
 
-        G4ThreeVector vdCenterInParent(0., 0., -psevac.halfLength() + vdg->getHalfLength());
+        G4ThreeVector vdCenterInParent(0., 0., zoffset + vdg->getHalfLength());
 
+        if ( verbosityLevel > 0) {
+          cout << __func__ << ": Constructing " << VirtualDetector::volumeName(vdId)
+               << " VD center in PS vacuum = " << vdCenterInParent
+               << " (zoffset = " << zoffset << ")\n";
+        }
         VolumeInfo vdInfo = nestTubs(VirtualDetector::volumeName(vdId),
                                      vdParams,
                                      upstreamVacuumMaterial,

--- a/ProductionSolenoidGeom/inc/PSEnclosure.hh
+++ b/ProductionSolenoidGeom/inc/PSEnclosure.hh
@@ -9,6 +9,11 @@
 // PSEnclosure a conical frustrum instead of a tube.  This is per as-built
 // geometry - see Doc 8047.
 
+// Sept  2021 - Michael MacKenzie and Dave (WKU - formerly Lou) Brown
+// add version 3.  This adds more detail and gets closer to the
+// representation in doc 8047.  Final code represents a merge of their
+// independent work.
+
 #include <vector>
 #include <ostream>
 
@@ -31,15 +36,26 @@ namespace mu2e {
     const Tube& shell()     const { return shell_; }
     const Cone& shellCone() const { return shellCone_; }
 
+    void setFlange( Tube aFlange ) { flange_ = aFlange; }
+    const Tube& flange()    const { return flange_; }
+
     const Tube& endPlate()  const { return endPlate_; }
     const std::vector<Tube>& windows() const { return windows_; }
+
     unsigned nWindows()     const { return windows_.size(); }
+
+    const std::vector<bool>& hasWindowFrames() const
+    { return hasFrames_; }
+    const std::vector<Tube>& wFrames() const { return  wFrames_; }
 
     const Polycone& endPlatePolycone()  const { return endPlatePolycone_; }
     const std::vector<Tube>& windowPipes() const { return windowPipes_; }
 
     void setExtraOffset( double zOff ) { zOffset_ = zOff; }
     const double& getExtraOffset() const { return zOffset_; }
+
+    const double& getEndPlateInset() const { return ePinset_; }
+    const double& getEndPlateRadius() const { return ePradius_; }
 
   protected:
     void setVersion( const int& aVers ) { version_ = aVers; }
@@ -51,11 +67,11 @@ namespace mu2e {
     PSEnclosure(const Tube& shell, const Tube& ep)
       : shell_(shell), shellCone_(), endPlate_(ep), version_(1)
     {};
-    PSEnclosure (const Cone& shellCone, const Tube& ep )
-      : shell_(), shellCone_(shellCone), endPlate_(ep), version_(2)
+    PSEnclosure (const Cone& shellCone, const Tube& ep, int vers=2 )
+      : shell_(), shellCone_(shellCone), endPlate_(ep), version_(vers)
     {};
-    PSEnclosure (const Cone& shellCone, const Polycone& ep )
-      : shell_(), shellCone_(shellCone), endPlatePolycone_(ep), version_(3)
+    PSEnclosure (const Cone& shellCone, const Polycone& ep, int vers=3 )
+      : shell_(), shellCone_(shellCone), endPlatePolycone_(ep), version_(vers)
     {};
 
     // Or read back from persistent storage
@@ -71,11 +87,20 @@ namespace mu2e {
     int version_;
     std::vector<Tube> windows_;
     std::vector<Tube> windowPipes_;
+    double ePinset_;
+    double ePradius_;
+
+    // For version 3, include flanges (or "frames") for each window
+
+    std::vector<bool> hasFrames_;
+    std::vector<Tube> wFrames_;
 
     // The updated version is shown in docdb-4087.  We use a conical frustrum.
     double zOffset_;
+    // In version 3 we add a flange and...
+    Tube flange_;
 
-    // The version - allow cylindrical or conical PSEnclosure
+
   };
 
   std::ostream& operator<<(std::ostream& os, const PSEnclosure& pse);

--- a/ProductionSolenoidGeom/inc/PSEnclosure.hh
+++ b/ProductionSolenoidGeom/inc/PSEnclosure.hh
@@ -59,7 +59,7 @@ namespace mu2e {
 
   protected:
     void setVersion( const int& aVers ) { version_ = aVers; }
-  private:
+  public:
 
     friend class PSEnclosureMaker;
 
@@ -73,7 +73,7 @@ namespace mu2e {
     PSEnclosure (const Cone& shellCone, const Polycone& ep, int vers=3 )
       : shell_(), shellCone_(shellCone), endPlatePolycone_(ep), version_(vers)
     {};
-
+  private:
     // Or read back from persistent storage
     PSEnclosure();
     template<class T> friend class art::Wrapper;

--- a/ProductionSolenoidGeom/inc/PSEnclosure.hh
+++ b/ProductionSolenoidGeom/inc/PSEnclosure.hh
@@ -12,6 +12,7 @@
 #include <vector>
 #include <ostream>
 
+#include "Offline/GeomPrimitives/inc/Polycone.hh"
 #include "Offline/GeomPrimitives/inc/Cone.hh"
 #include "Offline/GeomPrimitives/inc/Tube.hh"
 #include "Offline/Mu2eInterfaces/inc/Detector.hh"
@@ -32,8 +33,10 @@ namespace mu2e {
 
     const Tube& endPlate()  const { return endPlate_; }
     const std::vector<Tube>& windows() const { return windows_; }
-
     unsigned nWindows()     const { return windows_.size(); }
+
+    const Polycone& endPlatePolycone()  const { return endPlatePolycone_; }
+    const std::vector<Tube>& windowPipes() const { return windowPipes_; }
 
     void setExtraOffset( double zOff ) { zOffset_ = zOff; }
     const double& getExtraOffset() const { return zOffset_; }
@@ -51,6 +54,9 @@ namespace mu2e {
     PSEnclosure (const Cone& shellCone, const Tube& ep )
       : shell_(), shellCone_(shellCone), endPlate_(ep), version_(2)
     {};
+    PSEnclosure (const Cone& shellCone, const Polycone& ep )
+      : shell_(), shellCone_(shellCone), endPlatePolycone_(ep), version_(3)
+    {};
 
     // Or read back from persistent storage
     PSEnclosure();
@@ -61,8 +67,10 @@ namespace mu2e {
     Tube shell_;
     Cone shellCone_;
     Tube endPlate_;
+    Polycone endPlatePolycone_;
     int version_;
     std::vector<Tube> windows_;
+    std::vector<Tube> windowPipes_;
 
     // The updated version is shown in docdb-4087.  We use a conical frustrum.
     double zOffset_;

--- a/ProductionSolenoidGeom/src/PSEnclosure.cc
+++ b/ProductionSolenoidGeom/src/PSEnclosure.cc
@@ -28,7 +28,7 @@ namespace mu2e {
 
       }
 
-    } else {
+    } else if(pse.version() == 2){
 
       os<<"PSEnclosure("
 	<<"material="<<pse.shellCone().materialName()

--- a/ProductionSolenoidGeom/src/PSEnclosure.cc
+++ b/ProductionSolenoidGeom/src/PSEnclosure.cc
@@ -52,6 +52,28 @@ namespace mu2e {
 
       }
 
+    } else {
+
+      os<<"PSEnclosure("
+        <<"material="<<pse.shellCone().materialName()
+        <<", OD1="<<2*pse.shellCone().outerRadius1()
+        <<", OD2="<<2*pse.shellCone().outerRadius2()
+        <<", length="<<2*(pse.shellCone().halfLength() + pse.endPlate().halfLength())
+        <<", flange=" << pse.flange()
+        <<", endplate cone=" << pse.endPlatePolycone()
+        <<", windows = { "
+        ;
+
+      for(unsigned i=0; i<pse.nWindows(); ++i) {
+        const CLHEP::Hep3Vector tmp(pse.windows()[i].originInMu2e() - pse.endPlate().originInMu2e());
+        os<<"Window("
+          <<"materialName="<<pse.windows()[i].materialName()
+          <<", thickness="<<2*pse.windows()[i].halfLength()
+          <<", r="<<pse.windows()[i].outerRadius()
+          <<", xoff="<<tmp.x()
+          <<", yoff="<<tmp.y()
+          <<"), ";
+      }
     }
 
     os<<" } )";


### PR DESCRIPTION
Update the PS endcap model for radiation and background studies. This includes work done by Dave Brown (WKU) and
myself. Some relevant documentation of these updates is given in docdb 39987. A new top-level geometry file was created
for this update, `geom_2021_PhaseI_v02.txt`, and `geom_common_current.txt` was advanced to use this geometry.

Validation run:
ROOT overlap check
Geant4 overlap check
No issues running with `geom_common.txt` which uses the previous geometry, and by eye the geometry looks unchanged

Best,
Michael