### PR TITLE
FlagBkg clustering hit fix

### DIFF
--- a/TrkHitReco/fcl/prolog.fcl
+++ b/TrkHitReco/fcl/prolog.fcl
@@ -59,13 +59,7 @@ TNTClusterer : {
     MaxDistance      : 100.0
     MinHitError      : 5.0
     TimeRMS          : 2.0
-    DeltaTimeBinMin  : 10
     MedianCentroid   : false
-    preFilter        : false
-    pfTimeBin        : 20
-    pfPhiBin         : 0.1
-    pfMinHit         : 10
-    pfMinSumHit      : 20
     ComboInit        : true
     TestFlag         : true
     BackgroundMask   : []

--- a/TrkHitReco/src/FlagBkgHits_module.cc
+++ b/TrkHitReco/src/FlagBkgHits_module.cc
@@ -9,9 +9,7 @@
 
 #include "Offline/ConditionsService/inc/ConditionsHandle.hh"
 #include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
-#include "Offline/ConditionsService/inc/AcceleratorParams.hh"
 
-#include "Offline/DataProducts/inc/EventWindowMarker.hh"
 #include "Offline/MCDataProducts/inc/StrawDigiMC.hh"
 #include "Offline/RecoDataProducts/inc/StrawHit.hh"
 #include "Offline/RecoDataProducts/inc/StrawHitFlag.hh"
@@ -41,7 +39,6 @@ namespace mu2e
              using Comment = fhicl::Comment;
              fhicl::Atom<art::InputTag>            comboHitCollection{   Name("ComboHitCollection"),   Comment("ComboHit collection name") };
              fhicl::Atom<art::InputTag>            strawHitCollection{   Name("StrawHitCollection"),   Comment("StrawHit collection name") };
-	     fhicl::Atom<art::InputTag>            ewMarkerTag{          Name("EventWindowMarker"),    Comment("EventWindowMarker producer"),"EWMProducer" };
              fhicl::Atom<unsigned>                 minActiveHits{        Name("MinActiveHits"),        Comment("Minumim number of active hits in a cluster") };
              fhicl::Atom<unsigned>                 minNPlanes{           Name("MinNPlanes"),           Comment("Minumim number of planes in a cluster") };
              fhicl::Atom<float>                    clusterPositionError{ Name("ClusterPositionError"), Comment("Cluster poisiton error") };
@@ -68,7 +65,6 @@ namespace mu2e
       private:
          const art::ProductToken<ComboHitCollection> chtoken_;
          const art::ProductToken<StrawHitCollection> shtoken_;
-         const art::ProductToken<EventWindowMarker>  ewmtoken_;
          unsigned                                    minnhits_;
          unsigned                                    minnp_;
          bool                                        filter_, flagch_, flagsh_;
@@ -96,7 +92,6 @@ namespace mu2e
      art::EDProducer{config},
      chtoken_{     consumes<ComboHitCollection>(config().comboHitCollection()) },
      shtoken_{     consumes<StrawHitCollection>(config().strawHitCollection()) },
-     ewmtoken_{    consumes<EventWindowMarker>(config().ewMarkerTag()) },
      minnhits_(    config().minActiveHits() ),
      minnp_(       config().minNPlanes()),
      filter_(      config().filterOutput()),
@@ -155,16 +150,6 @@ namespace mu2e
      //unsigned iev=event.event();
       if (debug_ > 0 && iev_%printfreq_==0) std::cout<<"FlagBkgHits: event="<<iev_<<std::endl;
 
-      ConditionsHandle<AcceleratorParams> accPar("ignored");
-      float mbtime = accPar->deBuncherPeriod;
-
-      auto ewmH = event.getValidHandle(ewmtoken_);
-      const EventWindowMarker& ewMarker = *ewmH.product();
-      float eventWindowLength = ewMarker.eventLength();
-      bool onSpill = (ewMarker.spillType() == EventWindowMarker::SpillType::onspill);
-      if (!onSpill)
-        mbtime = eventWindowLength;
-
       auto chH = event.getValidHandle(chtoken_);
       const ComboHitCollection& chcol = *chH.product();
       unsigned nch = chcol.size();
@@ -181,7 +166,7 @@ namespace mu2e
 
 
       // find clusters, sort is needed for recovery algorithm. bkgccolFast has hits that are autmoatically marked as bkg.
-      clusterer_->findClusters(bkgccolFast,bkgccol,chcol, mbtime, iev_);
+      clusterer_->findClusters(bkgccolFast,bkgccol,chcol, iev_);
       sort(bkgccol.begin(),bkgccol.end(),[](const BkgCluster& c1,const BkgCluster& c2) {return c1.time() < c2.time();});
 
 

--- a/TrkReco/inc/BkgClusterer.hh
+++ b/TrkReco/inc/BkgClusterer.hh
@@ -1,8 +1,3 @@
-//
-// Base class for algorithm Objects used to cluster straw hits for background removal
-//
-//  David Brown (LBNL) 2013
-//
 #ifndef BkgClusterer_HH
 #define BkgClusterer_HH
 
@@ -15,10 +10,10 @@ namespace mu2e
     {
         public:
             virtual ~BkgClusterer() {}
-            virtual void  init() = 0;
+            virtual void  init        () = 0;
             virtual void  findClusters(BkgClusterCollection& preFilterClusters, BkgClusterCollection& postFilterClusters, 
-                                       const ComboHitCollection& shcol, float mbtime, int iev) = 0;
-            virtual float distance(const BkgCluster& cluster, const ComboHit& hit) const = 0; 
+                                       const ComboHitCollection& shcol, int iev) = 0;
+            virtual float distance    (const BkgCluster& cluster, const ComboHit& hit) const = 0; 
     };
 }
 

--- a/TrkReco/inc/ScanClusterer.hh
+++ b/TrkReco/inc/ScanClusterer.hh
@@ -44,14 +44,14 @@ namespace mu2e {
 
           void          init();
           virtual void  findClusters(BkgClusterCollection& preFilterClusters, BkgClusterCollection& postFilterClusters, 
-                                     const ComboHitCollection& shcol, float mbtime, int iev);
+                                     const ComboHitCollection& shcol, int iev);
 
           virtual float distance(const BkgCluster& cluster, const ComboHit& hit) const {return 0.0;} 
 
       private:         
           
-          void fastFilter1(BkgClusterCollection& clusters, const ComboHitCollection& chcol, const float mbtime);
-          void fastFilter2(BkgClusterCollection& clusters, const ComboHitCollection& chcol, const float mbtime);
+          void fastFilter1(BkgClusterCollection& clusters, const ComboHitCollection& chcol, const float maxTime);
+          void fastFilter2(BkgClusterCollection& clusters, const ComboHitCollection& chcol, const float maxTime);
                 
 
           float            tbin_; 

--- a/TrkReco/inc/TNTClusterer.hh
+++ b/TrkReco/inc/TNTClusterer.hh
@@ -40,7 +40,6 @@ namespace mu2e {
               fhicl::Atom<float>            seedDistance{     Name("SeedDistance"),     Comment("Minimum distance for cluster seed")  };
               fhicl::Atom<float>            clusterDiameter{  Name("ClusterDiameter"),  Comment("Average cluster diameter")  };
               fhicl::Atom<float>            clusterTime{      Name("ClusterTime"),      Comment("Average cluster time spread")  };
-              fhicl::Atom<float>            deltaTimeBinMin{  Name("DeltaTimeBinMin"),  Comment("Delta time for cluster lookup")  };
               fhicl::Atom<float>            maxHitTimeDiff{   Name("MaxHitTimeDiff"),   Comment("Maximum hit cluster tme difference")  };
               fhicl::Atom<float>            maxSumDistance{   Name("MaxSumDistance"),   Comment("Maximum sum pf hit-cluster distance for convergence") };        
               fhicl::Atom<float>            minHitError{      Name("MinHitError"),      Comment("Min value of hit error")  };
@@ -48,11 +47,6 @@ namespace mu2e {
               fhicl::Atom<float>            timeRMS{          Name("TimeRMS"),          Comment("Cluster time RMS")  };
               fhicl::Atom<unsigned>         maxCluIterations{ Name("MaxCluIterations"), Comment("Maximum number of cluster algo iterations") };
               fhicl::Atom<bool>             medianCentroid {  Name("MedianCentroid"),   Comment("Use median to calculate cluster centroid") };
-              fhicl::Atom<bool>             preFilter{        Name("preFilter"),        Comment("Fast preFiltering algorithm") };
-              fhicl::Atom<float>            pfTimeBin{        Name("pfTimeBin"),        Comment("Time bin size for preFiltering algorithm") };
-              fhicl::Atom<float>            pfPhiBin{         Name("pfPhiBin"),         Comment("Phi bin size for preFiltering algorithm") };
-              fhicl::Atom<unsigned>         pfMinHit{         Name("pfMinHit"),         Comment("Minimum number of hits inside bin for preFitlering algorithm") };
-              fhicl::Atom<unsigned>         pfMinSumHit{      Name("pfMinSumHit"),      Comment("Minimum number of hits for sum of bins for preFitlering algorithm") };
               fhicl::Atom<bool>             comboInit{        Name("ComboInit"),        Comment("Start with combo hits") };
               fhicl::Sequence<std::string>  bkgmsk{           Name("BackgroundMask"),   Comment("Bkg hit selection mask") };
               fhicl::Sequence<std::string>  sigmsk{           Name("SignalMask"),       Comment("Signal hit selection mask") };
@@ -64,29 +58,25 @@ namespace mu2e {
           explicit TNTClusterer(const Config& config);
           virtual ~TNTClusterer() {};
 
-          void          init();
+          void          init        ();
           virtual void  findClusters(BkgClusterCollection& preFilterClusters, BkgClusterCollection& postFilterClusters, 
-                                     const ComboHitCollection& shcol, float mbtime, int iev);
-          virtual float distance(const BkgCluster& cluster, const ComboHit& hit) const; 
+                                     const ComboHitCollection& shcol, int iev);
+          virtual float distance    (const BkgCluster& cluster, const ComboHit& hit) const; 
 
 
       private:                   
           static const int numBuckets = 256; //number of buckets to store the clusters vs time - optimized for speed
           using arrayVecBkg = std::array<std::vector<int>,numBuckets>;
 
-          void     initClu(const ComboHitCollection& chcol, std::vector<BkgCluster>& clusters, std::vector<BkgHit>& hinfo, const std::vector<unsigned>& hitSel ); 
-          void     preFilter(BkgClusterCollection& clusters, const ComboHitCollection& chcol, std::vector<unsigned>& hitSel, const float mbtime);
-
-          void     clusterAlgo(const ComboHitCollection& chcol, std::vector<BkgCluster>& clusters, 
-                               std::vector<BkgHit>& hinfo, float tbin);
-          unsigned formClusters(const ComboHitCollection& chcol, std::vector<BkgCluster>& clusters, float tbin, 
-                                std::vector<BkgHit>& hinfo, arrayVecBkg& hitIndex);
+          void     initClu      (const ComboHitCollection& chcol, std::vector<BkgCluster>& clusters, std::vector<BkgHit>& hinfo); 
+          void     clusterAlgo  (const ComboHitCollection& chcol, std::vector<BkgCluster>& clusters, std::vector<BkgHit>& hinfo, float tbin);
+          unsigned formClusters (const ComboHitCollection& chcol, std::vector<BkgCluster>& clusters, float tbin, 
+                                 std::vector<BkgHit>& hinfo, arrayVecBkg& hitIndex);
           void     mergeClusters(std::vector<BkgCluster>& clusters, const ComboHitCollection& chcol, 
                                  std::vector<BkgHit>& hinfo, float dt, float dd2);
-          void     mergeTwoClu(BkgCluster& clu1, BkgCluster& clu2 );
+          void     mergeTwoClu  (BkgCluster& clu1, BkgCluster& clu2 );
           void     updateCluster(BkgCluster& cluster, const ComboHitCollection& chcol, std::vector<BkgHit>& hinfo);
-
-          void     dump(const std::vector<BkgCluster>& clusters, std::vector<BkgHit>& hinfo);
+          void     dump         (const std::vector<BkgCluster>& clusters, std::vector<BkgHit>& hinfo);
 
           std::vector<int> hitDtIdx_;
           float            dhit_;      
@@ -97,16 +87,10 @@ namespace mu2e {
           float            maxwt_; 
           float            md2_;
           float            trms2inv_; 
-          float            tbinMin_;        
           float            maxHitdt_;   
           float            maxDistSum_; 
           unsigned         maxNiter_;    
           bool             useMedian_;  
-          bool             preFilter_;  
-          float            pfTimeBin_;
-          float            pfPhiBin_;
-          unsigned         pfMinHit_;
-          unsigned         pfMinSumHit_;
           bool             comboInit_;  
           StrawHitFlag     bkgmask_;    
           StrawHitFlag     sigmask_;    

--- a/TrkReco/src/ScanClusterer.cc
+++ b/TrkReco/src/ScanClusterer.cc
@@ -31,15 +31,20 @@ namespace mu2e
 
    //----------------------------------------------------------------------------------------------------------
    void ScanClusterer::findClusters(BkgClusterCollection& preFilterClusters, BkgClusterCollection& postFilterClusters,
-                                      const ComboHitCollection& chcol, float mbtime, int iev)
+                                      const ComboHitCollection& chcol, int iev)
    {             
+       if (chcol.empty()) return;
+        auto maxTime = std::max_element(chcol.begin(),chcol.end(),[](const auto a, const auto b){return a.time() <b.time();})->time()+0.1f;
+
+
+
        switch ( filterAlgo_ )
        {
          case 1:
-            fastFilter1(preFilterClusters,chcol,mbtime);
+            fastFilter1(preFilterClusters,chcol,maxTime);
             break;
          case 2:
-            fastFilter2(preFilterClusters,chcol,mbtime);
+            fastFilter2(preFilterClusters,chcol,maxTime);
             break;
         default:
             throw cet::exception("RECO")<< "[ScanClusterer] Unknown filter option " << filterAlgo_<< std::endl;
@@ -47,9 +52,9 @@ namespace mu2e
    }
    
    //----------------------------------------------------------------------------------------------------------------------
-   void ScanClusterer::fastFilter1(BkgClusterCollection& clusters, const ComboHitCollection& chcol, const float mbtime)
+   void ScanClusterer::fastFilter1(BkgClusterCollection& clusters, const ComboHitCollection& chcol, const float maxTime)
    {                            
-       const unsigned nTimeBins = unsigned(mbtime/tbin_)+1;
+       const unsigned nTimeBins = unsigned(maxTime/tbin_)+1;
        const unsigned nPhiBins  = unsigned(2*M_PI/pbin_)+1;
        const unsigned nRadBins  = unsigned((rmax_-rmin_)/rbin_)+1;
        const unsigned nRTBins   = nTimeBins*nRadBins;
@@ -107,9 +112,9 @@ namespace mu2e
 
 
    //----------------------------------------------------------------------------------------------------------------------
-   void ScanClusterer::fastFilter2(BkgClusterCollection& clusters, const ComboHitCollection& chcol, const float mbtime)
+   void ScanClusterer::fastFilter2(BkgClusterCollection& clusters, const ComboHitCollection& chcol, const float maxTime)
    {                            
-       const unsigned nTimeBins = unsigned(mbtime/tbin_)+1;
+       const unsigned nTimeBins = unsigned(maxTime/tbin_)+1;
        const unsigned nPhiBins  = unsigned(2*M_PI/pbin_)+1;
        const unsigned nRadBins  = unsigned((rmax_-rmin_)/rbin_)+1;
        const unsigned nRTBins   = nTimeBins*nRadBins;

--- a/TrkReco/src/TNTClusterer.cc
+++ b/TrkReco/src/TNTClusterer.cc
@@ -11,16 +11,10 @@ namespace mu2e
       dseed_      (config.seedDistance()),           
       dd_         (config.clusterDiameter()),   
       dt_         (config.clusterTime()),    
-      tbinMin_    (config.deltaTimeBinMin()),    
       maxHitdt_   (config.maxHitTimeDiff()),      
       maxDistSum_ (config.maxSumDistance()),   
       maxNiter_   (config.maxCluIterations()),
       useMedian_  (config.medianCentroid()),         
-      preFilter_  (config.preFilter()),         
-      pfTimeBin_  (config.pfTimeBin()),      
-      pfPhiBin_   (config.pfPhiBin()),      
-      pfMinHit_   (config.pfMinHit()),
-      pfMinSumHit_(config.pfMinSumHit()),
       comboInit_  (config.comboInit()),         
       bkgmask_    (config.bkgmsk()),
       sigmask_    (config.sigmsk()),
@@ -45,102 +39,41 @@ namespace mu2e
 
    //----------------------------------------------------------------------------------------------------------
    void TNTClusterer::findClusters(BkgClusterCollection& preFilterClusters, BkgClusterCollection& postFilterClusters, 
-                                   const ComboHitCollection& chcol, float mbtime, int iev)
+                                   const ComboHitCollection& chcol, int iev)
    {        
         std::vector<BkgHit> BkgHits;
         BkgHits.reserve(chcol.size());
+        if (chcol.empty()) return;
 
-        //adjust the time binning to index clusters in the clustering algo
-        float tbin = std::max(mbtime/float(numBuckets)+0.001f,tbinMin_);
-        if (int(mbtime/tbin) >= numBuckets) throw cet::exception("RECO")<< "Too many bucket bins requested for TNTCluster!"<< std::endl;        
-        int  ditime = int(maxHitdt_/tbin);
+        //Loop over hits to find max hit time and define the time binning to index clusters in the clustering algo
+        auto maxTime = std::max_element(chcol.begin(),chcol.end(),[](const auto a, const auto b){return a.time() <b.time();})->time()+1.0f;
+        float tbin   = maxTime/float(numBuckets);
+        int  ditime  = int(maxHitdt_/tbin);
         hitDtIdx_.clear();
-        for (int i=0;i<=ditime;++i) {hitDtIdx_.push_back(i); if (i>0) hitDtIdx_.push_back(-i);}                 
-
-        //Fast pre-filtering
-        std::vector<unsigned> hitSel(chcol.size(),1); 
-        if (preFilter_) preFilter(preFilterClusters,chcol,hitSel,mbtime);
+        for (int i=0;i<=ditime;++i) {hitDtIdx_.push_back(i); if (i>0) hitDtIdx_.push_back(-i);}    
 
         //Two stage clustering
-        initClu(chcol, postFilterClusters, BkgHits, hitSel);
+        initClu(chcol, postFilterClusters, BkgHits);
         clusterAlgo(chcol, postFilterClusters, BkgHits, tbin);
 
         //removing empty usters
-        postFilterClusters.erase(std::remove_if(postFilterClusters.begin(),postFilterClusters.end(),[](auto& cluster){return cluster.hits().empty();}),postFilterClusters.end());
+        auto removePred = [](auto& cluster){return cluster.hits().empty();};
+        postFilterClusters.erase(std::remove_if(postFilterClusters.begin(),postFilterClusters.end(),removePred),postFilterClusters.end());
 
         //Transform BkgHits indices into ComboHit indices
-        for (auto& cluster: postFilterClusters)
-            std::transform(cluster.hits().begin(),cluster.hits().end(),cluster.hits().begin(),
-                           [&BkgHits] (const int i){return BkgHits[i].chidx_;});
+        auto transPred = [&BkgHits] (const int i){return BkgHits[i].chidx_;};
+        for (auto& cluster: postFilterClusters) std::transform(cluster.hits().begin(),cluster.hits().end(),cluster.hits().begin(),transPred);
    }
-   
-
-   
-   //----------------------------------------------------------------------------------------------------------------------
-   // PRE-FILTRING ALGORITHM(S)
-   
-   void TNTClusterer::preFilter(BkgClusterCollection& clusters, const ComboHitCollection& chcol, std::vector<unsigned>& hitSel, const float mbtime)
-   {                            
-          
-       const unsigned nTimeBins = unsigned(mbtime/pfTimeBin_)+2;
-       const unsigned nPhiBins  = unsigned(2*M_PI/pfPhiBin_+1e-5)+1;
-       const unsigned nTotBins  = nTimeBins*nPhiBins;
-
-       std::vector<unsigned> timePhiHist(nTotBins,0), blindIdx(nTotBins,0);
-       for (unsigned ich=0; ich<chcol.size();++ich)
-       {
-           const ComboHit& hit = chcol[ich];          
-           if (testflag_ && (!hit.flag().hasAllProperties(sigmask_) || hit.flag().hasAnyProperty(bkgmask_))) continue;            
-
-           unsigned pOffset = unsigned( (hit.phi()+M_PI)/pfPhiBin_ );
-           unsigned tOffset = unsigned(  hit.time()/pfTimeBin_ );
-           unsigned idx     =  tOffset + pOffset*nTimeBins;
-           timePhiHist[idx] += 1;  //we could make it nStrawHits here instead
-       }
-
-       for (unsigned idx=1;idx<nTotBins-1;++idx)
-       {     
-           if (idx%nTimeBins==0 || idx%nTimeBins+1==nTimeBins) continue;   
-
-           unsigned idxUp    = (idx+nTimeBins+nTotBins)%nTotBins;
-           unsigned idxDown  = (idx-nTimeBins+nTotBins)%nTotBins;
-           unsigned sum      = timePhiHist[idx]+timePhiHist[idx-1]+timePhiHist[idx+1]+timePhiHist[idxUp]+
-                               timePhiHist[idxUp-1]+timePhiHist[idxUp+1]+timePhiHist[idxDown]+
-                               timePhiHist[idxDown-1]+timePhiHist[idxDown+1];
-           
-           if (timePhiHist[idx]<pfMinHit_ && sum < pfMinSumHit_) continue;   
-           
-           blindIdx[idx]     = 1;
-           blindIdx[idx+1]   = blindIdx[idx-1]     = 1;
-           blindIdx[idxUp]   = blindIdx[idxUp+1]   = blindIdx[idxUp-1]   = 1;
-           blindIdx[idxDown] = blindIdx[idxDown+1] = blindIdx[idxDown-1] = 1;
-       }
-
-       //collect all preFiltered hits in a single cluster
-       clusters.emplace_back(BkgCluster(XYZVectorF(0,0,0), 0));
-       for (unsigned ich=0; ich<chcol.size();++ich)
-       {
-           const ComboHit& hit = chcol[ich];          
-           unsigned pOffset = unsigned( (hit.phi()+M_PI)/pfPhiBin_);
-           unsigned tOffset = unsigned(  hit.time()/pfTimeBin_);
-           unsigned idx     =  tOffset + pOffset*nTimeBins;
-
-           if (blindIdx[idx]==0) continue;
-           hitSel[ich]=0;
-           clusters.back().addHit(ich);  
-       }
-   }    
    
    
    //----------------------------------------------------------------------------------------------------------------------
    // CLUSTERING ALGORITHM
-   
-   void TNTClusterer::initClu(const ComboHitCollection& chcol, std::vector<BkgCluster>& clusters, std::vector<BkgHit>& BkgHits, const std::vector<unsigned>& hitSel) 
+   //   
+   void TNTClusterer::initClu(const ComboHitCollection& chcol, std::vector<BkgCluster>& clusters, std::vector<BkgHit>& BkgHits) 
    {      
         for (size_t ich=0; ich<chcol.size(); ++ich)
         {         
-             if (hitSel[ich]==0) continue;
-             if (testflag_ && (!chcol[ich].flag().hasAllProperties(sigmask_) || chcol[ich].flag().hasAnyProperty(bkgmask_))) continue;           
+             if (testflag_ && (!chcol[ich].flag().hasAllProperties(sigmask_) || chcol[ich].flag().hasAnyProperty(bkgmask_))) continue; 
              BkgHits.emplace_back(BkgHit(ich));                 
         }
 
@@ -199,6 +132,7 @@ namespace mu2e
 
            for (auto i : hitDtIdx_)
            {
+               if (itime+i >= numBuckets || itime+i<0) continue; 
                for (const auto& ic : hitIndex[itime+i])
                {                
                    float dist = distance(clusters[ic],chcol[hit.chidx_]);
@@ -440,81 +374,3 @@ namespace mu2e
    }
    
 }
-
-
-/*
-   void TNTClusterer::preFilter2(BkgClusterCollection& clusters, const ComboHitCollection& chcol, std::vector<unsigned>& hitSel, const float mbtime)
-   {                            
-const unsigned pfMinExpandHit_(3);
-const float    pfminRadHit_(50);
-
-       const unsigned nTimeBins = unsigned(mbtime/pfTimeBin_);
-       const unsigned nPhiBins  = unsigned(2*M_PI/pfPhiBin_+1e-5)+1;
-       const unsigned nTotBins  = nTimeBins*nPhiBins;
-
-       std::vector<unsigned> timePhiHist(nTotBins,0), blindIdx(nTotBins,0);
-       std::vector<float>    radHist(nTotBins,0);      
-       for (unsigned ich=0; ich<chcol.size();++ich)
-       {
-           const ComboHit& hit = chcol[ich];          
-           if (testflag_ && (!hit.flag().hasAllProperties(sigmask_) || hit.flag().hasAnyProperty(bkgmask_))) continue;            
-
-           unsigned pOffset = unsigned( (hit.phi()+M_PI)/pfPhiBin_);
-           unsigned tOffset = unsigned( hit.time()/pfTimeBin_);
-           unsigned idx     =  tOffset + pOffset*nTimeBins;
-           timePhiHist[idx] += 1;  //we could make it nStrawHits here instead
-           radHist[idx] += sqrtf(hit.pos().perp2());
-       }
-
-       unsigned numCluster(1);
-       std::vector<float> radii{0};
-       for (unsigned idx=0;idx<nTotBins-1;++idx)
-       {          
-           unsigned numHitBox(timePhiHist[idx]);
-           if (idx%nTimeBins>0) numHitBox += timePhiHist[idx-1];
-           if (idx%nTimeBins+1<nTimeBins) numHitBox += timePhiHist[idx+1];
-           if (numHitBox<pfMinHit_) continue;
-
-           std::queue<unsigned> toProcess;
-           toProcess.emplace(idx);
-
-           float sumRad(0),sumNorm(0);
-           while (!toProcess.empty())
-           {             
-              unsigned j = toProcess.front();                          
-              if (timePhiHist[j] >= pfMinExpandHit_)
-              {
-                  blindIdx[j] = numCluster;
-                  sumRad  += radHist[j];
-                  sumNorm += timePhiHist[j];    
-
-                  if (j%nTimeBins>0)           toProcess.emplace(j-1);
-                  if (j%nTimeBins+1<nTimeBins) toProcess.emplace(j+1);
-                  toProcess.emplace((j+nTimeBins+nTotBins)%nTotBins);
-                  toProcess.emplace((j-nTimeBins+nTotBins)%nTotBins);
-              } 
-
-              timePhiHist[j]=0;                     
-              toProcess.pop();
-           }
-           radii.push_back(sumRad/sumNorm);                    
-           ++numCluster;           
-       }
-
-       //collect all preFiltered hits in a single cluster       
-       for (unsigned ich=0; ich<chcol.size();++ich)
-       {
-           const ComboHit& hit = chcol[ich];          
-           unsigned pOffset = unsigned( (hit.phi()+M_PI)/pfPhiBin_);
-           unsigned tOffset = unsigned(  hit.time()/pfTimeBin_);
-           unsigned idx     =  tOffset + pOffset*nTimeBins;
-
-           if (blindIdx[idx]==0) continue;
-           float dr = std::abs(sqrtf(hit.pos().perp2())-radii[blindIdx[idx]]);
-           if (dr < pfminRadHit_) continue;
-           
-           hitSel[ich]=0;
-           clusters.back().addHit(ich);  
-       }        
-   }
-*/


### PR DESCRIPTION
A fix for the bug Richie encountered with the FlagBkgHit module, making the module independent of the "microbunch length". I took the opportunity to do some cleaning as well. Check that the track reco performance is essentially unchanged (there is a small change in the hit flagging algo but the impact is very limited)