### PR TITLE
Cosmic resampler fix

### DIFF
--- a/EventMixing/src/Mu2eProductMixer.cc
+++ b/EventMixing/src/Mu2eProductMixer.cc
@@ -331,6 +331,9 @@ namespace mu2e {
       auto ie = getInputEventIndex(i, stepOffsets);
       auto& step = out[i];
       step.setSimParticle( remap(step.simParticle(), simOffsets_[ie]) );
+      if(applyTimeOffset_){
+        step.time() += stoff_.timeOffset_;
+      }
     }
 
     return true;
@@ -348,6 +351,9 @@ namespace mu2e {
       auto ie = getInputEventIndex(i, stepOffsets);
       auto& step = out[i];
       step.simParticle() = remap(step.simParticle(), simOffsets_[ie]);
+      if(applyTimeOffset_){
+        step.time() += stoff_.timeOffset_;
+      }
     }
 
     return true;
@@ -364,6 +370,10 @@ namespace mu2e {
       auto ie = getInputEventIndex(i, stepOffsets);
       auto& step = out[i];
       step.simParticle() = remap(step.simParticle(), simOffsets_[ie]);
+      if(applyTimeOffset_){
+        step.startTime() += stoff_.timeOffset_;
+        step.endTime() += stoff_.timeOffset_;
+      }
     }
 
     return true;

--- a/MCDataProducts/inc/CaloShowerStep.hh
+++ b/MCDataProducts/inc/CaloShowerStep.hh
@@ -10,13 +10,13 @@
 namespace mu2e {
 
 
-   class CaloShowerStep 
+   class CaloShowerStep
    {
-       public:         
+       public:
           CaloShowerStep(): sim_(),volumeG4ID_(-1),nCompress_(0),time_(0),energyDepG4_(0),energyDepBirks_(0),momentumIn_(0),pos_() {}
-          
-          CaloShowerStep(int volumeG4ID, const art::Ptr<SimParticle>& sim, unsigned nCompress, float time, float energyDepG4, 
-                         float energyDepBirks, float momentumIn, const CLHEP::Hep3Vector& pos): 
+
+          CaloShowerStep(int volumeG4ID, const art::Ptr<SimParticle>& sim, unsigned nCompress, float time, float energyDepG4,
+                         float energyDepBirks, float momentumIn, const CLHEP::Hep3Vector& pos):
             sim_(sim),
             volumeG4ID_(volumeG4ID),
             nCompress_(nCompress),
@@ -28,32 +28,33 @@ namespace mu2e {
           {}
 
           const art::Ptr<SimParticle>&   simParticle()    const {return sim_;}
-          const CLHEP::Hep3Vector&       position()       const {return pos_;}          
+          const CLHEP::Hep3Vector&       position()       const {return pos_;}
           int                            volumeG4ID()     const {return volumeG4ID_;}
           unsigned                       nCompress()      const {return nCompress_;}
           double                         time()           const {return time_;}
+          double&                        time()           {return time_;} // non-const used for resampling
           float                          energyDepG4()    const {return energyDepG4_;}
           float                          energyDepBirks() const {return energyDepBirks_;}
           float                          momentumIn()     const {return momentumIn_;}
 
-          void setSimParticle(const art::Ptr<SimParticle>& sim) {sim_ = sim;}                                                    
-          
+          void setSimParticle(const art::Ptr<SimParticle>& sim) {sim_ = sim;}
+
           void print(std::ostream& ost = std::cout) const {ost<<"Calo Shower content    volumeG4ID = "<<volumeG4ID_<<"  pid="<<sim_->pdgId()
                                                               <<"  edep="<<energyDepG4_<<"  evis="<<energyDepBirks_
                                                               <<"  time="<<time_       <<"  position = "<<pos_<<std::endl;}
-       private:       
-          art::Ptr<SimParticle>   sim_;            
-          int                     volumeG4ID_;       
-          unsigned                nCompress_;      
-          double                  time_;           
-          float                   energyDepG4_;    
-          float                   energyDepBirks_; 
-          float                   momentumIn_;     
-          CLHEP::Hep3Vector       pos_;            
+       private:
+          art::Ptr<SimParticle>   sim_;
+          int                     volumeG4ID_;
+          unsigned                nCompress_;
+          double                  time_;
+          float                   energyDepG4_;
+          float                   energyDepBirks_;
+          float                   momentumIn_;
+          CLHEP::Hep3Vector       pos_;
    };
 
 
    using CaloShowerStepCollection = std::vector<mu2e::CaloShowerStep>;
-} 
+}
 
 #endif

--- a/MCDataProducts/inc/CrvStep.hh
+++ b/MCDataProducts/inc/CrvStep.hh
@@ -2,7 +2,7 @@
 #define MCDataProducts_CrvStep_hh
 //
 // Class to summarize the passage of a single particle through a single CRV counter
-// This consolidates the G4 steps and insulates the downstream CRV response simulation 
+// This consolidates the G4 steps and insulates the downstream CRV response simulation
 // from details of the G4 model
 //
 #include "canvas/Persistency/Common/Ptr.h"
@@ -14,17 +14,17 @@
 #include "CLHEP/Vector/ThreeVector.h"
 #include <Rtypes.h>
 
-namespace mu2e 
+namespace mu2e
 {
-  class CrvStep 
+  class CrvStep
   {
     public:
 
       CrvStep() : _visibleEDep(0.0), _startTime(0.0), _endTime(0.0), _pathLength(0.0) {}
       CrvStep(CRSScintillatorBarIndex barIndex, float visibleEDep, double startTime, double endTime,
-              const XYZVectorF &startPos, const XYZVectorF &endPos, const XYZVectorF &startMom, float endMom, 
+              const XYZVectorF &startPos, const XYZVectorF &endPos, const XYZVectorF &startMom, float endMom,
               float pathLength, art::Ptr<SimParticle> const& simParticle) :
-              _barIndex(barIndex), _visibleEDep(visibleEDep), 
+              _barIndex(barIndex), _visibleEDep(visibleEDep),
               _startTime(startTime), _endTime(endTime), _startPos(startPos), _endPos(endPos),
               _startMom(startMom), _endMom(endMom),
               _pathLength(pathLength), _simParticle(simParticle) {}
@@ -33,6 +33,8 @@ namespace mu2e
       float                        visibleEDep() const {return _visibleEDep;}
       double                       startTime() const   {return _startTime;}
       double                       endTime() const     {return _endTime;}
+      double&                       startTime() {return _startTime;}; // non-const used for resampling
+      double&                       endTime() {return _endTime;}
 
       XYZVectorF const&                startPos() const    {return _startPos;}
       XYZVectorF const&                endPos() const      {return _endPos;}
@@ -50,12 +52,12 @@ namespace mu2e
 
     private:
       CRSScintillatorBarIndex _barIndex;
-      float                   _visibleEDep; 
+      float                   _visibleEDep;
       double                  _startTime, _endTime; //must be double to allow for long-lived particles
       XYZVectorF                  _startPos,  _endPos;
       XYZVectorF                  _startMom;
       float                   _endMom;              //direction of end momentum is not known
-      float                   _pathLength;          //the actual step length, which may be longer 
+      float                   _pathLength;          //the actual step length, which may be longer
                                                     //than the differences between endPos and startPos
       art::Ptr<SimParticle>   _simParticle;
   };
@@ -64,7 +66,7 @@ namespace mu2e
 
   inline std::ostream& operator<<( std::ostream& ost, CrvStep const& cs){
     ost << "CrvStep BarIndex " << cs.barIndex()
-    << " visible energy deposit " << cs.visibleEDep() 
+    << " visible energy deposit " << cs.visibleEDep()
     << " path length " << cs.pathLength();
     return ost;
   }

--- a/MCDataProducts/inc/StrawGasStep.hh
+++ b/MCDataProducts/inc/StrawGasStep.hh
@@ -2,7 +2,7 @@
 #define MCDataProducts_StrawGasStep_hh
 //
 // Class to summarize the passage of a single particle through a single straw's gas volume
-// This consolidates the G4 steps and insulates the downstream straw response ionization simulation 
+// This consolidates the G4 steps and insulates the downstream straw response ionization simulation
 // from details of the G4 model
 //
 #include "canvas/Persistency/Common/Ptr.h"
@@ -33,11 +33,11 @@ namespace mu2e {
 	Shape shape() const { return static_cast<Shape>(_stype & _smsk); }
 	Ionization ionization() const { return static_cast<Ionization>((_stype & _imsk) >> _isft); }
 
-      }; 
+      };
 
       StrawGasStep() : _eIon(0.0), _pathLen(0.), _width(0.0), _time(0.0) {}
       StrawGasStep( StrawId    strawId, StepType stype,
-	Float_t  Edep, Float_t    stepLength, Float_t width, Double_t   time, 
+	Float_t  Edep, Float_t    stepLength, Float_t width, Double_t   time,
 	XYZVectorF const& startPosition, XYZVectorF const& endPosition, XYZVectorF const& mom, art::Ptr<SimParticle> const& simp) :
 	_strawId(strawId), _stype(stype), _eIon(Edep),
 	_pathLen(stepLength), _width(width), _time(time),
@@ -48,8 +48,9 @@ namespace mu2e {
       StepType   stepType()    const { return _stype; }
       Float_t    ionizingEdep()    const { return _eIon; }
       Float_t    stepLength()   const { return _pathLen; }
-      Float_t    width()   const { return _width; } 
+      Float_t    width()   const { return _width; }
       Double_t   time()         const { return _time; } // time the particle entered the gas (without offsets!)
+      Double_t&   time()         { return _time; } // non-const used for resampling
       XYZVectorF const& startPosition() const { return _startpos; }
       XYZVectorF const& endPosition() const { return _endpos; }
       XYZVectorF const& momentum() const { return _mom; }
@@ -79,7 +80,7 @@ namespace mu2e {
   inline std::ostream& operator<<( std::ostream& ost, StrawGasStep const& sgs){
     ost << "StrawGasStep StrawId " << sgs.strawId() << " Type " << sgs.stepType()._stype
     << " Ionization " << sgs.ionizingEdep() << " path length " << sgs.stepLength()
-    << " Width " << sgs.width(); 
+    << " Width " << sgs.width();
     return ost;
   }
 


### PR DESCRIPTION
Resampling CrvSteps requires applying time offsets to these.  Add the capability of time offsets for all the steps, for symmetry and future applications.