### PR TITLE
Start pywrap

### DIFF
--- a/.muse
+++ b/.muse
@@ -1,7 +1,6 @@
 # prefer to build with this environment
-ENVSET p014
+ENVSET p016
 # add these to python path
-PYTHONPATH TrackerAlignment/scripts
 PYTHONPATH Trigger/python
 # add Offline/bin to path
 PATH bin

--- a/DbService/src/SConscript
+++ b/DbService/src/SConscript
@@ -46,6 +46,8 @@ helper.make_plugins( [ mainlib,
 BINLIBS   = [ mainlib, 'mu2e_DbTables' , 'cetlib', 'cetlib_except', "pq" ]
 helper.make_bin("dbTool",BINLIBS,[])
 
+# turn pywrap.i into a python interface
+helper.make_pywrap (['mu2e_DbTables'])
 
 # This tells emacs to view this file in python mode.
 # Local Variables:

--- a/DbService/src/pywrap.i
+++ b/DbService/src/pywrap.i
@@ -1,0 +1,22 @@
+//
+// swig interface file to wrap c++ code for python
+//
+
+%module DbService
+
+%include "std_vector.i"
+%include "std_string.i"
+%include "stdint.i"
+
+%apply const std::string& {std::string* foo};
+%template(vec_str) std::vector<std::string>;
+
+%{
+#include "Offline/DbTables/inc/DbTable.hh"
+#include "Offline/DbTables/inc/DbTableCollection.hh"
+#include "Offline/DbService/inc/DbTool.hh"
+%}
+
+%include "Offline/DbTables/inc/DbTable.hh"
+%include "Offline/DbTables/inc/DbTableCollection.hh"
+%include "Offline/DbService/inc/DbTool.hh"

--- a/DbTables/src/SConscript
+++ b/DbTables/src/SConscript
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 #
-
 Import('env')
 Import('mu2e_helper')
 
@@ -13,6 +12,9 @@ mainlib = helper.make_mainlib ( [ 'mu2e_GeneralUtilities',
                                   'cetlib',
                                   'cetlib_except'
                               ] )
+
+# turn pywrap.i into a python interface
+helper.make_pywrap ()
 
 # this tells emacs to view this file in python mode.
 # Local Variables:

--- a/DbTables/src/pywrap.i
+++ b/DbTables/src/pywrap.i
@@ -1,0 +1,20 @@
+//
+// swig interface file to wrap c++ code for python
+//
+
+%module DbTables
+
+%include "std_string.i"
+%include "stdint.i"
+
+%apply const std::string& {std::string* foo};
+
+%{
+#include "Offline/DbTables/inc/DbIoV.hh"
+#include "Offline/DbTables/inc/DbTable.hh"
+#include "Offline/DbTables/inc/DbTableCollection.hh"
+%}
+
+%include "Offline/DbTables/inc/DbIoV.hh"
+%include "Offline/DbTables/inc/DbTable.hh"
+%include "Offline/DbTables/inc/DbTableCollection.hh"

--- a/MCDataProducts/inc/GenId.hh
+++ b/MCDataProducts/inc/GenId.hh
@@ -47,6 +47,7 @@ namespace mu2e {
       lastEnum //51
     };
 
+#ifndef SWIG
     // Keep this in sync with the enum. Used in GenId.cc
 #define GENID_NAMES                                                     \
     "unknown",      "particleGun",       "CeEndpoint",               \
@@ -62,6 +63,7 @@ namespace mu2e {
       "CosmicCRY", "pbarFlat","fromAscii","ExternalRMC","InternalRMC","CeLeadingLog", "CosmicCORSIKA", \
     "MuCapProtonGenTool", "MuCapDeuteronGenTool", "DIOGenTool", "MuCapNeutronGenTool", \
       "MuCapPhotonGenTool", "MuCapGammaRayGenTool","CeLeadingLogGenTool"
+#endif
 
   public:
 
@@ -136,8 +138,10 @@ namespace mu2e {
       return isValid(_id);
     }
 
+#ifndef SWIG
     // List of names corresponding to the enum.
     const static char* _name[];
+#endif
 
     // Number of valid codes, not including lastEnum, but including "unknown".
     static std::size_t size(){

--- a/MCDataProducts/inc/ProcessCode.hh
+++ b/MCDataProducts/inc/ProcessCode.hh
@@ -93,6 +93,7 @@ namespace mu2e {
       mu2eHallAir = mu2eKillerVolume
     };
 
+#ifndef SWIG
     // Keep this list of names in sync with the enum. Used in ProcessCode.cc
     // lastEnum does not appear in this list of names.
 #define PROCESSCODE_NAMES                                                                                   \
@@ -143,6 +144,7 @@ namespace mu2e {
     "mu2eCePlusLeadingLog", "mu2eunused2", "mu2eunused3", "mu2eunused4", \
     "mu2eunused5", "mu2eunused6", "mu2eunused7", "mu2eunused8", \
     "uninitialized"
+#endif
 
   public:
 
@@ -169,6 +171,7 @@ namespace mu2e {
     // Return ProcessCode(unknown) if there is no such string.
     static ProcessCode findByName ( std::string const& name);
 
+#ifndef SWIG
     // This operator implements:
     //   ProcessCode a;
     //   enum_type b;
@@ -177,13 +180,16 @@ namespace mu2e {
       _id = c;
       return *this;
     }
+#endif
 
+#ifndef SWIG
     // This operator implements:
     //   ProcessCode a;
     //   enum_type b = a;
     operator ProcessCode::enum_type ()const{
       return _id;
     }
+#endif
 
     // Tests for equality.
     bool operator==(const ProcessCode g) const{
@@ -224,8 +230,10 @@ namespace mu2e {
       return isValid(_id);
     }
 
+#ifndef SWIG
     // List of names corresponding to the enum.
     const static char* _name[];
+#endif
 
   private:
 

--- a/MCDataProducts/src/SConscript
+++ b/MCDataProducts/src/SConscript
@@ -47,6 +47,10 @@ helper.make_dict_and_map( [ mainlib,
                           ],
                           [ '-fvar-tracking-assignments-toggle'] )
 
+
+# turn pywrap.i into a python interface
+helper.make_pywrap ()
+
 # This tells emacs to view this file in python mode.
 # Local Variables:
 # mode:python

--- a/MCDataProducts/src/pywrap.i
+++ b/MCDataProducts/src/pywrap.i
@@ -1,0 +1,21 @@
+//
+// swig interface file to wrap c++ code for python
+//
+
+%module MCDataProducts
+
+%include "std_vector.i"
+%include "std_string.i"
+%include "stdint.i"
+
+%apply const std::string& {std::string* foo};
+%template(vec_str) std::vector<std::string>;
+
+%{
+#include "Offline/MCDataProducts/inc/ProcessCode.hh"
+#include "Offline/MCDataProducts/inc/GenId.hh"
+%}
+
+%include "Offline/MCDataProducts/inc/ProcessCode.hh"
+%include "Offline/MCDataProducts/inc/GenId.hh"
+


### PR DESCRIPTION
This should all be turned off and harmless by default.  To build wrappers, use Muse v2_10_00 or higher and add the switch "--mu2ePyWrap" to the muse build command.  Muse has added the output directories to the PTYTHONPATH, so the wrappers are ready to use.  See [the wiki](https://mu2ewiki.fnal.gov/wiki/PyWrap) for examples.  I had to ifdef out some code in the enum classes. The swig interface files have lots of features, so this code could probably accommodated with some more work on the interface specification.  In any case, the code works now for translating the enums.

A note to Mackenzie and Rob.  I went from p014 to p016, which is necessary to setup swig.  I see p015 is in development now, so when that is ready, please add the swig setup before committing it.  Since p015 is already out there, I'd make your p015 plus swig into p017.  Please commit them to MuseConfig.