### PR TITLE
Add SimEfficiencies2 table, change SimBookkeeper prodition to use it

### DIFF
--- a/DbService/data/create.sql
+++ b/DbService/data/create.sql
@@ -292,3 +292,10 @@ CREATE TABLE sim.efficiencies
    CONSTRAINT sim_efficiencies_pk PRIMARY KEY (cid,tag) );
 GRANT SELECT ON sim.efficiencies TO PUBLIC;
 GRANT INSERT ON sim.efficiencies TO sim_role;
+
+CREATE TABLE sim.efficiencies2
+  (cid INTEGER, 
+   tag TEXT, numerator BIGINT, denominator BIGINT, eff NUMERIC,  
+   CONSTRAINT sim_efficiencies2_pk PRIMARY KEY (cid,tag) );
+GRANT SELECT ON sim.efficiencies2 TO PUBLIC;
+GRANT INSERT ON sim.efficiencies2 TO sim_role;

--- a/DbTables/inc/SimEfficiencies2.hh
+++ b/DbTables/inc/SimEfficiencies2.hh
@@ -1,0 +1,79 @@
+#ifndef DbTables_SimEfficiencies2_hh
+#define DbTables_SimEfficiencies2_hh
+
+
+#include <string>
+#include <iomanip>
+#include <sstream>
+#include <map>
+#include "cetlib_except/exception.h"
+#include "Offline/DbTables/inc/DbTable.hh"
+
+namespace mu2e {
+
+  class SimEfficiencies2 : public DbTable {
+  public:
+    typedef std::shared_ptr<SimEfficiencies2> ptr_t;
+    typedef std::shared_ptr<const SimEfficiencies2> cptr_t;
+
+    class Row {
+    public:
+      Row(std::string tag, unsigned long numerator, unsigned long denominator, double eff):
+        _tag(tag),_numerator(numerator),_denominator(denominator),_eff(eff) {}
+
+      std::string  tag() const { return _tag;}
+      unsigned long long numerator() const { return _numerator; }
+      unsigned long long denominator() const { return _denominator; }
+      double  eff() const { return _eff; }
+
+    private:
+      std::string _tag;
+      unsigned long long _numerator;
+      unsigned long long _denominator;
+      double _eff;
+    };
+
+    constexpr static const char* cxname = "SimEfficiencies2";
+
+    SimEfficiencies2():DbTable(cxname,"sim.efficiencies2","tag,numerator,denominator,eff") { }
+
+    const Row& rowAt(const std::size_t index) const { return _rows.at(index);}
+    const Row& row(const int idx) const { return _rows.at(idx); }
+    std::vector<Row> const& rows() const {return _rows;}
+    std::size_t nrow() const override { return _rows.size(); };
+    //    virtual std::size_t nrowFix() const { return 3; };
+    size_t size() const override { return baseSize() + nrow()*sizeof(Row); };
+
+    void addRow(const std::vector<std::string>& columns) override {
+      //      int idx = std::stoi(columns[0]);
+      _rows.emplace_back(columns[0],
+                         std::stoull(columns[1]),
+                         std::stoull(columns[2]),
+                         std::stof(columns[3]));
+    }
+
+    void rowToCsv(std::ostringstream& sstream, std::size_t irow) const  override {
+      Row const& r = _rows.at(irow);
+      sstream << r.tag()<<",";
+      sstream << r.numerator()<<",";
+      sstream << r.denominator()<<",";
+      sstream << std::fixed << std::setprecision(6) << r.eff();
+    }
+
+    void findEff(std::string name, double& eff) const {
+      for (const auto& i_row : _rows) {
+        if (i_row.tag() == name) {
+          eff =  i_row.eff();
+          return;
+        }
+      }
+      throw cet::exception("SIMEFFICIENCIES2_BAD_TAG") << "Efficiency with tag " << name << " not found in database" << std::endl;
+    }
+
+    virtual void clear() override { baseClear(); _rows.clear();}
+
+  private:
+    std::vector<Row> _rows;
+  };
+};
+#endif

--- a/DbTables/src/DbTableFactory.cc
+++ b/DbTables/src/DbTableFactory.cc
@@ -13,8 +13,8 @@
 #include "Offline/DbTables/inc/AnaTrkQualDb.hh"
 #include "Offline/DbTables/inc/CalRoIDMapDIRACToOffline.hh"
 #include "Offline/DbTables/inc/CalRoIDMapOfflineToDIRAC.hh"
-
 #include "Offline/DbTables/inc/SimEfficiencies.hh"
+#include "Offline/DbTables/inc/SimEfficiencies2.hh"
 
 mu2e::DbTable::ptr_t mu2e::DbTableFactory::newTable(std::string const& name) {
   if (name=="TstCalib1") {
@@ -49,6 +49,8 @@ mu2e::DbTable::ptr_t mu2e::DbTableFactory::newTable(std::string const& name) {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::AnaTrkQualDb());
   } else if (name=="SimEfficiencies") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::SimEfficiencies());
+  } else if (name=="SimEfficiencies2") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::SimEfficiencies2());
   } else if (name=="CalRoIDMapDIRACToOffline") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::CalRoIDMapDIRACToOffline());
   } else if (name=="CalRoIDMapOfflineToDIRAC") {

--- a/SimulationConditions/inc/SimBookkeeper.hh
+++ b/SimulationConditions/inc/SimBookkeeper.hh
@@ -6,7 +6,7 @@
 // simulation proditions
 //
 // As of Oct 2020 this includes:
-// 1) simulation stage efficiencies (DbTable: SimEfficiencies)
+// 1) simulation stage efficiencies (DbTable: SimEfficiencies2)
 // and nothing else
 //
 

--- a/SimulationConditions/inc/SimBookkeeperCache.hh
+++ b/SimulationConditions/inc/SimBookkeeperCache.hh
@@ -11,7 +11,7 @@
 #include "Offline/Mu2eInterfaces/inc/ProditionsCache.hh"
 #include "Offline/DbTables/inc/DbIoV.hh"
 #include "Offline/DbService/inc/DbHandle.hh"
-#include "Offline/DbTables/inc/SimEfficiencies.hh"
+#include "Offline/DbTables/inc/SimEfficiencies2.hh"
 #include "Offline/SimulationConditions/inc/SimBookkeeperMaker.hh"
 
 namespace mu2e {
@@ -33,7 +33,7 @@ namespace mu2e {
 
     // these handles are not default constructed
     // so the db can be completely turned off
-    std::unique_ptr<DbHandle<SimEfficiencies> > _tqDb_p;
+    std::unique_ptr<DbHandle<SimEfficiencies2> > _tqDb_p;
   };
 };
 

--- a/SimulationConditions/inc/SimBookkeeperMaker.hh
+++ b/SimulationConditions/inc/SimBookkeeperMaker.hh
@@ -7,7 +7,7 @@
 
 #include "Offline/SimulationConditions/inc/SimBookkeeper.hh"
 #include "Offline/SimulationConfig/inc/SimBookkeeperConfig.hh"
-#include "Offline/DbTables/inc/SimEfficiencies.hh"
+#include "Offline/DbTables/inc/SimEfficiencies2.hh"
 
 namespace mu2e {
 
@@ -16,7 +16,7 @@ namespace mu2e {
     SimBookkeeperMaker(SimBookkeeperConfig const& config):_config(config) {}
 
     SimBookkeeper::ptr_t fromFcl();
-    SimBookkeeper::ptr_t fromDb(SimEfficiencies::cptr_t effDb);
+    SimBookkeeper::ptr_t fromDb(SimEfficiencies2::cptr_t effDb);
 
   private:
     // this object needs to be thread safe,

--- a/SimulationConditions/src/SimBookkeeperCache.cc
+++ b/SimulationConditions/src/SimBookkeeperCache.cc
@@ -10,7 +10,7 @@ namespace mu2e {
 
   void SimBookkeeperCache::initialize() {
     if(_useDb) {
-      _tqDb_p  = std::make_unique<DbHandle<SimEfficiencies> >();
+      _tqDb_p  = std::make_unique<DbHandle<SimEfficiencies2> >();
     }
   }
 

--- a/SimulationConditions/src/SimBookkeeperMaker.cc
+++ b/SimulationConditions/src/SimBookkeeperMaker.cc
@@ -14,7 +14,7 @@ namespace mu2e {
     return ptr;
   }
 
-  SimBookkeeper::ptr_t SimBookkeeperMaker::fromDb(SimEfficiencies::cptr_t effDb) {
+  SimBookkeeper::ptr_t SimBookkeeperMaker::fromDb(SimEfficiencies2::cptr_t effDb) {
     // fill the SimBookkeeper with initial values
     auto ptr = fromFcl();
     // now overwrite with values from database


### PR DESCRIPTION
The SimEfficiencies table used int to store the numerator and denominator of the efficiency ratio, which is now overflowing.  The table SimEfficiencies2 is the same, but using long long for these numbers (BIGINT in the database).  The prodition in this commit now can only use SimEfficiencies2 and doesn't know about the original table.  

This is our first table version migration.  The old code can continue to use old conditions sets but the new code will only run on new conditions sets with the new table.  I'll add the topic of table migration to a slide to my discussion talk with some details.