### PR TITLE
constant reference edits for TFileDirectory objects

### DIFF
--- a/Validation/inc/ValBkgCluster.hh
+++ b/Validation/inc/ValBkgCluster.hh
@@ -15,7 +15,7 @@ namespace mu2e {
 
   public:
     ValBkgCluster(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const BkgClusterCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValBkgQual.hh
+++ b/Validation/inc/ValBkgQual.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValBkgQual(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const BkgQualCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValCaloCluster.hh
+++ b/Validation/inc/ValCaloCluster.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValCaloCluster(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const CaloClusterCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValCaloDigi.hh
+++ b/Validation/inc/ValCaloDigi.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValCaloDigi(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const CaloDigiCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValCaloHit.hh
+++ b/Validation/inc/ValCaloHit.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValCaloHit(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const CaloHitCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValCaloRecoDigi.hh
+++ b/Validation/inc/ValCaloRecoDigi.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValCaloRecoDigi(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const CaloRecoDigiCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValCaloShowerStep.hh
+++ b/Validation/inc/ValCaloShowerStep.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValCaloShowerStep(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const CaloShowerStepCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValComboHit.hh
+++ b/Validation/inc/ValComboHit.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValComboHit(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const ComboHitCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValCrvCoincidenceCluster.hh
+++ b/Validation/inc/ValCrvCoincidenceCluster.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValCrvCoincidenceCluster(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const CrvCoincidenceClusterCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValCrvDigi.hh
+++ b/Validation/inc/ValCrvDigi.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValCrvDigi(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const CrvDigiCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValCrvDigiMC.hh
+++ b/Validation/inc/ValCrvDigiMC.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValCrvDigiMC(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const CrvDigiMCCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValCrvRecoPulse.hh
+++ b/Validation/inc/ValCrvRecoPulse.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValCrvRecoPulse(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const CrvRecoPulseCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValCrvStep.hh
+++ b/Validation/inc/ValCrvStep.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValCrvStep(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const CrvStepCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValEventWindowMarker.hh
+++ b/Validation/inc/ValEventWindowMarker.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValEventWindowMarker(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const EventWindowMarker & obj, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValGenParticle.hh
+++ b/Validation/inc/ValGenParticle.hh
@@ -15,7 +15,7 @@ namespace mu2e {
 
   public:
     ValGenParticle(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const GenParticleCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValHelixSeed.hh
+++ b/Validation/inc/ValHelixSeed.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValHelixSeed(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const HelixSeedCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValId.hh
+++ b/Validation/inc/ValId.hh
@@ -14,7 +14,7 @@ namespace mu2e {
   class ValId {
 
   public:
-    int declare( art::TFileDirectory tfs, 
+    int declare( const art::TFileDirectory& tfs, 
 		 std::string name="id", std::string title="id fold");
     int fill(int id);
     int compress(int id);

--- a/Validation/inc/ValKalSeed.hh
+++ b/Validation/inc/ValKalSeed.hh
@@ -13,7 +13,7 @@ namespace mu2e {
 
   public:
     ValKalSeed(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const KalSeedCollection & coll, art::Event const& event);
     double mcTrkP(art::Event const& event);
     std::string& name() { return _name; }

--- a/Validation/inc/ValProtonBunchIntensity.hh
+++ b/Validation/inc/ValProtonBunchIntensity.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValProtonBunchIntensity(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const ProtonBunchIntensity & obj, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValProtonBunchTime.hh
+++ b/Validation/inc/ValProtonBunchTime.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValProtonBunchTime(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const ProtonBunchTime & obj, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValProtonBunchTimeMC.hh
+++ b/Validation/inc/ValProtonBunchTimeMC.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValProtonBunchTimeMC(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const ProtonBunchTimeMC & obj, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValSimParticle.hh
+++ b/Validation/inc/ValSimParticle.hh
@@ -16,7 +16,7 @@ namespace mu2e {
 
   public:
     ValSimParticle(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const SimParticleCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValSimParticleTimeMap.hh
+++ b/Validation/inc/ValSimParticleTimeMap.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValSimParticleTimeMap(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const SimParticleTimeMap & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValStatusG4.hh
+++ b/Validation/inc/ValStatusG4.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValStatusG4(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const StatusG4 & obj, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValStepPointMC.hh
+++ b/Validation/inc/ValStepPointMC.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValStepPointMC(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const StepPointMCCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValStrawDigi.hh
+++ b/Validation/inc/ValStrawDigi.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValStrawDigi(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const StrawDigiCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValStrawDigiADCWaveform.hh
+++ b/Validation/inc/ValStrawDigiADCWaveform.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValStrawDigiADCWaveform(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const StrawDigiADCWaveformCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValStrawDigiMC.hh
+++ b/Validation/inc/ValStrawDigiMC.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValStrawDigiMC(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const StrawDigiMCCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValStrawGasStep.hh
+++ b/Validation/inc/ValStrawGasStep.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValStrawGasStep(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const StrawGasStepCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValStrawHit.hh
+++ b/Validation/inc/ValStrawHit.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValStrawHit(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const StrawHitCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValStrawHitFlag.hh
+++ b/Validation/inc/ValStrawHitFlag.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValStrawHitFlag(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const StrawHitFlagCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValTimeCluster.hh
+++ b/Validation/inc/ValTimeCluster.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValTimeCluster(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const TimeClusterCollection & coll, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValTrackClusterMatch.hh
+++ b/Validation/inc/ValTrackClusterMatch.hh
@@ -13,7 +13,7 @@ namespace mu2e {
 
   public:
     ValTrackClusterMatch(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const TrackClusterMatchCollection & coll, art::Event const& event);
     double mcTrkP(art::Event const& event);
     std::string& name() { return _name; }

--- a/Validation/inc/ValTrackSummary.hh
+++ b/Validation/inc/ValTrackSummary.hh
@@ -13,7 +13,7 @@ namespace mu2e {
 
   public:
     ValTrackSummary(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const TrackSummaryCollection & coll, art::Event const& event);
     double mcTrkP(art::Event const& event);
     std::string& name() { return _name; }

--- a/Validation/inc/ValTriggerInfo.hh
+++ b/Validation/inc/ValTriggerInfo.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValTriggerInfo(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const mu2e::TriggerInfo & obj, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/inc/ValTriggerResults.hh
+++ b/Validation/inc/ValTriggerResults.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     ValTriggerResults(std::string name):_name(name){}
-    int declare( art::TFileDirectory tfs);
+    int declare( const art::TFileDirectory& tfs);
     int fill(const art::TriggerResults & obj, art::Event const& event);
     std::string& name() { return _name; }
 

--- a/Validation/src/ValBkgCluster.cc
+++ b/Validation/src/ValBkgCluster.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValBkgCluster.hh"
 
 
-int mu2e::ValBkgCluster::declare(art::TFileDirectory tfs) {
+int mu2e::ValBkgCluster::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NClus", "N Clusters", 100, 0.001, 500.0);
   _hr = tfs.make<TH1D>( "R", "Radius",100, 370.0, 680.0);

--- a/Validation/src/ValBkgQual.cc
+++ b/Validation/src/ValBkgQual.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValBkgQual.hh"
 
 
-int mu2e::ValBkgQual::declare(art::TFileDirectory tfs) {
+int mu2e::ValBkgQual::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NClus", "N Clusters", 100, 0.001, 500.0);
   _hmva = tfs.make<TH1D>( "mva", "mva", 50, -0.02, 1.02);

--- a/Validation/src/ValCaloCluster.cc
+++ b/Validation/src/ValCaloCluster.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValCaloCluster.hh"
 
 
-int mu2e::ValCaloCluster::declare(art::TFileDirectory tfs) {
+int mu2e::ValCaloCluster::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NClus", "N Clusters", 31, -0.05, 30.0);
   _ht = tfs.make<TH1D>( "t", "time", 100, 0.0, 2000.0);

--- a/Validation/src/ValCaloDigi.cc
+++ b/Validation/src/ValCaloDigi.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValCaloDigi.hh"
 
 
-int mu2e::ValCaloDigi::declare(art::TFileDirectory tfs) {
+int mu2e::ValCaloDigi::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NDigis", "N Digis", 101, -0.5, 100.5);
   _hN2= tfs.make<TH1D>( "NDigis2", "N Digis", 100, -0.5, 4999.5);

--- a/Validation/src/ValCaloHit.cc
+++ b/Validation/src/ValCaloHit.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValCaloHit.hh"
 
 
-int mu2e::ValCaloHit::declare(art::TFileDirectory tfs) {
+int mu2e::ValCaloHit::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NDigis", "N Hits", 101, -0.5, 100.5);
   _hN2= tfs.make<TH1D>( "NDigis2", "N Hits", 100, -0.5,4999.5);

--- a/Validation/src/ValCaloRecoDigi.cc
+++ b/Validation/src/ValCaloRecoDigi.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValCaloRecoDigi.hh"
 
 
-int mu2e::ValCaloRecoDigi::declare(art::TFileDirectory tfs) {
+int mu2e::ValCaloRecoDigi::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NDigis", "N RecoDigis", 101, -0.5, 100.5);
   _hN2= tfs.make<TH1D>( "NDigis2", "N RecoDigis", 100, -0.5,4999.5);

--- a/Validation/src/ValCaloShowerStep.cc
+++ b/Validation/src/ValCaloShowerStep.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValCaloShowerStep.hh"
 
 
-int mu2e::ValCaloShowerStep::declare(art::TFileDirectory tfs) {
+int mu2e::ValCaloShowerStep::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NStep", "N Steps", 51, -0.5, 50.5);
   _hN2 = tfs.make<TH1D>( "NStep2", "N Steps", 101, -9.5, 1000.5);

--- a/Validation/src/ValComboHit.cc
+++ b/Validation/src/ValComboHit.cc
@@ -1,7 +1,7 @@
 
 #include "Offline/Validation/inc/ValComboHit.hh"
 
-int mu2e::ValComboHit::declare(art::TFileDirectory tfs) {
+int mu2e::ValComboHit::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NHit", "N Combo Hits", 101, -0.5, 100.0);
   _hN2 = tfs.make<TH1D>( "NHit2", "N Combo Hits", 100, -0.5, 9999.5);

--- a/Validation/src/ValCrvCoincidenceCluster.cc
+++ b/Validation/src/ValCrvCoincidenceCluster.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValCrvCoincidenceCluster.hh"
 
 
-int mu2e::ValCrvCoincidenceCluster::declare(art::TFileDirectory tfs) {
+int mu2e::ValCrvCoincidenceCluster::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NClus", "N Clusters", 101, -0.5, 100.5);
   _hSec = tfs.make<TH1D>( "SecType", "Sector type",21, -10.5, 10.5);

--- a/Validation/src/ValCrvDigi.cc
+++ b/Validation/src/ValCrvDigi.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValCrvDigi.hh"
 
 
-int mu2e::ValCrvDigi::declare(art::TFileDirectory tfs) {
+int mu2e::ValCrvDigi::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NDigis", "N Digis", 101, -0.5, 100.5);
   _hN2= tfs.make<TH1D>( "NDigis2", "N Digis", 100, -0.5, 4999.5);

--- a/Validation/src/ValCrvDigiMC.cc
+++ b/Validation/src/ValCrvDigiMC.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValCrvDigiMC.hh"
 
 
-int mu2e::ValCrvDigiMC::declare(art::TFileDirectory tfs) {
+int mu2e::ValCrvDigiMC::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NDigis", "N Digis", 101, -0.5, 100.5);
   _hN2= tfs.make<TH1D>( "NDigis2", "N Digis", 100, -0.5, 4999.5);

--- a/Validation/src/ValCrvRecoPulse.cc
+++ b/Validation/src/ValCrvRecoPulse.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValCrvRecoPulse.hh"
 
 
-int mu2e::ValCrvRecoPulse::declare(art::TFileDirectory tfs) {
+int mu2e::ValCrvRecoPulse::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NPulses", "N Pulses", 101, -0.5, 100.5);
   _hN2= tfs.make<TH1D>( "NPulse2", "N Pulses", 100, -0.5, 2000.0);

--- a/Validation/src/ValCrvStep.cc
+++ b/Validation/src/ValCrvStep.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValCrvStep.hh"
 
 
-int mu2e::ValCrvStep::declare(art::TFileDirectory tfs) {
+int mu2e::ValCrvStep::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NStep", "N Steps", 101, -9.5, 1000.5);
   _hb = tfs.make<TH1D>( "bar", "bar number", 100, -0.5, 5503.5);

--- a/Validation/src/ValEventWindowMarker.cc
+++ b/Validation/src/ValEventWindowMarker.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValEventWindowMarker.hh"
 
 
-int mu2e::ValEventWindowMarker::declare(art::TFileDirectory tfs) {
+int mu2e::ValEventWindowMarker::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hst = tfs.make<TH1D>( "st", "Spill type", 6, -0.5, 5.5);
   _hlen = tfs.make<TH1D>( "len", "Event length", 50, 1600.0, 1800.0);

--- a/Validation/src/ValGenParticle.cc
+++ b/Validation/src/ValGenParticle.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValGenParticle.hh"
 
 
-int mu2e::ValGenParticle::declare(art::TFileDirectory tfs) {
+int mu2e::ValGenParticle::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "Ngen", "N Particle", 100, -0.05, 1000.0);
   _id.declare(tfs);

--- a/Validation/src/ValHelixSeed.cc
+++ b/Validation/src/ValHelixSeed.cc
@@ -4,7 +4,7 @@
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 #include "Offline/Mu2eUtilities/inc/HelixTool.hh"
 
-int mu2e::ValHelixSeed::declare(art::TFileDirectory tfs) {
+int mu2e::ValHelixSeed::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.5);
   _hN = tfs.make<TH1D>( "NSeed", "N KalSeed", 11, -0.5, 10.5);
   _hNCombo = tfs.make<TH1D>( "NCombo", "N Combo Hits", 101, -0.5, 100.5);

--- a/Validation/src/ValId.cc
+++ b/Validation/src/ValId.cc
@@ -1,7 +1,7 @@
 
 #include "Offline/Validation/inc/ValId.hh"
 
-int mu2e::ValId::declare(art::TFileDirectory tfs, 
+int mu2e::ValId::declare(const art::TFileDirectory& tfs, 
 			 std::string name, std::string title) {
   _hid = tfs.make<TH1D>( name.c_str(), title.c_str(), 121, -60.5, 60.5);
   return 0;

--- a/Validation/src/ValKalSeed.cc
+++ b/Validation/src/ValKalSeed.cc
@@ -3,7 +3,7 @@
 #include "Offline/MCDataProducts/inc/SimParticle.hh"
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 
-int mu2e::ValKalSeed::declare(art::TFileDirectory tfs) {
+int mu2e::ValKalSeed::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NSeed", "N KalSeed", 11, -0.5, 10.0);
   _hNStraw = tfs.make<TH1D>( "NHit", "N Hits", 101, -0.5, 100.0);

--- a/Validation/src/ValProtonBunchIntensity.cc
+++ b/Validation/src/ValProtonBunchIntensity.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValProtonBunchIntensity.hh"
 
 
-int mu2e::ValProtonBunchIntensity::declare(art::TFileDirectory tfs) {
+int mu2e::ValProtonBunchIntensity::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hint = tfs.make<TH1D>( "int", "PBI/1e6", 100, 0.0, 200.0);
 

--- a/Validation/src/ValProtonBunchTime.cc
+++ b/Validation/src/ValProtonBunchTime.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValProtonBunchTime.hh"
 
 
-int mu2e::ValProtonBunchTime::declare(art::TFileDirectory tfs) {
+int mu2e::ValProtonBunchTime::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _htime = tfs.make<TH1D>( "time", "time", 50, -250.0, -150.0);
   _hterr = tfs.make<TH1D>( "terr", "time error", 50, 0.0, 20.0);

--- a/Validation/src/ValProtonBunchTimeMC.cc
+++ b/Validation/src/ValProtonBunchTimeMC.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValProtonBunchTimeMC.hh"
 
 
-int mu2e::ValProtonBunchTimeMC::declare(art::TFileDirectory tfs) {
+int mu2e::ValProtonBunchTimeMC::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _htime = tfs.make<TH1D>( "time", "time", 50, -250.0, -150.0);
 

--- a/Validation/src/ValSimParticle.cc
+++ b/Validation/src/ValSimParticle.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValSimParticle.hh"
 #include <vector>
 
-int mu2e::ValSimParticle::declare(art::TFileDirectory tfs) {
+int mu2e::ValSimParticle::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "Nsim", "N particle", 100, -0.05, 1000.0);
   _hN2 = tfs.make<TH1D>( "Nsim2", "log10(N particle)", 100, 0.0, 6.00);

--- a/Validation/src/ValSimParticleTimeMap.cc
+++ b/Validation/src/ValSimParticleTimeMap.cc
@@ -1,7 +1,7 @@
 
 #include "Offline/Validation/inc/ValSimParticleTimeMap.hh"
 
-int mu2e::ValSimParticleTimeMap::declare(art::TFileDirectory tfs) {
+int mu2e::ValSimParticleTimeMap::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "Nsim", "N particle", 101, -0.5, 100.5);
   _ht = tfs.make<TH1D>( "t", "time", 100, 0.0, 2000.0);

--- a/Validation/src/ValStatusG4.cc
+++ b/Validation/src/ValStatusG4.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValStatusG4.hh"
 
 
-int mu2e::ValStatusG4::declare(art::TFileDirectory tfs) {
+int mu2e::ValStatusG4::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hstat = tfs.make<TH1D>( "stat", "Status", 50, -0.5, 50.5);
   _hnTrk = tfs.make<TH1D>( "Ntrk", "N gtrk", 101, -0.5, 100.5);

--- a/Validation/src/ValStepPointMC.cc
+++ b/Validation/src/ValStepPointMC.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValStepPointMC.hh"
 
 
-int mu2e::ValStepPointMC::declare(art::TFileDirectory tfs) {
+int mu2e::ValStepPointMC::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NStep", "N Steps", 100, -0.05, 1000.0);
   _id.declare(tfs);

--- a/Validation/src/ValStrawDigi.cc
+++ b/Validation/src/ValStrawDigi.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValStrawDigi.hh"
 #include "Offline/DataProducts/inc/StrawEnd.hh"
 
-int mu2e::ValStrawDigi::declare(art::TFileDirectory tfs) {
+int mu2e::ValStrawDigi::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NHit", "N Straw Hits", 101, -0.5, 100.0);
   _hN2 = tfs.make<TH1D>( "NHit2", "N Straw Hits", 100, -0.5, 9999.5);

--- a/Validation/src/ValStrawDigiADCWaveform.cc
+++ b/Validation/src/ValStrawDigiADCWaveform.cc
@@ -3,7 +3,7 @@
 #include "Offline/Validation/inc/ValStrawDigiADCWaveform.hh"
 #include "Offline/DataProducts/inc/StrawEnd.hh"
 
-int mu2e::ValStrawDigiADCWaveform::declare(art::TFileDirectory tfs) {
+int mu2e::ValStrawDigiADCWaveform::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NHit", "N Waveform", 101, -0.5, 100.0);
   _hN2 = tfs.make<TH1D>( "NHit2", "N Waveform", 100, -0.5, 9999.5);

--- a/Validation/src/ValStrawDigiMC.cc
+++ b/Validation/src/ValStrawDigiMC.cc
@@ -1,7 +1,7 @@
 
 #include "Offline/Validation/inc/ValStrawDigiMC.hh"
 
-int mu2e::ValStrawDigiMC::declare(art::TFileDirectory tfs) {
+int mu2e::ValStrawDigiMC::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NHit", "N Straw Hits", 101, -0.5, 100.0);
   _hN2 = tfs.make<TH1D>( "NHit2", "N Straw Hits", 100, -0.5, 9999.5);

--- a/Validation/src/ValStrawGasStep.cc
+++ b/Validation/src/ValStrawGasStep.cc
@@ -2,7 +2,7 @@
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 
-int mu2e::ValStrawGasStep::declare(art::TFileDirectory tfs) {
+int mu2e::ValStrawGasStep::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NHit", "N Straw Hits", 101, -0.5, 100.0);
   _hN2 = tfs.make<TH1D>( "NHit2", "N Straw Hits", 100, -0.5, 9999.5);

--- a/Validation/src/ValStrawHit.cc
+++ b/Validation/src/ValStrawHit.cc
@@ -3,7 +3,7 @@
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 
-int mu2e::ValStrawHit::declare(art::TFileDirectory tfs) {
+int mu2e::ValStrawHit::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NHit", "N Straw Hits", 101, -0.5, 100.0);
   _hN2 = tfs.make<TH1D>( "NHit2", "N Straw Hits", 100, -0.5, 9999.5);

--- a/Validation/src/ValStrawHitFlag.cc
+++ b/Validation/src/ValStrawHitFlag.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValStrawHitFlag.hh"
 #include <cmath>
 
-int mu2e::ValStrawHitFlag::declare(art::TFileDirectory tfs) {
+int mu2e::ValStrawHitFlag::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hN = tfs.make<TH1D>( "NFlag", "N Straw Hit flags", 101, -0.5, 100.5);
   _hN2 = tfs.make<TH1D>( "NFlag2", "N Straw Hit flags", 100, -0.5, 9999.5);

--- a/Validation/src/ValTimeCluster.cc
+++ b/Validation/src/ValTimeCluster.cc
@@ -1,7 +1,7 @@
 
 #include "Offline/Validation/inc/ValTimeCluster.hh"
 
-int mu2e::ValTimeCluster::declare(art::TFileDirectory tfs) {
+int mu2e::ValTimeCluster::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.5);
   _hN = tfs.make<TH1D>( "N", "N Time Clusters", 101, -0.5, 100.5);
   _hNhit = tfs.make<TH1D>( "NHit", "N Hits", 101, -0.5, 100.5);

--- a/Validation/src/ValTrackClusterMatch.cc
+++ b/Validation/src/ValTrackClusterMatch.cc
@@ -5,7 +5,7 @@
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include "TMath.h"
 
-int mu2e::ValTrackClusterMatch::declare(art::TFileDirectory tfs) {
+int mu2e::ValTrackClusterMatch::declare(const art::TFileDirectory& tfs) {
 
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
 

--- a/Validation/src/ValTrackSummary.cc
+++ b/Validation/src/ValTrackSummary.cc
@@ -5,7 +5,7 @@
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include "TMath.h"
 
-int mu2e::ValTrackSummary::declare(art::TFileDirectory tfs) {
+int mu2e::ValTrackSummary::declare(const art::TFileDirectory& tfs) {
 
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
 

--- a/Validation/src/ValTriggerInfo.cc
+++ b/Validation/src/ValTriggerInfo.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValTriggerInfo.hh"
 
 
-int mu2e::ValTriggerInfo::declare(art::TFileDirectory tfs) {
+int mu2e::ValTriggerInfo::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hccs = tfs.make<TH1D>( "Ncss", "N caloClusters", 21, -0.5, 20.5);
   _htrk = tfs.make<TH1D>( "Ntrk", "N tracks", 21, -0.5, 20.5);

--- a/Validation/src/ValTriggerResults.cc
+++ b/Validation/src/ValTriggerResults.cc
@@ -2,7 +2,7 @@
 #include "Offline/Validation/inc/ValTriggerResults.hh"
 
 
-int mu2e::ValTriggerResults::declare(art::TFileDirectory tfs) {
+int mu2e::ValTriggerResults::declare(const art::TFileDirectory& tfs) {
   _hVer = tfs.make<TH1D>( "Ver", "Version Number", 101, -0.5, 100.0);
   _hNpath = tfs.make<TH1D>( "Npath", "N path", 50, -0.5, 50.5);
   _hState = tfs.make<TH1D>( "State", "PathNo*4+State(i)", 201, -0.5, 200.5);

--- a/Validation/src/Validation_module.cc
+++ b/Validation/src/Validation_module.cc
@@ -230,7 +230,7 @@ int mu2e::Validation::analyzeProduct(
     if ( prd == nullptr ) {
       prd = std::make_shared<V>(name);
       // create root file subdirectory
-      art::TFileDirectory tfdir = _tfs->mkdir(name);
+      const art::TFileDirectory& tfdir = _tfs->mkdir(name);
       // create histograms
       prd->declare(tfdir);
       // add it to the list of products being histogrammed


### PR DESCRIPTION
This work is intermediate work being completed between iterations of art, v3.9 and v3.10, where TFileDirectory objects now need to be passed by constant reference. The modifications here were validated with 1k ceSimReco events against a reference branch, returning perfect matches:

macndev@mu2ebuild01.fnal.gov:/mu2e/app/users/macndev/OfflineArt310_ref:valCompare -s val_ref.root ../OfflineArt310/val_working.root
TValCompare Status Summary:
  370 Compared
    6 marked to skip
    0 had unknown status
    0 could not be compared
   24 had at least one histogram empty
    0 failed loose comparison
    0 passed loose comparison, failed tight
    0 passed tight comparison, not perfect match
  364 had perfect match
  364 passed loose or better
  364 passed tight or better