### PR TITLE
new CRV light default print

### DIFF
--- a/CRVResponse/inc/MakeCrvPhotons.hh
+++ b/CRVResponse/inc/MakeCrvPhotons.hh
@@ -100,7 +100,7 @@ class MakeCrvPhotons
 
     const std::string         &GetFileName() const {return _fileName;}
 
-    void                      LoadLookupTable(const std::string &filename);
+  void                      LoadLookupTable(const std::string &filename, int debug);
     void                      MakePhotons(const CLHEP::Hep3Vector &stepStart,   //they need to be points
                                       const CLHEP::Hep3Vector &stepEnd,         //local to the CRV bar
                                       double timeStart, double timeEnd,

--- a/CRVResponse/src/CrvPhotonGenerator_module.cc
+++ b/CRVResponse/src/CrvPhotonGenerator_module.cc
@@ -222,6 +222,7 @@ namespace mu2e
       filedirs.insert( std::filesystem::path(filespec).parent_path() );
       photonMaker->LoadLookupTable(filespec,_debug);
       photonMaker->SetScintillationYield(_scintillationYields[i]);
+      if(_debug>0) std::cout<<"CRV sector "<<i<<" ("<<_CRVSectors[i]<<") uses "<<_makeCrvPhotons.back()->GetFileName()<<" with scintillation yield of "<<_scintillationYields[i]<<" photons/MeV"<<std::endl;
     }
 
     std::cout << "CRV light files:";

--- a/CRVResponse/src/CrvPhotonGenerator_module.cc
+++ b/CRVResponse/src/CrvPhotonGenerator_module.cc
@@ -210,7 +210,7 @@ namespace mu2e
         {
            tableLoaded=true;
            _makeCrvPhotons.emplace_back(_makeCrvPhotons[j]);
-           if(_debug>0) std::cout<<"CRV sector "<<i<<" ("<<_CRVSectors[i]<<") uses "<<_makeCrvPhotons.back()->GetFileName()<<std::endl;
+	   if(_debug>0) std::cout<<"CRV sector "<<i<<" ("<<_CRVSectors[i]<<") uses "<<_makeCrvPhotons.back()->GetFileName()<<" with scintillation yield of "<<_scintillationYields[i]<<" photons/MeV"<<std::endl;
            break;
         }
       }
@@ -222,7 +222,6 @@ namespace mu2e
       filedirs.insert( std::filesystem::path(filespec).parent_path() );
       photonMaker->LoadLookupTable(filespec,_debug);
       photonMaker->SetScintillationYield(_scintillationYields[i]);
-      if(_debug>0) std::cout<<"CRV sector "<<i<<" ("<<_CRVSectors[i]<<") uses "<<_makeCrvPhotons.back()->GetFileName()<<" with scintillation yield of "<<_scintillationYields[i]<<" photons/MeV"<<std::endl;
     }
 
     std::cout << "CRV light files:";

--- a/CRVResponse/src/MakeCrvPhotons.cc
+++ b/CRVResponse/src/MakeCrvPhotons.cc
@@ -249,7 +249,7 @@ void LookupBin::Read(std::ifstream &lookupfile, const unsigned int &i)
   if(i!=binNumber) throw std::logic_error("Corrupt lookup table.");
 }
 
-void MakeCrvPhotons::LoadLookupTable(const std::string &filename)
+  void MakeCrvPhotons::LoadLookupTable(const std::string &filename, int debug)
 {
   _fileName = filename;
   std::ifstream lookupfile(filename,std::ios::binary);
@@ -271,11 +271,11 @@ void MakeCrvPhotons::LoadLookupTable(const std::string &filename)
   _bins[1].resize(nScintillatorCerenkovBins);
   _bins[2].resize(nFiberCerenkovBins);
 
-  std::cout<<"Reading CRV lookup tables "<<filename<<" ... "<<std::flush;
+  if(debug>0) std::cout<<"Reading CRV lookup tables "<<filename<<" ... "<<std::flush;
   for(unsigned int i=0; i<nScintillatorScintillationBins; i++) _bins[0][i].Read(lookupfile,i);
   for(unsigned int i=0; i<nScintillatorCerenkovBins; i++)      _bins[1][i].Read(lookupfile,i);
   for(unsigned int i=0; i<nFiberCerenkovBins; i++)             _bins[2][i].Read(lookupfile,i);
-  std::cout<<"Done."<<std::endl;
+  if(debug>0) std::cout<<"Done."<<std::endl;
 
   lookupfile.close();
 }

--- a/Validation/src/Validation_module.cc
+++ b/Validation/src/Validation_module.cc
@@ -67,7 +67,6 @@ namespace mu2e {
     explicit Validation(const Parameters& conf);
     void analyze  ( art::Event const&  event  ) override;
     void beginJob () override;
-    void endJob () override;
 
   private:
 
@@ -173,13 +172,6 @@ void mu2e::Validation::analyze(art::Event const& event){
   analyzeProduct<TrackClusterMatchCollection,ValTrackClusterMatch>(_mtch,event);
   analyzeProduct<art::TriggerResults,ValTriggerResults>       (_trrs,event);
   analyzeProduct<TriggerInfo,ValTriggerInfo>                  (_tris,event);
-
-}
-
-
-void mu2e::Validation::endJob () {
-
-  std::cout << "end Validation::endJob summary" << std::endl;
 
 }
 


### PR DESCRIPTION
After consulting with Ralf, reduce default Crv light file prints from several stanzas of

Reading CRV lookup tables /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_4550_0 ... Done.
CRV sector 0 (R1) uses /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0/LookupTable_4550_0 with scintillation yield of 16548 photons/MeV

to
CRV light files: /cvmfs/mu2e.opensciencegrid.org/DataFiles/CRVConditions/v6_0
CRV light sectors: 23 hash:10539762652061218902
mirroring the default prints for other input files.

The previous format is still available with a debug flag.

In other default print cases, the hashes are over the entire input file content, but here the hash is just on the file names.  Hashing the content would require intrusive code, or re-reading the files. 


