### PR TITLE
Move stable geometry forward to current version

### DIFF
--- a/Mu2eG4/geom/geom_common.txt
+++ b/Mu2eG4/geom/geom_common.txt
@@ -3,7 +3,7 @@
 // The file that is included will be time dependent.
 //
 
-#include "Offline/Mu2eG4/geom/geom_2021_PhaseI.txt"
+#include "Offline/Mu2eG4/geom/geom_2021_PhaseI_v02.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:


### PR DESCRIPTION
Update `geom_common` to use the latest geometry version, with the updated PS endcap model, from `geom_common_current`.
The only validation done is that a job writing out the gdml file for `geom_common` properly runs, as the underlying model was
already validated for `geom_common_current`.