### PR TITLE
start alternate particle list service

### DIFF
--- a/GlobalConstantsService/data/ParticleList.txt
+++ b/GlobalConstantsService/data/ParticleList.txt
@@ -1,0 +1,3646 @@
+        -1           anti_d_quark                              anti_d       dbar   0.333333          330            0
+         1                d_quark                                   d       none  -0.333333          330            0
+        -2           anti_u_quark                              anti_u       ubar  -0.666667          330            0
+         2                u_quark                                   u       none   0.666667          330            0
+        -3           anti_s_quark                              anti_s       sbar   0.333333          500            0
+         3                s_quark                                   s       none  -0.333333          500            0
+        -4           anti_c_quark                              anti_c       cbar  -0.666667         1500            0
+         4                c_quark                                   c       none   0.666667         1500            0
+        -5           anti_b_quark                              anti_b       bbar   0.333333         4800            0
+         5                b_quark                                   b       none  -0.333333         4800            0
+        -6           anti_t_quark                              anti_t       tbar  -0.666667       175000   4.7077e-25
+         6                t_quark                                   t       none   0.666667       175000   4.7077e-25
+        -7                anti_b'                              anti_l       none   0.333333       400000            0
+         7                     b'                                   l       none  -0.333333       400000            0
+        -8                anti_t'                              anti_h       none  -0.666667       400000            0
+         8                     t'                                   h       none   0.666667       400000            0
+       -11                     e+                              e_plus   positron          1     0.510999            0
+        11                     e-                             e_minus   electron         -1     0.510999            0
+       -12              anti_nu_e                           anti_nu_e       none          0            0            0
+        12                   nu_e                                nu_e       none          0            0            0
+       -13                    mu+                             mu_plus   antimuon          1      105.658  2.18245e-06
+        13                    mu-                            mu_minus       muon         -1      105.658  2.18245e-06
+       -14             anti_nu_mu                          anti_nu_mu       none          0            0            0
+        14                  nu_mu                               nu_mu       none          0            0            0
+       -15                   tau+                            tau_plus       none          1      1776.84  2.88689e-13
+        15                   tau-                           tau_minus       none         -1      1776.84  2.88689e-13
+       -16            anti_nu_tau                         anti_nu_tau       none          0            0            0
+        16                 nu_tau                              nu_tau       none          0            0            0
+       -17                  tau'+                              L_plus       none          1       400000            0
+        17                  tau'-                             L_minus       none         -1       400000            0
+       -18           anti_nu_tau'                           anti_nu_L       none          0            0            0
+        18                nu_tau'                                nu_L       none          0            0            0
+        21                  gluon                                   g       none          0            0            0
+        22                  gamma                               gamma     photon          0            0            0
+        23                     Z0                                  Z0       none          0      91187.6  2.63791e-25
+       -24                     W-                             W_minus       none         -1        80398  3.07576e-25
+        24                     W+                              W_plus       none          1        80398  3.07576e-25
+        25                   H_10                              Higgs0       none          0       115000  1.79349e-22
+        32                   Z_20                            Z_prime0       none          0       500000  4.52681e-26
+        33                   Z_30                      Z_prime_prime0       none          0       900000            0
+       -34                   W_2-                       W_prime_minus       none         -1       500000  3.95062e-26
+        34                   W_2+                        W_prime_plus       none          1       500000  3.95062e-26
+        35                   H_20                        Higgs_prime0       none          0       300000  7.84667e-26
+        36                   H_30                                  A0       none          0       300000  1.95014e-25
+       -37                     H-                         Higgs_minus       none         -1       300000  1.57592e-25
+        37                     H+                          Higgs_plus       none          1       300000  1.57592e-25
+        39                      G                                   G       none          0            0            0
+       -41                anti_R0                             anti_R0       none          0        5e+06  1.57734e-27
+        41                     R0                                  R0       none          0        5e+06  1.57734e-27
+       -42              anti_LQ_c                           anti_LQ_c       none   0.333333       200000  1.68074e-24
+        42                   LQ_c                                LQ_c       none  -0.333333       200000  1.68074e-24
+        81  generator-specific+81               generator_specific_81       none          0            0            0
+       -82  generator-specific-82               generator_specific_82       none          0            0            0
+        82  generator-specific+82               generator_specific_82       none          0            0            0
+        83  generator-specific+83               generator_specific_83       none          0         1000            0
+       -84  generator-specific-84               generator_specific_84       none  -0.666667         2000          0.1
+        84  generator-specific+84               generator_specific_84       none   0.666667         2000          0.1
+       -85  generator-specific-85               generator_specific_85       none   0.333333         5000        0.387
+        85  generator-specific+85               generator_specific_85       none  -0.333333         5000        0.387
+        88  generator-specific+88               generator_specific_88       none          0            0            0
+        90  generator-specific+90               generator_specific_90       none          0            0            0
+        91  generator-specific+91               generator_specific_91       none          0            0            0
+        92  generator-specific+92               generator_specific_92       none          0            0            0
+        93  generator-specific+93               generator_specific_93       none          0            0            0
+        94  generator-specific+94               generator_specific_94       none          0            0            0
+        95  generator-specific+95               generator_specific_95       none          0            0            0
+        96  generator-specific+96               generator_specific_96       none          0            0            0
+        97  generator-specific+97               generator_specific_97       none          0            0            0
+        98  generator-specific+98               generator_specific_98       none          0            0            0
+        99  generator-specific+99               generator_specific_99       none          0            0            0
+       110                reggeon                             reggeon       none          0            0            0
+       111                    pi0                                 pi0       none          0      134.977   8.3318e-17
+       113                   rho0                                rho0       none          0       775.49   4.4057e-24
+       115              a2(1320)0                                a_20       none          0       1318.3  6.15151e-24
+       130                 kaon0L                                K_L0       none          0      497.614  5.08272e-08
+      -211                    pi-                            pi_minus       none         -1       139.57  2.58609e-08
+       211                    pi+                             pi_plus       none          1       139.57  2.58609e-08
+      -213                   rho-                           rho_minus       none         -1       775.49   4.4057e-24
+       213                   rho+                            rho_plus       none          1       775.49   4.4057e-24
+      -215              a2(1320)-                           a_2_minus       none         -1       1318.3  6.15151e-24
+       215              a2(1320)+                            a_2_plus       none          1       1318.3  6.15151e-24
+       221                    eta                                 eta       none          0      547.853  5.06317e-19
+       223                  omega                               omega       none          0       782.65  7.75279e-23
+       225               f2(1270)                                 f_2       none          0       1275.1   3.5579e-24
+       310                 kaon0S                                K_S0       none          0      497.614  8.89836e-11
+      -311             anti_kaon0                             anti_K0       none          0      497.614            0
+       311                  kaon0                                  K0       none          0      497.614            0
+      -313           anti_k_star0                        anti_K_star0       none          0          896  1.30857e-23
+       313                k_star0                             K_star0       none          0          896  1.30857e-23
+      -315    anti_k2_star(1430)0                      anti_K_2_star0       none          0       1432.4  6.03864e-24
+       315         k2_star(1430)0                           K_2_star0       none          0       1432.4  6.03864e-24
+      -321                  kaon-                             K_minus       none         -1      493.677  1.22984e-08
+       321                  kaon+                              K_plus       none          1      493.677  1.22984e-08
+      -323                k_star-                        K_star_minus       none         -1       891.66  1.29569e-23
+       323                k_star+                         K_star_plus       none          1       891.66  1.29569e-23
+      -325         k2_star(1430)-                      K_2_star_minus       none         -1       1425.6  6.68235e-24
+       325         k2_star(1430)+                       K_2_star_plus       none          1       1425.6  6.68235e-24
+       331              eta_prime                           eta_prime       none          0       957.66  3.21079e-21
+       333                    phi                                 phi       none          0      1019.46   1.5451e-22
+       335         f2_prime(1525)                           f_prime_2       none          0         1525   9.0166e-24
+      -411                     D-                             D_minus       none         -1      1869.62   1.0333e-12
+       411                     D+                              D_plus       none          1      1869.62   1.0333e-12
+      -413              D*(2010)-                        D_star_minus       none         -1      2010.27  6.85637e-21
+       413              D*(2010)+                         D_star_plus       none          1      2010.27  6.85637e-21
+      -415            D*_2(2460)-                      D_2_star_minus       none         -1       2460.1  1.77895e-23
+       415            D*_2(2460)+                       D_2_star_plus       none          1       2460.1  1.77895e-23
+      -421                anti_D0                             anti_D0       none          0      1864.84  4.07309e-13
+       421                     D0                                  D0       none          0      1864.84  4.07309e-13
+      -423         anti_D*(2007)0                        anti_D_star0       none          0      2006.97            0
+       423              D*(2007)0                             D_star0       none          0      2006.97            0
+      -425       anti_D*_2(2460)0                      anti_D_2_star0       none          0       2461.1  1.53073e-23
+       425            D*_2(2460)0                           D_2_star0       none          0       2461.1  1.53073e-23
+      -431                    Ds-                           D_s_minus       none         -1      1968.49  4.96764e-13
+       431                    Ds+                            D_s_plus       none          1      1968.49  4.96764e-13
+      -433                  D*_s-                      D_s_star_minus       none         -1       2112.3            0
+       433                  D*_s+                       D_s_star_plus       none          1       2112.3            0
+      -435           D*_s2(2573)-                     D_s2_star_minus       none         -1       2572.6  3.29106e-23
+       435           D*_s2(2573)+                      D_s2_star_plus       none          1       2572.6  3.29106e-23
+       441                   etac                               eta_c       none          0       2980.3  2.46521e-23
+       443                  J/psi                               J_psi       none          0      3096.92  7.06236e-21
+       445             chi_c2(1P)                              chi_c2       none          0       3556.2  3.24242e-22
+      -511                anti_B0                             anti_B0       none          0      5279.53  1.51977e-12
+       511                     B0                                  B0       none          0      5279.53  1.51977e-12
+      -513               anti_B*0                        anti_B_star0       none          0       5325.1            0
+       513                    B*0                             B_star0       none          0       5325.1            0
+      -515             anti_B*_20                      anti_B_2_star0       none          0       5746.9            0
+       515                  B*_20                           B_2_star0       none          0       5746.9            0
+      -521                     B-                             B_minus       none         -1      5279.15  1.62722e-12
+       521                     B+                              B_plus       none          1      5279.15  1.62722e-12
+      -523                    B*-                        B_star_minus       none         -1       5325.1            0
+       523                    B*+                         B_star_plus       none          1       5325.1            0
+      -525                  B*_2-                      B_2_star_minus       none         -1       5746.9            0
+       525                  B*_2+                       B_2_star_plus       none          1       5746.9            0
+      -531               anti_Bs0                           anti_B_s0       none          0       5366.3  1.41551e-12
+       531                    Bs0                                B_s0       none          0       5366.3  1.41551e-12
+      -533             anti_B*_s0                      anti_B_s_star0       none          0       5412.8            0
+       533                  B*_s0                           B_s_star0       none          0       5412.8            0
+      -535            anti_B*_s20                     anti_B_s2_star0       none          0       5839.7            0
+       535                 B*_s20                          B_s2_star0       none          0       5839.7            0
+      -541                    Bc-                           B_c_minus       none         -1         6276  4.60288e-13
+       541                    Bc+                            B_c_plus       none          1         6276  4.60288e-13
+      -543                  B*_c-                      B_c_star_minus       none         -1         6602            0
+       543                  B*_c+                       B_c_star_plus       none          1         6602            0
+      -545                 B*_c2-                     B_c2_star_minus       none         -1         7350  3.29106e-23
+       545                 B*_c2+                      B_c2_star_plus       none          1         7350  3.29106e-23
+       551              eta_b(1S)                              chi_b0       none          0         9400            0
+       553                Upsilon                             Upsilon       none          0       9460.3  1.21891e-20
+       555             chi_b2(1P)                              chi_b2       none          0       9912.2            0
+       990                pomeron                             pomeron       none          0            0            0
+     -1103       anti_dd1_diquark                           anti_dd_1       none   0.666667       771.33            0
+      1103            dd1_diquark                                dd_1       none  -0.666667       771.33            0
+     -1114            anti_delta-                     anti_Delta_plus       none          1         1232  5.57807e-24
+      1114                 delta-                         Delta_minus       none         -1         1232  5.57807e-24
+     -2101       anti_ud0_diquark                           anti_ud_0       none  -0.333333       579.33            0
+      2101            ud0_diquark                                ud_0       none   0.333333       579.33            0
+     -2103       anti_ud1_diquark                           anti_ud_1       none  -0.333333       771.33            0
+      2103            ud1_diquark                                ud_1       none   0.333333       771.33            0
+     -2112           anti_neutron                             anti_n0       none          0      939.565      879.962
+      2112                neutron                                  n0       none          0      939.565      879.962
+     -2114            anti_delta0                         anti_Delta0       none          0         1232  5.57807e-24
+      2114                 delta0                              Delta0       none          0         1232  5.57807e-24
+     -2203       anti_uu1_diquark                           anti_uu_1       none   -1.33333       771.33            0
+      2203            uu1_diquark                                uu_1       none    1.33333       771.33            0
+     -2212            anti_proton                         anti_proton       pbar         -1      938.272            0
+      2212                 proton                              proton          p          1      938.272            0
+     -2214            anti_delta+                    anti_Delta_minus       none         -1         1232  5.57807e-24
+      2214                 delta+                          Delta_plus       none          1         1232  5.57807e-24
+     -2224           anti_delta++              anti_Delta_minus_minus       none         -2         1232  5.57807e-24
+      2224                delta++                     Delta_plus_plus       none          2         1232  5.57807e-24
+     -3101       anti_sd0_diquark                           anti_sd_0       none   0.666667       804.73            0
+      3101            sd0_diquark                                sd_0       none  -0.666667       804.73            0
+     -3103       anti_sd1_diquark                           anti_sd_1       none   0.666667       929.53            0
+      3103            sd1_diquark                                sd_1       none  -0.666667       929.53            0
+     -3112            anti_sigma-                     anti_Sigma_plus       none          1      1197.45  1.46922e-10
+      3112                 sigma-                         Sigma_minus       none         -1      1197.45  1.46922e-10
+     -3114      anti_sigma(1385)-                anti_Sigma_star_plus       none          1       1387.2  1.67059e-23
+      3114           sigma(1385)-                    Sigma_star_minus       none         -1       1387.2  1.67059e-23
+     -3122            anti_lambda                        anti_Lambda0       none          0      1115.68  2.61403e-10
+      3122                 lambda                             Lambda0       none          0      1115.68  2.61403e-10
+     -3201       anti_su0_diquark                           anti_su_0       none  -0.333333       804.73            0
+      3201            su0_diquark                                su_0       none   0.333333       804.73            0
+     -3203       anti_su1_diquark                           anti_su_1       none  -0.333333       929.53            0
+      3203            su1_diquark                                su_1       none   0.333333       929.53            0
+     -3212            anti_sigma0                         anti_Sigma0       none          0      1192.64  7.31347e-20
+      3212                 sigma0                              Sigma0       none          0      1192.64  7.31347e-20
+     -3214      anti_sigma(1385)0                    anti_Sigma_star0       none          0       1383.7  1.82837e-23
+      3214           sigma(1385)0                         Sigma_star0       none          0       1383.7  1.82837e-23
+     -3222            anti_sigma+                    anti_Sigma_minus       none         -1      1189.37  7.96481e-11
+      3222                 sigma+                          Sigma_plus       none          1      1189.37  7.96481e-11
+     -3224      anti_sigma(1385)+               anti_Sigma_star_minus       none         -1       1382.8  1.83858e-23
+      3224           sigma(1385)+                     Sigma_star_plus       none          1       1382.8  1.83858e-23
+     -3303       anti_ss1_diquark                           anti_ss_1       none   0.666667      1093.61            0
+      3303            ss1_diquark                                ss_1       none  -0.666667      1093.61            0
+     -3312               anti_xi-                        anti_Xi_plus       none          1      1321.71  1.62924e-10
+      3312                    xi-                            Xi_minus       none         -1      1321.71  1.62924e-10
+     -3314         anti_xi(1530)-                   anti_Xi_star_plus       none          1         1535   6.6486e-23
+      3314              xi(1530)-                       Xi_star_minus       none         -1         1535   6.6486e-23
+     -3322               anti_xi0                            anti_Xi0       none          0      1314.86  2.88689e-10
+      3322                    xi0                                 Xi0       none          0      1314.86  2.88689e-10
+     -3324         anti_xi(1530)0                       anti_Xi_star0       none          0       1531.8   7.2331e-23
+      3324              xi(1530)0                            Xi_star0       none          0       1531.8   7.2331e-23
+     -3334            anti_omega-                     anti_Omega_plus       none          1      1672.45  8.15628e-11
+      3334                 omega-                         Omega_minus       none         -1      1672.45  8.15628e-11
+     -4101       anti_cd0_diquark                           anti_cd_0       none  -0.333333      1969.08            0
+      4101            cd0_diquark                                cd_0       none   0.333333      1969.08            0
+     -4103       anti_cd1_diquark                           anti_cd_1       none  -0.333333      2008.08            0
+      4103            cd1_diquark                                cd_1       none   0.333333      2008.08            0
+     -4112          anti_sigma_c0                       anti_Sigma_c0       none          0      2453.76  2.99187e-22
+      4112               sigma_c0                            Sigma_c0       none          0      2453.76  2.99187e-22
+     -4114         anti_Sigma*_c0                  anti_Sigma_c_star0       none          0         2518  4.08827e-23
+      4114              Sigma*_c0                       Sigma_c_star0       none          0         2518  4.08827e-23
+     -4122         anti_lambda_c+                 anti_Lambda_c_minus       none         -1      2286.46  1.98257e-13
+      4122              lambda_c+                       Lambda_c_plus       none          1      2286.46  1.98257e-13
+     -4132             anti_xi_c0                          anti_Xi_c0       none          0         2471  1.11561e-13
+      4132                  xi_c0                               Xi_c0       none          0         2471  1.11561e-13
+     -4201       anti_cu0_diquark                           anti_cu_0       none   -1.33333      1969.08            0
+      4201            cu0_diquark                                cu_0       none    1.33333      1969.08            0
+     -4203       anti_cu1_diquark                           anti_cu_1       none   -1.33333      2008.08            0
+      4203            cu1_diquark                                cu_1       none    1.33333      2008.08            0
+     -4212          anti_sigma_c+                  anti_Sigma_c_minus       none         -1       2452.9            0
+      4212               sigma_c+                        Sigma_c_plus       none          1       2452.9            0
+     -4214         anti_Sigma*_c-             anti_Sigma_c_star_minus       none         -1       2517.5            0
+      4214              Sigma*_c+                   Sigma_c_star_plus       none          1       2517.5            0
+     -4222         anti_sigma_c++            anti_Sigma_c_minus_minus       none         -2      2454.02  2.95162e-22
+      4222              sigma_c++                   Sigma_c_plus_plus       none          2      2454.02  2.95162e-22
+     -4224        anti_Sigma*_c--       anti_Sigma_c_star_minus_minus       none         -2       2518.4  4.41753e-23
+      4224             Sigma*_c++              Sigma_c_star_plus_plus       none          2       2518.4  4.41753e-23
+     -4232             anti_xi_c+               Xi_primeanti__c_minus       none         -1       2467.9  4.38808e-13
+      4232                  xi_c+                     Xi_prime_c_plus       none          1       2467.9  4.38808e-13
+     -4301       anti_cs0_diquark                           anti_cs_0       none  -0.333333      2154.32            0
+      4301            cs0_diquark                                cs_0       none   0.333333      2154.32            0
+     -4303       anti_cs1_diquark                           anti_cs_1       none  -0.333333      2179.67            0
+      4303            cs1_diquark                                cs_1       none   0.333333      2179.67            0
+     -4312            anti_Xi'_c0                    Xi_primeanti__c0       none          0         2578            0
+      4312                 Xi'_c0                         Xi_prime_c0       none          0         2578            0
+     -4314            anti_Xi*_c0                     anti_Xi_c_star0       none          0       2646.1            0
+      4314                 Xi*_c0                          Xi_c_star0       none          0       2646.1            0
+     -4322            anti_Xi'_c-                     anti_Xi_c_minus       none         -1       2575.7            0
+      4322                 Xi'_c+                           Xi_c_plus       none          1       2575.7            0
+     -4324            anti_Xi*_c-                anti_Xi_c_star_minus       none         -1       2646.6            0
+      4324                 Xi*_c+                      Xi_c_star_plus       none          1       2646.6            0
+     -4332          anti_omega_c0                       anti_Omega_c0       none          0       2697.5  6.85637e-14
+      4332               omega_c0                            Omega_c0       none          0       2697.5  6.85637e-14
+     -4334         anti_Omega*_c0                  anti_Omega_c_star0       none          0       2768.3            0
+      4334              Omega*_c0                       Omega_c_star0       none          0       2768.3            0
+     -4403       anti_cc1_diquark                           anti_cc_1       none   -1.33333      3275.31            0
+      4403            cc1_diquark                                cc_1       none    1.33333      3275.31            0
+     -4412            anti_Xi_cc-                    anti_Xi_cc_minus       none         -1      3597.98          0.1
+      4412                 Xi_cc+                          Xi_cc_plus       none          1      3597.98          0.1
+     -4414           anti_Xi*_cc-               anti_Xi_star_cc_minus       none         -1      3656.48          0.1
+      4414                Xi*_cc+                     Xi_star_cc_plus       none          1      3656.48          0.1
+     -4422           anti_Xi_cc--                       anti_Xi_cc_mm       none         -2      3597.98          0.1
+      4422                Xi_cc++                            Xi_cc_pp       none          2      3597.98          0.1
+     -4424          anti_Xi*_cc--                  anti_Xi_star_cc_mm       none         -2      3656.48          0.1
+      4424               Xi*_cc++                       Xi_star_cc_pp       none          2      3656.48          0.1
+     -4432         anti_Omega_cc-                 anti_Omega_cc_minus       none         -1      3786.63          0.1
+      4432              Omega_cc+                       Omega_cc_plus       none          1      3786.63          0.1
+     -4434        anti_Omega*_cc-            anti_Omega_star_cc_minus       none         -1      3824.66          0.1
+      4434             Omega*_cc+                  Omega_star_cc_plus       none          1      3824.66          0.1
+     -4444      anti_Omega*_ccc--              anti_Omega_star_ccc_mm       none         -2      4915.94          0.1
+      4444           Omega*_ccc++                   Omega_star_ccc_pp       none          2      4915.94          0.1
+     -5101       anti_bd0_diquark                           anti_bd_0       none   0.666667      5388.97            0
+      5101            bd0_diquark                                bd_0       none  -0.666667      5388.97            0
+     -5103       anti_bd1_diquark                           anti_bd_1       none   0.666667      5401.45            0
+      5103            bd1_diquark                                bd_1       none  -0.666667      5401.45            0
+     -5112          anti_sigma_b-                   anti_Sigma_b_plus       none          1       5815.2            0
+      5112               sigma_b-                       Sigma_b_minus       none         -1       5815.2            0
+     -5114         anti_Sigma*_b+              anti_Sigma_b_star_plus       none          1       5836.4            0
+      5114              Sigma*_b-                  Sigma_b_star_minus       none         -1       5836.4            0
+     -5122          anti_lambda_b                      anti_Lambda_b0       none          0       5620.2  1.37414e-12
+      5122               lambda_b                           Lambda_b0       none          0       5620.2  1.37414e-12
+     -5132             anti_xi_b-                      anti_Xi_b_plus       none          1       5792.4  1.40045e-12
+      5132                  xi_b-                          Xi_b_minus       none         -1       5792.4  1.40045e-12
+     -5142            anti_Xi_bc0                         anti_Xi_bc0       none          0      7005.75        0.387
+      5142                 Xi_bc0                              Xi_bc0       none          0      7005.75        0.387
+     -5201       anti_bu0_diquark                           anti_bu_0       none  -0.333333      5388.97            0
+      5201            bu0_diquark                                bu_0       none   0.333333      5388.97            0
+     -5203       anti_bu1_diquark                           anti_bu_1       none  -0.333333      5401.45            0
+      5203            bu1_diquark                                bu_1       none   0.333333      5401.45            0
+     -5212          anti_sigma_b0                       anti_Sigma_b0       none          0       5807.8            0
+      5212               sigma_b0                            Sigma_b0       none          0       5807.8            0
+     -5214         anti_Sigma*_b0                  anti_Sigma_b_star0       none          0         5829            0
+      5214              Sigma*_b0                       Sigma_b_star0       none          0         5829            0
+     -5222          anti_sigma_b+                  anti_Sigma_b_minus       none         -1       5807.8            0
+      5222               sigma_b+                        Sigma_b_plus       none          1       5807.8            0
+     -5224         anti_Sigma*_b-             anti_Sigma_b_star_minus       none         -1         5829            0
+      5224              Sigma*_b+                         Sigma_star_       none          1         5829            0
+     -5232             anti_xi_b0                          anti_Xi_b0       none          0       5792.4  4.63529e-10
+      5232                  xi_b0                               Xi_b0       none          0       5792.4  4.63529e-10
+     -5242            anti_Xi_bc-                    anti_Xi_bc_minus       none         -1      7005.75        0.387
+      5242                 Xi_bc+                          Xi_bc_plus       none          1      7005.75        0.387
+     -5301       anti_bs0_diquark                           anti_bs_0       none   0.666667      5567.25            0
+      5301            bs0_diquark                                bs_0       none  -0.666667      5567.25            0
+     -5303       anti_bs1_diquark                           anti_bs_1       none   0.666667      5575.36            0
+      5303            bs1_diquark                                bs_1       none  -0.666667      5575.36            0
+     -5312            anti_Xi'_b+                anti_Xi_prime_b_plus       none          1         5960            0
+      5312                 Xi'_b-                    Xi_prime_b_minus       none         -1         5960            0
+     -5314            anti_Xi*_b+                 anti_Xi_b_star_plus       none          1         5970            0
+      5314                 Xi*_b-                     Xi_b_star_minus       none         -1         5970            0
+     -5322            anti_Xi'_b0                    anti_Xi_prime_b0       none          0         5960            0
+      5322                 Xi'_b0                         Xi_prime_b0       none          0         5960            0
+     -5324            anti_Xi*_b0                     anti_Xi_b_star0       none          0         5970            0
+      5324                 Xi*_b0                          Xi_b_star0       none          0         5970            0
+     -5332          anti_omega_b-                   anti_Omega_b_plus       none          1         6120        0.387
+      5332               omega_b-                       Omega_b_minus       none         -1         6120        0.387
+     -5334         anti_Omega*_b+              anti_Omega_b_star_plus       none          1         6130            0
+      5334              Omega*_b-                  Omega_b_star_minus       none         -1         6130            0
+     -5342         anti_Omega_bc0                      anti_Omega_bc0       none          0      7190.99        0.387
+      5342              Omega_bc0                           Omega_bc0       none          0      7190.99        0.387
+     -5401       anti_bc0_diquark                           anti_bc_0       none  -0.333333      6671.43            0
+      5401            bc0_diquark                                bc_0       none   0.333333      6671.43            0
+     -5403       anti_bc1_diquark                           anti_bc_1       none  -0.333333      6673.97            0
+      5403            bc1_diquark                                bc_1       none   0.333333      6673.97            0
+     -5412           anti_Xi'_bc0                   anti_Xi_prime_bc0       none          0      7037.24        0.387
+      5412                Xi'_bc0                        Xi_prime_bc0       none          0      7037.24        0.387
+     -5414           anti_Xi*_bc0                    anti_Xi_star_bc0       none          0       7048.5        0.387
+      5414                Xi*_bc0                         Xi_star_bc0       none          0       7048.5        0.387
+     -5422           anti_Xi'_bc-              anti_Xi_prime_bc_minus       none         -1      7037.24        0.387
+      5422                Xi'_bc+                    Xi_prime_bc_plus       none          1      7037.24        0.387
+     -5424           anti_Xi*_bc-               anti_Xi_star_bc_minus       none         -1       7048.5        0.387
+      5424                Xi*_bc+                     Xi_star_bc_plus       none          1       7048.5        0.387
+     -5432        anti_Omega'_bc0                anti_Omega_prime_bc0       none          0      7211.01        0.387
+      5432             Omega'_bc0                     Omega_prime_bc0       none          0      7211.01        0.387
+     -5434        anti_Omega*_bc0                 anti_Omega_star_bc0       none          0         7219        0.387
+      5434             Omega*_bc0                      Omega_star_bc0       none          0         7219        0.387
+     -5442        anti_Omega_bcc-                anti_Omega_bcc_minus       none         -1      8309.45        0.387
+      5442             Omega_bcc+                      Omega_bcc_plus       none          1      8309.45        0.387
+     -5444       anti_Omega*_bcc-           anti_Omega_star_bcc_minus       none         -1      8313.25        0.387
+      5444            Omega*_bcc+                 Omega_star_bcc_plus       none          1      8313.25        0.387
+     -5503       anti_bb1_diquark                           anti_bb_1       none   0.666667      10073.5            0
+      5503            bb1_diquark                                bb_1       none  -0.666667      10073.5            0
+     -5512            anti_Xi_bb+                     anti_Xi_bb_plus       none          1      10422.7        0.387
+      5512                 Xi_bb-                         Xi_bb_minus       none         -1      10422.7        0.387
+     -5514           anti_Xi*_bb+                anti_Xi_star_bb_plus       none          1      10441.4        0.387
+      5514                Xi*_bb-                    Xi_star_bb_minus       none         -1      10441.4        0.387
+     -5522            anti_Xi_bb0                         anti_Xi_bb0       none          0      10422.7        0.387
+      5522                 Xi_bb0                              Xi_bb0       none          0      10422.7        0.387
+     -5524           anti_Xi*_bb0                    anti_Xi_star_bb0       none          0      10441.4        0.387
+      5524                Xi*_bb0                         Xi_star_bb0       none          0      10441.4        0.387
+     -5532         anti_Omega_bb+                  anti_Omega_bb_plus       none          1      10602.1        0.387
+      5532              Omega_bb-                      Omega_bb_minus       none         -1      10602.1        0.387
+     -5534        anti_Omega*_bb+             anti_Omega_star_bb_plus       none          1      10614.3        0.387
+      5534             Omega*_bb-                 Omega_star_bb_minus       none         -1      10614.3        0.387
+     -5542        anti_Omega_bbc0                     anti_Omega_bbc0       none          0      11707.7        0.387
+      5542             Omega_bbc0                          Omega_bbc0       none          0      11707.7        0.387
+     -5544       anti_Omega*_bbc0                anti_Omega_star_bbc0       none          0      11711.5        0.387
+      5544            Omega*_bbc0                     Omega_star_bbc0       none          0      11711.5        0.387
+     -5554       anti_Omega*_bbb+            anti_Omega_star_bbb_plus       none          1      15110.6        0.387
+      5554            Omega*_bbb-                Omega_star_bbb_minus       none         -1      15110.6        0.387
+     10113              b1(1235)0                                b_10       none          0       1229.5  4.63529e-24
+    -10213              b1(1235)-                           b_1_minus       none         -1       1229.5  4.63529e-24
+     10213              b1(1235)+                            b_1_plus       none          1       1229.5  4.63529e-24
+     10221              f_0(1370)                                 f_0       none          0         1400  2.63285e-24
+     10223               h1(1170)                                 h_1       none          0         1170  1.82837e-24
+    -10311    anti_k0_star(1430)0                      anti_K_0_star0       none          0         1420  2.43782e-24
+     10311         k0_star(1430)0                           K_0_star0       none          0         1420  2.43782e-24
+    -10313         anti_k1(1270)0                           anti_K_10       none          0         1272  7.31347e-24
+     10313              k1(1270)0                                K_10       none          0         1272  7.31347e-24
+    -10321         k0_star(1430)-                      K_0_star_minus       none         -1         1420  2.43782e-24
+     10321         k0_star(1430)+                       K_0_star_plus       none          1         1420  2.43782e-24
+    -10323              k1(1270)-                           K_1_minus       none         -1         1272  7.31347e-24
+     10323              k1(1270)+                            K_1_plus       none          1         1272  7.31347e-24
+     10333               h1(1380)                           h_prime_1       none          0         1400  8.22765e-24
+    -10411            D*_0(2400)-                      D_0_star_minus       none         -1         2272  1.31642e-23
+     10411            D*_0(2400)+                       D_0_star_plus       none          1         2272  1.31642e-23
+    -10413             D_1(2420)-                           D_1_minus       none         -1         2424  3.29106e-23
+     10413             D_1(2420)+                            D_1_plus       none          1         2424  3.29106e-23
+    -10421       anti_D*_0(2400)0                      anti_D_0_star0       none          0         2272  1.31642e-23
+     10421            D*_0(2400)0                           D_0_star0       none          0         2272  1.31642e-23
+    -10423        anti_D_1(2420)0                           anti_D_10       none          0       2422.3  3.22653e-23
+     10423             D_1(2420)0                                D_10       none          0       2422.3  3.22653e-23
+    -10431           D*_s0(2317)-                     D_s0_star_minus       none         -1       2317.8            0
+     10431           D*_s0(2317)+                      D_s0_star_plus       none          1       2317.8            0
+    -10433            D_s1(2536)-                          D_s1_minus       none         -1       2535.3            0
+     10433            D_s1(2536)+                           D_s1_plus       none          1       2535.3            0
+     10441             chi_c0(1P)                              chi_c0       none          0      3414.75  6.45306e-23
+     10443                 hc(1P)                              chi_c1       none          0      3525.93            0
+    -10511             anti_B*_00                      anti_B_0_star0       none          0         5680  1.31642e-23
+     10511                  B*_00                           B_0_star0       none          0         5680  1.31642e-23
+    -10513           anti_B_1(L)0                           anti_B_10       none          0         5730  1.31642e-23
+     10513                B_1(L)0                                B_10       none          0         5730  1.31642e-23
+    -10521                  B*_0-                      B_0_star_minus       none         -1         5680  1.31642e-23
+     10521                  B*_0+                       B_0_star_plus       none          1         5680  1.31642e-23
+    -10523                B_1(L)-                           B_1_minus       none         -1         5730  1.31642e-23
+     10523                B_1(L)+                            B_1_plus       none          1         5730  1.31642e-23
+    -10531            anti_B*_s00                     anti_B_s0_star0       none          0         5920  1.31642e-23
+     10531                 B*_s00                          B_s0_star0       none          0         5920  1.31642e-23
+    -10533          anti_B_s1(L)0                          anti_B_s10       none          0         5970  1.31642e-23
+     10533               B_s1(L)0                               B_s10       none          0         5970  1.31642e-23
+    -10541                 B*_c0-                     B_c0_star_minus       none         -1         7250  1.31642e-23
+     10541                 B*_c0+                      B_c0_star_plus       none          1         7250  1.31642e-23
+    -10543               B_c1(L)-                          B_c1_minus       none         -1         7300  1.31642e-23
+     10543               B_c1(L)+                           B_c1_plus       none          1         7300  1.31642e-23
+     10551             chi_b0(1P)                            chi_b01P       none          0       9859.4            0
+     10553                h_b(1P)                                 h_b       none          0         9875  6.58212e-23
+     20113              a1(1260)0                                a_10       none          0         1230  1.56717e-24
+    -20213              a1(1260)-                           a_1_minus       none         -1         1230  1.56717e-24
+     20213              a1(1260)+                            a_1_plus       none          1         1230  1.56717e-24
+     20223               f1(1285)                                 f_1       none          0       1281.8  2.70869e-23
+    -20313         anti_k1(1400)0                     anti_K_prime_10       none          0         1403  3.78283e-24
+     20313              k1(1400)0                          K_prime_10       none          0         1403  3.78283e-24
+    -20323              k1(1400)-                     K_prime_1_minus       none         -1         1403  3.78283e-24
+     20323              k1(1400)+                      K_prime_1_plus       none          1         1403  3.78283e-24
+     20333               f1(1420)                           f_prime_1       none          0       1426.4  1.19893e-23
+    -20413                D_1(H)-                     D_prime_1_minus       none         -1         2372  1.31642e-23
+     20413                D_1(H)+                      D_prime_1_plus       none          1         2372  1.31642e-23
+    -20423        anti_D_1(2430)0                     anti_D_prime_10       none          0         2372  1.31642e-23
+     20423             D_1(2430)0                          D_prime_10       none          0         2372  1.31642e-23
+    -20433            D_s1(2460)-                    D_prime_s1_minus       none         -1       2459.6            0
+     20433            D_s1(2460)+                     D_prime_s1_plus       none          1       2459.6            0
+     20443             chi_c1(1P)                              psi_2S       none          0      3510.66  7.39564e-22
+    -20513           anti_B_1(H)0                     anti_B_prime_10       none          0         5780  1.31642e-23
+     20513                B_1(H)0                          B_prime_10       none          0         5780  1.31642e-23
+    -20523                B_1(H)-                     B_prime_1_minus       none         -1         5780  1.31642e-23
+     20523                B_1(H)+                      B_prime_1_plus       none          1         5780  1.31642e-23
+    -20533          anti_B_s1(H)0                    anti_B_prime_s10       none          0         6020  1.31642e-23
+     20533               B_s1(H)0                         B_prime_s10       none          0         6020  1.31642e-23
+    -20543               B_c1(H)-                    B_prime_c1_minus       none         -1         7300  1.31642e-23
+     20543               B_c1(H)+                     B_prime_c1_plus       none          1         7300  1.31642e-23
+     20553             chi_b1(1P)                          Upsilon_2S       none          0       9892.8            0
+    100441              eta_c(2S)                             eta_c2S       none          0         3637  4.70151e-23
+    100443                psi(2S)                               psi2S       none          0      3686.09  2.07638e-21
+    100553            Upsilon(2S)                              h_b_3P       none          0      10023.3  2.05691e-20
+  -1000001          anti_susy-d_L                       anti_susy_d_L       none   0.333333       500000  6.58212e-25
+   1000001               susy-d_L                            susy_d_L       none  -0.333333       500000  6.58212e-25
+  -1000002          anti_susy-u_L                       anti_susy_u_L       none  -0.666667       500000  6.58212e-25
+   1000002               susy-u_L                            susy_u_L       none   0.666667       500000  6.58212e-25
+  -1000003          anti_susy-s_L                       anti_susy_s_L       none   0.333333       500000  6.58212e-25
+   1000003               susy-s_L                            susy_s_L       none  -0.333333       500000  6.58212e-25
+  -1000004          anti_susy-c_L                       anti_susy_c_L       none  -0.666667       500000  6.58212e-25
+   1000004               susy-c_L                            susy_c_L       none   0.666667       500000  6.58212e-25
+  -1000005          anti_susy-b_1                       anti_susy_b_1       none   0.333333       500000  6.58212e-25
+   1000005               susy-b_1                            susy_b_1       none  -0.333333       500000  6.58212e-25
+  -1000006          anti_susy-t_1                       anti_susy_t_1       none  -0.666667       500000  6.58212e-25
+   1000006               susy-t_1                            susy_t_1       none   0.666667       500000  6.58212e-25
+  -1000011              susy-e_L+                       susy_e_L_plus       none          1       500000  6.58212e-25
+   1000011              susy-e_L-                      susy_e_L_minus       none         -1       500000  6.58212e-25
+  -1000012        anti_susy-nu_eL                     anti_susy_nu_eL       none          0       500000  6.58212e-25
+   1000012             susy-nu_eL                          susy_nu_eL       none          0       500000  6.58212e-25
+  -1000013             susy-mu_L+                      susy_mu_L_plus       none          1       500000  6.58212e-25
+   1000013             susy-mu_L-                     susy_mu_L_minus       none         -1       500000  6.58212e-25
+  -1000014       anti_susy-nu_muL                    anti_susy_nu_muL       none          0       500000  6.58212e-25
+   1000014            susy-nu_muL                         susy_nu_muL       none          0       500000  6.58212e-25
+  -1000015            susy-tau_L+                     susy_tau_L_plus       none          1       500000  6.58212e-25
+   1000015            susy-tau_L-                    susy_tau_L_minus       none         -1       500000  6.58212e-25
+  -1000016      anti_susy-nu_tauL                   anti_susy_nu_tauL       none          0       500000  6.58212e-25
+   1000016           susy-nu_tauL                        susy_nu_tauL       none          0       500000  6.58212e-25
+   1000021                 gluino                              gluino       none          0       500000  6.58212e-25
+   1000022            susy-chi_10                         susy_chi_10       none          0       500000  6.58212e-25
+   1000023            susy-chi_20                         susy_chi_20       none          0       500000  6.58212e-25
+  -1000024            susy-chi_1-                    susy_chi_1_minus       none         -1       500000  6.58212e-25
+   1000024            susy-chi_1+                     susy_chi_1_plus       none          1       500000  6.58212e-25
+   1000025            susy-chi_30                         susy_chi_30       none          0       500000  6.58212e-25
+   1000035            susy-chi_40                         susy_chi_40       none          0       500000  6.58212e-25
+  -1000037            susy-chi_2-                    susy_chi_2_minus       none         -1       500000  6.58212e-25
+   1000037            susy-chi_2+                     susy_chi_2_plus       none          1       500000  6.58212e-25
+   1000039              gravitino                           gravitino       none          0       500000            0
+  -2000001          anti_susy-d_R                       anti_susy_d_R       none   0.333333       500000  6.58212e-25
+   2000001               susy-d_R                            susy_d_R       none  -0.333333       500000  6.58212e-25
+  -2000002          anti_susy-u_R                       anti_susy_u_R       none  -0.666667       500000  6.58212e-25
+   2000002               susy-u_R                            susy_u_R       none   0.666667       500000  6.58212e-25
+  -2000003          anti_susy-s_R                       anti_susy_s_R       none   0.333333       500000  6.58212e-25
+   2000003               susy-s_R                            susy_s_R       none  -0.333333       500000  6.58212e-25
+  -2000004          anti_susy-c_R                       anti_susy_c_R       none  -0.666667       500000  6.58212e-25
+   2000004               susy-c_R                            susy_c_R       none   0.666667       500000  6.58212e-25
+  -2000005          anti_susy-b_R                       anti_susy_b_R       none   0.333333       500000  6.58212e-25
+   2000005               susy-b_R                            susy_b_R       none  -0.333333       500000  6.58212e-25
+  -2000006          anti_susy-t_R                       anti_susy_t_R       none  -0.666667       500000  6.58212e-25
+   2000006               susy-t_R                            susy_t_R       none   0.666667       500000  6.58212e-25
+  -2000011              susy-e_R+                       susy_e_R_plus       none          1       500000  6.58212e-25
+   2000011              susy-e_R-                      susy_e_R_minus       none         -1       500000  6.58212e-25
+  -2000012        anti_susy-nu_eR                     anti_susy_nu_eR       none          0       500000            0
+   2000012             susy-nu_eR                          susy_nu_eR       none          0       500000            0
+  -2000013             susy-mu_R+                      susy_mu_R_plus       none          1       500000  6.58212e-25
+   2000013             susy-mu_R-                     susy_mu_R_minus       none         -1       500000  6.58212e-25
+  -2000014       anti_susy-nu_muR                    anti_susy_nu_muR       none          0       500000            0
+   2000014            susy-nu_muR                         susy_nu_muR       none          0       500000            0
+  -2000015            susy-tau_R+                     susy_tau_R_plus       none          1       500000  6.58212e-25
+   2000015            susy-tau_R-                    susy_tau_R_minus       none         -1       500000  6.58212e-25
+  -2000016      anti_susy-nu_tauR                   anti_susy_nu_tauR       none          0       500000            0
+   2000016           susy-nu_tauR                        susy_nu_tauR       none          0       500000            0
+   3000111               pi_tech0                            pi_tech0       none          0       110000  2.26112e-23
+   3000113              rho_tech0                           rho_tech0       none          0       210000  7.57785e-25
+  -3000211               pi_tech-                       pi_tech_minus       none         -1       110000  3.78065e-23
+   3000211               pi_tech+                        pi_tech_plus       none          1       110000  3.78065e-23
+  -3000213              rho_tech-                      rho_tech_minus       none         -1       210000  1.05491e-24
+   3000213              rho_tech+                       rho_tech_plus       none          1       210000  1.05491e-24
+   3000221               pi'_tech                       pi_prime_tech       none          0       110000  1.45108e-23
+   3000223             omega_tech                          omega_tech       none          0       210000  3.42962e-24
+   3060111           pi_tech_22_1                        pi_tech_22_1       none          0       125000  2.86678e-23
+   3100021                V8_tech                             V8_tech       none          0       500000  5.33932e-27
+   3100221               eta_tech                            eta_tech       none          0       350000  6.92053e-24
+   3130113            rho_tech_11                         rho_tech_11       none          0       400000  2.82881e-26
+   3140113            rho_tech_12                         rho_tech_12       none          0       350000  2.29898e-25
+   3150113            rho_tech_21                         rho_tech_21       none          0       350000            0
+   3160111           pi_tech_22_8                        pi_tech_22_8       none          0       250000  3.48518e-24
+   3160113            rho_tech_22                         rho_tech_22       none          0       300000  1.90288e-25
+  -4000001                anti_d*                         anti_d_star       none   0.333333       400000  2.53784e-25
+   4000001                     d*                              d_star       none  -0.333333       400000  2.53784e-25
+  -4000002                anti_u*                         anti_u_star       none  -0.666667       400000  2.53464e-25
+   4000002                     u*                              u_star       none   0.666667       400000  2.53464e-25
+  -4000011                    e*+                         e_star_plus       none          1       400000  1.53444e-24
+   4000011                    e*-                        e_star_minus       none         -1       400000  1.53444e-24
+  -4000012             anti_nu*_e                      anti_nu_star_e       none          0       400000  1.57046e-24
+   4000012                  nu*_e                           nu_star_e       none          0       400000  1.57046e-24
+   4000039                     G*                              G_star       none          0        1e+06  4.65069e-24
+   9000111               a0(980)0                              a09800       none          0        984.7  8.77616e-24
+  -9000211               a0(980)-                         a0980_minus       none         -1        984.7  8.77616e-24
+   9000211               a0(980)+                          a0980_plus       none          1        984.7  8.77616e-24
+   9010221                f0(980)                               f0980       none          0          980  9.40303e-24
+   9900012                  nu_Re                               nu_Re       none          0       500000  6.71645e-22
+   9900014                 nu_Rmu                              nu_Rmu       none          0       500000  6.71645e-22
+   9900016                nu_Rtau                             nu_Rtau       none          0       500000  6.78569e-22
+   9900023                   Z_R0                                Z_R0       none          0      1.2e+06  2.46295e-26
+  -9900024                   W_R-                           W_R_minus       none         -1       750000  3.02638e-26
+   9900024                   W_R+                            W_R_plus       none          1       750000  3.02638e-26
+  -9900041                  H_L--                              H_L_mm       none         -2       200000  7.46619e-25
+   9900041                  H_L++                              H_L_pp       none          2       200000  7.46619e-25
+  -9900042                  H_R--                              H_R_mm       none         -2       200000   7.4796e-25
+   9900042                  H_R++                              H_R_pp       none          2       200000   7.4796e-25
+   9910113             rho_diffr0                          rho_diffr0       none          0            0            0
+  -9910211              pi_diffr-                      pi_diffr_minus       none         -1            0            0
+   9910211              pi_diffr+                       pi_diffr_plus       none          1            0            0
+   9910223            omega_diffr                         omega_diffr       none          0            0            0
+   9910333              phi_diffr                           phi_diffr       none          0            0            0
+   9910443              psi_diffr                           psi_diffr       none          0            0            0
+  -9912112          anti_n_diffr0                       anti_n_diffr0       none          0            0            0
+   9912112               n_diffr0                            n_diffr0       none          0            0            0
+  -9912212          anti_p_diffr-                  anti_p_diffr_minus       none         -1            0            0
+   9912212               p_diffr+                        p_diffr_plus       none          1            0            0
+1000010020               deuteron                            deuteron       none          1      1875.61            0
+1000010030                 triton                             tritium       none          1      2809.25            0
+1000010040                H4[0.0]                              H4_0_0       none          1      3751.37            0
+1000010050                H5[0.0]                              H5_0_0       none          1      4689.85            0
+1000010060                H6[0.0]                              H6_0_0       none          1      5630.32            0
+1000010070                H7[0.0]                              H7_0_0       none          1      6569.08            0
+1000020030                    He3                                 He3       none          2      2809.23            0
+1000020040                  alpha                               alpha       none          2      3727.42            0
+1000020050               He5[0.0]                             He5_0_0       none          2      4667.83            0
+1000020060               He6[0.0]                             He6_0_0       none          2      5605.54            0
+1000020070               He7[0.0]                             He7_0_0       none          2      6545.54            0
+1000020080               He8[0.0]                             He8_0_0       none          2      7482.53            0
+1000020090               He9[0.0]                             He9_0_0       none          2      8423.36            0
+1000020100              He10[0.0]                            He10_0_0       none          2      9362.73            0
+1000030030               Li3[0.0]                             Li3_0_0       none          3      2821.62            0
+1000030040               Li4[0.0]                             Li4_0_0       none          3      3749.77            0
+1000030050               Li5[0.0]                             Li5_0_0       none          3      4667.62            0
+1000030060               Li6[0.0]                             Li6_0_0       none          3      5601.52            0
+1000030070               Li7[0.0]                             Li7_0_0       none          3      6533.83            0
+1000030080               Li8[0.0]                             Li8_0_0       none          3      7471.37            0
+1000030090               Li9[0.0]                             Li9_0_0       none          3      8406.87            0
+1000030100              Li10[0.0]                            Li10_0_0       none          3      9346.46            0
+1000030110              Li11[0.0]                            Li11_0_0       none          3      10285.7            0
+1000030120              Li12[0.0]                            Li12_0_0       none          3      11226.5            0
+1000040050               Be5[0.0]                             Be5_0_0       none          4      4693.42            0
+1000040060               Be6[0.0]                             Be6_0_0       none          4       5605.3            0
+1000040070               Be7[0.0]                             Be7_0_0       none          4      6534.18            0
+1000040080               Be8[0.0]                             Be8_0_0       none          4      7454.85            0
+1000040090               Be9[0.0]                             Be9_0_0       none          4      8392.75            0
+1000040100              Be10[0.0]                            Be10_0_0       none          4       9325.5            0
+1000040110              Be11[0.0]                            Be11_0_0       none          4      10264.6            0
+1000040120              Be12[0.0]                            Be12_0_0       none          4        11201            0
+1000040130              Be13[0.0]                            Be13_0_0       none          4      12140.6            0
+1000040140              Be14[0.0]                            Be14_0_0       none          4      13078.8            0
+1000040150              Be15[0.0]                            Be15_0_0       none          4      14020.2            0
+1000040160              Be16[0.0]                            Be16_0_0       none          4      14959.5            0
+1000050060                B6[0.0]                              B6_0_0       none          5      5630.01            0
+1000050070                B7[0.0]                              B7_0_0       none          5      6545.77            0
+1000050080                B8[0.0]                              B8_0_0       none          5      7472.32            0
+1000050090                B9[0.0]                              B9_0_0       none          5      8393.31            0
+1000050100               B10[0.0]                             B10_0_0       none          5      9324.44            0
+1000050110               B11[0.0]                             B11_0_0       none          5      10252.5            0
+1000050120               B12[0.0]                             B12_0_0       none          5      11188.7            0
+1000050130               B13[0.0]                             B13_0_0       none          5      12123.4            0
+1000050140               B14[0.0]                             B14_0_0       none          5        13062            0
+1000050150               B15[0.0]                             B15_0_0       none          5      13998.8            0
+1000050160               B16[0.0]                             B16_0_0       none          5      14938.4            0
+1000050170               B17[0.0]                             B17_0_0       none          5      15876.6            0
+1000050180               B18[0.0]                             B18_0_0       none          5      16816.7            0
+1000050190               B19[0.0]                             B19_0_0       none          5      17755.2            0
+1000060080                C8[0.0]                              C8_0_0       none          6      7483.98            0
+1000060090                C9[0.0]                              C9_0_0       none          6      8409.29            0
+1000060100               C10[0.0]                             C10_0_0       none          6      9327.57            0
+1000060110               C11[0.0]                             C11_0_0       none          6        10254            0
+1000060120               C12[0.0]                             C12_0_0       none          6      11174.9            0
+1000060130               C13[0.0]                             C13_0_0       none          6      12109.5            0
+1000060140               C14[0.0]                             C14_0_0       none          6      13040.9            0
+1000060150               C15[0.0]                             C15_0_0       none          6      13979.2            0
+1000060160               C16[0.0]                             C16_0_0       none          6      14914.5            0
+1000060170               C17[0.0]                             C17_0_0       none          6      15853.4            0
+1000060180               C18[0.0]                             C18_0_0       none          6      16788.8            0
+1000060190               C19[0.0]                             C19_0_0       none          6      17727.7            0
+1000060200               C20[0.0]                             C20_0_0       none          6      18664.4            0
+1000060210               C21[0.0]                             C21_0_0       none          6      19604.3            0
+1000060220               C22[0.0]                             C22_0_0       none          6      20543.1            0
+1000070100               N10[0.0]                             N10_0_0       none          7      9350.16            0
+1000070110               N11[0.0]                             N11_0_0       none          7      10267.2            0
+1000070120               N12[0.0]                             N12_0_0       none          7      11191.7            0
+1000070130               N13[0.0]                             N13_0_0       none          7      12111.2            0
+1000070140               N14[0.0]                             N14_0_0       none          7      13040.2            0
+1000070150               N15[0.0]                             N15_0_0       none          7      13968.9            0
+1000070160               N16[0.0]                             N16_0_0       none          7        14906            0
+1000070170               N17[0.0]                             N17_0_0       none          7      15839.7            0
+1000070180               N18[0.0]                             N18_0_0       none          7      16776.4            0
+1000070190               N19[0.0]                             N19_0_0       none          7      17710.7            0
+1000070200               N20[0.0]                             N20_0_0       none          7      18648.1            0
+1000070210               N21[0.0]                             N21_0_0       none          7      19583.1            0
+1000070220               N22[0.0]                             N22_0_0       none          7      20521.3            0
+1000070230               N23[0.0]                             N23_0_0       none          7      21459.2            0
+1000070240               N24[0.0]                             N24_0_0       none          7      22399.8            0
+1000070250               N25[0.0]                             N25_0_0       none          7      23340.3            0
+1000080120               O12[0.0]                             O12_0_0       none          8      11205.9            0
+1000080130               O13[0.0]                             O13_0_0       none          8      12128.4            0
+1000080140               O14[0.0]                             O14_0_0       none          8      13044.8            0
+1000080150               O15[0.0]                             O15_0_0       none          8      13971.2            0
+1000080160               O16[0.0]                             O16_0_0       none          8      14895.1            0
+1000080170               O17[0.0]                             O17_0_0       none          8      15830.5            0
+1000080180               O18[0.0]                             O18_0_0       none          8        16762            0
+1000080190               O19[0.0]                             O19_0_0       none          8      17697.6            0
+1000080200               O20[0.0]                             O20_0_0       none          8      18629.6            0
+1000080210               O21[0.0]                             O21_0_0       none          8      19565.4            0
+1000080220               O22[0.0]                             O22_0_0       none          8      20498.1            0
+1000080230               O23[0.0]                             O23_0_0       none          8      21434.9            0
+1000080240               O24[0.0]                             O24_0_0       none          8      22370.8            0
+1000080250               O25[0.0]                             O25_0_0       none          8      23310.7            0
+1000080260               O26[0.0]                             O26_0_0       none          8      24250.5            0
+1000080270               O27[0.0]                             O27_0_0       none          8      25191.2            0
+1000080280               O28[0.0]                             O28_0_0       none          8      26131.6            0
+1000090140               F14[0.0]                             F14_0_0       none          9        13069            0
+1000090150               F15[0.0]                             F15_0_0       none          9      13984.6            0
+1000090160               F16[0.0]                             F16_0_0       none          9        14910            0
+1000090170               F17[0.0]                             F17_0_0       none          9      15832.8            0
+1000090180               F18[0.0]                             F18_0_0       none          9      16763.2            0
+1000090190               F19[0.0]                             F19_0_0       none          9      17692.3            0
+1000090200               F20[0.0]                             F20_0_0       none          9      18625.3            0
+1000090210               F21[0.0]                             F21_0_0       none          9      19556.7            0
+1000090220               F22[0.0]                             F22_0_0       none          9      20491.1            0
+1000090230               F23[0.0]                             F23_0_0       none          9      21423.1            0
+1000090240               F24[0.0]                             F24_0_0       none          9      22358.8            0
+1000090250               F25[0.0]                             F25_0_0       none          9        23294            0
+1000090260               F26[0.0]                             F26_0_0       none          9      24232.5            0
+1000090270               F27[0.0]                             F27_0_0       none          9      25170.7            0
+1000090280               F28[0.0]                             F28_0_0       none          9      26110.5            0
+1000090290               F29[0.0]                             F29_0_0       none          9        27049            0
+1000090300               F30[0.0]                             F30_0_0       none          9      27989.1            0
+1000090310               F31[0.0]                             F31_0_0       none          9        28928            0
+1000100160              Ne16[0.0]                            Ne16_0_0       none         10      14922.8            0
+1000100170              Ne17[0.0]                            Ne17_0_0       none         10      15846.8            0
+1000100180              Ne18[0.0]                            Ne18_0_0       none         10      16767.1            0
+1000100190              Ne19[0.0]                            Ne19_0_0       none         10        17695            0
+1000100200              Ne20[0.0]                            Ne20_0_0       none         10      18617.7            0
+1000100210              Ne21[0.0]                            Ne21_0_0       none         10      19550.5            0
+1000100220              Ne22[0.0]                            Ne22_0_0       none         10      20479.7            0
+1000100230              Ne23[0.0]                            Ne23_0_0       none         10      21414.1            0
+1000100240              Ne24[0.0]                            Ne24_0_0       none         10      22344.8            0
+1000100250              Ne25[0.0]                            Ne25_0_0       none         10      23280.1            0
+1000100260              Ne26[0.0]                            Ne26_0_0       none         10      24214.2            0
+1000100270              Ne27[0.0]                            Ne27_0_0       none         10      25152.3            0
+1000100280              Ne28[0.0]                            Ne28_0_0       none         10        26088            0
+1000100290              Ne29[0.0]                            Ne29_0_0       none         10      27026.3            0
+1000100300              Ne30[0.0]                            Ne30_0_0       none         10      27962.8            0
+1000100310              Ne31[0.0]                            Ne31_0_0       none         10      28902.1            0
+1000100320              Ne32[0.0]                            Ne32_0_0       none         10        29840            0
+1000100330              Ne33[0.0]                            Ne33_0_0       none         10      30780.2            0
+1000100340              Ne34[0.0]                            Ne34_0_0       none         10      31718.8            0
+1000110180              Na18[0.0]                            Na18_0_0       none         11      16785.5            0
+1000110190              Na19[0.0]                            Na19_0_0       none         11      17705.7            0
+1000110200              Na20[0.0]                            Na20_0_0       none         11      18631.1            0
+1000110210              Na21[0.0]                            Na21_0_0       none         11      19553.6            0
+1000110220              Na22[0.0]                            Na22_0_0       none         11      20482.1            0
+1000110230              Na23[0.0]                            Na23_0_0       none         11      21409.2            0
+1000110240              Na24[0.0]                            Na24_0_0       none         11      22341.8            0
+1000110250              Na25[0.0]                            Na25_0_0       none         11      23272.4            0
+1000110260              Na26[0.0]                            Na26_0_0       none         11      24206.4            0
+1000110270              Na27[0.0]                            Na27_0_0       none         11      25139.2            0
+1000110280              Na28[0.0]                            Na28_0_0       none         11      26075.2            0
+1000110290              Na29[0.0]                            Na29_0_0       none         11      27010.4            0
+1000110300              Na30[0.0]                            Na30_0_0       none         11      27947.6            0
+1000110310              Na31[0.0]                            Na31_0_0       none         11      28883.4            0
+1000110320              Na32[0.0]                            Na32_0_0       none         11      29821.3            0
+1000110330              Na33[0.0]                            Na33_0_0       none         11      30758.6            0
+1000110340              Na34[0.0]                            Na34_0_0       none         11      31697.9            0
+1000110350              Na35[0.0]                            Na35_0_0       none         11      32636.3            0
+1000110360              Na36[0.0]                            Na36_0_0       none         11      33576.1            0
+1000110370              Na37[0.0]                            Na37_0_0       none         11      34514.9            0
+1000120190              Mg19[0.0]                            Mg19_0_0       none         12      17725.3            0
+1000120200              Mg20[0.0]                            Mg20_0_0       none         12      18641.3            0
+1000120210              Mg21[0.0]                            Mg21_0_0       none         12      19566.2            0
+1000120220              Mg22[0.0]                            Mg22_0_0       none         12      20486.3            0
+1000120230              Mg23[0.0]                            Mg23_0_0       none         12      21412.8            0
+1000120240              Mg24[0.0]                            Mg24_0_0       none         12      22335.8            0
+1000120241            Mg24[284.4]                          Mg24_284_4       none         12      22336.1            0
+1000120250              Mg25[0.0]                            Mg25_0_0       none         12        23268            0
+1000120260              Mg26[0.0]                            Mg26_0_0       none         12      24196.5            0
+1000120270              Mg27[0.0]                            Mg27_0_0       none         12      25129.6            0
+1000120280              Mg28[0.0]                            Mg28_0_0       none         12      26060.7            0
+1000120290              Mg29[0.0]                            Mg29_0_0       none         12      26996.6            0
+1000120300              Mg30[0.0]                            Mg30_0_0       none         12      27929.8            0
+1000120310              Mg31[0.0]                            Mg31_0_0       none         12        28867            0
+1000120320              Mg32[0.0]                            Mg32_0_0       none         12      29800.7            0
+1000120330              Mg33[0.0]                            Mg33_0_0       none         12      30738.1            0
+1000120340              Mg34[0.0]                            Mg34_0_0       none         12      31673.5            0
+1000120350              Mg35[0.0]                            Mg35_0_0       none         12      32612.3            0
+1000120360              Mg36[0.0]                            Mg36_0_0       none         12      33549.1            0
+1000120370              Mg37[0.0]                            Mg37_0_0       none         12      34488.4            0
+1000120380              Mg38[0.0]                            Mg38_0_0       none         12      35425.6            0
+1000120390              Mg39[0.0]                            Mg39_0_0       none         12      36365.7            0
+1000120400              Mg40[0.0]                            Mg40_0_0       none         12      37303.9            0
+1000130210              Al21[0.0]                            Al21_0_0       none         13      19580.9            0
+1000130220              Al22[0.0]                            Al22_0_0       none         13      20504.4            0
+1000130230              Al23[0.0]                            Al23_0_0       none         13      21424.5            0
+1000130240              Al24[0.0]                            Al24_0_0       none         13      22349.2            0
+1000130250              Al25[0.0]                            Al25_0_0       none         13      23271.8            0
+1000130260              Al26[0.0]                            Al26_0_0       none         13        24200            0
+1000130270              Al27[0.0]                            Al27_0_0       none         13      25126.5            0
+1000130280              Al28[0.0]                            Al28_0_0       none         13      26058.3            0
+1000130290              Al29[0.0]                            Al29_0_0       none         13      26988.5            0
+1000130300              Al30[0.0]                            Al30_0_0       none         13      27922.3            0
+1000130310              Al31[0.0]                            Al31_0_0       none         13      28854.7            0
+1000130320              Al32[0.0]                            Al32_0_0       none         13      29790.1            0
+1000130330              Al33[0.0]                            Al33_0_0       none         13      30724.1            0
+1000130340              Al34[0.0]                            Al34_0_0       none         13      31661.2            0
+1000130350              Al35[0.0]                            Al35_0_0       none         13      32595.5            0
+1000130360              Al36[0.0]                            Al36_0_0       none         13      33532.9            0
+1000130370              Al37[0.0]                            Al37_0_0       none         13      34468.6            0
+1000130380              Al38[0.0]                            Al38_0_0       none         13      35406.2            0
+1000130390              Al39[0.0]                            Al39_0_0       none         13        36343            0
+1000130400              Al40[0.0]                            Al40_0_0       none         13      37282.4            0
+1000130410              Al41[0.0]                            Al41_0_0       none         13      38220.3            0
+1000130420              Al42[0.0]                            Al42_0_0       none         13      39159.8            0
+1000140220              Si22[0.0]                            Si22_0_0       none         14      20517.9            0
+1000140230              Si23[0.0]                            Si23_0_0       none         14        21441            0
+1000140240              Si24[0.0]                            Si24_0_0       none         14      22359.5            0
+1000140250              Si25[0.0]                            Si25_0_0       none         14        23284            0
+1000140260              Si26[0.0]                            Si26_0_0       none         14      24204.6            0
+1000140270              Si27[0.0]                            Si27_0_0       none         14      25130.8            0
+1000140280              Si28[0.0]                            Si28_0_0       none         14      26053.2            0
+1000140290              Si29[0.0]                            Si29_0_0       none         14      26984.3            0
+1000140300              Si30[0.0]                            Si30_0_0       none         14      27913.2            0
+1000140310              Si31[0.0]                            Si31_0_0       none         14      28846.2            0
+1000140320              Si32[0.0]                            Si32_0_0       none         14      29776.6            0
+1000140330              Si33[0.0]                            Si33_0_0       none         14      30711.7            0
+1000140340              Si34[0.0]                            Si34_0_0       none         14      31643.7            0
+1000140350              Si35[0.0]                            Si35_0_0       none         14      32580.8            0
+1000140360              Si36[0.0]                            Si36_0_0       none         14      33514.2            0
+1000140370              Si37[0.0]                            Si37_0_0       none         14      34451.6            0
+1000140380              Si38[0.0]                            Si38_0_0       none         14      35385.6            0
+1000140390              Si39[0.0]                            Si39_0_0       none         14        36323            0
+1000140400              Si40[0.0]                            Si40_0_0       none         14      37258.1            0
+1000140410              Si41[0.0]                            Si41_0_0       none         14      38197.7            0
+1000140420              Si42[0.0]                            Si42_0_0       none         14        39134            0
+1000140430              Si43[0.0]                            Si43_0_0       none         14      40073.8            0
+1000140440              Si44[0.0]                            Si44_0_0       none         14      41011.4            0
+1000150240               P24[0.0]                             P24_0_0       none         15      22380.2            0
+1000150250               P25[0.0]                             P25_0_0       none         15      23298.6            0
+1000150260               P26[0.0]                             P26_0_0       none         15      24222.2            0
+1000150270               P27[0.0]                             P27_0_0       none         15        25142            0
+1000150280               P28[0.0]                             P28_0_0       none         15        26067            0
+1000150290               P29[0.0]                             P29_0_0       none         15      26988.7            0
+1000150300               P30[0.0]                             P30_0_0       none         15        27917            0
+1000150310               P31[0.0]                             P31_0_0       none         15      28844.2            0
+1000150320               P32[0.0]                             P32_0_0       none         15      29775.8            0
+1000150330               P33[0.0]                             P33_0_0       none         15      30705.3            0
+1000150340               P34[0.0]                             P34_0_0       none         15      31638.6            0
+1000150350               P35[0.0]                             P35_0_0       none         15      32569.8            0
+1000150360               P36[0.0]                             P36_0_0       none         15      33505.9            0
+1000150370               P37[0.0]                             P37_0_0       none         15      34438.6            0
+1000150380               P38[0.0]                             P38_0_0       none         15      35374.4            0
+1000150390               P39[0.0]                             P39_0_0       none         15      36307.7            0
+1000150400               P40[0.0]                             P40_0_0       none         15        37244            0
+1000150410               P41[0.0]                             P41_0_0       none         15      38178.3            0
+1000150420               P42[0.0]                             P42_0_0       none         15        39116            0
+1000150430               P43[0.0]                             P43_0_0       none         15      40052.4            0
+1000150440               P44[0.0]                             P44_0_0       none         15      40990.2            0
+1000150450               P45[0.0]                             P45_0_0       none         15      41927.5            0
+1000150460               P46[0.0]                             P46_0_0       none         15      42866.6            0
+1000160260               S26[0.0]                             S26_0_0       none         16      24236.6            0
+1000160270               S27[0.0]                             S27_0_0       none         16      25159.7            0
+1000160280               S28[0.0]                             S28_0_0       none         16      26077.7            0
+1000160290               S29[0.0]                             S29_0_0       none         16        27002            0
+1000160300               S30[0.0]                             S30_0_0       none         16      27922.6            0
+1000160310               S31[0.0]                             S31_0_0       none         16      28849.1            0
+1000160320               S32[0.0]                             S32_0_0       none         16      29773.6            0
+1000160330               S33[0.0]                             S33_0_0       none         16      30704.6            0
+1000160340               S34[0.0]                             S34_0_0       none         16      31632.7            0
+1000160350               S35[0.0]                             S35_0_0       none         16      32565.3            0
+1000160360               S36[0.0]                             S36_0_0       none         16        33495            0
+1000160370               S37[0.0]                             S37_0_0       none         16      34430.2            0
+1000160380               S38[0.0]                             S38_0_0       none         16      35361.7            0
+1000160390               S39[0.0]                             S39_0_0       none         16      36296.9            0
+1000160400               S40[0.0]                             S40_0_0       none         16      37228.7            0
+1000160410               S41[0.0]                             S41_0_0       none         16      38164.1            0
+1000160420               S42[0.0]                             S42_0_0       none         16      39096.9            0
+1000160430               S43[0.0]                             S43_0_0       none         16      40034.1            0
+1000160440               S44[0.0]                             S44_0_0       none         16      40968.5            0
+1000160450               S45[0.0]                             S45_0_0       none         16      41905.8            0
+1000160460               S46[0.0]                             S46_0_0       none         16      42841.3            0
+1000160470               S47[0.0]                             S47_0_0       none         16      43780.1            0
+1000160480               S48[0.0]                             S48_0_0       none         16      44716.7            0
+1000160490               S49[0.0]                             S49_0_0       none         16        45657            0
+1000170280              Cl28[0.0]                            Cl28_0_0       none         17      26099.7            0
+1000170290              Cl29[0.0]                            Cl29_0_0       none         17      27017.8            0
+1000170300              Cl30[0.0]                            Cl30_0_0       none         17      27940.6            0
+1000170310              Cl31[0.0]                            Cl31_0_0       none         17      28860.6            0
+1000170320              Cl32[0.0]                            Cl32_0_0       none         17      29785.8            0
+1000170330              Cl33[0.0]                            Cl33_0_0       none         17      30709.6            0
+1000170340              Cl34[0.0]                            Cl34_0_0       none         17      31637.7            0
+1000170350              Cl35[0.0]                            Cl35_0_0       none         17      32564.6            0
+1000170360              Cl36[0.0]                            Cl36_0_0       none         17      33495.6            0
+1000170370              Cl37[0.0]                            Cl37_0_0       none         17      34424.8            0
+1000170380              Cl38[0.0]                            Cl38_0_0       none         17      35358.3            0
+1000170390              Cl39[0.0]                            Cl39_0_0       none         17      36289.8            0
+1000170400              Cl40[0.0]                            Cl40_0_0       none         17      37223.5            0
+1000170410              Cl41[0.0]                            Cl41_0_0       none         17      38155.3            0
+1000170420              Cl42[0.0]                            Cl42_0_0       none         17      39089.2            0
+1000170430              Cl43[0.0]                            Cl43_0_0       none         17      40021.4            0
+1000170440              Cl44[0.0]                            Cl44_0_0       none         17      40956.8            0
+1000170450              Cl45[0.0]                            Cl45_0_0       none         17      41890.2            0
+1000170460              Cl46[0.0]                            Cl46_0_0       none         17      42825.3            0
+1000170470              Cl47[0.0]                            Cl47_0_0       none         17        43761            0
+1000170480              Cl48[0.0]                            Cl48_0_0       none         17      44698.3            0
+1000170490              Cl49[0.0]                            Cl49_0_0       none         17      45634.8            0
+1000170500              Cl50[0.0]                            Cl50_0_0       none         17      46573.3            0
+1000170510              Cl51[0.0]                            Cl51_0_0       none         17        47511            0
+1000180300              Ar30[0.0]                            Ar30_0_0       none         18      27955.7            0
+1000180310              Ar31[0.0]                            Ar31_0_0       none         18      28878.4            0
+1000180320              Ar32[0.0]                            Ar32_0_0       none         18      29796.4            0
+1000180330              Ar33[0.0]                            Ar33_0_0       none         18      30720.7            0
+1000180340              Ar34[0.0]                            Ar34_0_0       none         18      31643.2            0
+1000180350              Ar35[0.0]                            Ar35_0_0       none         18      32570.1            0
+1000180360              Ar36[0.0]                            Ar36_0_0       none         18      33494.4            0
+1000180370              Ar37[0.0]                            Ar37_0_0       none         18      34425.1            0
+1000180380              Ar38[0.0]                            Ar38_0_0       none         18      35352.9            0
+1000180390              Ar39[0.0]                            Ar39_0_0       none         18      36285.8            0
+1000180400              Ar40[0.0]                            Ar40_0_0       none         18      37215.5            0
+1000180410              Ar41[0.0]                            Ar41_0_0       none         18        38149            0
+1000180420              Ar42[0.0]                            Ar42_0_0       none         18      39079.1            0
+1000180430              Ar43[0.0]                            Ar43_0_0       none         18        40013            0
+1000180440              Ar44[0.0]                            Ar44_0_0       none         18      40943.9            0
+1000180450              Ar45[0.0]                            Ar45_0_0       none         18      41878.3            0
+1000180460              Ar46[0.0]                            Ar46_0_0       none         18      42809.8            0
+1000180470              Ar47[0.0]                            Ar47_0_0       none         18      43745.1            0
+1000180480              Ar48[0.0]                            Ar48_0_0       none         18      44678.8            0
+1000180490              Ar49[0.0]                            Ar49_0_0       none         18      45615.9            0
+1000180500              Ar50[0.0]                            Ar50_0_0       none         18        46551            0
+1000180510              Ar51[0.0]                            Ar51_0_0       none         18      47489.2            0
+1000180520              Ar52[0.0]                            Ar52_0_0       none         18      48425.5            0
+1000180530              Ar53[0.0]                            Ar53_0_0       none         18      49364.6            0
+1000190320               K32[0.0]                             K32_0_0       none         19      29818.5            0
+1000190330               K33[0.0]                             K33_0_0       none         19      30736.4            0
+1000190340               K34[0.0]                             K34_0_0       none         19      31659.6            0
+1000190350               K35[0.0]                             K35_0_0       none         19      32581.4            0
+1000190360               K36[0.0]                             K36_0_0       none         19      33506.7            0
+1000190370               K37[0.0]                             K37_0_0       none         19      34430.8            0
+1000190380               K38[0.0]                             K38_0_0       none         19      35358.3            0
+1000190390               K39[0.0]                             K39_0_0       none         19      36284.8            0
+1000190391             K39[924.1]                           K39_924_1       none         19      36285.7            0
+1000190400               K40[0.0]                             K40_0_0       none         19      37216.5            0
+1000190410               K41[0.0]                             K41_0_0       none         19        38146            0
+1000190420               K42[0.0]                             K42_0_0       none         19        39078            0
+1000190430               K43[0.0]                             K43_0_0       none         19        40008            0
+1000190440               K44[0.0]                             K44_0_0       none         19      40940.2            0
+1000190450               K45[0.0]                             K45_0_0       none         19      41870.9            0
+1000190460               K46[0.0]                             K46_0_0       none         19      42803.6            0
+1000190470               K47[0.0]                             K47_0_0       none         19      43734.8            0
+1000190480               K48[0.0]                             K48_0_0       none         19      44669.9            0
+1000190490               K49[0.0]                             K49_0_0       none         19      45603.2            0
+1000190500               K50[0.0]                             K50_0_0       none         19      46539.7            0
+1000190510               K51[0.0]                             K51_0_0       none         19      47474.5            0
+1000190520               K52[0.0]                             K52_0_0       none         19      48411.8            0
+1000190530               K53[0.0]                             K53_0_0       none         19      49347.5            0
+1000190540               K54[0.0]                             K54_0_0       none         19      50285.6            0
+1000190550               K55[0.0]                             K55_0_0       none         19      51222.2            0
+1000200340              Ca34[0.0]                            Ca34_0_0       none         20      31673.7            0
+1000200350              Ca35[0.0]                            Ca35_0_0       none         20      32596.7            0
+1000200360              Ca36[0.0]                            Ca36_0_0       none         20      33517.1            0
+1000200370              Ca37[0.0]                            Ca37_0_0       none         20      34441.9            0
+1000200380              Ca38[0.0]                            Ca38_0_0       none         20      35364.5            0
+1000200390              Ca39[0.0]                            Ca39_0_0       none         20      36290.8            0
+1000200400              Ca40[0.0]                            Ca40_0_0       none         20      37214.7            0
+1000200410              Ca41[0.0]                            Ca41_0_0       none         20      38145.9            0
+1000200420              Ca42[0.0]                            Ca42_0_0       none         20        39074            0
+1000200430              Ca43[0.0]                            Ca43_0_0       none         20      40005.6            0
+1000200440              Ca44[0.0]                            Ca44_0_0       none         20      40934.1            0
+1000200450              Ca45[0.0]                            Ca45_0_0       none         20      41866.2            0
+1000200460              Ca46[0.0]                            Ca46_0_0       none         20      42795.4            0
+1000200470              Ca47[0.0]                            Ca47_0_0       none         20      43727.7            0
+1000200480              Ca48[0.0]                            Ca48_0_0       none         20      44657.3            0
+1000200490              Ca49[0.0]                            Ca49_0_0       none         20      45591.7            0
+1000200500              Ca50[0.0]                            Ca50_0_0       none         20      46524.9            0
+1000200510              Ca51[0.0]                            Ca51_0_0       none         20      47460.1            0
+1000200520              Ca52[0.0]                            Ca52_0_0       none         20        48395            0
+1000200530              Ca53[0.0]                            Ca53_0_0       none         20      49331.1            0
+1000200540              Ca54[0.0]                            Ca54_0_0       none         20      50266.6            0
+1000200550              Ca55[0.0]                            Ca55_0_0       none         20      51203.9            0
+1000200560              Ca56[0.0]                            Ca56_0_0       none         20        52140            0
+1000200570              Ca57[0.0]                            Ca57_0_0       none         20      53077.8            0
+1000210360              Sc36[0.0]                            Sc36_0_0       none         21        33537            0
+1000210370              Sc37[0.0]                            Sc37_0_0       none         21      34457.4            0
+1000210380              Sc38[0.0]                            Sc38_0_0       none         21      35381.1            0
+1000210390              Sc39[0.0]                            Sc39_0_0       none         21      36303.4            0
+1000210400              Sc40[0.0]                            Sc40_0_0       none         21      37228.5            0
+1000210410              Sc41[0.0]                            Sc41_0_0       none         21      38151.9            0
+1000210420              Sc42[0.0]                            Sc42_0_0       none         21      39079.9            0
+1000210430              Sc43[0.0]                            Sc43_0_0       none         21      40007.3            0
+1000210440              Sc44[0.0]                            Sc44_0_0       none         21      40937.2            0
+1000210450              Sc45[0.0]                            Sc45_0_0       none         21      41865.5            0
+1000210460              Sc46[0.0]                            Sc46_0_0       none         21      42796.3            0
+1000210470              Sc47[0.0]                            Sc47_0_0       none         21      43725.2            0
+1000210480              Sc48[0.0]                            Sc48_0_0       none         21      44656.5            0
+1000210490              Sc49[0.0]                            Sc49_0_0       none         21      45585.9            0
+1000210500              Sc50[0.0]                            Sc50_0_0       none         21      46519.5            0
+1000210510              Sc51[0.0]                            Sc51_0_0       none         21      47452.3            0
+1000210520              Sc52[0.0]                            Sc52_0_0       none         21      48386.6            0
+1000210530              Sc53[0.0]                            Sc53_0_0       none         21      49320.9            0
+1000210540              Sc54[0.0]                            Sc54_0_0       none         21      50255.7            0
+1000210550              Sc55[0.0]                            Sc55_0_0       none         21      51191.9            0
+1000210560              Sc56[0.0]                            Sc56_0_0       none         21      52127.7            0
+1000210570              Sc57[0.0]                            Sc57_0_0       none         21      53063.8            0
+1000210580              Sc58[0.0]                            Sc58_0_0       none         21      54000.8            0
+1000210590              Sc59[0.0]                            Sc59_0_0       none         21      54937.4            0
+1000210600              Sc60[0.0]                            Sc60_0_0       none         21      55874.9            0
+1000220380              Ti38[0.0]                            Ti38_0_0       none         22      35394.7            0
+1000220390              Ti39[0.0]                            Ti39_0_0       none         22      36318.5            0
+1000220400              Ti40[0.0]                            Ti40_0_0       none         22      37239.7            0
+1000220410              Ti41[0.0]                            Ti41_0_0       none         22      38164.3            0
+1000220420              Ti42[0.0]                            Ti42_0_0       none         22      39086.4            0
+1000220430              Ti43[0.0]                            Ti43_0_0       none         22      40013.7            0
+1000220440              Ti44[0.0]                            Ti44_0_0       none         22        40937            0
+1000220450              Ti45[0.0]                            Ti45_0_0       none         22        41867            0
+1000220460              Ti46[0.0]                            Ti46_0_0       none         22      42793.4            0
+1000220470              Ti47[0.0]                            Ti47_0_0       none         22      43724.1            0
+1000220480              Ti48[0.0]                            Ti48_0_0       none         22        44652            0
+1000220490              Ti49[0.0]                            Ti49_0_0       none         22      45583.4            0
+1000220500              Ti50[0.0]                            Ti50_0_0       none         22      46512.1            0
+1000220510              Ti51[0.0]                            Ti51_0_0       none         22      47445.2            0
+1000220520              Ti52[0.0]                            Ti52_0_0       none         22        48377            0
+1000220530              Ti53[0.0]                            Ti53_0_0       none         22      49311.1            0
+1000220540              Ti54[0.0]                            Ti54_0_0       none         22      50243.9            0
+1000220550              Ti55[0.0]                            Ti55_0_0       none         22      51179.3            0
+1000220560              Ti56[0.0]                            Ti56_0_0       none         22      52113.5            0
+1000220570              Ti57[0.0]                            Ti57_0_0       none         22      53050.4            0
+1000220580              Ti58[0.0]                            Ti58_0_0       none         22      53984.7            0
+1000220590              Ti59[0.0]                            Ti59_0_0       none         22      54921.7            0
+1000220600              Ti60[0.0]                            Ti60_0_0       none         22      55856.8            0
+1000220610              Ti61[0.0]                            Ti61_0_0       none         22      56794.3            0
+1000220620              Ti62[0.0]                            Ti62_0_0       none         22      57729.8            0
+1000220630              Ti63[0.0]                            Ti63_0_0       none         22      58667.7            0
+1000230400               V40[0.0]                             V40_0_0       none         23      37258.4            0
+1000230410               V41[0.0]                             V41_0_0       none         23      38179.3            0
+1000230420               V42[0.0]                             V42_0_0       none         23      39102.9            0
+1000230430               V43[0.0]                             V43_0_0       none         23      40024.5            0
+1000230440               V44[0.0]                             V44_0_0       none         23      40949.9            0
+1000230450               V45[0.0]                             V45_0_0       none         23      41873.6            0
+1000230460               V46[0.0]                             V46_0_0       none         23      42799.9            0
+1000230470               V47[0.0]                             V47_0_0       none         23      43726.5            0
+1000230480               V48[0.0]                             V48_0_0       none         23      44655.5            0
+1000230490               V49[0.0]                             V49_0_0       none         23      45583.5            0
+1000230500               V50[0.0]                             V50_0_0       none         23      46513.8            0
+1000230510               V51[0.0]                             V51_0_0       none         23      47442.3            0
+1000230520               V52[0.0]                             V52_0_0       none         23      48374.5            0
+1000230530               V53[0.0]                             V53_0_0       none         23      49305.6            0
+1000230540               V54[0.0]                             V54_0_0       none         23      50239.1            0
+1000230550               V55[0.0]                             V55_0_0       none         23      51171.3            0
+1000230560               V56[0.0]                             V56_0_0       none         23      52105.9            0
+1000230570               V57[0.0]                             V57_0_0       none         23      53039.2            0
+1000230580               V58[0.0]                             V58_0_0       none         23      53974.7            0
+1000230590               V59[0.0]                             V59_0_0       none         23      54909.4            0
+1000230600               V60[0.0]                             V60_0_0       none         23      55845.3            0
+1000230610               V61[0.0]                             V61_0_0       none         23        56780            0
+1000230620               V62[0.0]                             V62_0_0       none         23      57716.5            0
+1000230630               V63[0.0]                             V63_0_0       none         23      58651.5            0
+1000230640               V64[0.0]                             V64_0_0       none         23      59588.5            0
+1000230650               V65[0.0]                             V65_0_0       none         23      60524.1            0
+1000240420              Cr42[0.0]                            Cr42_0_0       none         24      39116.5            0
+1000240430              Cr43[0.0]                            Cr43_0_0       none         24      40039.9            0
+1000240440              Cr44[0.0]                            Cr44_0_0       none         24        40960            0
+1000240450              Cr45[0.0]                            Cr45_0_0       none         24        41886            0
+1000240460              Cr46[0.0]                            Cr46_0_0       none         24        42807            0
+1000240470              Cr47[0.0]                            Cr47_0_0       none         24      43733.4            0
+1000240480              Cr48[0.0]                            Cr48_0_0       none         24      44656.7            0
+1000240490              Cr49[0.0]                            Cr49_0_0       none         24      45585.6            0
+1000240500              Cr50[0.0]                            Cr50_0_0       none         24      46512.2            0
+1000240510              Cr51[0.0]                            Cr51_0_0       none         24      47442.5            0
+1000240520              Cr52[0.0]                            Cr52_0_0       none         24        48370            0
+1000240530              Cr53[0.0]                            Cr53_0_0       none         24      49301.7            0
+1000240540              Cr54[0.0]                            Cr54_0_0       none         24      50231.5            0
+1000240550              Cr55[0.0]                            Cr55_0_0       none         24      51164.8            0
+1000240560              Cr56[0.0]                            Cr56_0_0       none         24      52096.1            0
+1000240570              Cr57[0.0]                            Cr57_0_0       none         24      53030.4            0
+1000240580              Cr58[0.0]                            Cr58_0_0       none         24      53962.6            0
+1000240590              Cr59[0.0]                            Cr59_0_0       none         24        54898            0
+1000240600              Cr60[0.0]                            Cr60_0_0       none         24      55830.9            0
+1000240610              Cr61[0.0]                            Cr61_0_0       none         24      56766.7            0
+1000240620              Cr62[0.0]                            Cr62_0_0       none         24        57700            0
+1000240630              Cr63[0.0]                            Cr63_0_0       none         24      58636.4            0
+1000240640              Cr64[0.0]                            Cr64_0_0       none         24      59570.2            0
+1000240650              Cr65[0.0]                            Cr65_0_0       none         24      60507.1            0
+1000240660              Cr66[0.0]                            Cr66_0_0       none         24      61441.6            0
+1000240670              Cr67[0.0]                            Cr67_0_0       none         24      62378.8            0
+1000250440              Mn44[0.0]                            Mn44_0_0       none         25      40979.4            0
+1000250450              Mn45[0.0]                            Mn45_0_0       none         25      41899.4            0
+1000250460              Mn46[0.0]                            Mn46_0_0       none         25      42823.6            0
+1000250470              Mn47[0.0]                            Mn47_0_0       none         25      43745.2            0
+1000250480              Mn48[0.0]                            Mn48_0_0       none         25      44669.6            0
+1000250490              Mn49[0.0]                            Mn49_0_0       none         25      45592.8            0
+1000250500              Mn50[0.0]                            Mn50_0_0       none         25      46519.3            0
+1000250510              Mn51[0.0]                            Mn51_0_0       none         25      47445.2            0
+1000250520              Mn52[0.0]                            Mn52_0_0       none         25      48374.2            0
+1000250530              Mn53[0.0]                            Mn53_0_0       none         25      49301.8            0
+1000250540              Mn54[0.0]                            Mn54_0_0       none         25      50232.4            0
+1000250550              Mn55[0.0]                            Mn55_0_0       none         25      51161.7            0
+1000250560              Mn56[0.0]                            Mn56_0_0       none         25        52094            0
+1000250570              Mn57[0.0]                            Mn57_0_0       none         25      53024.9            0
+1000250580              Mn58[0.0]                            Mn58_0_0       none         25        53958            0
+1000250590              Mn59[0.0]                            Mn59_0_0       none         25      54889.9            0
+1000250600              Mn60[0.0]                            Mn60_0_0       none         25      55823.7            0
+1000250610              Mn61[0.0]                            Mn61_0_0       none         25      56756.8            0
+1000250620              Mn62[0.0]                            Mn62_0_0       none         25      57691.8            0
+1000250630              Mn63[0.0]                            Mn63_0_0       none         25        58625            0
+1000250640              Mn64[0.0]                            Mn64_0_0       none         25      59560.3            0
+1000250650              Mn65[0.0]                            Mn65_0_0       none         25      60493.7            0
+1000250660              Mn66[0.0]                            Mn66_0_0       none         25      61429.6            0
+1000250670              Mn67[0.0]                            Mn67_0_0       none         25        62364            0
+1000250680              Mn68[0.0]                            Mn68_0_0       none         25      63300.3            0
+1000250690              Mn69[0.0]                            Mn69_0_0       none         25        64235            0
+1000260450              Fe45[0.0]                            Fe45_0_0       none         26      41917.6            0
+1000260460              Fe46[0.0]                            Fe46_0_0       none         26      42836.2            0
+1000260470              Fe47[0.0]                            Fe47_0_0       none         26      43760.3            0
+1000260480              Fe48[0.0]                            Fe48_0_0       none         26      44680.3            0
+1000260490              Fe49[0.0]                            Fe49_0_0       none         26      45605.4            0
+1000260500              Fe50[0.0]                            Fe50_0_0       none         26        46527            0
+1000260510              Fe51[0.0]                            Fe51_0_0       none         26      47452.7            0
+1000260520              Fe52[0.0]                            Fe52_0_0       none         26      48376.1            0
+1000260530              Fe53[0.0]                            Fe53_0_0       none         26        49305            0
+1000260540              Fe54[0.0]                            Fe54_0_0       none         26      50231.2            0
+1000260550              Fe55[0.0]                            Fe55_0_0       none         26      51161.4            0
+1000260560              Fe56[0.0]                            Fe56_0_0       none         26      52089.8            0
+1000260570              Fe57[0.0]                            Fe57_0_0       none         26      53021.7            0
+1000260580              Fe58[0.0]                            Fe58_0_0       none         26      53951.2            0
+1000260590              Fe59[0.0]                            Fe59_0_0       none         26      54884.2            0
+1000260600              Fe60[0.0]                            Fe60_0_0       none         26        55815            0
+1000260610              Fe61[0.0]                            Fe61_0_0       none         26        56749            0
+1000260620              Fe62[0.0]                            Fe62_0_0       none         26      57680.5            0
+1000260630              Fe63[0.0]                            Fe63_0_0       none         26      58615.3            0
+1000260640              Fe64[0.0]                            Fe64_0_0       none         26      59547.6            0
+1000260650              Fe65[0.0]                            Fe65_0_0       none         26        60483            0
+1000260660              Fe66[0.0]                            Fe66_0_0       none         26      61415.8            0
+1000260670              Fe67[0.0]                            Fe67_0_0       none         26      62351.2            0
+1000260680              Fe68[0.0]                            Fe68_0_0       none         26      63285.2            0
+1000260690              Fe69[0.0]                            Fe69_0_0       none         26      64221.4            0
+1000260700              Fe70[0.0]                            Fe70_0_0       none         26      65155.4            0
+1000260710              Fe71[0.0]                            Fe71_0_0       none         26      66091.8            0
+1000260720              Fe72[0.0]                            Fe72_0_0       none         26        67026            0
+1000270470              Co47[0.0]                            Co47_0_0       none         27      43777.2            0
+1000270480              Co48[0.0]                            Co48_0_0       none         27      44699.6            0
+1000270490              Co49[0.0]                            Co49_0_0       none         27      45619.9            0
+1000270500              Co50[0.0]                            Co50_0_0       none         27      46543.7            0
+1000270510              Co51[0.0]                            Co51_0_0       none         27      47465.2            0
+1000270520              Co52[0.0]                            Co52_0_0       none         27        48390            0
+1000270530              Co53[0.0]                            Co53_0_0       none         27      49312.8            0
+1000270540              Co54[0.0]                            Co54_0_0       none         27      50238.9            0
+1000270550              Co55[0.0]                            Co55_0_0       none         27      51164.4            0
+1000270560              Co56[0.0]                            Co56_0_0       none         27      52093.9            0
+1000270570              Co57[0.0]                            Co57_0_0       none         27      53022.1            0
+1000270580              Co58[0.0]                            Co58_0_0       none         27        53953            0
+1000270590              Co59[0.0]                            Co59_0_0       none         27      54882.2            0
+1000270600              Co60[0.0]                            Co60_0_0       none         27      55814.2            0
+1000270610              Co61[0.0]                            Co61_0_0       none         27      56744.5            0
+1000270620              Co62[0.0]                            Co62_0_0       none         27      57677.4            0
+1000270630              Co63[0.0]                            Co63_0_0       none         27      58608.5            0
+1000270640              Co64[0.0]                            Co64_0_0       none         27      59542.1            0
+1000270650              Co65[0.0]                            Co65_0_0       none         27      60474.2            0
+1000270660              Co66[0.0]                            Co66_0_0       none         27      61408.7            0
+1000270670              Co67[0.0]                            Co67_0_0       none         27      62341.3            0
+1000270680              Co68[0.0]                            Co68_0_0       none         27      63276.5            0
+1000270690              Co69[0.0]                            Co69_0_0       none         27      64209.3            0
+1000270700              Co70[0.0]                            Co70_0_0       none         27      65145.2            0
+1000270710              Co71[0.0]                            Co71_0_0       none         27      66078.4            0
+1000270720              Co72[0.0]                            Co72_0_0       none         27      67014.5            0
+1000270730              Co73[0.0]                            Co73_0_0       none         27      67948.3            0
+1000270740              Co74[0.0]                            Co74_0_0       none         27      68884.6            0
+1000270750              Co75[0.0]                            Co75_0_0       none         27      69818.8            0
+1000280480              Ni48[0.0]                            Ni48_0_0       none         28      44715.8            0
+1000280490              Ni49[0.0]                            Ni49_0_0       none         28      45637.9            0
+1000280500              Ni50[0.0]                            Ni50_0_0       none         28      46556.6            0
+1000280510              Ni51[0.0]                            Ni51_0_0       none         28      47480.5            0
+1000280520              Ni52[0.0]                            Ni52_0_0       none         28      48400.8            0
+1000280530              Ni53[0.0]                            Ni53_0_0       none         28      49325.5            0
+1000280540              Ni54[0.0]                            Ni54_0_0       none         28      50247.2            0
+1000280550              Ni55[0.0]                            Ni55_0_0       none         28      51172.6            0
+1000280560              Ni56[0.0]                            Ni56_0_0       none         28      52095.5            0
+1000280570              Ni57[0.0]                            Ni57_0_0       none         28      53024.8            0
+1000280580              Ni58[0.0]                            Ni58_0_0       none         28      53952.2            0
+1000280590              Ni59[0.0]                            Ni59_0_0       none         28      54882.7            0
+1000280600              Ni60[0.0]                            Ni60_0_0       none         28      55810.9            0
+1000280610              Ni61[0.0]                            Ni61_0_0       none         28      56742.6            0
+1000280620              Ni62[0.0]                            Ni62_0_0       none         28      57671.6            0
+1000280630              Ni63[0.0]                            Ni63_0_0       none         28      58604.3            0
+1000280640              Ni64[0.0]                            Ni64_0_0       none         28      59534.3            0
+1000280650              Ni65[0.0]                            Ni65_0_0       none         28      60467.7            0
+1000280660              Ni66[0.0]                            Ni66_0_0       none         28      61398.3            0
+1000280670              Ni67[0.0]                            Ni67_0_0       none         28      62332.1            0
+1000280680              Ni68[0.0]                            Ni68_0_0       none         28      63263.9            0
+1000280690              Ni69[0.0]                            Ni69_0_0       none         28      64198.8            0
+1000280700              Ni70[0.0]                            Ni70_0_0       none         28      65131.2            0
+1000280710              Ni71[0.0]                            Ni71_0_0       none         28      66066.6            0
+1000280720              Ni72[0.0]                            Ni72_0_0       none         28      66999.4            0
+1000280730              Ni73[0.0]                            Ni73_0_0       none         28      67934.9            0
+1000280740              Ni74[0.0]                            Ni74_0_0       none         28      68867.9            0
+1000280750              Ni75[0.0]                            Ni75_0_0       none         28      69803.9            0
+1000280760              Ni76[0.0]                            Ni76_0_0       none         28      70737.7            0
+1000280770              Ni77[0.0]                            Ni77_0_0       none         28        71674            0
+1000280780              Ni78[0.0]                            Ni78_0_0       none         28        72608            0
+1000290520              Cu52[0.0]                            Cu52_0_0       none         29      48420.3            0
+1000290530              Cu53[0.0]                            Cu53_0_0       none         29      49340.9            0
+1000290540              Cu54[0.0]                            Cu54_0_0       none         29      50264.2            0
+1000290550              Cu55[0.0]                            Cu55_0_0       none         29      51185.8            0
+1000290560              Cu56[0.0]                            Cu56_0_0       none         29      52110.3            0
+1000290570              Cu57[0.0]                            Cu57_0_0       none         29      53033.1            0
+1000290580              Cu58[0.0]                            Cu58_0_0       none         29      53960.2            0
+1000290590              Cu59[0.0]                            Cu59_0_0       none         29        54887            0
+1000290600              Cu60[0.0]                            Cu60_0_0       none         29      55816.5            0
+1000290610              Cu61[0.0]                            Cu61_0_0       none         29      56744.4            0
+1000290620              Cu62[0.0]                            Cu62_0_0       none         29      57675.1            0
+1000290630              Cu63[0.0]                            Cu63_0_0       none         29      58603.8            0
+1000290640              Cu64[0.0]                            Cu64_0_0       none         29      59535.4            0
+1000290650              Cu65[0.0]                            Cu65_0_0       none         29      60465.1            0
+1000290660              Cu66[0.0]                            Cu66_0_0       none         29      61397.6            0
+1000290670              Cu67[0.0]                            Cu67_0_0       none         29        62328            0
+1000290680              Cu68[0.0]                            Cu68_0_0       none         29      63261.3            0
+1000290690              Cu69[0.0]                            Cu69_0_0       none         29      64192.6            0
+1000290700              Cu70[0.0]                            Cu70_0_0       none         29      65126.8            0
+1000290710              Cu71[0.0]                            Cu71_0_0       none         29      66058.6            0
+1000290720              Cu72[0.0]                            Cu72_0_0       none         29        66993            0
+1000290730              Cu73[0.0]                            Cu73_0_0       none         29      67925.3            0
+1000290740              Cu74[0.0]                            Cu74_0_0       none         29      68859.8            0
+1000290750              Cu75[0.0]                            Cu75_0_0       none         29      69793.2            0
+1000290760              Cu76[0.0]                            Cu76_0_0       none         29      70727.8            0
+1000290770              Cu77[0.0]                            Cu77_0_0       none         29      71661.7            0
+1000290780              Cu78[0.0]                            Cu78_0_0       none         29        72597            0
+1000290790              Cu79[0.0]                            Cu79_0_0       none         29      73530.9            0
+1000290800              Cu80[0.0]                            Cu80_0_0       none         29      74468.3            0
+1000300540              Zn54[0.0]                            Zn54_0_0       none         30      50278.8            0
+1000300550              Zn55[0.0]                            Zn55_0_0       none         30        51202            0
+1000300560              Zn56[0.0]                            Zn56_0_0       none         30      52122.7            0
+1000300570              Zn57[0.0]                            Zn57_0_0       none         30      53047.1            0
+1000300580              Zn58[0.0]                            Zn58_0_0       none         30      53969.1            0
+1000300590              Zn59[0.0]                            Zn59_0_0       none         30      54895.6            0
+1000300600              Zn60[0.0]                            Zn60_0_0       none         30      55820.2            0
+1000300610              Zn61[0.0]                            Zn61_0_0       none         30      56749.5            0
+1000300620              Zn62[0.0]                            Zn62_0_0       none         30      57676.2            0
+1000300630              Zn63[0.0]                            Zn63_0_0       none         30      58606.6            0
+1000300640              Zn64[0.0]                            Zn64_0_0       none         30      59534.3            0
+1000300650              Zn65[0.0]                            Zn65_0_0       none         30      60465.9            0
+1000300660              Zn66[0.0]                            Zn66_0_0       none         30      61394.4            0
+1000300670              Zn67[0.0]                            Zn67_0_0       none         30      62326.9            0
+1000300680              Zn68[0.0]                            Zn68_0_0       none         30      63256.3            0
+1000300690              Zn69[0.0]                            Zn69_0_0       none         30      64189.4            0
+1000300700              Zn70[0.0]                            Zn70_0_0       none         30      65119.7            0
+1000300710              Zn71[0.0]                            Zn71_0_0       none         30      66053.5            0
+1000300720              Zn72[0.0]                            Zn72_0_0       none         30      66984.2            0
+1000300730              Zn73[0.0]                            Zn73_0_0       none         30      67918.4            0
+1000300740              Zn74[0.0]                            Zn74_0_0       none         30      68849.6            0
+1000300750              Zn75[0.0]                            Zn75_0_0       none         30      69784.3            0
+1000300760              Zn76[0.0]                            Zn76_0_0       none         30      70716.1            0
+1000300770              Zn77[0.0]                            Zn77_0_0       none         30        71651            0
+1000300780              Zn78[0.0]                            Zn78_0_0       none         30      72583.9            0
+1000300790              Zn79[0.0]                            Zn79_0_0       none         30      73519.3            0
+1000300800              Zn80[0.0]                            Zn80_0_0       none         30      74452.4            0
+1000300810              Zn81[0.0]                            Zn81_0_0       none         30      75389.6            0
+1000300820              Zn82[0.0]                            Zn82_0_0       none         30      76324.8            0
+1000300830              Zn83[0.0]                            Zn83_0_0       none         30      77262.4            0
+1000310560              Ga56[0.0]                            Ga56_0_0       none         31      52143.1            0
+1000310570              Ga57[0.0]                            Ga57_0_0       none         31      53063.5            0
+1000310580              Ga58[0.0]                            Ga58_0_0       none         31      53986.9            0
+1000310590              Ga59[0.0]                            Ga59_0_0       none         31      54908.2            0
+1000310600              Ga60[0.0]                            Ga60_0_0       none         31      55833.9            0
+1000310610              Ga61[0.0]                            Ga61_0_0       none         31      56758.3            0
+1000310620              Ga62[0.0]                            Ga62_0_0       none         31      57684.8            0
+1000310630              Ga63[0.0]                            Ga63_0_0       none         31      58611.8            0
+1000310640              Ga64[0.0]                            Ga64_0_0       none         31        59541            0
+1000310650              Ga65[0.0]                            Ga65_0_0       none         31      60468.7            0
+1000310660              Ga66[0.0]                            Ga66_0_0       none         31      61399.1            0
+1000310670              Ga67[0.0]                            Ga67_0_0       none         31      62327.4            0
+1000310680              Ga68[0.0]                            Ga68_0_0       none         31      63258.7            0
+1000310690              Ga69[0.0]                            Ga69_0_0       none         31        64188            0
+1000310700              Ga70[0.0]                            Ga70_0_0       none         31      65119.9            0
+1000310710              Ga71[0.0]                            Ga71_0_0       none         31      66050.1            0
+1000310720              Ga72[0.0]                            Ga72_0_0       none         31      66983.2            0
+1000310730              Ga73[0.0]                            Ga73_0_0       none         31      67913.6            0
+1000310740              Ga74[0.0]                            Ga74_0_0       none         31      68846.7            0
+1000310750              Ga75[0.0]                            Ga75_0_0       none         31      69777.8            0
+1000310760              Ga76[0.0]                            Ga76_0_0       none         31      70711.5            0
+1000310770              Ga77[0.0]                            Ga77_0_0       none         31      71643.3            0
+1000310780              Ga78[0.0]                            Ga78_0_0       none         31        72577            0
+1000310790              Ga79[0.0]                            Ga79_0_0       none         31      73509.7            0
+1000310800              Ga80[0.0]                            Ga80_0_0       none         31      74444.6            0
+1000310810              Ga81[0.0]                            Ga81_0_0       none         31      75377.2            0
+1000310820              Ga82[0.0]                            Ga82_0_0       none         31      76313.6            0
+1000310830              Ga83[0.0]                            Ga83_0_0       none         31      77248.8            0
+1000310840              Ga84[0.0]                            Ga84_0_0       none         31      78185.6            0
+1000310850              Ga85[0.0]                            Ga85_0_0       none         31      79121.2            0
+1000310860              Ga86[0.0]                            Ga86_0_0       none         31      80058.3            0
+1000320580              Ge58[0.0]                            Ge58_0_0       none         32        54002            0
+1000320590              Ge59[0.0]                            Ge59_0_0       none         32      54924.9            0
+1000320600              Ge60[0.0]                            Ge60_0_0       none         32      55845.6            0
+1000320610              Ge61[0.0]                            Ge61_0_0       none         32      56771.1            0
+1000320620              Ge62[0.0]                            Ge62_0_0       none         32      57694.1            0
+1000320630              Ge63[0.0]                            Ge63_0_0       none         32      58620.9            0
+1000320640              Ge64[0.0]                            Ge64_0_0       none         32        59545            0
+1000320650              Ge65[0.0]                            Ge65_0_0       none         32      60474.4            0
+1000320660              Ge66[0.0]                            Ge66_0_0       none         32      61400.7            0
+1000320670              Ge67[0.0]                            Ge67_0_0       none         32      62331.1            0
+1000320680              Ge68[0.0]                            Ge68_0_0       none         32      63258.3            0
+1000320690              Ge69[0.0]                            Ge69_0_0       none         32      64189.7            0
+1000320700              Ge70[0.0]                            Ge70_0_0       none         32      65117.7            0
+1000320710              Ge71[0.0]                            Ge71_0_0       none         32      66049.9            0
+1000320720              Ge72[0.0]                            Ge72_0_0       none         32      66978.7            0
+1000320730              Ge73[0.0]                            Ge73_0_0       none         32      67911.5            0
+1000320740              Ge74[0.0]                            Ge74_0_0       none         32      68840.8            0
+1000320750              Ge75[0.0]                            Ge75_0_0       none         32      69773.9            0
+1000320760              Ge76[0.0]                            Ge76_0_0       none         32        70704            0
+1000320770              Ge77[0.0]                            Ge77_0_0       none         32      71637.5            0
+1000320780              Ge78[0.0]                            Ge78_0_0       none         32      72568.4            0
+1000320790              Ge79[0.0]                            Ge79_0_0       none         32      73502.2            0
+1000320800              Ge80[0.0]                            Ge80_0_0       none         32      74433.7            0
+1000320810              Ge81[0.0]                            Ge81_0_0       none         32      75368.4            0
+1000320820              Ge82[0.0]                            Ge82_0_0       none         32      76300.6            0
+1000320830              Ge83[0.0]                            Ge83_0_0       none         32      77236.8            0
+1000320840              Ge84[0.0]                            Ge84_0_0       none         32        78171            0
+1000320850              Ge85[0.0]                            Ge85_0_0       none         32      79107.6            0
+1000320860              Ge86[0.0]                            Ge86_0_0       none         32      80042.3            0
+1000320870              Ge87[0.0]                            Ge87_0_0       none         32      80979.4            0
+1000320880              Ge88[0.0]                            Ge88_0_0       none         32        81915            0
+1000320890              Ge89[0.0]                            Ge89_0_0       none         32        82853            0
+1000330600              As60[0.0]                            As60_0_0       none         33      55866.4            0
+1000330610              As61[0.0]                            As61_0_0       none         33      56786.3            0
+1000330620              As62[0.0]                            As62_0_0       none         33      57710.9            0
+1000330630              As63[0.0]                            As63_0_0       none         33      58633.5            0
+1000330640              As64[0.0]                            As64_0_0       none         33      59559.3            0
+1000330650              As65[0.0]                            As65_0_0       none         33      60483.3            0
+1000330660              As66[0.0]                            As66_0_0       none         33      61410.3            0
+1000330670              As67[0.0]                            As67_0_0       none         33      62336.7            0
+1000330680              As68[0.0]                            As68_0_0       none         33      63265.9            0
+1000330690              As69[0.0]                            As69_0_0       none         33      64193.2            0
+1000330700              As70[0.0]                            As70_0_0       none         33      65123.4            0
+1000330710              As71[0.0]                            As71_0_0       none         33      66051.4            0
+1000330720              As72[0.0]                            As72_0_0       none         33      66982.5            0
+1000330730              As73[0.0]                            As73_0_0       none         33      67911.3            0
+1000330740              As74[0.0]                            As74_0_0       none         33      68842.9            0
+1000330750              As75[0.0]                            As75_0_0       none         33      69772.2            0
+1000330760              As76[0.0]                            As76_0_0       none         33      70704.5            0
+1000330770              As77[0.0]                            As77_0_0       none         33      71634.3            0
+1000330780              As78[0.0]                            As78_0_0       none         33      72566.9            0
+1000330790              As79[0.0]                            As79_0_0       none         33      73497.6            0
+1000330800              As80[0.0]                            As80_0_0       none         33      74430.6            0
+1000330810              As81[0.0]                            As81_0_0       none         33      75361.7            0
+1000330820              As82[0.0]                            As82_0_0       none         33      76295.4            0
+1000330830              As83[0.0]                            As83_0_0       none         33      77227.3            0
+1000330840              As84[0.0]                            As84_0_0       none         33      78162.6            0
+1000330850              As85[0.0]                            As85_0_0       none         33      79096.9            0
+1000330860              As86[0.0]                            As86_0_0       none         33      80032.5            0
+1000330870              As87[0.0]                            As87_0_0       none         33      80967.2            0
+1000330880              As88[0.0]                            As88_0_0       none         33      81903.4            0
+1000330890              As89[0.0]                            As89_0_0       none         33        82839            0
+1000330900              As90[0.0]                            As90_0_0       none         33      83776.2            0
+1000330910              As91[0.0]                            As91_0_0       none         33      84712.3            0
+1000330920              As92[0.0]                            As92_0_0       none         33      85649.7            0
+1000340650              Se65[0.0]                            Se65_0_0       none         34      60496.9            0
+1000340660              Se66[0.0]                            Se66_0_0       none         34      61419.6            0
+1000340670              Se67[0.0]                            Se67_0_0       none         34      62346.3            0
+1000340680              Se68[0.0]                            Se68_0_0       none         34      63270.1            0
+1000340690              Se69[0.0]                            Se69_0_0       none         34      64199.5            0
+1000340700              Se70[0.0]                            Se70_0_0       none         34      65125.2            0
+1000340710              Se71[0.0]                            Se71_0_0       none         34      66055.7            0
+1000340720              Se72[0.0]                            Se72_0_0       none         34      66982.4            0
+1000340730              Se73[0.0]                            Se73_0_0       none         34      67913.5            0
+1000340740              Se74[0.0]                            Se74_0_0       none         34        68841            0
+1000340750              Se75[0.0]                            Se75_0_0       none         34      69772.6            0
+1000340760              Se76[0.0]                            Se76_0_0       none         34        70701            0
+1000340770              Se77[0.0]                            Se77_0_0       none         34      71633.1            0
+1000340780              Se78[0.0]                            Se78_0_0       none         34      72562.2            0
+1000340790              Se79[0.0]                            Se79_0_0       none         34      73494.8            0
+1000340800              Se80[0.0]                            Se80_0_0       none         34      74424.5            0
+1000340810              Se81[0.0]                            Se81_0_0       none         34      75357.3            0
+1000340820              Se82[0.0]                            Se82_0_0       none         34      76287.6            0
+1000340830              Se83[0.0]                            Se83_0_0       none         34      77221.4            0
+1000340840              Se84[0.0]                            Se84_0_0       none         34      78152.2            0
+1000340850              Se85[0.0]                            Se85_0_0       none         34      79087.3            0
+1000340860              Se86[0.0]                            Se86_0_0       none         34      80020.6            0
+1000340870              Se87[0.0]                            Se87_0_0       none         34      80956.1            0
+1000340880              Se88[0.0]                            Se88_0_0       none         34      81890.3            0
+1000340890              Se89[0.0]                            Se89_0_0       none         34      82826.5            0
+1000340900              Se90[0.0]                            Se90_0_0       none         34      83761.2            0
+1000340910              Se91[0.0]                            Se91_0_0       none         34      84698.3            0
+1000340920              Se92[0.0]                            Se92_0_0       none         34      85633.5            0
+1000340930              Se93[0.0]                            Se93_0_0       none         34      86570.9            0
+1000340940              Se94[0.0]                            Se94_0_0       none         34      87506.3            0
+1000350670              Br67[0.0]                            Br67_0_0       none         35      62359.5            0
+1000350680              Br68[0.0]                            Br68_0_0       none         35      63285.1            0
+1000350690              Br69[0.0]                            Br69_0_0       none         35      64208.8            0
+1000350700              Br70[0.0]                            Br70_0_0       none         35      65135.3            0
+1000350710              Br71[0.0]                            Br71_0_0       none         35      66061.2            0
+1000350720              Br72[0.0]                            Br72_0_0       none         35      66990.7            0
+1000350730              Br73[0.0]                            Br73_0_0       none         35      67917.6            0
+1000350740              Br74[0.0]                            Br74_0_0       none         35      68847.4            0
+1000350750              Br75[0.0]                            Br75_0_0       none         35      69775.1            0
+1000350760              Br76[0.0]                            Br76_0_0       none         35      70705.4            0
+1000350770              Br77[0.0]                            Br77_0_0       none         35        71634            0
+1000350780              Br78[0.0]                            Br78_0_0       none         35      72565.3            0
+1000350790              Br79[0.0]                            Br79_0_0       none         35      73494.1            0
+1000350800              Br80[0.0]                            Br80_0_0       none         35      74425.8            0
+1000350810              Br81[0.0]                            Br81_0_0       none         35      75355.2            0
+1000350820              Br82[0.0]                            Br82_0_0       none         35      76287.2            0
+1000350830              Br83[0.0]                            Br83_0_0       none         35      77217.2            0
+1000350840              Br84[0.0]                            Br84_0_0       none         35      78149.9            0
+1000350850              Br85[0.0]                            Br85_0_0       none         35      79080.6            0
+1000350860              Br86[0.0]                            Br86_0_0       none         35        80015            0
+1000350870              Br87[0.0]                            Br87_0_0       none         35      80948.3            0
+1000350880              Br88[0.0]                            Br88_0_0       none         35      81882.9            0
+1000350890              Br89[0.0]                            Br89_0_0       none         35      82816.6            0
+1000350900              Br90[0.0]                            Br90_0_0       none         35        83752            0
+1000350910              Br91[0.0]                            Br91_0_0       none         35      84686.6            0
+1000350920              Br92[0.0]                            Br92_0_0       none         35      85623.1            0
+1000350930              Br93[0.0]                            Br93_0_0       none         35      86558.1            0
+1000350940              Br94[0.0]                            Br94_0_0       none         35      87494.8            0
+1000350950              Br95[0.0]                            Br95_0_0       none         35      88430.2            0
+1000350960              Br96[0.0]                            Br96_0_0       none         35        89367            0
+1000350970              Br97[0.0]                            Br97_0_0       none         35      90302.5            0
+1000360690              Kr69[0.0]                            Kr69_0_0       none         36      64222.3            0
+1000360700              Kr70[0.0]                            Kr70_0_0       none         36      65144.6            0
+1000360710              Kr71[0.0]                            Kr71_0_0       none         36      66070.8            0
+1000360720              Kr72[0.0]                            Kr72_0_0       none         36      66995.3            0
+1000360730              Kr73[0.0]                            Kr73_0_0       none         36      67924.2            0
+1000360740              Kr74[0.0]                            Kr74_0_0       none         36      68849.9            0
+1000360750              Kr75[0.0]                            Kr75_0_0       none         36      69779.4            0
+1000360760              Kr76[0.0]                            Kr76_0_0       none         36      70706.2            0
+1000360770              Kr77[0.0]                            Kr77_0_0       none         36      71636.6            0
+1000360780              Kr78[0.0]                            Kr78_0_0       none         36        72564            0
+1000360790              Kr79[0.0]                            Kr79_0_0       none         36      73495.3            0
+1000360800              Kr80[0.0]                            Kr80_0_0       none         36      74423.3            0
+1000360810              Kr81[0.0]                            Kr81_0_0       none         36        75355            0
+1000360820              Kr82[0.0]                            Kr82_0_0       none         36      76283.6            0
+1000360830              Kr83[0.0]                            Kr83_0_0       none         36      77215.7            0
+1000360840              Kr84[0.0]                            Kr84_0_0       none         36      78144.7            0
+1000360850              Kr85[0.0]                            Kr85_0_0       none         36      79077.2            0
+1000360860              Kr86[0.0]                            Kr86_0_0       none         36      80006.9            0
+1000360870              Kr87[0.0]                            Kr87_0_0       none         36        80941            0
+1000360880              Kr88[0.0]                            Kr88_0_0       none         36      81873.5            0
+1000360890              Kr89[0.0]                            Kr89_0_0       none         36      82807.9            0
+1000360900              Kr90[0.0]                            Kr90_0_0       none         36      83741.2            0
+1000360910              Kr91[0.0]                            Kr91_0_0       none         36      84676.3            0
+1000360920              Kr92[0.0]                            Kr92_0_0       none         36      85610.3            0
+1000360930              Kr93[0.0]                            Kr93_0_0       none         36      86546.6            0
+1000360940              Kr94[0.0]                            Kr94_0_0       none         36        87481            0
+1000360950              Kr95[0.0]                            Kr95_0_0       none         36      88417.6            0
+1000360960              Kr96[0.0]                            Kr96_0_0       none         36      89352.1            0
+1000360970              Kr97[0.0]                            Kr97_0_0       none         36      90288.7            0
+1000360980              Kr98[0.0]                            Kr98_0_0       none         36      91223.3            0
+1000360990              Kr99[0.0]                            Kr99_0_0       none         36      92160.1            0
+1000361000             Kr100[0.0]                           Kr100_0_0       none         36      93094.9            0
+1000370710              Rb71[0.0]                            Rb71_0_0       none         37      66084.9            0
+1000370720              Rb72[0.0]                            Rb72_0_0       none         37      67010.6            0
+1000370730              Rb73[0.0]                            Rb73_0_0       none         37      67934.2            0
+1000370740              Rb74[0.0]                            Rb74_0_0       none         37      68859.8            0
+1000370750              Rb75[0.0]                            Rb75_0_0       none         37        69786            0
+1000370760              Rb76[0.0]                            Rb76_0_0       none         37      70714.2            0
+1000370770              Rb77[0.0]                            Rb77_0_0       none         37      71641.4            0
+1000370780              Rb78[0.0]                            Rb78_0_0       none         37      72570.8            0
+1000370790              Rb79[0.0]                            Rb79_0_0       none         37      73498.4            0
+1000370800              Rb80[0.0]                            Rb80_0_0       none         37      74428.5            0
+1000370810              Rb81[0.0]                            Rb81_0_0       none         37      75356.7            0
+1000370820              Rb82[0.0]                            Rb82_0_0       none         37      76287.5            0
+1000370830              Rb83[0.0]                            Rb83_0_0       none         37      77216.1            0
+1000370840              Rb84[0.0]                            Rb84_0_0       none         37      78146.9            0
+1000370850              Rb85[0.0]                            Rb85_0_0       none         37        79076            0
+1000370860              Rb86[0.0]                            Rb86_0_0       none         37      80006.9            0
+1000370870              Rb87[0.0]                            Rb87_0_0       none         37      80936.6            0
+1000370880              Rb88[0.0]                            Rb88_0_0       none         37        81870            0
+1000370890              Rb89[0.0]                            Rb89_0_0       none         37      82802.4            0
+1000370900              Rb90[0.0]                            Rb90_0_0       none         37      83736.3            0
+1000370910              Rb91[0.0]                            Rb91_0_0       none         37      84669.4            0
+1000370920              Rb92[0.0]                            Rb92_0_0       none         37      85603.9            0
+1000370930              Rb93[0.0]                            Rb93_0_0       none         37      86537.5            0
+1000370940              Rb94[0.0]                            Rb94_0_0       none         37      87473.1            0
+1000370950              Rb95[0.0]                            Rb95_0_0       none         37      88407.3            0
+1000370960              Rb96[0.0]                            Rb96_0_0       none         37      89343.4            0
+1000370970              Rb97[0.0]                            Rb97_0_0       none         37      90277.7            0
+1000370980              Rb98[0.0]                            Rb98_0_0       none         37      91213.4            0
+1000370990              Rb99[0.0]                            Rb99_0_0       none         37      92148.2            0
+1000371000             Rb100[0.0]                           Rb100_0_0       none         37      93083.9            0
+1000371010             Rb101[0.0]                           Rb101_0_0       none         37      94018.5            0
+1000371020             Rb102[0.0]                           Rb102_0_0       none         37      94955.3            0
+1000380730              Sr73[0.0]                            Sr73_0_0       none         38        67948            0
+1000380740              Sr74[0.0]                            Sr74_0_0       none         38      68870.5            0
+1000380750              Sr75[0.0]                            Sr75_0_0       none         38      69796.1            0
+1000380760              Sr76[0.0]                            Sr76_0_0       none         38        70720            0
+1000380770              Sr77[0.0]                            Sr77_0_0       none         38      71647.9            0
+1000380780              Sr78[0.0]                            Sr78_0_0       none         38        72574            0
+1000380790              Sr79[0.0]                            Sr79_0_0       none         38      73503.2            0
+1000380800              Sr80[0.0]                            Sr80_0_0       none         38      74429.9            0
+1000380810              Sr81[0.0]                            Sr81_0_0       none         38      75360.2            0
+1000380820              Sr82[0.0]                            Sr82_0_0       none         38      76287.2            0
+1000380830              Sr83[0.0]                            Sr83_0_0       none         38      77217.9            0
+1000380840              Sr84[0.0]                            Sr84_0_0       none         38      78145.5            0
+1000380850              Sr85[0.0]                            Sr85_0_0       none         38      79076.6            0
+1000380860              Sr86[0.0]                            Sr86_0_0       none         38      80004.6            0
+1000380870              Sr87[0.0]                            Sr87_0_0       none         38      80935.8            0
+1000380880              Sr88[0.0]                            Sr88_0_0       none         38      81864.2            0
+1000380890              Sr89[0.0]                            Sr89_0_0       none         38      82797.4            0
+1000380900              Sr90[0.0]                            Sr90_0_0       none         38      83729.2            0
+1000380910              Sr91[0.0]                            Sr91_0_0       none         38        84663            0
+1000380920              Sr92[0.0]                            Sr92_0_0       none         38      85595.3            0
+1000380930              Sr93[0.0]                            Sr93_0_0       none         38      86529.5            0
+1000380940              Sr94[0.0]                            Sr94_0_0       none         38      87462.3            0
+1000380950              Sr95[0.0]                            Sr95_0_0       none         38      88397.5            0
+1000380960              Sr96[0.0]                            Sr96_0_0       none         38      89331.2            0
+1000380970              Sr97[0.0]                            Sr97_0_0       none         38      90266.8            0
+1000380980              Sr98[0.0]                            Sr98_0_0       none         38      91200.4            0
+1000380990              Sr99[0.0]                            Sr99_0_0       none         38      92136.4            0
+1000381000             Sr100[0.0]                           Sr100_0_0       none         38      93069.9            0
+1000381010             Sr101[0.0]                           Sr101_0_0       none         38      94006.2            0
+1000381020             Sr102[0.0]                           Sr102_0_0       none         38        94940            0
+1000381030             Sr103[0.0]                           Sr103_0_0       none         38        95877            0
+1000381040             Sr104[0.0]                           Sr104_0_0       none         38      96811.6            0
+1000381050             Sr105[0.0]                           Sr105_0_0       none         38        97749            0
+1000390760               Y76[0.0]                             Y76_0_0       none         39        70735            0
+1000390770               Y77[0.0]                             Y77_0_0       none         39      71658.3            0
+1000390780               Y78[0.0]                             Y78_0_0       none         39      72584.2            0
+1000390790               Y79[0.0]                             Y79_0_0       none         39      73509.8            0
+1000390800               Y80[0.0]                             Y80_0_0       none         39      74438.5            0
+1000390810               Y81[0.0]                             Y81_0_0       none         39      75365.2            0
+1000390820               Y82[0.0]                             Y82_0_0       none         39      76294.5            0
+1000390830               Y83[0.0]                             Y83_0_0       none         39      77221.8            0
+1000390840               Y84[0.0]                             Y84_0_0       none         39      78151.5            0
+1000390850               Y85[0.0]                             Y85_0_0       none         39      79079.3            0
+1000390860               Y86[0.0]                             Y86_0_0       none         39      80009.4            0
+1000390870               Y87[0.0]                             Y87_0_0       none         39      80937.1            0
+1000390880               Y88[0.0]                             Y88_0_0       none         39      81867.3            0
+1000390890               Y89[0.0]                             Y89_0_0       none         39      82795.4            0
+1000390900               Y90[0.0]                             Y90_0_0       none         39      83728.1            0
+1000390910               Y91[0.0]                             Y91_0_0       none         39      84659.8            0
+1000390920               Y92[0.0]                             Y92_0_0       none         39      85592.8            0
+1000390930               Y93[0.0]                             Y93_0_0       none         39      86524.9            0
+1000390940               Y94[0.0]                             Y94_0_0       none         39      87458.3            0
+1000390950               Y95[0.0]                             Y95_0_0       none         39      88390.9            0
+1000390960               Y96[0.0]                             Y96_0_0       none         39      89325.2            0
+1000390970               Y97[0.0]                             Y97_0_0       none         39      90258.8            0
+1000390980               Y98[0.0]                             Y98_0_0       none         39      91194.1            0
+1000390990               Y99[0.0]                             Y99_0_0       none         39      92127.9            0
+1000391000              Y100[0.0]                            Y100_0_0       none         39      93062.3            0
+1000391010              Y101[0.0]                            Y101_0_0       none         39      93996.1            0
+1000391020              Y102[0.0]                            Y102_0_0       none         39      94930.7            0
+1000391030              Y103[0.0]                            Y103_0_0       none         39      95865.1            0
+1000391040              Y104[0.0]                            Y104_0_0       none         39      96800.6            0
+1000391050              Y105[0.0]                            Y105_0_0       none         39      97735.7            0
+1000391060              Y106[0.0]                            Y106_0_0       none         39      98671.8            0
+1000391070              Y107[0.0]                            Y107_0_0       none         39      99607.3            0
+1000391080              Y108[0.0]                            Y108_0_0       none         39       100544            0
+1000400780              Zr78[0.0]                            Zr78_0_0       none         40      72594.5            0
+1000400790              Zr79[0.0]                            Zr79_0_0       none         40      73520.3            0
+1000400800              Zr80[0.0]                            Zr80_0_0       none         40      74443.7            0
+1000400810              Zr81[0.0]                            Zr81_0_0       none         40      75372.2            0
+1000400820              Zr82[0.0]                            Zr82_0_0       none         40        76298            0
+1000400830              Zr83[0.0]                            Zr83_0_0       none         40      77227.2            0
+1000400840              Zr84[0.0]                            Zr84_0_0       none         40      78153.7            0
+1000400850              Zr85[0.0]                            Zr85_0_0       none         40      79083.5            0
+1000400860              Zr86[0.0]                            Zr86_0_0       none         40      80010.3            0
+1000400870              Zr87[0.0]                            Zr87_0_0       none         40      80940.3            0
+1000400880              Zr88[0.0]                            Zr88_0_0       none         40      81867.5            0
+1000400890              Zr89[0.0]                            Zr89_0_0       none         40      82797.8            0
+1000400900              Zr90[0.0]                            Zr90_0_0       none         40      83725.4            0
+1000400910              Zr91[0.0]                            Zr91_0_0       none         40      84657.7            0
+1000400920              Zr92[0.0]                            Zr92_0_0       none         40      85588.7            0
+1000400930              Zr93[0.0]                            Zr93_0_0       none         40      86521.5            0
+1000400940              Zr94[0.0]                            Zr94_0_0       none         40      87452.8            0
+1000400950              Zr95[0.0]                            Zr95_0_0       none         40      88385.9            0
+1000400960              Zr96[0.0]                            Zr96_0_0       none         40      89317.6            0
+1000400970              Zr97[0.0]                            Zr97_0_0       none         40      90251.6            0
+1000400980              Zr98[0.0]                            Zr98_0_0       none         40      91184.8            0
+1000400990              Zr99[0.0]                            Zr99_0_0       none         40      92119.8            0
+1000401000             Zr100[0.0]                           Zr100_0_0       none         40      93052.5            0
+1000401010             Zr101[0.0]                           Zr101_0_0       none         40      93987.1            0
+1000401020             Zr102[0.0]                           Zr102_0_0       none         40      94920.3            0
+1000401030             Zr103[0.0]                           Zr103_0_0       none         40      95855.2            0
+1000401040             Zr104[0.0]                           Zr104_0_0       none         40      96788.7            0
+1000401050             Zr105[0.0]                           Zr105_0_0       none         40      97724.2            0
+1000401060             Zr106[0.0]                           Zr106_0_0       none         40      98658.3            0
+1000401070             Zr107[0.0]                           Zr107_0_0       none         40      99594.3            0
+1000401080             Zr108[0.0]                           Zr108_0_0       none         40       100529            0
+1000401090             Zr109[0.0]                           Zr109_0_0       none         40       101465            0
+1000401100             Zr110[0.0]                           Zr110_0_0       none         40       102400            0
+1000410810              Nb81[0.0]                            Nb81_0_0       none         41      75382.7            0
+1000410820              Nb82[0.0]                            Nb82_0_0       none         41      76308.7            0
+1000410830              Nb83[0.0]                            Nb83_0_0       none         41      77234.2            0
+1000410840              Nb84[0.0]                            Nb84_0_0       none         41      78162.8            0
+1000410850              Nb85[0.0]                            Nb85_0_0       none         41        79089            0
+1000410860              Nb86[0.0]                            Nb86_0_0       none         41      80017.8            0
+1000410870              Nb87[0.0]                            Nb87_0_0       none         41        80945            0
+1000410880              Nb88[0.0]                            Nb88_0_0       none         41      81874.6            0
+1000410890              Nb89[0.0]                            Nb89_0_0       none         41      82801.5            0
+1000410900              Nb90[0.0]                            Nb90_0_0       none         41        83731            0
+1000410910              Nb91[0.0]                            Nb91_0_0       none         41      84658.5            0
+1000410920              Nb92[0.0]                            Nb92_0_0       none         41      85590.2            0
+1000410930              Nb93[0.0]                            Nb93_0_0       none         41      86520.9            0
+1000410940              Nb94[0.0]                            Nb94_0_0       none         41      87453.2            0
+1000410950              Nb95[0.0]                            Nb95_0_0       none         41      88384.3            0
+1000410960              Nb96[0.0]                            Nb96_0_0       none         41        89317            0
+1000410970              Nb97[0.0]                            Nb97_0_0       none         41      90248.5            0
+1000410980              Nb98[0.0]                            Nb98_0_0       none         41        91182            0
+1000410990              Nb99[0.0]                            Nb99_0_0       none         41      92114.7            0
+1000411000             Nb100[0.0]                           Nb100_0_0       none         41      93048.6            0
+1000411010             Nb101[0.0]                           Nb101_0_0       none         41      93981.1            0
+1000411020             Nb102[0.0]                           Nb102_0_0       none         41      94915.2            0
+1000411030             Nb103[0.0]                           Nb103_0_0       none         41      95847.7            0
+1000411040             Nb104[0.0]                           Nb104_0_0       none         41      96782.3            0
+1000411050             Nb105[0.0]                           Nb105_0_0       none         41      97715.2            0
+1000411060             Nb106[0.0]                           Nb106_0_0       none         41      98650.4            0
+1000411070             Nb107[0.0]                           Nb107_0_0       none         41      99584.1            0
+1000411080             Nb108[0.0]                           Nb108_0_0       none         41       100520            0
+1000411090             Nb109[0.0]                           Nb109_0_0       none         41       101454            0
+1000411100             Nb110[0.0]                           Nb110_0_0       none         41       102390            0
+1000411110             Nb111[0.0]                           Nb111_0_0       none         41       103324            0
+1000411120             Nb112[0.0]                           Nb112_0_0       none         41       104261            0
+1000411130             Nb113[0.0]                           Nb113_0_0       none         41       105196            0
+1000420830              Mo83[0.0]                            Mo83_0_0       none         42      77244.9            0
+1000420840              Mo84[0.0]                            Mo84_0_0       none         42      78168.3            0
+1000420850              Mo85[0.0]                            Mo85_0_0       none         42      79096.5            0
+1000420860              Mo86[0.0]                            Mo86_0_0       none         42      80022.6            0
+1000420870              Mo87[0.0]                            Mo87_0_0       none         42      80950.9            0
+1000420880              Mo88[0.0]                            Mo88_0_0       none         42      81877.4            0
+1000420890              Mo89[0.0]                            Mo89_0_0       none         42      82806.6            0
+1000420900              Mo90[0.0]                            Mo90_0_0       none         42      83732.9            0
+1000420910              Mo91[0.0]                            Mo91_0_0       none         42      84662.4            0
+1000420920              Mo92[0.0]                            Mo92_0_0       none         42      85589.3            0
+1000420930              Mo93[0.0]                            Mo93_0_0       none         42      86520.8            0
+1000420940              Mo94[0.0]                            Mo94_0_0       none         42      87450.7            0
+1000420950              Mo95[0.0]                            Mo95_0_0       none         42      88382.9            0
+1000420960              Mo96[0.0]                            Mo96_0_0       none         42      89313.3            0
+1000420970              Mo97[0.0]                            Mo97_0_0       none         42        90246            0
+1000420980              Mo98[0.0]                            Mo98_0_0       none         42        91177            0
+1000420990              Mo99[0.0]                            Mo99_0_0       none         42      92110.6            0
+1000421000             Mo100[0.0]                           Mo100_0_0       none         42      93041.9            0
+1000421010             Mo101[0.0]                           Mo101_0_0       none         42        93976            0
+1000421020             Mo102[0.0]                           Mo102_0_0       none         42      94907.5            0
+1000421030             Mo103[0.0]                           Mo103_0_0       none         42      95841.7            0
+1000421040             Mo104[0.0]                           Mo104_0_0       none         42      96773.7            0
+1000421050             Mo105[0.0]                           Mo105_0_0       none         42      97708.2            0
+1000421060             Mo106[0.0]                           Mo106_0_0       none         42      98640.8            0
+1000421070             Mo107[0.0]                           Mo107_0_0       none         42      99575.6            0
+1000421080             Mo108[0.0]                           Mo108_0_0       none         42       100509            0
+1000421090             Mo109[0.0]                           Mo109_0_0       none         42       101444            0
+1000421100             Mo110[0.0]                           Mo110_0_0       none         42       102378            0
+1000421110             Mo111[0.0]                           Mo111_0_0       none         42       103313            0
+1000421120             Mo112[0.0]                           Mo112_0_0       none         42       104247            0
+1000421130             Mo113[0.0]                           Mo113_0_0       none         42       105183            0
+1000421140             Mo114[0.0]                           Mo114_0_0       none         42       106118            0
+1000421150             Mo115[0.0]                           Mo115_0_0       none         42       107054            0
+1000430850              Tc85[0.0]                            Tc85_0_0       none         43      79107.5            0
+1000430860              Tc86[0.0]                            Tc86_0_0       none         43      80033.4            0
+1000430870              Tc87[0.0]                            Tc87_0_0       none         43        80959            0
+1000430880              Tc88[0.0]                            Tc88_0_0       none         43      81886.9            0
+1000430890              Tc89[0.0]                            Tc89_0_0       none         43      82813.3            0
+1000430900              Tc90[0.0]                            Tc90_0_0       none         43      83741.4            0
+1000430910              Tc91[0.0]                            Tc91_0_0       none         43      84668.1            0
+1000430920              Tc92[0.0]                            Tc92_0_0       none         43      85596.7            0
+1000430930              Tc93[0.0]                            Tc93_0_0       none         43      86523.5            0
+1000430940              Tc94[0.0]                            Tc94_0_0       none         43      87454.4            0
+1000430950              Tc95[0.0]                            Tc95_0_0       none         43      88384.1            0
+1000430960              Tc96[0.0]                            Tc96_0_0       none         43      89315.8            0
+1000430970              Tc97[0.0]                            Tc97_0_0       none         43      90245.8            0
+1000430980              Tc98[0.0]                            Tc98_0_0       none         43      91178.1            0
+1000430990              Tc99[0.0]                            Tc99_0_0       none         43      92108.7            0
+1000431000             Tc100[0.0]                           Tc100_0_0       none         43      93041.5            0
+1000431010             Tc101[0.0]                           Tc101_0_0       none         43      93972.7            0
+1000431020             Tc102[0.0]                           Tc102_0_0       none         43        94906            0
+1000431030             Tc103[0.0]                           Tc103_0_0       none         43      95837.4            0
+1000431040             Tc104[0.0]                           Tc104_0_0       none         43        96771            0
+1000431050             Tc105[0.0]                           Tc105_0_0       none         43      97702.7            0
+1000431060             Tc106[0.0]                           Tc106_0_0       none         43      98636.7            0
+1000431070             Tc107[0.0]                           Tc107_0_0       none         43      99568.9            0
+1000431080             Tc108[0.0]                           Tc108_0_0       none         43       100504            0
+1000431090             Tc109[0.0]                           Tc109_0_0       none         43       101436            0
+1000431100             Tc110[0.0]                           Tc110_0_0       none         43       102372            0
+1000431110             Tc111[0.0]                           Tc111_0_0       none         43       103305            0
+1000431120             Tc112[0.0]                           Tc112_0_0       none         43       104239            0
+1000431130             Tc113[0.0]                           Tc113_0_0       none         43       105173            0
+1000431140             Tc114[0.0]                           Tc114_0_0       none         43       106109            0
+1000431150             Tc115[0.0]                           Tc115_0_0       none         43       107043            0
+1000431160             Tc116[0.0]                           Tc116_0_0       none         43       107979            0
+1000431170             Tc117[0.0]                           Tc117_0_0       none         43       108913            0
+1000431180             Tc118[0.0]                           Tc118_0_0       none         43       109849            0
+1000440870              Ru87[0.0]                            Ru87_0_0       none         44      80970.3            0
+1000440880              Ru88[0.0]                            Ru88_0_0       none         44      81893.5            0
+1000440890              Ru89[0.0]                            Ru89_0_0       none         44      82821.1            0
+1000440900              Ru90[0.0]                            Ru90_0_0       none         44      83746.8            0
+1000440910              Ru91[0.0]                            Ru91_0_0       none         44      84674.9            0
+1000440920              Ru92[0.0]                            Ru92_0_0       none         44      85600.7            0
+1000440930              Ru93[0.0]                            Ru93_0_0       none         44      86529.3            0
+1000440940              Ru94[0.0]                            Ru94_0_0       none         44      87455.5            0
+1000440950              Ru95[0.0]                            Ru95_0_0       none         44      88386.1            0
+1000440960              Ru96[0.0]                            Ru96_0_0       none         44        89315            0
+1000440970              Ru97[0.0]                            Ru97_0_0       none         44      90246.4            0
+1000440980              Ru98[0.0]                            Ru98_0_0       none         44      91175.8            0
+1000440990              Ru99[0.0]                            Ru99_0_0       none         44      92107.9            0
+1000441000             Ru100[0.0]                           Ru100_0_0       none         44      93037.8            0
+1000441010             Ru101[0.0]                           Ru101_0_0       none         44      93970.6            0
+1000441020             Ru102[0.0]                           Ru102_0_0       none         44      94900.9            0
+1000441030             Ru103[0.0]                           Ru103_0_0       none         44      95834.3            0
+1000441040             Ru104[0.0]                           Ru104_0_0       none         44      96764.9            0
+1000441050             Ru105[0.0]                           Ru105_0_0       none         44      97698.6            0
+1000441060             Ru106[0.0]                           Ru106_0_0       none         44      98629.7            0
+1000441070             Ru107[0.0]                           Ru107_0_0       none         44      99563.6            0
+1000441080             Ru108[0.0]                           Ru108_0_0       none         44       100495            0
+1000441090             Ru109[0.0]                           Ru109_0_0       none         44       101430            0
+1000441100             Ru110[0.0]                           Ru110_0_0       none         44       102362            0
+1000441110             Ru111[0.0]                           Ru111_0_0       none         44       103297            0
+1000441120             Ru112[0.0]                           Ru112_0_0       none         44       104229            0
+1000441130             Ru113[0.0]                           Ru113_0_0       none         44       105164            0
+1000441140             Ru114[0.0]                           Ru114_0_0       none         44       106097            0
+1000441150             Ru115[0.0]                           Ru115_0_0       none         44       107033            0
+1000441160             Ru116[0.0]                           Ru116_0_0       none         44       107966            0
+1000441170             Ru117[0.0]                           Ru117_0_0       none         44       108902            0
+1000441180             Ru118[0.0]                           Ru118_0_0       none         44       109836            0
+1000441190             Ru119[0.0]                           Ru119_0_0       none         44       110772            0
+1000441200             Ru120[0.0]                           Ru120_0_0       none         44       111706            0
+1000450890              Rh89[0.0]                            Rh89_0_0       none         45      82832.4            0
+1000450900              Rh90[0.0]                            Rh90_0_0       none         45      83758.4            0
+1000450910              Rh91[0.0]                            Rh91_0_0       none         45        84684            0
+1000450920              Rh92[0.0]                            Rh92_0_0       none         45      85611.2            0
+1000450930              Rh93[0.0]                            Rh93_0_0       none         45      86536.9            0
+1000450940              Rh94[0.0]                            Rh94_0_0       none         45      87464.6            0
+1000450950              Rh95[0.0]                            Rh95_0_0       none         45      88390.7            0
+1000450960              Rh96[0.0]                            Rh96_0_0       none         45      89320.9            0
+1000450970              Rh97[0.0]                            Rh97_0_0       none         45      90249.5            0
+1000450980              Rh98[0.0]                            Rh98_0_0       none         45      91180.4            0
+1000450990              Rh99[0.0]                            Rh99_0_0       none         45      92109.5            0
+1000451000             Rh100[0.0]                           Rh100_0_0       none         45        93041            0
+1000451010             Rh101[0.0]                           Rh101_0_0       none         45      93970.6            0
+1000451020             Rh102[0.0]                           Rh102_0_0       none         45      94902.8            0
+1000451030             Rh103[0.0]                           Rh103_0_0       none         45        95833            0
+1000451040             Rh104[0.0]                           Rh104_0_0       none         45      96765.6            0
+1000451050             Rh105[0.0]                           Rh105_0_0       none         45      97696.2            0
+1000451060             Rh106[0.0]                           Rh106_0_0       none         45      98629.1            0
+1000451070             Rh107[0.0]                           Rh107_0_0       none         45      99560.1            0
+1000451080             Rh108[0.0]                           Rh108_0_0       none         45       100493            0
+1000451090             Rh109[0.0]                           Rh109_0_0       none         45       101425            0
+1000451100             Rh110[0.0]                           Rh110_0_0       none         45       102359            0
+1000451110             Rh111[0.0]                           Rh111_0_0       none         45       103291            0
+1000451120             Rh112[0.0]                           Rh112_0_0       none         45       104225            0
+1000451130             Rh113[0.0]                           Rh113_0_0       none         45       105157            0
+1000451140             Rh114[0.0]                           Rh114_0_0       none         45       106092            0
+1000451150             Rh115[0.0]                           Rh115_0_0       none         45       107025            0
+1000451160             Rh116[0.0]                           Rh116_0_0       none         45       107960            0
+1000451170             Rh117[0.0]                           Rh117_0_0       none         45       108893            0
+1000451180             Rh118[0.0]                           Rh118_0_0       none         45       109828            0
+1000451190             Rh119[0.0]                           Rh119_0_0       none         45       110762            0
+1000451200             Rh120[0.0]                           Rh120_0_0       none         45       111697            0
+1000451210             Rh121[0.0]                           Rh121_0_0       none         45       112631            0
+1000451220             Rh122[0.0]                           Rh122_0_0       none         45       113567            0
+1000460910              Pd91[0.0]                            Pd91_0_0       none         46      84695.2            0
+1000460920              Pd92[0.0]                            Pd92_0_0       none         46      85618.6            0
+1000460930              Pd93[0.0]                            Pd93_0_0       none         46      86545.9            0
+1000460940              Pd94[0.0]                            Pd94_0_0       none         46      87470.7            0
+1000460950              Pd95[0.0]                            Pd95_0_0       none         46      88398.4            0
+1000460960              Pd96[0.0]                            Pd96_0_0       none         46      89323.8            0
+1000460970              Pd97[0.0]                            Pd97_0_0       none         46      90253.8            0
+1000460980              Pd98[0.0]                            Pd98_0_0       none         46      91181.7            0
+1000460990              Pd99[0.0]                            Pd99_0_0       none         46      92112.4            0
+1000461000             Pd100[0.0]                           Pd100_0_0       none         46      93040.8            0
+1000461010             Pd101[0.0]                           Pd101_0_0       none         46      93972.1            0
+1000461020             Pd102[0.0]                           Pd102_0_0       none         46      94901.1            0
+1000461030             Pd103[0.0]                           Pd103_0_0       none         46        95833            0
+1000461040             Pd104[0.0]                           Pd104_0_0       none         46      96762.6            0
+1000461050             Pd105[0.0]                           Pd105_0_0       none         46      97695.1            0
+1000461060             Pd106[0.0]                           Pd106_0_0       none         46      98625.1            0
+1000461070             Pd107[0.0]                           Pd107_0_0       none         46      99558.1            0
+1000461080             Pd108[0.0]                           Pd108_0_0       none         46       100488            0
+1000461090             Pd109[0.0]                           Pd109_0_0       none         46       101422            0
+1000461100             Pd110[0.0]                           Pd110_0_0       none         46       102353            0
+1000461110             Pd111[0.0]                           Pd111_0_0       none         46       103286            0
+1000461120             Pd112[0.0]                           Pd112_0_0       none         46       104218            0
+1000461130             Pd113[0.0]                           Pd113_0_0       none         46       105152            0
+1000461140             Pd114[0.0]                           Pd114_0_0       none         46       106083            0
+1000461150             Pd115[0.0]                           Pd115_0_0       none         46       107018            0
+1000461160             Pd116[0.0]                           Pd116_0_0       none         46       107950            0
+1000461170             Pd117[0.0]                           Pd117_0_0       none         46       108885            0
+1000461180             Pd118[0.0]                           Pd118_0_0       none         46       109817            0
+1000461190             Pd119[0.0]                           Pd119_0_0       none         46       110753            0
+1000461200             Pd120[0.0]                           Pd120_0_0       none         46       111686            0
+1000461210             Pd121[0.0]                           Pd121_0_0       none         46       112621            0
+1000461220             Pd122[0.0]                           Pd122_0_0       none         46       113554            0
+1000461230             Pd123[0.0]                           Pd123_0_0       none         46       114490            0
+1000461240             Pd124[0.0]                           Pd124_0_0       none         46       115423            0
+1000470930              Ag93[0.0]                            Ag93_0_0       none         47      86558.3            0
+1000470940              Ag94[0.0]                            Ag94_0_0       none         47      87483.3            0
+1000470950              Ag95[0.0]                            Ag95_0_0       none         47        88408            0
+1000470960              Ag96[0.0]                            Ag96_0_0       none         47        89335            0
+1000470970              Ag97[0.0]                            Ag97_0_0       none         47      90260.2            0
+1000470980              Ag98[0.0]                            Ag98_0_0       none         47      91189.5            0
+1000470990              Ag99[0.0]                            Ag99_0_0       none         47      92117.3            0
+1000471000             Ag100[0.0]                           Ag100_0_0       none         47      93047.4            0
+1000471010             Ag101[0.0]                           Ag101_0_0       none         47      93975.8            0
+1000471020             Ag102[0.0]                           Ag102_0_0       none         47      94906.3            0
+1000471030             Ag103[0.0]                           Ag103_0_0       none         47      95835.2            0
+1000471040             Ag104[0.0]                           Ag104_0_0       none         47      96766.4            0
+1000471050             Ag105[0.0]                           Ag105_0_0       none         47      97695.9            0
+1000471060             Ag106[0.0]                           Ag106_0_0       none         47      98627.6            0
+1000471070             Ag107[0.0]                           Ag107_0_0       none         47      99557.6            0
+1000471080             Ag108[0.0]                           Ag108_0_0       none         47       100490            0
+1000471090             Ag109[0.0]                           Ag109_0_0       none         47       101420            0
+1000471100             Ag110[0.0]                           Ag110_0_0       none         47       102353            0
+1000471110             Ag111[0.0]                           Ag111_0_0       none         47       103284            0
+1000471120             Ag112[0.0]                           Ag112_0_0       none         47       104217            0
+1000471130             Ag113[0.0]                           Ag113_0_0       none         47       105148            0
+1000471140             Ag114[0.0]                           Ag114_0_0       none         47       106081            0
+1000471150             Ag115[0.0]                           Ag115_0_0       none         47       107013            0
+1000471160             Ag116[0.0]                           Ag116_0_0       none         47       107947            0
+1000471170             Ag117[0.0]                           Ag117_0_0       none         47       108879            0
+1000471180             Ag118[0.0]                           Ag118_0_0       none         47       109813            0
+1000471190             Ag119[0.0]                           Ag119_0_0       none         47       110745            0
+1000471200             Ag120[0.0]                           Ag120_0_0       none         47       111680            0
+1000471210             Ag121[0.0]                           Ag121_0_0       none         47       112612            0
+1000471220             Ag122[0.0]                           Ag122_0_0       none         47       113547            0
+1000471230             Ag123[0.0]                           Ag123_0_0       none         47       114480            0
+1000471240             Ag124[0.0]                           Ag124_0_0       none         47       115415            0
+1000471250             Ag125[0.0]                           Ag125_0_0       none         47       116348            0
+1000471260             Ag126[0.0]                           Ag126_0_0       none         47       117283            0
+1000471270             Ag127[0.0]                           Ag127_0_0       none         47       118217            0
+1000471280             Ag128[0.0]                           Ag128_0_0       none         47       119153            0
+1000471290             Ag129[0.0]                           Ag129_0_0       none         47       120086            0
+1000471300             Ag130[0.0]                           Ag130_0_0       none         47       121024            0
+1000480950              Cd95[0.0]                            Cd95_0_0       none         48      88420.9            0
+1000480960              Cd96[0.0]                            Cd96_0_0       none         48      89342.9            0
+1000480970              Cd97[0.0]                            Cd97_0_0       none         48      90269.9            0
+1000480980              Cd98[0.0]                            Cd98_0_0       none         48      91194.4            0
+1000480990              Cd99[0.0]                            Cd99_0_0       none         48      92123.7            0
+1000481000             Cd100[0.0]                           Cd100_0_0       none         48      93050.8            0
+1000481010             Cd101[0.0]                           Cd101_0_0       none         48      93980.8            0
+1000481020             Cd102[0.0]                           Cd102_0_0       none         48      94908.3            0
+1000481030             Cd103[0.0]                           Cd103_0_0       none         48      95838.9            0
+1000481040             Cd104[0.0]                           Cd104_0_0       none         48        96767            0
+1000481050             Cd105[0.0]                           Cd105_0_0       none         48      97698.2            0
+1000481060             Cd106[0.0]                           Cd106_0_0       none         48      98626.9            0
+1000481070             Cd107[0.0]                           Cd107_0_0       none         48      99558.5            0
+1000481080             Cd108[0.0]                           Cd108_0_0       none         48       100488            0
+1000481090             Cd109[0.0]                           Cd109_0_0       none         48       101420            0
+1000481100             Cd110[0.0]                           Cd110_0_0       none         48       102350            0
+1000481110             Cd111[0.0]                           Cd111_0_0       none         48       103282            0
+1000481120             Cd112[0.0]                           Cd112_0_0       none         48       104212            0
+1000481130             Cd113[0.0]                           Cd113_0_0       none         48       105145            0
+1000481140             Cd114[0.0]                           Cd114_0_0       none         48       106076            0
+1000481150             Cd115[0.0]                           Cd115_0_0       none         48       107009            0
+1000481160             Cd116[0.0]                           Cd116_0_0       none         48       107940            0
+1000481170             Cd117[0.0]                           Cd117_0_0       none         48       108874            0
+1000481180             Cd118[0.0]                           Cd118_0_0       none         48       109805            0
+1000481190             Cd119[0.0]                           Cd119_0_0       none         48       110740            0
+1000481200             Cd120[0.0]                           Cd120_0_0       none         48       111671            0
+1000481210             Cd121[0.0]                           Cd121_0_0       none         48       112605            0
+1000481220             Cd122[0.0]                           Cd122_0_0       none         48       113537            0
+1000481230             Cd123[0.0]                           Cd123_0_0       none         48       114472            0
+1000481240             Cd124[0.0]                           Cd124_0_0       none         48       115404            0
+1000481250             Cd125[0.0]                           Cd125_0_0       none         48       116339            0
+1000481260             Cd126[0.0]                           Cd126_0_0       none         48       117272            0
+1000481270             Cd127[0.0]                           Cd127_0_0       none         48       118207            0
+1000481280             Cd128[0.0]                           Cd128_0_0       none         48       119140            0
+1000481290             Cd129[0.0]                           Cd129_0_0       none         48       120075            0
+1000481300             Cd130[0.0]                           Cd130_0_0       none         48       121008            0
+1000481310             Cd131[0.0]                           Cd131_0_0       none         48       121946            0
+1000481320             Cd132[0.0]                           Cd132_0_0       none         48       122882            0
+1000490970              In97[0.0]                            In97_0_0       none         49        90283            0
+1000490980              In98[0.0]                            In98_0_0       none         49      91207.6            0
+1000490990              In99[0.0]                            In99_0_0       none         49      92131.8            0
+1000491000             In100[0.0]                           In100_0_0       none         49      93060.4            0
+1000491010             In101[0.0]                           In101_0_0       none         49      93987.4            0
+1000491020             In102[0.0]                           In102_0_0       none         49      94916.8            0
+1000491030             In103[0.0]                           In103_0_0       none         49      95844.4            0
+1000491040             In104[0.0]                           In104_0_0       none         49      96774.4            0
+1000491050             In105[0.0]                           In105_0_0       none         49      97702.5            0
+1000491060             In106[0.0]                           In106_0_0       none         49      98632.9            0
+1000491070             In107[0.0]                           In107_0_0       none         49      99561.4            0
+1000491080             In108[0.0]                           In108_0_0       none         49       100492            0
+1000491090             In109[0.0]                           In109_0_0       none         49       101421            0
+1000491100             In110[0.0]                           In110_0_0       none         49       102353            0
+1000491110             In111[0.0]                           In111_0_0       none         49       103283            0
+1000491120             In112[0.0]                           In112_0_0       none         49       104214            0
+1000491130             In113[0.0]                           In113_0_0       none         49       105145            0
+1000491140             In114[0.0]                           In114_0_0       none         49       106077            0
+1000491150             In115[0.0]                           In115_0_0       none         49       107007            0
+1000491160             In116[0.0]                           In116_0_0       none         49       107940            0
+1000491170             In117[0.0]                           In117_0_0       none         49       108871            0
+1000491180             In118[0.0]                           In118_0_0       none         49       109804            0
+1000491190             In119[0.0]                           In119_0_0       none         49       110735            0
+1000491200             In120[0.0]                           In120_0_0       none         49       111669            0
+1000491210             In121[0.0]                           In121_0_0       none         49       112600            0
+1000491220             In122[0.0]                           In122_0_0       none         49       113534            0
+1000491230             In123[0.0]                           In123_0_0       none         49       114465            0
+1000491240             In124[0.0]                           In124_0_0       none         49       115400            0
+1000491250             In125[0.0]                           In125_0_0       none         49       116331            0
+1000491260             In126[0.0]                           In126_0_0       none         49       117266            0
+1000491270             In127[0.0]                           In127_0_0       none         49       118198            0
+1000491280             In128[0.0]                           In128_0_0       none         49       119132            0
+1000491290             In129[0.0]                           In129_0_0       none         49       120065            0
+1000491300             In130[0.0]                           In130_0_0       none         49       120999            0
+1000491310             In131[0.0]                           In131_0_0       none         49       121933            0
+1000491320             In132[0.0]                           In132_0_0       none         49       122870            0
+1000491330             In133[0.0]                           In133_0_0       none         49       123806            0
+1000491340             In134[0.0]                           In134_0_0       none         49       124743            0
+1000491350             In135[0.0]                           In135_0_0       none         49       125680            0
+1000500990              Sn99[0.0]                            Sn99_0_0       none         50      92145.3            0
+1000501000             Sn100[0.0]                           Sn100_0_0       none         50      93067.2            0
+1000501010             Sn101[0.0]                           Sn101_0_0       none         50        93996            0
+1000501020             Sn102[0.0]                           Sn102_0_0       none         50      94922.1            0
+1000501030             Sn103[0.0]                           Sn103_0_0       none         50      95851.5            0
+1000501040             Sn104[0.0]                           Sn104_0_0       none         50      96778.4            0
+1000501050             Sn105[0.0]                           Sn105_0_0       none         50      97708.2            0
+1000501060             Sn106[0.0]                           Sn106_0_0       none         50      98635.6            0
+1000501070             Sn107[0.0]                           Sn107_0_0       none         50      99565.9            0
+1000501080             Sn108[0.0]                           Sn108_0_0       none         50       100494            0
+1000501090             Sn109[0.0]                           Sn109_0_0       none         50       101425            0
+1000501100             Sn110[0.0]                           Sn110_0_0       none         50       102353            0
+1000501110             Sn111[0.0]                           Sn111_0_0       none         50       103285            0
+1000501120             Sn112[0.0]                           Sn112_0_0       none         50       104213            0
+1000501130             Sn113[0.0]                           Sn113_0_0       none         50       105145            0
+1000501140             Sn114[0.0]                           Sn114_0_0       none         50       106074            0
+1000501150             Sn115[0.0]                           Sn115_0_0       none         50       107006            0
+1000501160             Sn116[0.0]                           Sn116_0_0       none         50       107936            0
+1000501170             Sn117[0.0]                           Sn117_0_0       none         50       108869            0
+1000501180             Sn118[0.0]                           Sn118_0_0       none         50       109799            0
+1000501190             Sn119[0.0]                           Sn119_0_0       none         50       110732            0
+1000501200             Sn120[0.0]                           Sn120_0_0       none         50       111663            0
+1000501210             Sn121[0.0]                           Sn121_0_0       none         50       112596            0
+1000501220             Sn122[0.0]                           Sn122_0_0       none         50       113527            0
+1000501230             Sn123[0.0]                           Sn123_0_0       none         50       114461            0
+1000501240             Sn124[0.0]                           Sn124_0_0       none         50       115392            0
+1000501250             Sn125[0.0]                           Sn125_0_0       none         50       116325            0
+1000501260             Sn126[0.0]                           Sn126_0_0       none         50       117257            0
+1000501270             Sn127[0.0]                           Sn127_0_0       none         50       118191            0
+1000501280             Sn128[0.0]                           Sn128_0_0       none         50       119123            0
+1000501290             Sn129[0.0]                           Sn129_0_0       none         50       120057            0
+1000501300             Sn130[0.0]                           Sn130_0_0       none         50       120989            0
+1000501310             Sn131[0.0]                           Sn131_0_0       none         50       121923            0
+1000501320             Sn132[0.0]                           Sn132_0_0       none         50       122855            0
+1000501330             Sn133[0.0]                           Sn133_0_0       none         50       123792            0
+1000501340             Sn134[0.0]                           Sn134_0_0       none         50       124728            0
+1000501350             Sn135[0.0]                           Sn135_0_0       none         50       125666            0
+1000501360             Sn136[0.0]                           Sn136_0_0       none         50       126601            0
+1000501370             Sn137[0.0]                           Sn137_0_0       none         50       127539            0
+1000511030             Sb103[0.0]                           Sb103_0_0       none         51      95861.8            0
+1000511040             Sb104[0.0]                           Sb104_0_0       none         51      96790.3            0
+1000511050             Sb105[0.0]                           Sb105_0_0       none         51      97717.2            0
+1000511060             Sb106[0.0]                           Sb106_0_0       none         51      98646.2            0
+1000511070             Sb107[0.0]                           Sb107_0_0       none         51      99573.3            0
+1000511080             Sb108[0.0]                           Sb108_0_0       none         51       100503            0
+1000511090             Sb109[0.0]                           Sb109_0_0       none         51       101431            0
+1000511100             Sb110[0.0]                           Sb110_0_0       none         51       102361            0
+1000511110             Sb111[0.0]                           Sb111_0_0       none         51       103289            0
+1000511120             Sb112[0.0]                           Sb112_0_0       none         51       104220            0
+1000511130             Sb113[0.0]                           Sb113_0_0       none         51       105149            0
+1000511140             Sb114[0.0]                           Sb114_0_0       none         51       106080            0
+1000511150             Sb115[0.0]                           Sb115_0_0       none         51       107009            0
+1000511160             Sb116[0.0]                           Sb116_0_0       none         51       107941            0
+1000511170             Sb117[0.0]                           Sb117_0_0       none         51       108870            0
+1000511180             Sb118[0.0]                           Sb118_0_0       none         51       109802            0
+1000511190             Sb119[0.0]                           Sb119_0_0       none         51       110732            0
+1000511200             Sb120[0.0]                           Sb120_0_0       none         51       111665            0
+1000511210             Sb121[0.0]                           Sb121_0_0       none         51       112595            0
+1000511220             Sb122[0.0]                           Sb122_0_0       none         51       113528            0
+1000511230             Sb123[0.0]                           Sb123_0_0       none         51       114459            0
+1000511240             Sb124[0.0]                           Sb124_0_0       none         51       115392            0
+1000511250             Sb125[0.0]                           Sb125_0_0       none         51       116323            0
+1000511260             Sb126[0.0]                           Sb126_0_0       none         51       117256            0
+1000511270             Sb127[0.0]                           Sb127_0_0       none         51       118187            0
+1000511280             Sb128[0.0]                           Sb128_0_0       none         51       119121            0
+1000511290             Sb129[0.0]                           Sb129_0_0       none         51       120052            0
+1000511300             Sb130[0.0]                           Sb130_0_0       none         51       120986            0
+1000511310             Sb131[0.0]                           Sb131_0_0       none         51       121918            0
+1000511320             Sb132[0.0]                           Sb132_0_0       none         51       122852            0
+1000511330             Sb133[0.0]                           Sb133_0_0       none         51       123784            0
+1000511340             Sb134[0.0]                           Sb134_0_0       none         51       124720            0
+1000511350             Sb135[0.0]                           Sb135_0_0       none         51       125656            0
+1000511360             Sb136[0.0]                           Sb136_0_0       none         51       126592            0
+1000511370             Sb137[0.0]                           Sb137_0_0       none         51       127529            0
+1000511380             Sb138[0.0]                           Sb138_0_0       none         51       128465            0
+1000511390             Sb139[0.0]                           Sb139_0_0       none         51       129401            0
+1000521050             Te105[0.0]                           Te105_0_0       none         52        97728            0
+1000521060             Te106[0.0]                           Te106_0_0       none         52      98653.8            0
+1000521070             Te107[0.0]                           Te107_0_0       none         52      99582.9            0
+1000521080             Te108[0.0]                           Te108_0_0       none         52       100509            0
+1000521090             Te109[0.0]                           Te109_0_0       none         52       101439            0
+1000521100             Te110[0.0]                           Te110_0_0       none         52       102366            0
+1000521110             Te111[0.0]                           Te111_0_0       none         52       103296            0
+1000521120             Te112[0.0]                           Te112_0_0       none         52       104224            0
+1000521130             Te113[0.0]                           Te113_0_0       none         52       105154            0
+1000521140             Te114[0.0]                           Te114_0_0       none         52       106082            0
+1000521150             Te115[0.0]                           Te115_0_0       none         52       107013            0
+1000521160             Te116[0.0]                           Te116_0_0       none         52       107942            0
+1000521170             Te117[0.0]                           Te117_0_0       none         52       108873            0
+1000521180             Te118[0.0]                           Te118_0_0       none         52       109802            0
+1000521190             Te119[0.0]                           Te119_0_0       none         52       110734            0
+1000521200             Te120[0.0]                           Te120_0_0       none         52       111663            0
+1000521210             Te121[0.0]                           Te121_0_0       none         52       112596            0
+1000521220             Te122[0.0]                           Te122_0_0       none         52       113526            0
+1000521230             Te123[0.0]                           Te123_0_0       none         52       114458            0
+1000521240             Te124[0.0]                           Te124_0_0       none         52       115388            0
+1000521250             Te125[0.0]                           Te125_0_0       none         52       116321            0
+1000521260             Te126[0.0]                           Te126_0_0       none         52       117252            0
+1000521270             Te127[0.0]                           Te127_0_0       none         52       118185            0
+1000521280             Te128[0.0]                           Te128_0_0       none         52       119116            0
+1000521290             Te129[0.0]                           Te129_0_0       none         52       120049            0
+1000521300             Te130[0.0]                           Te130_0_0       none         52       120980            0
+1000521310             Te131[0.0]                           Te131_0_0       none         52       121914            0
+1000521320             Te132[0.0]                           Te132_0_0       none         52       122846            0
+1000521330             Te133[0.0]                           Te133_0_0       none         52       123779            0
+1000521340             Te134[0.0]                           Te134_0_0       none         52       124711            0
+1000521350             Te135[0.0]                           Te135_0_0       none         52       125647            0
+1000521360             Te136[0.0]                           Te136_0_0       none         52       126582            0
+1000521370             Te137[0.0]                           Te137_0_0       none         52       127519            0
+1000521380             Te138[0.0]                           Te138_0_0       none         52       128454            0
+1000521390             Te139[0.0]                           Te139_0_0       none         52       129390            0
+1000521400             Te140[0.0]                           Te140_0_0       none         52       130326            0
+1000521410             Te141[0.0]                           Te141_0_0       none         52       131263            0
+1000521420             Te142[0.0]                           Te142_0_0       none         52       132198            0
+1000531080              I108[0.0]                            I108_0_0       none         53       100522            0
+1000531090              I109[0.0]                            I109_0_0       none         53       101448            0
+1000531100              I110[0.0]                            I110_0_0       none         53       102377            0
+1000531110              I111[0.0]                            I111_0_0       none         53       103304            0
+1000531120              I112[0.0]                            I112_0_0       none         53       104233            0
+1000531130              I113[0.0]                            I113_0_0       none         53       105161            0
+1000531140              I114[0.0]                            I114_0_0       none         53       106091            0
+1000531150              I115[0.0]                            I115_0_0       none         53       107019            0
+1000531160              I116[0.0]                            I116_0_0       none         53       107949            0
+1000531170              I117[0.0]                            I117_0_0       none         53       108877            0
+1000531180              I118[0.0]                            I118_0_0       none         53       109808            0
+1000531190              I119[0.0]                            I119_0_0       none         53       110737            0
+1000531200              I120[0.0]                            I120_0_0       none         53       111669            0
+1000531210              I121[0.0]                            I121_0_0       none         53       112598            0
+1000531220              I122[0.0]                            I122_0_0       none         53       113529            0
+1000531230              I123[0.0]                            I123_0_0       none         53       114459            0
+1000531240              I124[0.0]                            I124_0_0       none         53       115391            0
+1000531250              I125[0.0]                            I125_0_0       none         53       116321            0
+1000531260              I126[0.0]                            I126_0_0       none         53       117253            0
+1000531270              I127[0.0]                            I127_0_0       none         53       118184            0
+1000531280              I128[0.0]                            I128_0_0       none         53       119117            0
+1000531290              I129[0.0]                            I129_0_0       none         53       120047            0
+1000531300              I130[0.0]                            I130_0_0       none         53       120980            0
+1000531310              I131[0.0]                            I131_0_0       none         53       121911            0
+1000531320              I132[0.0]                            I132_0_0       none         53       122845            0
+1000531330              I133[0.0]                            I133_0_0       none         53       123776            0
+1000531340              I134[0.0]                            I134_0_0       none         53       124709            0
+1000531350              I135[0.0]                            I135_0_0       none         53       125641            0
+1000531360              I136[0.0]                            I136_0_0       none         53       126577            0
+1000531370              I137[0.0]                            I137_0_0       none         53       127511            0
+1000531380              I138[0.0]                            I138_0_0       none         53       128447            0
+1000531390              I139[0.0]                            I139_0_0       none         53       129382            0
+1000531400              I140[0.0]                            I140_0_0       none         53       130318            0
+1000531410              I141[0.0]                            I141_0_0       none         53       131253            0
+1000531420              I142[0.0]                            I142_0_0       none         53       132190            0
+1000531430              I143[0.0]                            I143_0_0       none         53       133125            0
+1000531440              I144[0.0]                            I144_0_0       none         53       134062            0
+1000541100             Xe110[0.0]                           Xe110_0_0       none         54       102385            0
+1000541110             Xe111[0.0]                           Xe111_0_0       none         54       103314            0
+1000541120             Xe112[0.0]                           Xe112_0_0       none         54       104240            0
+1000541130             Xe113[0.0]                           Xe113_0_0       none         54       105169            0
+1000541140             Xe114[0.0]                           Xe114_0_0       none         54       106096            0
+1000541150             Xe115[0.0]                           Xe115_0_0       none         54       107026            0
+1000541160             Xe116[0.0]                           Xe116_0_0       none         54       107953            0
+1000541170             Xe117[0.0]                           Xe117_0_0       none         54       108883            0
+1000541180             Xe118[0.0]                           Xe118_0_0       none         54       109811            0
+1000541190             Xe119[0.0]                           Xe119_0_0       none         54       110742            0
+1000541200             Xe120[0.0]                           Xe120_0_0       none         54       111670            0
+1000541210             Xe121[0.0]                           Xe121_0_0       none         54       112601            0
+1000541220             Xe122[0.0]                           Xe122_0_0       none         54       113530            0
+1000541230             Xe123[0.0]                           Xe123_0_0       none         54       114461            0
+1000541240             Xe124[0.0]                           Xe124_0_0       none         54       115390            0
+1000541250             Xe125[0.0]                           Xe125_0_0       none         54       116322            0
+1000541260             Xe126[0.0]                           Xe126_0_0       none         54       117252            0
+1000541270             Xe127[0.0]                           Xe127_0_0       none         54       118184            0
+1000541280             Xe128[0.0]                           Xe128_0_0       none         54       119114            0
+1000541290             Xe129[0.0]                           Xe129_0_0       none         54       120047            0
+1000541300             Xe130[0.0]                           Xe130_0_0       none         54       120977            0
+1000541310             Xe131[0.0]                           Xe131_0_0       none         54       121910            0
+1000541320             Xe132[0.0]                           Xe132_0_0       none         54       122841            0
+1000541330             Xe133[0.0]                           Xe133_0_0       none         54       123774            0
+1000541340             Xe134[0.0]                           Xe134_0_0       none         54       124705            0
+1000541350             Xe135[0.0]                           Xe135_0_0       none         54       125638            0
+1000541360             Xe136[0.0]                           Xe136_0_0       none         54       126569            0
+1000541370             Xe137[0.0]                           Xe137_0_0       none         54       127505            0
+1000541380             Xe138[0.0]                           Xe138_0_0       none         54       128439            0
+1000541390             Xe139[0.0]                           Xe139_0_0       none         54       129375            0
+1000541400             Xe140[0.0]                           Xe140_0_0       none         54       130309            0
+1000541410             Xe141[0.0]                           Xe141_0_0       none         54       131245            0
+1000541420             Xe142[0.0]                           Xe142_0_0       none         54       132179            0
+1000541430             Xe143[0.0]                           Xe143_0_0       none         54       133116            0
+1000541440             Xe144[0.0]                           Xe144_0_0       none         54       134050            0
+1000541450             Xe145[0.0]                           Xe145_0_0       none         54       134987            0
+1000541460             Xe146[0.0]                           Xe146_0_0       none         54       135922            0
+1000541470             Xe147[0.0]                           Xe147_0_0       none         54       136859            0
+1000551120             Cs112[0.0]                           Cs112_0_0       none         55       104253            0
+1000551130             Cs113[0.0]                           Cs113_0_0       none         55       105179            0
+1000551140             Cs114[0.0]                           Cs114_0_0       none         55       106108            0
+1000551150             Cs115[0.0]                           Cs115_0_0       none         55       107034            0
+1000551160             Cs116[0.0]                           Cs116_0_0       none         55       107963            0
+1000551170             Cs117[0.0]                           Cs117_0_0       none         55       108890            0
+1000551180             Cs118[0.0]                           Cs118_0_0       none         55       109820            0
+1000551190             Cs119[0.0]                           Cs119_0_0       none         55       110748            0
+1000551200             Cs120[0.0]                           Cs120_0_0       none         55       111678            0
+1000551210             Cs121[0.0]                           Cs121_0_0       none         55       112606            0
+1000551220             Cs122[0.0]                           Cs122_0_0       none         55       113536            0
+1000551230             Cs123[0.0]                           Cs123_0_0       none         55       114465            0
+1000551240             Cs124[0.0]                           Cs124_0_0       none         55       115396            0
+1000551250             Cs125[0.0]                           Cs125_0_0       none         55       116325            0
+1000551260             Cs126[0.0]                           Cs126_0_0       none         55       117256            0
+1000551270             Cs127[0.0]                           Cs127_0_0       none         55       118186            0
+1000551280             Cs128[0.0]                           Cs128_0_0       none         55       119117            0
+1000551290             Cs129[0.0]                           Cs129_0_0       none         55       120047            0
+1000551300             Cs130[0.0]                           Cs130_0_0       none         55       120979            0
+1000551310             Cs131[0.0]                           Cs131_0_0       none         55       121910            0
+1000551320             Cs132[0.0]                           Cs132_0_0       none         55       122842            0
+1000551330             Cs133[0.0]                           Cs133_0_0       none         55       123773            0
+1000551340             Cs134[0.0]                           Cs134_0_0       none         55       124705            0
+1000551350             Cs135[0.0]                           Cs135_0_0       none         55       125636            0
+1000551360             Cs136[0.0]                           Cs136_0_0       none         55       126569            0
+1000551370             Cs137[0.0]                           Cs137_0_0       none         55       127500            0
+1000551380             Cs138[0.0]                           Cs138_0_0       none         55       128435            0
+1000551390             Cs139[0.0]                           Cs139_0_0       none         55       129369            0
+1000551400             Cs140[0.0]                           Cs140_0_0       none         55       130304            0
+1000551410             Cs141[0.0]                           Cs141_0_0       none         55       131238            0
+1000551420             Cs142[0.0]                           Cs142_0_0       none         55       132174            0
+1000551430             Cs143[0.0]                           Cs143_0_0       none         55       133108            0
+1000551440             Cs144[0.0]                           Cs144_0_0       none         55       134044            0
+1000551450             Cs145[0.0]                           Cs145_0_0       none         55       134979            0
+1000551460             Cs146[0.0]                           Cs146_0_0       none         55       135915            0
+1000551470             Cs147[0.0]                           Cs147_0_0       none         55       136850            0
+1000551480             Cs148[0.0]                           Cs148_0_0       none         55       137786            0
+1000551490             Cs149[0.0]                           Cs149_0_0       none         55       138721            0
+1000551500             Cs150[0.0]                           Cs150_0_0       none         55       139657            0
+1000551510             Cs151[0.0]                           Cs151_0_0       none         55       140592            0
+1000561140             Ba114[0.0]                           Ba114_0_0       none         56       106116            0
+1000561150             Ba115[0.0]                           Ba115_0_0       none         56       107044            0
+1000561160             Ba116[0.0]                           Ba116_0_0       none         56       107970            0
+1000561170             Ba117[0.0]                           Ba117_0_0       none         56       108899            0
+1000561180             Ba118[0.0]                           Ba118_0_0       none         56       109826            0
+1000561190             Ba119[0.0]                           Ba119_0_0       none         56       110755            0
+1000561200             Ba120[0.0]                           Ba120_0_0       none         56       111682            0
+1000561210             Ba121[0.0]                           Ba121_0_0       none         56       112612            0
+1000561220             Ba122[0.0]                           Ba122_0_0       none         56       113539            0
+1000561230             Ba123[0.0]                           Ba123_0_0       none         56       114470            0
+1000561240             Ba124[0.0]                           Ba124_0_0       none         56       115398            0
+1000561250             Ba125[0.0]                           Ba125_0_0       none         56       116329            0
+1000561260             Ba126[0.0]                           Ba126_0_0       none         56       117257            0
+1000561270             Ba127[0.0]                           Ba127_0_0       none         56       118189            0
+1000561280             Ba128[0.0]                           Ba128_0_0       none         56       119117            0
+1000561290             Ba129[0.0]                           Ba129_0_0       none         56       120049            0
+1000561300             Ba130[0.0]                           Ba130_0_0       none         56       120979            0
+1000561310             Ba131[0.0]                           Ba131_0_0       none         56       121911            0
+1000561320             Ba132[0.0]                           Ba132_0_0       none         56       122840            0
+1000561330             Ba133[0.0]                           Ba133_0_0       none         56       123773            0
+1000561340             Ba134[0.0]                           Ba134_0_0       none         56       124703            0
+1000561350             Ba135[0.0]                           Ba135_0_0       none         56       125635            0
+1000561360             Ba136[0.0]                           Ba136_0_0       none         56       126566            0
+1000561370             Ba137[0.0]                           Ba137_0_0       none         56       127499            0
+1000561380             Ba138[0.0]                           Ba138_0_0       none         56       128430            0
+1000561390             Ba139[0.0]                           Ba139_0_0       none         56       129364            0
+1000561400             Ba140[0.0]                           Ba140_0_0       none         56       130297            0
+1000561410             Ba141[0.0]                           Ba141_0_0       none         56       131233            0
+1000561420             Ba142[0.0]                           Ba142_0_0       none         56       132166            0
+1000561430             Ba143[0.0]                           Ba143_0_0       none         56       133101            0
+1000561440             Ba144[0.0]                           Ba144_0_0       none         56       134035            0
+1000561450             Ba145[0.0]                           Ba145_0_0       none         56       134971            0
+1000561460             Ba146[0.0]                           Ba146_0_0       none         56       135905            0
+1000561470             Ba147[0.0]                           Ba147_0_0       none         56       136841            0
+1000561480             Ba148[0.0]                           Ba148_0_0       none         56       137775            0
+1000561490             Ba149[0.0]                           Ba149_0_0       none         56       138711            0
+1000561500             Ba150[0.0]                           Ba150_0_0       none         56       139645            0
+1000561510             Ba151[0.0]                           Ba151_0_0       none         56       140581            0
+1000561520             Ba152[0.0]                           Ba152_0_0       none         56       141516            0
+1000561530             Ba153[0.0]                           Ba153_0_0       none         56       142453            0
+1000571170             La117[0.0]                           La117_0_0       none         57       108909            0
+1000571180             La118[0.0]                           La118_0_0       none         57       109838            0
+1000571190             La119[0.0]                           La119_0_0       none         57       110764            0
+1000571200             La120[0.0]                           La120_0_0       none         57       111693            0
+1000571210             La121[0.0]                           La121_0_0       none         57       112619            0
+1000571220             La122[0.0]                           La122_0_0       none         57       113549            0
+1000571230             La123[0.0]                           La123_0_0       none         57       114476            0
+1000571240             La124[0.0]                           La124_0_0       none         57       115406            0
+1000571250             La125[0.0]                           La125_0_0       none         57       116334            0
+1000571260             La126[0.0]                           La126_0_0       none         57       117264            0
+1000571270             La127[0.0]                           La127_0_0       none         57       118193            0
+1000571280             La128[0.0]                           La128_0_0       none         57       119124            0
+1000571290             La129[0.0]                           La129_0_0       none         57       120053            0
+1000571300             La130[0.0]                           La130_0_0       none         57       120984            0
+1000571310             La131[0.0]                           La131_0_0       none         57       121913            0
+1000571320             La132[0.0]                           La132_0_0       none         57       122845            0
+1000571330             La133[0.0]                           La133_0_0       none         57       123774            0
+1000571340             La134[0.0]                           La134_0_0       none         57       124706            0
+1000571350             La135[0.0]                           La135_0_0       none         57       125636            0
+1000571360             La136[0.0]                           La136_0_0       none         57       126568            0
+1000571370             La137[0.0]                           La137_0_0       none         57       127499            0
+1000571380             La138[0.0]                           La138_0_0       none         57       128431            0
+1000571390             La139[0.0]                           La139_0_0       none         57       129362            0
+1000571400             La140[0.0]                           La140_0_0       none         57       130296            0
+1000571410             La141[0.0]                           La141_0_0       none         57       131229            0
+1000571420             La142[0.0]                           La142_0_0       none         57       132163            0
+1000571430             La143[0.0]                           La143_0_0       none         57       133097            0
+1000571440             La144[0.0]                           La144_0_0       none         57       134031            0
+1000571450             La145[0.0]                           La145_0_0       none         57       134965            0
+1000571460             La146[0.0]                           La146_0_0       none         57       135900            0
+1000571470             La147[0.0]                           La147_0_0       none         57       136834            0
+1000571480             La148[0.0]                           La148_0_0       none         57       137769            0
+1000571490             La149[0.0]                           La149_0_0       none         57       138703            0
+1000571500             La150[0.0]                           La150_0_0       none         57       139638            0
+1000571510             La151[0.0]                           La151_0_0       none         57       140572            0
+1000571520             La152[0.0]                           La152_0_0       none         57       141508            0
+1000571530             La153[0.0]                           La153_0_0       none         57       142443            0
+1000571540             La154[0.0]                           La154_0_0       none         57       143379            0
+1000571550             La155[0.0]                           La155_0_0       none         57       144314            0
+1000581190             Ce119[0.0]                           Ce119_0_0       none         58       110774            0
+1000581200             Ce120[0.0]                           Ce120_0_0       none         58       111700            0
+1000581210             Ce121[0.0]                           Ce121_0_0       none         58       112629            0
+1000581220             Ce122[0.0]                           Ce122_0_0       none         58       113555            0
+1000581230             Ce123[0.0]                           Ce123_0_0       none         58       114484            0
+1000581240             Ce124[0.0]                           Ce124_0_0       none         58       115411            0
+1000581250             Ce125[0.0]                           Ce125_0_0       none         58       116341            0
+1000581260             Ce126[0.0]                           Ce126_0_0       none         58       117268            0
+1000581270             Ce127[0.0]                           Ce127_0_0       none         58       118198            0
+1000581280             Ce128[0.0]                           Ce128_0_0       none         58       119126            0
+1000581290             Ce129[0.0]                           Ce129_0_0       none         58       120057            0
+1000581300             Ce130[0.0]                           Ce130_0_0       none         58       120985            0
+1000581310             Ce131[0.0]                           Ce131_0_0       none         58       121917            0
+1000581320             Ce132[0.0]                           Ce132_0_0       none         58       122845            0
+1000581330             Ce133[0.0]                           Ce133_0_0       none         58       123777            0
+1000581340             Ce134[0.0]                           Ce134_0_0       none         58       124706            0
+1000581350             Ce135[0.0]                           Ce135_0_0       none         58       125638            0
+1000581360             Ce136[0.0]                           Ce136_0_0       none         58       126567            0
+1000581370             Ce137[0.0]                           Ce137_0_0       none         58       127499            0
+1000581380             Ce138[0.0]                           Ce138_0_0       none         58       128429            0
+1000581390             Ce139[0.0]                           Ce139_0_0       none         58       129361            0
+1000581400             Ce140[0.0]                           Ce140_0_0       none         58       130292            0
+1000581410             Ce141[0.0]                           Ce141_0_0       none         58       131226            0
+1000581420             Ce142[0.0]                           Ce142_0_0       none         58       132158            0
+1000581430             Ce143[0.0]                           Ce143_0_0       none         58       133093            0
+1000581440             Ce144[0.0]                           Ce144_0_0       none         58       134025            0
+1000581450             Ce145[0.0]                           Ce145_0_0       none         58       134960            0
+1000581460             Ce146[0.0]                           Ce146_0_0       none         58       135893            0
+1000581470             Ce147[0.0]                           Ce147_0_0       none         58       136828            0
+1000581480             Ce148[0.0]                           Ce148_0_0       none         58       137761            0
+1000581490             Ce149[0.0]                           Ce149_0_0       none         58       138697            0
+1000581500             Ce150[0.0]                           Ce150_0_0       none         58       139630            0
+1000581510             Ce151[0.0]                           Ce151_0_0       none         58       140565            0
+1000581520             Ce152[0.0]                           Ce152_0_0       none         58       141499            0
+1000581530             Ce153[0.0]                           Ce153_0_0       none         58       142434            0
+1000581540             Ce154[0.0]                           Ce154_0_0       none         58       143368            0
+1000581550             Ce155[0.0]                           Ce155_0_0       none         58       144304            0
+1000581560             Ce156[0.0]                           Ce156_0_0       none         58       145238            0
+1000581570             Ce157[0.0]                           Ce157_0_0       none         58       146174            0
+1000591210             Pr121[0.0]                           Pr121_0_0       none         59       112639            0
+1000591220             Pr122[0.0]                           Pr122_0_0       none         59       113567            0
+1000591230             Pr123[0.0]                           Pr123_0_0       none         59       114494            0
+1000591240             Pr124[0.0]                           Pr124_0_0       none         59       115422            0
+1000591250             Pr125[0.0]                           Pr125_0_0       none         59       116349            0
+1000591260             Pr126[0.0]                           Pr126_0_0       none         59       117278            0
+1000591270             Pr127[0.0]                           Pr127_0_0       none         59       118205            0
+1000591280             Pr128[0.0]                           Pr128_0_0       none         59       119135            0
+1000591290             Pr129[0.0]                           Pr129_0_0       none         59       120063            0
+1000591300             Pr130[0.0]                           Pr130_0_0       none         59       120993            0
+1000591310             Pr131[0.0]                           Pr131_0_0       none         59       121922            0
+1000591320             Pr132[0.0]                           Pr132_0_0       none         59       122852            0
+1000591330             Pr133[0.0]                           Pr133_0_0       none         59       123781            0
+1000591340             Pr134[0.0]                           Pr134_0_0       none         59       124712            0
+1000591350             Pr135[0.0]                           Pr135_0_0       none         59       125641            0
+1000591360             Pr136[0.0]                           Pr136_0_0       none         59       126572            0
+1000591370             Pr137[0.0]                           Pr137_0_0       none         59       127502            0
+1000591380             Pr138[0.0]                           Pr138_0_0       none         59       128433            0
+1000591390             Pr139[0.0]                           Pr139_0_0       none         59       129363            0
+1000591400             Pr140[0.0]                           Pr140_0_0       none         59       130295            0
+1000591410             Pr141[0.0]                           Pr141_0_0       none         59       131225            0
+1000591420             Pr142[0.0]                           Pr142_0_0       none         59       132158            0
+1000591430             Pr143[0.0]                           Pr143_0_0       none         59       133091            0
+1000591440             Pr144[0.0]                           Pr144_0_0       none         59       134024            0
+1000591450             Pr145[0.0]                           Pr145_0_0       none         59       134957            0
+1000591460             Pr146[0.0]                           Pr146_0_0       none         59       135892            0
+1000591470             Pr147[0.0]                           Pr147_0_0       none         59       136824            0
+1000591480             Pr148[0.0]                           Pr148_0_0       none         59       137759            0
+1000591490             Pr149[0.0]                           Pr149_0_0       none         59       138692            0
+1000591500             Pr150[0.0]                           Pr150_0_0       none         59       139626            0
+1000591510             Pr151[0.0]                           Pr151_0_0       none         59       140559            0
+1000591520             Pr152[0.0]                           Pr152_0_0       none         59       141493            0
+1000591530             Pr153[0.0]                           Pr153_0_0       none         59       142427            0
+1000591540             Pr154[0.0]                           Pr154_0_0       none         59       143362            0
+1000591550             Pr155[0.0]                           Pr155_0_0       none         59       144296            0
+1000591560             Pr156[0.0]                           Pr156_0_0       none         59       145231            0
+1000591570             Pr157[0.0]                           Pr157_0_0       none         59       146166            0
+1000591580             Pr158[0.0]                           Pr158_0_0       none         59       147101            0
+1000591590             Pr159[0.0]                           Pr159_0_0       none         59       148036            0
+1000601240             Nd124[0.0]                           Nd124_0_0       none         60       115430            0
+1000601250             Nd125[0.0]                           Nd125_0_0       none         60       116359            0
+1000601260             Nd126[0.0]                           Nd126_0_0       none         60       117285            0
+1000601270             Nd127[0.0]                           Nd127_0_0       none         60       118214            0
+1000601280             Nd128[0.0]                           Nd128_0_0       none         60       119141            0
+1000601290             Nd129[0.0]                           Nd129_0_0       none         60       120070            0
+1000601300             Nd130[0.0]                           Nd130_0_0       none         60       120997            0
+1000601310             Nd131[0.0]                           Nd131_0_0       none         60       121928            0
+1000601320             Nd132[0.0]                           Nd132_0_0       none         60       122855            0
+1000601330             Nd133[0.0]                           Nd133_0_0       none         60       123786            0
+1000601340             Nd134[0.0]                           Nd134_0_0       none         60       124714            0
+1000601350             Nd135[0.0]                           Nd135_0_0       none         60       125645            0
+1000601360             Nd136[0.0]                           Nd136_0_0       none         60       126574            0
+1000601370             Nd137[0.0]                           Nd137_0_0       none         60       127505            0
+1000601380             Nd138[0.0]                           Nd138_0_0       none         60       128434            0
+1000601390             Nd139[0.0]                           Nd139_0_0       none         60       129365            0
+1000601400             Nd140[0.0]                           Nd140_0_0       none         60       130295            0
+1000601410             Nd141[0.0]                           Nd141_0_0       none         60       131226            0
+1000601420             Nd142[0.0]                           Nd142_0_0       none         60       132156            0
+1000601430             Nd143[0.0]                           Nd143_0_0       none         60       133089            0
+1000601440             Nd144[0.0]                           Nd144_0_0       none         60       134021            0
+1000601450             Nd145[0.0]                           Nd145_0_0       none         60       134955            0
+1000601460             Nd146[0.0]                           Nd146_0_0       none         60       135887            0
+1000601470             Nd147[0.0]                           Nd147_0_0       none         60       136821            0
+1000601480             Nd148[0.0]                           Nd148_0_0       none         60       137753            0
+1000601490             Nd149[0.0]                           Nd149_0_0       none         60       138688            0
+1000601500             Nd150[0.0]                           Nd150_0_0       none         60       139620            0
+1000601510             Nd151[0.0]                           Nd151_0_0       none         60       140554            0
+1000601520             Nd152[0.0]                           Nd152_0_0       none         60       141487            0
+1000601530             Nd153[0.0]                           Nd153_0_0       none         60       142421            0
+1000601540             Nd154[0.0]                           Nd154_0_0       none         60       143354            0
+1000601550             Nd155[0.0]                           Nd155_0_0       none         60       144289            0
+1000601560             Nd156[0.0]                           Nd156_0_0       none         60       145222            0
+1000601570             Nd157[0.0]                           Nd157_0_0       none         60       146157            0
+1000601580             Nd158[0.0]                           Nd158_0_0       none         60       147091            0
+1000601590             Nd159[0.0]                           Nd159_0_0       none         60       148027            0
+1000601600             Nd160[0.0]                           Nd160_0_0       none         60       148961            0
+1000601610             Nd161[0.0]                           Nd161_0_0       none         60       149897            0
+1000611260             Pm126[0.0]                           Pm126_0_0       none         61       117298            0
+1000611270             Pm127[0.0]                           Pm127_0_0       none         61       118224            0
+1000611280             Pm128[0.0]                           Pm128_0_0       none         61       119152            0
+1000611290             Pm129[0.0]                           Pm129_0_0       none         61       120079            0
+1000611300             Pm130[0.0]                           Pm130_0_0       none         61       121008            0
+1000611310             Pm131[0.0]                           Pm131_0_0       none         61       121935            0
+1000611320             Pm132[0.0]                           Pm132_0_0       none         61       122865            0
+1000611330             Pm133[0.0]                           Pm133_0_0       none         61       123792            0
+1000611340             Pm134[0.0]                           Pm134_0_0       none         61       124723            0
+1000611350             Pm135[0.0]                           Pm135_0_0       none         61       125651            0
+1000611360             Pm136[0.0]                           Pm136_0_0       none         61       126581            0
+1000611370             Pm137[0.0]                           Pm137_0_0       none         61       127510            0
+1000611380             Pm138[0.0]                           Pm138_0_0       none         61       128440            0
+1000611390             Pm139[0.0]                           Pm139_0_0       none         61       129369            0
+1000611400             Pm140[0.0]                           Pm140_0_0       none         61       130300            0
+1000611410             Pm141[0.0]                           Pm141_0_0       none         61       131229            0
+1000611420             Pm142[0.0]                           Pm142_0_0       none         61       132160            0
+1000611430             Pm143[0.0]                           Pm143_0_0       none         61       133090            0
+1000611440             Pm144[0.0]                           Pm144_0_0       none         61       134023            0
+1000611450             Pm145[0.0]                           Pm145_0_0       none         61       134954            0
+1000611460             Pm146[0.0]                           Pm146_0_0       none         61       135888            0
+1000611470             Pm147[0.0]                           Pm147_0_0       none         61       136820            0
+1000611480             Pm148[0.0]                           Pm148_0_0       none         61       137753            0
+1000611490             Pm149[0.0]                           Pm149_0_0       none         61       138686            0
+1000611500             Pm150[0.0]                           Pm150_0_0       none         61       139620            0
+1000611510             Pm151[0.0]                           Pm151_0_0       none         61       140551            0
+1000611520             Pm152[0.0]                           Pm152_0_0       none         61       141485            0
+1000611530             Pm153[0.0]                           Pm153_0_0       none         61       142417            0
+1000611540             Pm154[0.0]                           Pm154_0_0       none         61       143351            0
+1000611550             Pm155[0.0]                           Pm155_0_0       none         61       144284            0
+1000611560             Pm156[0.0]                           Pm156_0_0       none         61       145218            0
+1000611570             Pm157[0.0]                           Pm157_0_0       none         61       146151            0
+1000611580             Pm158[0.0]                           Pm158_0_0       none         61       147086            0
+1000611590             Pm159[0.0]                           Pm159_0_0       none         61       148020            0
+1000611600             Pm160[0.0]                           Pm160_0_0       none         61       148955            0
+1000611610             Pm161[0.0]                           Pm161_0_0       none         61       149889            0
+1000611620             Pm162[0.0]                           Pm162_0_0       none         61       150825            0
+1000611630             Pm163[0.0]                           Pm163_0_0       none         61       151759            0
+1000621280             Sm128[0.0]                           Sm128_0_0       none         62       119161            0
+1000621290             Sm129[0.0]                           Sm129_0_0       none         62       120089            0
+1000621300             Sm130[0.0]                           Sm130_0_0       none         62       121015            0
+1000621310             Sm131[0.0]                           Sm131_0_0       none         62       121944            0
+1000621320             Sm132[0.0]                           Sm132_0_0       none         62       122871            0
+1000621330             Sm133[0.0]                           Sm133_0_0       none         62       123800            0
+1000621340             Sm134[0.0]                           Sm134_0_0       none         62       124727            0
+1000621350             Sm135[0.0]                           Sm135_0_0       none         62       125657            0
+1000621360             Sm136[0.0]                           Sm136_0_0       none         62       126585            0
+1000621370             Sm137[0.0]                           Sm137_0_0       none         62       127515            0
+1000621380             Sm138[0.0]                           Sm138_0_0       none         62       128443            0
+1000621390             Sm139[0.0]                           Sm139_0_0       none         62       129374            0
+1000621400             Sm140[0.0]                           Sm140_0_0       none         62       130302            0
+1000621410             Sm141[0.0]                           Sm141_0_0       none         62       131233            0
+1000621420             Sm142[0.0]                           Sm142_0_0       none         62       132162            0
+1000621430             Sm143[0.0]                           Sm143_0_0       none         62       133093            0
+1000621440             Sm144[0.0]                           Sm144_0_0       none         62       134022            0
+1000621450             Sm145[0.0]                           Sm145_0_0       none         62       134955            0
+1000621460             Sm146[0.0]                           Sm146_0_0       none         62       135886            0
+1000621470             Sm147[0.0]                           Sm147_0_0       none         62       136819            0
+1000621480             Sm148[0.0]                           Sm148_0_0       none         62       137750            0
+1000621490             Sm149[0.0]                           Sm149_0_0       none         62       138684            0
+1000621500             Sm150[0.0]                           Sm150_0_0       none         62       139616            0
+1000621510             Sm151[0.0]                           Sm151_0_0       none         62       140550            0
+1000621520             Sm152[0.0]                           Sm152_0_0       none         62       141481            0
+1000621530             Sm153[0.0]                           Sm153_0_0       none         62       142415            0
+1000621540             Sm154[0.0]                           Sm154_0_0       none         62       143346            0
+1000621550             Sm155[0.0]                           Sm155_0_0       none         62       144280            0
+1000621560             Sm156[0.0]                           Sm156_0_0       none         62       145212            0
+1000621570             Sm157[0.0]                           Sm157_0_0       none         62       146146            0
+1000621580             Sm158[0.0]                           Sm158_0_0       none         62       147079            0
+1000621590             Sm159[0.0]                           Sm159_0_0       none         62       148014            0
+1000621600             Sm160[0.0]                           Sm160_0_0       none         62       148947            0
+1000621610             Sm161[0.0]                           Sm161_0_0       none         62       149882            0
+1000621620             Sm162[0.0]                           Sm162_0_0       none         62       150816            0
+1000621630             Sm163[0.0]                           Sm163_0_0       none         62       151751            0
+1000621640             Sm164[0.0]                           Sm164_0_0       none         62       152685            0
+1000621650             Sm165[0.0]                           Sm165_0_0       none         62       153621            0
+1000631300             Eu130[0.0]                           Eu130_0_0       none         63       121028            0
+1000631310             Eu131[0.0]                           Eu131_0_0       none         63       121954            0
+1000631320             Eu132[0.0]                           Eu132_0_0       none         63       122883            0
+1000631330             Eu133[0.0]                           Eu133_0_0       none         63       123810            0
+1000631340             Eu134[0.0]                           Eu134_0_0       none         63       124738            0
+1000631350             Eu135[0.0]                           Eu135_0_0       none         63       125666            0
+1000631360             Eu136[0.0]                           Eu136_0_0       none         63       126595            0
+1000631370             Eu137[0.0]                           Eu137_0_0       none         63       127523            0
+1000631380             Eu138[0.0]                           Eu138_0_0       none         63       128453            0
+1000631390             Eu139[0.0]                           Eu139_0_0       none         63       129380            0
+1000631400             Eu140[0.0]                           Eu140_0_0       none         63       130310            0
+1000631410             Eu141[0.0]                           Eu141_0_0       none         63       131239            0
+1000631420             Eu142[0.0]                           Eu142_0_0       none         63       132169            0
+1000631430             Eu143[0.0]                           Eu143_0_0       none         63       133098            0
+1000631440             Eu144[0.0]                           Eu144_0_0       none         63       134028            0
+1000631450             Eu145[0.0]                           Eu145_0_0       none         63       134957            0
+1000631460             Eu146[0.0]                           Eu146_0_0       none         63       135889            0
+1000631470             Eu147[0.0]                           Eu147_0_0       none         63       136820            0
+1000631480             Eu148[0.0]                           Eu148_0_0       none         63       137753            0
+1000631490             Eu149[0.0]                           Eu149_0_0       none         63       138684            0
+1000631500             Eu150[0.0]                           Eu150_0_0       none         63       139617            0
+1000631510             Eu151[0.0]                           Eu151_0_0       none         63       140549            0
+1000631520             Eu152[0.0]                           Eu152_0_0       none         63       141482            0
+1000631530             Eu153[0.0]                           Eu153_0_0       none         63       142413            0
+1000631540             Eu154[0.0]                           Eu154_0_0       none         63       143346            0
+1000631550             Eu155[0.0]                           Eu155_0_0       none         63       144278            0
+1000631560             Eu156[0.0]                           Eu156_0_0       none         63       145211            0
+1000631570             Eu157[0.0]                           Eu157_0_0       none         63       146143            0
+1000631580             Eu158[0.0]                           Eu158_0_0       none         63       147077            0
+1000631590             Eu159[0.0]                           Eu159_0_0       none         63       148010            0
+1000631600             Eu160[0.0]                           Eu160_0_0       none         63       148944            0
+1000631610             Eu161[0.0]                           Eu161_0_0       none         63       149877            0
+1000631620             Eu162[0.0]                           Eu162_0_0       none         63       150811            0
+1000631630             Eu163[0.0]                           Eu163_0_0       none         63       151745            0
+1000631640             Eu164[0.0]                           Eu164_0_0       none         63       152680            0
+1000631650             Eu165[0.0]                           Eu165_0_0       none         63       153614            0
+1000631660             Eu166[0.0]                           Eu166_0_0       none         63       154550            0
+1000631670             Eu167[0.0]                           Eu167_0_0       none         63       155484            0
+1000641340             Gd134[0.0]                           Gd134_0_0       none         64       124746            0
+1000641350             Gd135[0.0]                           Gd135_0_0       none         64       125675            0
+1000641360             Gd136[0.0]                           Gd136_0_0       none         64       126602            0
+1000641370             Gd137[0.0]                           Gd137_0_0       none         64       127531            0
+1000641380             Gd138[0.0]                           Gd138_0_0       none         64       128458            0
+1000641390             Gd139[0.0]                           Gd139_0_0       none         64       129388            0
+1000641400             Gd140[0.0]                           Gd140_0_0       none         64       130315            0
+1000641410             Gd141[0.0]                           Gd141_0_0       none         64       131245            0
+1000641420             Gd142[0.0]                           Gd142_0_0       none         64       132173            0
+1000641430             Gd143[0.0]                           Gd143_0_0       none         64       133103            0
+1000641440             Gd144[0.0]                           Gd144_0_0       none         64       134031            0
+1000641450             Gd145[0.0]                           Gd145_0_0       none         64       134961            0
+1000641460             Gd146[0.0]                           Gd146_0_0       none         64       135890            0
+1000641470             Gd147[0.0]                           Gd147_0_0       none         64       136822            0
+1000641480             Gd148[0.0]                           Gd148_0_0       none         64       137752            0
+1000641490             Gd149[0.0]                           Gd149_0_0       none         64       138685            0
+1000641500             Gd150[0.0]                           Gd150_0_0       none         64       139616            0
+1000641510             Gd151[0.0]                           Gd151_0_0       none         64       140549            0
+1000641520             Gd152[0.0]                           Gd152_0_0       none         64       141480            0
+1000641530             Gd153[0.0]                           Gd153_0_0       none         64       142413            0
+1000641540             Gd154[0.0]                           Gd154_0_0       none         64       143344            0
+1000641550             Gd155[0.0]                           Gd155_0_0       none         64       144277            0
+1000641560             Gd156[0.0]                           Gd156_0_0       none         64       145208            0
+1000641570             Gd157[0.0]                           Gd157_0_0       none         64       146141            0
+1000641580             Gd158[0.0]                           Gd158_0_0       none         64       147073            0
+1000641590             Gd159[0.0]                           Gd159_0_0       none         64       148007            0
+1000641600             Gd160[0.0]                           Gd160_0_0       none         64       148939            0
+1000641610             Gd161[0.0]                           Gd161_0_0       none         64       149873            0
+1000641620             Gd162[0.0]                           Gd162_0_0       none         64       150805            0
+1000641630             Gd163[0.0]                           Gd163_0_0       none         64       151740            0
+1000641640             Gd164[0.0]                           Gd164_0_0       none         64       152673            0
+1000641650             Gd165[0.0]                           Gd165_0_0       none         64       153608            0
+1000641660             Gd166[0.0]                           Gd166_0_0       none         64       154541            0
+1000641670             Gd167[0.0]                           Gd167_0_0       none         64       155476            0
+1000641680             Gd168[0.0]                           Gd168_0_0       none         64       156410            0
+1000641690             Gd169[0.0]                           Gd169_0_0       none         64       157346            0
+1000651360             Tb136[0.0]                           Tb136_0_0       none         65       126614            0
+1000651370             Tb137[0.0]                           Tb137_0_0       none         65       127541            0
+1000651380             Tb138[0.0]                           Tb138_0_0       none         65       128470            0
+1000651390             Tb139[0.0]                           Tb139_0_0       none         65       129397            0
+1000651400             Tb140[0.0]                           Tb140_0_0       none         65       130326            0
+1000651410             Tb141[0.0]                           Tb141_0_0       none         65       131253            0
+1000651420             Tb142[0.0]                           Tb142_0_0       none         65       132182            0
+1000651430             Tb143[0.0]                           Tb143_0_0       none         65       133110            0
+1000651440             Tb144[0.0]                           Tb144_0_0       none         65       134040            0
+1000651450             Tb145[0.0]                           Tb145_0_0       none         65       134968            0
+1000651460             Tb146[0.0]                           Tb146_0_0       none         65       135897            0
+1000651470             Tb147[0.0]                           Tb147_0_0       none         65       136826            0
+1000651480             Tb148[0.0]                           Tb148_0_0       none         65       137758            0
+1000651490             Tb149[0.0]                           Tb149_0_0       none         65       138688            0
+1000651500             Tb150[0.0]                           Tb150_0_0       none         65       139620            0
+1000651510             Tb151[0.0]                           Tb151_0_0       none         65       140551            0
+1000651520             Tb152[0.0]                           Tb152_0_0       none         65       141483            0
+1000651530             Tb153[0.0]                           Tb153_0_0       none         65       142414            0
+1000651540             Tb154[0.0]                           Tb154_0_0       none         65       143347            0
+1000651550             Tb155[0.0]                           Tb155_0_0       none         65       144277            0
+1000651560             Tb156[0.0]                           Tb156_0_0       none         65       145210            0
+1000651570             Tb157[0.0]                           Tb157_0_0       none         65       146141            0
+1000651580             Tb158[0.0]                           Tb158_0_0       none         65       147074            0
+1000651590             Tb159[0.0]                           Tb159_0_0       none         65       148005            0
+1000651600             Tb160[0.0]                           Tb160_0_0       none         65       148938            0
+1000651610             Tb161[0.0]                           Tb161_0_0       none         65       149870            0
+1000651620             Tb162[0.0]                           Tb162_0_0       none         65       150803            0
+1000651630             Tb163[0.0]                           Tb163_0_0       none         65       151736            0
+1000651640             Tb164[0.0]                           Tb164_0_0       none         65       152670            0
+1000651650             Tb165[0.0]                           Tb165_0_0       none         65       153603            0
+1000651660             Tb166[0.0]                           Tb166_0_0       none         65       154537            0
+1000651670             Tb167[0.0]                           Tb167_0_0       none         65       155471            0
+1000651680             Tb168[0.0]                           Tb168_0_0       none         65       156406            0
+1000651690             Tb169[0.0]                           Tb169_0_0       none         65       157339            0
+1000651700             Tb170[0.0]                           Tb170_0_0       none         65       158275            0
+1000651710             Tb171[0.0]                           Tb171_0_0       none         65       159209            0
+1000661380             Dy138[0.0]                           Dy138_0_0       none         66       128478            0
+1000661390             Dy139[0.0]                           Dy139_0_0       none         66       129407            0
+1000661400             Dy140[0.0]                           Dy140_0_0       none         66       130333            0
+1000661410             Dy141[0.0]                           Dy141_0_0       none         66       131262            0
+1000661420             Dy142[0.0]                           Dy142_0_0       none         66       132189            0
+1000661430             Dy143[0.0]                           Dy143_0_0       none         66       133118            0
+1000661440             Dy144[0.0]                           Dy144_0_0       none         66       134045            0
+1000661450             Dy145[0.0]                           Dy145_0_0       none         66       134975            0
+1000661460             Dy146[0.0]                           Dy146_0_0       none         66       135902            0
+1000661470             Dy147[0.0]                           Dy147_0_0       none         66       136832            0
+1000661480             Dy148[0.0]                           Dy148_0_0       none         66       137760            0
+1000661490             Dy149[0.0]                           Dy149_0_0       none         66       138691            0
+1000661500             Dy150[0.0]                           Dy150_0_0       none         66       139621            0
+1000661510             Dy151[0.0]                           Dy151_0_0       none         66       140553            0
+1000661520             Dy152[0.0]                           Dy152_0_0       none         66       141484            0
+1000661530             Dy153[0.0]                           Dy153_0_0       none         66       142416            0
+1000661540             Dy154[0.0]                           Dy154_0_0       none         66       143346            0
+1000661550             Dy155[0.0]                           Dy155_0_0       none         66       144279            0
+1000661560             Dy156[0.0]                           Dy156_0_0       none         66       145209            0
+1000661570             Dy157[0.0]                           Dy157_0_0       none         66       146142            0
+1000661580             Dy158[0.0]                           Dy158_0_0       none         66       147072            0
+1000661590             Dy159[0.0]                           Dy159_0_0       none         66       148005            0
+1000661600             Dy160[0.0]                           Dy160_0_0       none         66       148936            0
+1000661610             Dy161[0.0]                           Dy161_0_0       none         66       149869            0
+1000661620             Dy162[0.0]                           Dy162_0_0       none         66       150800            0
+1000661630             Dy163[0.0]                           Dy163_0_0       none         66       151734            0
+1000661640             Dy164[0.0]                           Dy164_0_0       none         66       152666            0
+1000661650             Dy165[0.0]                           Dy165_0_0       none         66       153600            0
+1000661660             Dy166[0.0]                           Dy166_0_0       none         66       154532            0
+1000661670             Dy167[0.0]                           Dy167_0_0       none         66       155466            0
+1000661680             Dy168[0.0]                           Dy168_0_0       none         66       156399            0
+1000661690             Dy169[0.0]                           Dy169_0_0       none         66       157333            0
+1000661700             Dy170[0.0]                           Dy170_0_0       none         66       158267            0
+1000661710             Dy171[0.0]                           Dy171_0_0       none         66       159202            0
+1000661720             Dy172[0.0]                           Dy172_0_0       none         66       160136            0
+1000661730             Dy173[0.0]                           Dy173_0_0       none         66       161071            0
+1000671400             Ho140[0.0]                           Ho140_0_0       none         67       130346            0
+1000671410             Ho141[0.0]                           Ho141_0_0       none         67       131272            0
+1000671420             Ho142[0.0]                           Ho142_0_0       none         67       132201            0
+1000671430             Ho143[0.0]                           Ho143_0_0       none         67       133127            0
+1000671440             Ho144[0.0]                           Ho144_0_0       none         67       134056            0
+1000671450             Ho145[0.0]                           Ho145_0_0       none         67       134984            0
+1000671460             Ho146[0.0]                           Ho146_0_0       none         67       135913            0
+1000671470             Ho147[0.0]                           Ho147_0_0       none         67       136840            0
+1000671480             Ho148[0.0]                           Ho148_0_0       none         67       137769            0
+1000671490             Ho149[0.0]                           Ho149_0_0       none         67       138697            0
+1000671500             Ho150[0.0]                           Ho150_0_0       none         67       139628            0
+1000671510             Ho151[0.0]                           Ho151_0_0       none         67       140558            0
+1000671520             Ho152[0.0]                           Ho152_0_0       none         67       141490            0
+1000671530             Ho153[0.0]                           Ho153_0_0       none         67       142420            0
+1000671540             Ho154[0.0]                           Ho154_0_0       none         67       143352            0
+1000671550             Ho155[0.0]                           Ho155_0_0       none         67       144282            0
+1000671560             Ho156[0.0]                           Ho156_0_0       none         67       145214            0
+1000671570             Ho157[0.0]                           Ho157_0_0       none         67       146144            0
+1000671580             Ho158[0.0]                           Ho158_0_0       none         67       147076            0
+1000671590             Ho159[0.0]                           Ho159_0_0       none         67       148006            0
+1000671600             Ho160[0.0]                           Ho160_0_0       none         67       148939            0
+1000671610             Ho161[0.0]                           Ho161_0_0       none         67       149869            0
+1000671620             Ho162[0.0]                           Ho162_0_0       none         67       150802            0
+1000671630             Ho163[0.0]                           Ho163_0_0       none         67       151733            0
+1000671640             Ho164[0.0]                           Ho164_0_0       none         67       152666            0
+1000671650             Ho165[0.0]                           Ho165_0_0       none         67       153598            0
+1000671660             Ho166[0.0]                           Ho166_0_0       none         67       154531            0
+1000671670             Ho167[0.0]                           Ho167_0_0       none         67       155463            0
+1000671680             Ho168[0.0]                           Ho168_0_0       none         67       156397            0
+1000671690             Ho169[0.0]                           Ho169_0_0       none         67       157330            0
+1000671700             Ho170[0.0]                           Ho170_0_0       none         67       158264            0
+1000671710             Ho171[0.0]                           Ho171_0_0       none         67       159197            0
+1000671720             Ho172[0.0]                           Ho172_0_0       none         67       160132            0
+1000671730             Ho173[0.0]                           Ho173_0_0       none         67       161065            0
+1000671740             Ho174[0.0]                           Ho174_0_0       none         67       162001            0
+1000671750             Ho175[0.0]                           Ho175_0_0       none         67       162935            0
+1000681430             Er143[0.0]                           Er143_0_0       none         68       133138            0
+1000681440             Er144[0.0]                           Er144_0_0       none         68       134064            0
+1000681450             Er145[0.0]                           Er145_0_0       none         68       134993            0
+1000681460             Er146[0.0]                           Er146_0_0       none         68       135919            0
+1000681470             Er147[0.0]                           Er147_0_0       none         68       136848            0
+1000681480             Er148[0.0]                           Er148_0_0       none         68       137775            0
+1000681490             Er149[0.0]                           Er149_0_0       none         68       138704            0
+1000681500             Er150[0.0]                           Er150_0_0       none         68       139632            0
+1000681510             Er151[0.0]                           Er151_0_0       none         68       140563            0
+1000681520             Er152[0.0]                           Er152_0_0       none         68       141492            0
+1000681530             Er153[0.0]                           Er153_0_0       none         68       142424            0
+1000681540             Er154[0.0]                           Er154_0_0       none         68       143353            0
+1000681550             Er155[0.0]                           Er155_0_0       none         68       144285            0
+1000681560             Er156[0.0]                           Er156_0_0       none         68       145214            0
+1000681570             Er157[0.0]                           Er157_0_0       none         68       146147            0
+1000681580             Er158[0.0]                           Er158_0_0       none         68       147076            0
+1000681590             Er159[0.0]                           Er159_0_0       none         68       148009            0
+1000681600             Er160[0.0]                           Er160_0_0       none         68       148939            0
+1000681610             Er161[0.0]                           Er161_0_0       none         68       149871            0
+1000681620             Er162[0.0]                           Er162_0_0       none         68       150801            0
+1000681630             Er163[0.0]                           Er163_0_0       none         68       151734            0
+1000681640             Er164[0.0]                           Er164_0_0       none         68       152665            0
+1000681650             Er165[0.0]                           Er165_0_0       none         68       153598            0
+1000681660             Er166[0.0]                           Er166_0_0       none         68       154529            0
+1000681670             Er167[0.0]                           Er167_0_0       none         68       155462            0
+1000681680             Er168[0.0]                           Er168_0_0       none         68       156394            0
+1000681690             Er169[0.0]                           Er169_0_0       none         68       157327            0
+1000681700             Er170[0.0]                           Er170_0_0       none         68       158259            0
+1000681710             Er171[0.0]                           Er171_0_0       none         68       159193            0
+1000681720             Er172[0.0]                           Er172_0_0       none         68       160126            0
+1000681730             Er173[0.0]                           Er173_0_0       none         68       161060            0
+1000681740             Er174[0.0]                           Er174_0_0       none         68       161994            0
+1000681750             Er175[0.0]                           Er175_0_0       none         68       162928            0
+1000681760             Er176[0.0]                           Er176_0_0       none         68       163862            0
+1000681770             Er177[0.0]                           Er177_0_0       none         68       164797            0
+1000691450             Tm145[0.0]                           Tm145_0_0       none         69       135004            0
+1000691460             Tm146[0.0]                           Tm146_0_0       none         69       135932            0
+1000691470             Tm147[0.0]                           Tm147_0_0       none         69       136858            0
+1000691480             Tm148[0.0]                           Tm148_0_0       none         69       137787            0
+1000691490             Tm149[0.0]                           Tm149_0_0       none         69       138714            0
+1000691500             Tm150[0.0]                           Tm150_0_0       none         69       139643            0
+1000691510             Tm151[0.0]                           Tm151_0_0       none         69       140570            0
+1000691520             Tm152[0.0]                           Tm152_0_0       none         69       141500            0
+1000691530             Tm153[0.0]                           Tm153_0_0       none         69       142430            0
+1000691540             Tm154[0.0]                           Tm154_0_0       none         69       143361            0
+1000691550             Tm155[0.0]                           Tm155_0_0       none         69       144290            0
+1000691560             Tm156[0.0]                           Tm156_0_0       none         69       145221            0
+1000691570             Tm157[0.0]                           Tm157_0_0       none         69       146151            0
+1000691580             Tm158[0.0]                           Tm158_0_0       none         69       147082            0
+1000691590             Tm159[0.0]                           Tm159_0_0       none         69       148012            0
+1000691600             Tm160[0.0]                           Tm160_0_0       none         69       148944            0
+1000691610             Tm161[0.0]                           Tm161_0_0       none         69       149874            0
+1000691620             Tm162[0.0]                           Tm162_0_0       none         69       150806            0
+1000691630             Tm163[0.0]                           Tm163_0_0       none         69       151736            0
+1000691640             Tm164[0.0]                           Tm164_0_0       none         69       152668            0
+1000691650             Tm165[0.0]                           Tm165_0_0       none         69       153599            0
+1000691660             Tm166[0.0]                           Tm166_0_0       none         69       154531            0
+1000691670             Tm167[0.0]                           Tm167_0_0       none         69       155462            0
+1000691680             Tm168[0.0]                           Tm168_0_0       none         69       156395            0
+1000691690             Tm169[0.0]                           Tm169_0_0       none         69       157326            0
+1000691700             Tm170[0.0]                           Tm170_0_0       none         69       158259            0
+1000691710             Tm171[0.0]                           Tm171_0_0       none         69       159191            0
+1000691720             Tm172[0.0]                           Tm172_0_0       none         69       160125            0
+1000691730             Tm173[0.0]                           Tm173_0_0       none         69       161057            0
+1000691740             Tm174[0.0]                           Tm174_0_0       none         69       161991            0
+1000691750             Tm175[0.0]                           Tm175_0_0       none         69       162924            0
+1000691760             Tm176[0.0]                           Tm176_0_0       none         69       163859            0
+1000691770             Tm177[0.0]                           Tm177_0_0       none         69       164792            0
+1000691780             Tm178[0.0]                           Tm178_0_0       none         69       165727            0
+1000691790             Tm179[0.0]                           Tm179_0_0       none         69       166661            0
+1000701480             Yb148[0.0]                           Yb148_0_0       none         70       137795            0
+1000701490             Yb149[0.0]                           Yb149_0_0       none         70       138724            0
+1000701500             Yb150[0.0]                           Yb150_0_0       none         70       139650            0
+1000701510             Yb151[0.0]                           Yb151_0_0       none         70       140579            0
+1000701520             Yb152[0.0]                           Yb152_0_0       none         70       141505            0
+1000701530             Yb153[0.0]                           Yb153_0_0       none         70       142436            0
+1000701540             Yb154[0.0]                           Yb154_0_0       none         70       143365            0
+1000701550             Yb155[0.0]                           Yb155_0_0       none         70       144296            0
+1000701560             Yb156[0.0]                           Yb156_0_0       none         70       145224            0
+1000701570             Yb157[0.0]                           Yb157_0_0       none         70       146156            0
+1000701580             Yb158[0.0]                           Yb158_0_0       none         70       147085            0
+1000701590             Yb159[0.0]                           Yb159_0_0       none         70       148016            0
+1000701600             Yb160[0.0]                           Yb160_0_0       none         70       148945            0
+1000701610             Yb161[0.0]                           Yb161_0_0       none         70       149877            0
+1000701620             Yb162[0.0]                           Yb162_0_0       none         70       150807            0
+1000701630             Yb163[0.0]                           Yb163_0_0       none         70       151739            0
+1000701640             Yb164[0.0]                           Yb164_0_0       none         70       152669            0
+1000701650             Yb165[0.0]                           Yb165_0_0       none         70       153601            0
+1000701660             Yb166[0.0]                           Yb166_0_0       none         70       154531            0
+1000701670             Yb167[0.0]                           Yb167_0_0       none         70       155464            0
+1000701680             Yb168[0.0]                           Yb168_0_0       none         70       156394            0
+1000701690             Yb169[0.0]                           Yb169_0_0       none         70       157327            0
+1000701700             Yb170[0.0]                           Yb170_0_0       none         70       158258            0
+1000701710             Yb171[0.0]                           Yb171_0_0       none         70       159191            0
+1000701720             Yb172[0.0]                           Yb172_0_0       none         70       160122            0
+1000701730             Yb173[0.0]                           Yb173_0_0       none         70       161056            0
+1000701740             Yb174[0.0]                           Yb174_0_0       none         70       161988            0
+1000701750             Yb175[0.0]                           Yb175_0_0       none         70       162921            0
+1000701760             Yb176[0.0]                           Yb176_0_0       none         70       163854            0
+1000701770             Yb177[0.0]                           Yb177_0_0       none         70       164788            0
+1000701780             Yb178[0.0]                           Yb178_0_0       none         70       165721            0
+1000701790             Yb179[0.0]                           Yb179_0_0       none         70       166656            0
+1000701800             Yb180[0.0]                           Yb180_0_0       none         70       167589            0
+1000701810             Yb181[0.0]                           Yb181_0_0       none         70       168524            0
+1000711500             Lu150[0.0]                           Lu150_0_0       none         71       139663            0
+1000711510             Lu151[0.0]                           Lu151_0_0       none         71       140590            0
+1000711520             Lu152[0.0]                           Lu152_0_0       none         71       141518            0
+1000711530             Lu153[0.0]                           Lu153_0_0       none         71       142444            0
+1000711540             Lu154[0.0]                           Lu154_0_0       none         71       143375            0
+1000711550             Lu155[0.0]                           Lu155_0_0       none         71       144303            0
+1000711560             Lu156[0.0]                           Lu156_0_0       none         71       145233            0
+1000711570             Lu157[0.0]                           Lu157_0_0       none         71       146162            0
+1000711580             Lu158[0.0]                           Lu158_0_0       none         71       147093            0
+1000711590             Lu159[0.0]                           Lu159_0_0       none         71       148022            0
+1000711600             Lu160[0.0]                           Lu160_0_0       none         71       148953            0
+1000711610             Lu161[0.0]                           Lu161_0_0       none         71       149882            0
+1000711620             Lu162[0.0]                           Lu162_0_0       none         71       150813            0
+1000711630             Lu163[0.0]                           Lu163_0_0       none         71       151743            0
+1000711640             Lu164[0.0]                           Lu164_0_0       none         71       152674            0
+1000711650             Lu165[0.0]                           Lu165_0_0       none         71       153604            0
+1000711660             Lu166[0.0]                           Lu166_0_0       none         71       154536            0
+1000711670             Lu167[0.0]                           Lu167_0_0       none         71       155466            0
+1000711680             Lu168[0.0]                           Lu168_0_0       none         71       156398            0
+1000711690             Lu169[0.0]                           Lu169_0_0       none         71       157329            0
+1000711700             Lu170[0.0]                           Lu170_0_0       none         71       158261            0
+1000711710             Lu171[0.0]                           Lu171_0_0       none         71       159192            0
+1000711720             Lu172[0.0]                           Lu172_0_0       none         71       160124            0
+1000711730             Lu173[0.0]                           Lu173_0_0       none         71       161056            0
+1000711740             Lu174[0.0]                           Lu174_0_0       none         71       161989            0
+1000711750             Lu175[0.0]                           Lu175_0_0       none         71       162920            0
+1000711760             Lu176[0.0]                           Lu176_0_0       none         71       163854            0
+1000711770             Lu177[0.0]                           Lu177_0_0       none         71       164786            0
+1000711780             Lu178[0.0]                           Lu178_0_0       none         71       165720            0
+1000711790             Lu179[0.0]                           Lu179_0_0       none         71       166652            0
+1000711800             Lu180[0.0]                           Lu180_0_0       none         71       167586            0
+1000711810             Lu181[0.0]                           Lu181_0_0       none         71       168520            0
+1000711820             Lu182[0.0]                           Lu182_0_0       none         71       169454            0
+1000711830             Lu183[0.0]                           Lu183_0_0       none         71       170388            0
+1000711840             Lu184[0.0]                           Lu184_0_0       none         71       171323            0
+1000721530             Hf153[0.0]                           Hf153_0_0       none         72       142455            0
+1000721540             Hf154[0.0]                           Hf154_0_0       none         72       143381            0
+1000721550             Hf155[0.0]                           Hf155_0_0       none         72       144311            0
+1000721560             Hf156[0.0]                           Hf156_0_0       none         72       145239            0
+1000721570             Hf157[0.0]                           Hf157_0_0       none         72       146169            0
+1000721580             Hf158[0.0]                           Hf158_0_0       none         72       147098            0
+1000721590             Hf159[0.0]                           Hf159_0_0       none         72       148028            0
+1000721600             Hf160[0.0]                           Hf160_0_0       none         72       148957            0
+1000721610             Hf161[0.0]                           Hf161_0_0       none         72       149888            0
+1000721620             Hf162[0.0]                           Hf162_0_0       none         72       150816            0
+1000721630             Hf163[0.0]                           Hf163_0_0       none         72       151748            0
+1000721640             Hf164[0.0]                           Hf164_0_0       none         72       152677            0
+1000721650             Hf165[0.0]                           Hf165_0_0       none         72       153608            0
+1000721660             Hf166[0.0]                           Hf166_0_0       none         72       154538            0
+1000721670             Hf167[0.0]                           Hf167_0_0       none         72       155470            0
+1000721680             Hf168[0.0]                           Hf168_0_0       none         72       156399            0
+1000721690             Hf169[0.0]                           Hf169_0_0       none         72       157331            0
+1000721700             Hf170[0.0]                           Hf170_0_0       none         72       158261            0
+1000721710             Hf171[0.0]                           Hf171_0_0       none         72       159194            0
+1000721720             Hf172[0.0]                           Hf172_0_0       none         72       160124            0
+1000721730             Hf173[0.0]                           Hf173_0_0       none         72       161057            0
+1000721740             Hf174[0.0]                           Hf174_0_0       none         72       161988            0
+1000721750             Hf175[0.0]                           Hf175_0_0       none         72       162921            0
+1000721760             Hf176[0.0]                           Hf176_0_0       none         72       163852            0
+1000721770             Hf177[0.0]                           Hf177_0_0       none         72       164785            0
+1000721780             Hf178[0.0]                           Hf178_0_0       none         72       165717            0
+1000721790             Hf179[0.0]                           Hf179_0_0       none         72       166651            0
+1000721800             Hf180[0.0]                           Hf180_0_0       none         72       167583            0
+1000721810             Hf181[0.0]                           Hf181_0_0       none         72       168517            0
+1000721820             Hf182[0.0]                           Hf182_0_0       none         72       169449            0
+1000721830             Hf183[0.0]                           Hf183_0_0       none         72       170384            0
+1000721840             Hf184[0.0]                           Hf184_0_0       none         72       171317            0
+1000721850             Hf185[0.0]                           Hf185_0_0       none         72       172252            0
+1000721860             Hf186[0.0]                           Hf186_0_0       none         72       173185            0
+1000721870             Hf187[0.0]                           Hf187_0_0       none         72       174120            0
+1000721880             Hf188[0.0]                           Hf188_0_0       none         72       175054            0
+1000731550             Ta155[0.0]                           Ta155_0_0       none         73       144321            0
+1000731560             Ta156[0.0]                           Ta156_0_0       none         73       145250            0
+1000731570             Ta157[0.0]                           Ta157_0_0       none         73       146178            0
+1000731580             Ta158[0.0]                           Ta158_0_0       none         73       147108            0
+1000731590             Ta159[0.0]                           Ta159_0_0       none         73       148036            0
+1000731600             Ta160[0.0]                           Ta160_0_0       none         73       148966            0
+1000731610             Ta161[0.0]                           Ta161_0_0       none         73       149895            0
+1000731620             Ta162[0.0]                           Ta162_0_0       none         73       150825            0
+1000731630             Ta163[0.0]                           Ta163_0_0       none         73       151754            0
+1000731640             Ta164[0.0]                           Ta164_0_0       none         73       152685            0
+1000731650             Ta165[0.0]                           Ta165_0_0       none         73       153614            0
+1000731660             Ta166[0.0]                           Ta166_0_0       none         73       154545            0
+1000731670             Ta167[0.0]                           Ta167_0_0       none         73       155474            0
+1000731680             Ta168[0.0]                           Ta168_0_0       none         73       156406            0
+1000731690             Ta169[0.0]                           Ta169_0_0       none         73       157335            0
+1000731700             Ta170[0.0]                           Ta170_0_0       none         73       158267            0
+1000731710             Ta171[0.0]                           Ta171_0_0       none         73       159197            0
+1000731720             Ta172[0.0]                           Ta172_0_0       none         73       160129            0
+1000731730             Ta173[0.0]                           Ta173_0_0       none         73       161059            0
+1000731740             Ta174[0.0]                           Ta174_0_0       none         73       161991            0
+1000731750             Ta175[0.0]                           Ta175_0_0       none         73       162922            0
+1000731760             Ta176[0.0]                           Ta176_0_0       none         73       163855            0
+1000731770             Ta177[0.0]                           Ta177_0_0       none         73       164786            0
+1000731780             Ta178[0.0]                           Ta178_0_0       none         73       165719            0
+1000731790             Ta179[0.0]                           Ta179_0_0       none         73       166650            0
+1000731800             Ta180[0.0]                           Ta180_0_0       none         73       167583            0
+1000731810             Ta181[0.0]                           Ta181_0_0       none         73       168515            0
+1000731820             Ta182[0.0]                           Ta182_0_0       none         73       169449            0
+1000731830             Ta183[0.0]                           Ta183_0_0       none         73       170381            0
+1000731840             Ta184[0.0]                           Ta184_0_0       none         73       171315            0
+1000731850             Ta185[0.0]                           Ta185_0_0       none         73       172248            0
+1000731860             Ta186[0.0]                           Ta186_0_0       none         73       173182            0
+1000731870             Ta187[0.0]                           Ta187_0_0       none         73       174116            0
+1000731880             Ta188[0.0]                           Ta188_0_0       none         73       175050            0
+1000731890             Ta189[0.0]                           Ta189_0_0       none         73       175984            0
+1000731900             Ta190[0.0]                           Ta190_0_0       none         73       176918            0
+1000741580              W158[0.0]                            W158_0_0       none         74       147115            0
+1000741590              W159[0.0]                            W159_0_0       none         74       148045            0
+1000741600              W160[0.0]                            W160_0_0       none         74       148972            0
+1000741610              W161[0.0]                            W161_0_0       none         74       149903            0
+1000741620              W162[0.0]                            W162_0_0       none         74       150831            0
+1000741630              W163[0.0]                            W163_0_0       none         74       151761            0
+1000741640              W164[0.0]                            W164_0_0       none         74       152689            0
+1000741650              W165[0.0]                            W165_0_0       none         74       153620            0
+1000741660              W166[0.0]                            W166_0_0       none         74       154549            0
+1000741670              W167[0.0]                            W167_0_0       none         74       155480            0
+1000741680              W168[0.0]                            W168_0_0       none         74       156409            0
+1000741690              W169[0.0]                            W169_0_0       none         74       157340            0
+1000741700              W170[0.0]                            W170_0_0       none         74       158269            0
+1000741710              W171[0.0]                            W171_0_0       none         74       159201            0
+1000741720              W172[0.0]                            W172_0_0       none         74       160131            0
+1000741730              W173[0.0]                            W173_0_0       none         74       161062            0
+1000741740              W174[0.0]                            W174_0_0       none         74       161992            0
+1000741750              W175[0.0]                            W175_0_0       none         74       162924            0
+1000741760              W176[0.0]                            W176_0_0       none         74       163855            0
+1000741770              W177[0.0]                            W177_0_0       none         74       164787            0
+1000741780              W178[0.0]                            W178_0_0       none         74       165718            0
+1000741790              W179[0.0]                            W179_0_0       none         74       166651            0
+1000741800              W180[0.0]                            W180_0_0       none         74       167582            0
+1000741810              W181[0.0]                            W181_0_0       none         74       168515            0
+1000741820              W182[0.0]                            W182_0_0       none         74       169446            0
+1000741830              W183[0.0]                            W183_0_0       none         74       170380            0
+1000741840              W184[0.0]                            W184_0_0       none         74       171312            0
+1000741850              W185[0.0]                            W185_0_0       none         74       172246            0
+1000741860              W186[0.0]                            W186_0_0       none         74       173178            0
+1000741870              W187[0.0]                            W187_0_0       none         74       174112            0
+1000741880              W188[0.0]                            W188_0_0       none         74       175045            0
+1000741890              W189[0.0]                            W189_0_0       none         74       175980            0
+1000741900              W190[0.0]                            W190_0_0       none         74       176912            0
+1000741910              W191[0.0]                            W191_0_0       none         74       177847            0
+1000741920              W192[0.0]                            W192_0_0       none         74       178780            0
+1000751600             Re160[0.0]                           Re160_0_0       none         75       148985            0
+1000751610             Re161[0.0]                           Re161_0_0       none         75       149912            0
+1000751620             Re162[0.0]                           Re162_0_0       none         75       150842            0
+1000751630             Re163[0.0]                           Re163_0_0       none         75       151770            0
+1000751640             Re164[0.0]                           Re164_0_0       none         75       152700            0
+1000751650             Re165[0.0]                           Re165_0_0       none         75       153628            0
+1000751660             Re166[0.0]                           Re166_0_0       none         75       154558            0
+1000751670             Re167[0.0]                           Re167_0_0       none         75       155487            0
+1000751680             Re168[0.0]                           Re168_0_0       none         75       156417            0
+1000751690             Re169[0.0]                           Re169_0_0       none         75       157346            0
+1000751700             Re170[0.0]                           Re170_0_0       none         75       158277            0
+1000751710             Re171[0.0]                           Re171_0_0       none         75       159206            0
+1000751720             Re172[0.0]                           Re172_0_0       none         75       160138            0
+1000751730             Re173[0.0]                           Re173_0_0       none         75       161067            0
+1000751740             Re174[0.0]                           Re174_0_0       none         75       161998            0
+1000751750             Re175[0.0]                           Re175_0_0       none         75       162928            0
+1000751760             Re176[0.0]                           Re176_0_0       none         75       163860            0
+1000751770             Re177[0.0]                           Re177_0_0       none         75       164790            0
+1000751780             Re178[0.0]                           Re178_0_0       none         75       165722            0
+1000751790             Re179[0.0]                           Re179_0_0       none         75       166653            0
+1000751800             Re180[0.0]                           Re180_0_0       none         75       167585            0
+1000751810             Re181[0.0]                           Re181_0_0       none         75       168516            0
+1000751820             Re182[0.0]                           Re182_0_0       none         75       169449            0
+1000751830             Re183[0.0]                           Re183_0_0       none         75       170380            0
+1000751840             Re184[0.0]                           Re184_0_0       none         75       171313            0
+1000751850             Re185[0.0]                           Re185_0_0       none         75       172245            0
+1000751860             Re186[0.0]                           Re186_0_0       none         75       173178            0
+1000751870             Re187[0.0]                           Re187_0_0       none         75       174110            0
+1000751880             Re188[0.0]                           Re188_0_0       none         75       175044            0
+1000751890             Re189[0.0]                           Re189_0_0       none         75       175977            0
+1000751900             Re190[0.0]                           Re190_0_0       none         75       176910            0
+1000751910             Re191[0.0]                           Re191_0_0       none         75       177843            0
+1000751920             Re192[0.0]                           Re192_0_0       none         75       178777            0
+1000751930             Re193[0.0]                           Re193_0_0       none         75       179710            0
+1000751940             Re194[0.0]                           Re194_0_0       none         75       180644            0
+1000761620             Os162[0.0]                           Os162_0_0       none         76       150849            0
+1000761630             Os163[0.0]                           Os163_0_0       none         76       151779            0
+1000761640             Os164[0.0]                           Os164_0_0       none         76       152706            0
+1000761650             Os165[0.0]                           Os165_0_0       none         76       153637            0
+1000761660             Os166[0.0]                           Os166_0_0       none         76       154564            0
+1000761670             Os167[0.0]                           Os167_0_0       none         76       155495            0
+1000761680             Os168[0.0]                           Os168_0_0       none         76       156423            0
+1000761690             Os169[0.0]                           Os169_0_0       none         76       157353            0
+1000761700             Os170[0.0]                           Os170_0_0       none         76       158282            0
+1000761710             Os171[0.0]                           Os171_0_0       none         76       159213            0
+1000761720             Os172[0.0]                           Os172_0_0       none         76       160141            0
+1000761730             Os173[0.0]                           Os173_0_0       none         76       161073            0
+1000761740             Os174[0.0]                           Os174_0_0       none         76       162002            0
+1000761750             Os175[0.0]                           Os175_0_0       none         76       162933            0
+1000761760             Os176[0.0]                           Os176_0_0       none         76       163862            0
+1000761770             Os177[0.0]                           Os177_0_0       none         76       164794            0
+1000761780             Os178[0.0]                           Os178_0_0       none         76       165724            0
+1000761790             Os179[0.0]                           Os179_0_0       none         76       166656            0
+1000761800             Os180[0.0]                           Os180_0_0       none         76       167586            0
+1000761810             Os181[0.0]                           Os181_0_0       none         76       168518            0
+1000761820             Os182[0.0]                           Os182_0_0       none         76       169449            0
+1000761830             Os183[0.0]                           Os183_0_0       none         76       170381            0
+1000761840             Os184[0.0]                           Os184_0_0       none         76       171312            0
+1000761850             Os185[0.0]                           Os185_0_0       none         76       172245            0
+1000761860             Os186[0.0]                           Os186_0_0       none         76       173177            0
+1000761870             Os187[0.0]                           Os187_0_0       none         76       174110            0
+1000761880             Os188[0.0]                           Os188_0_0       none         76       175041            0
+1000761890             Os189[0.0]                           Os189_0_0       none         76       175975            0
+1000761900             Os190[0.0]                           Os190_0_0       none         76       176907            0
+1000761910             Os191[0.0]                           Os191_0_0       none         76       177841            0
+1000761920             Os192[0.0]                           Os192_0_0       none         76       178773            0
+1000761930             Os193[0.0]                           Os193_0_0       none         76       179707            0
+1000761940             Os194[0.0]                           Os194_0_0       none         76       180639            0
+1000761950             Os195[0.0]                           Os195_0_0       none         76       181573            0
+1000761960             Os196[0.0]                           Os196_0_0       none         76       182506            0
+1000771640             Ir164[0.0]                           Ir164_0_0       none         77       152719            0
+1000771650             Ir165[0.0]                           Ir165_0_0       none         77       153646            0
+1000771660             Ir166[0.0]                           Ir166_0_0       none         77       154576            0
+1000771670             Ir167[0.0]                           Ir167_0_0       none         77       155504            0
+1000771680             Ir168[0.0]                           Ir168_0_0       none         77       156433            0
+1000771690             Ir169[0.0]                           Ir169_0_0       none         77       157362            0
+1000771700             Ir170[0.0]                           Ir170_0_0       none         77       158292            0
+1000771710             Ir171[0.0]                           Ir171_0_0       none         77       159220            0
+1000771720             Ir172[0.0]                           Ir172_0_0       none         77       160151            0
+1000771730             Ir173[0.0]                           Ir173_0_0       none         77       161079            0
+1000771740             Ir174[0.0]                           Ir174_0_0       none         77       162010            0
+1000771750             Ir175[0.0]                           Ir175_0_0       none         77       162939            0
+1000771760             Ir176[0.0]                           Ir176_0_0       none         77       163870            0
+1000771770             Ir177[0.0]                           Ir177_0_0       none         77       164800            0
+1000771780             Ir178[0.0]                           Ir178_0_0       none         77       165731            0
+1000771790             Ir179[0.0]                           Ir179_0_0       none         77       166660            0
+1000771800             Ir180[0.0]                           Ir180_0_0       none         77       167592            0
+1000771810             Ir181[0.0]                           Ir181_0_0       none         77       168522            0
+1000771820             Ir182[0.0]                           Ir182_0_0       none         77       169454            0
+1000771830             Ir183[0.0]                           Ir183_0_0       none         77       170384            0
+1000771840             Ir184[0.0]                           Ir184_0_0       none         77       171316            0
+1000771850             Ir185[0.0]                           Ir185_0_0       none         77       172247            0
+1000771860             Ir186[0.0]                           Ir186_0_0       none         77       173180            0
+1000771870             Ir187[0.0]                           Ir187_0_0       none         77       174111            0
+1000771880             Ir188[0.0]                           Ir188_0_0       none         77       175044            0
+1000771890             Ir189[0.0]                           Ir189_0_0       none         77       175975            0
+1000771900             Ir190[0.0]                           Ir190_0_0       none         77       176908            0
+1000771910             Ir191[0.0]                           Ir191_0_0       none         77       177840            0
+1000771920             Ir192[0.0]                           Ir192_0_0       none         77       178773            0
+1000771930             Ir193[0.0]                           Ir193_0_0       none         77       179705            0
+1000771940             Ir194[0.0]                           Ir194_0_0       none         77       180638            0
+1000771950             Ir195[0.0]                           Ir195_0_0       none         77       181571            0
+1000771960             Ir196[0.0]                           Ir196_0_0       none         77       182505            0
+1000771970             Ir197[0.0]                           Ir197_0_0       none         77       183437            0
+1000771980             Ir198[0.0]                           Ir198_0_0       none         77       184371            0
+1000771990             Ir199[0.0]                           Ir199_0_0       none         77       185304            0
+1000781660             Pt166[0.0]                           Pt166_0_0       none         78       154584            0
+1000781670             Pt167[0.0]                           Pt167_0_0       none         78       155514            0
+1000781680             Pt168[0.0]                           Pt168_0_0       none         78       156441            0
+1000781690             Pt169[0.0]                           Pt169_0_0       none         78       157371            0
+1000781700             Pt170[0.0]                           Pt170_0_0       none         78       158298            0
+1000781710             Pt171[0.0]                           Pt171_0_0       none         78       159229            0
+1000781720             Pt172[0.0]                           Pt172_0_0       none         78       160157            0
+1000781730             Pt173[0.0]                           Pt173_0_0       none         78       161087            0
+1000781740             Pt174[0.0]                           Pt174_0_0       none         78       162015            0
+1000781750             Pt175[0.0]                           Pt175_0_0       none         78       162946            0
+1000781760             Pt176[0.0]                           Pt176_0_0       none         78       163875            0
+1000781770             Pt177[0.0]                           Pt177_0_0       none         78       164806            0
+1000781780             Pt178[0.0]                           Pt178_0_0       none         78       165735            0
+1000781790             Pt179[0.0]                           Pt179_0_0       none         78       166666            0
+1000781800             Pt180[0.0]                           Pt180_0_0       none         78       167595            0
+1000781810             Pt181[0.0]                           Pt181_0_0       none         78       168527            0
+1000781820             Pt182[0.0]                           Pt182_0_0       none         78       169456            0
+1000781830             Pt183[0.0]                           Pt183_0_0       none         78       170388            0
+1000781840             Pt184[0.0]                           Pt184_0_0       none         78       171318            0
+1000781850             Pt185[0.0]                           Pt185_0_0       none         78       172250            0
+1000781860             Pt186[0.0]                           Pt186_0_0       none         78       173181            0
+1000781870             Pt187[0.0]                           Pt187_0_0       none         78       174113            0
+1000781880             Pt188[0.0]                           Pt188_0_0       none         78       175044            0
+1000781890             Pt189[0.0]                           Pt189_0_0       none         78       175977            0
+1000781900             Pt190[0.0]                           Pt190_0_0       none         78       176907            0
+1000781910             Pt191[0.0]                           Pt191_0_0       none         78       177840            0
+1000781920             Pt192[0.0]                           Pt192_0_0       none         78       178771            0
+1000781930             Pt193[0.0]                           Pt193_0_0       none         78       179705            0
+1000781940             Pt194[0.0]                           Pt194_0_0       none         78       180636            0
+1000781950             Pt195[0.0]                           Pt195_0_0       none         78       181569            0
+1000781960             Pt196[0.0]                           Pt196_0_0       none         78       182501            0
+1000781970             Pt197[0.0]                           Pt197_0_0       none         78       183435            0
+1000781980             Pt198[0.0]                           Pt198_0_0       none         78       184367            0
+1000781990             Pt199[0.0]                           Pt199_0_0       none         78       185301            0
+1000782000             Pt200[0.0]                           Pt200_0_0       none         78       186233            0
+1000782010             Pt201[0.0]                           Pt201_0_0       none         78       187167            0
+1000782020             Pt202[0.0]                           Pt202_0_0       none         78       188100            0
+1000791690             Au169[0.0]                           Au169_0_0       none         79       157381            0
+1000791700             Au170[0.0]                           Au170_0_0       none         79       158311            0
+1000791710             Au171[0.0]                           Au171_0_0       none         79       159238            0
+1000791720             Au172[0.0]                           Au172_0_0       none         79       160168            0
+1000791730             Au173[0.0]                           Au173_0_0       none         79       161096            0
+1000791740             Au174[0.0]                           Au174_0_0       none         79       162026            0
+1000791750             Au175[0.0]                           Au175_0_0       none         79       162954            0
+1000791760             Au176[0.0]                           Au176_0_0       none         79       163885            0
+1000791770             Au177[0.0]                           Au177_0_0       none         79       164813            0
+1000791780             Au178[0.0]                           Au178_0_0       none         79       165744            0
+1000791790             Au179[0.0]                           Au179_0_0       none         79       166673            0
+1000791800             Au180[0.0]                           Au180_0_0       none         79       167603            0
+1000791810             Au181[0.0]                           Au181_0_0       none         79       168533            0
+1000791820             Au182[0.0]                           Au182_0_0       none         79       169464            0
+1000791830             Au183[0.0]                           Au183_0_0       none         79       170393            0
+1000791840             Au184[0.0]                           Au184_0_0       none         79       171325            0
+1000791850             Au185[0.0]                           Au185_0_0       none         79       172255            0
+1000791860             Au186[0.0]                           Au186_0_0       none         79       173186            0
+1000791870             Au187[0.0]                           Au187_0_0       none         79       174117            0
+1000791880             Au188[0.0]                           Au188_0_0       none         79       175049            0
+1000791890             Au189[0.0]                           Au189_0_0       none         79       175979            0
+1000791900             Au190[0.0]                           Au190_0_0       none         79       176911            0
+1000791910             Au191[0.0]                           Au191_0_0       none         79       177842            0
+1000791920             Au192[0.0]                           Au192_0_0       none         79       178774            0
+1000791930             Au193[0.0]                           Au193_0_0       none         79       179705            0
+1000791940             Au194[0.0]                           Au194_0_0       none         79       180638            0
+1000791950             Au195[0.0]                           Au195_0_0       none         79       181569            0
+1000791960             Au196[0.0]                           Au196_0_0       none         79       182502            0
+1000791970             Au197[0.0]                           Au197_0_0       none         79       183433            0
+1000791980             Au198[0.0]                           Au198_0_0       none         79       184366            0
+1000791990             Au199[0.0]                           Au199_0_0       none         79       185298            0
+1000792000             Au200[0.0]                           Au200_0_0       none         79       186232            0
+1000792010             Au201[0.0]                           Au201_0_0       none         79       187164            0
+1000792020             Au202[0.0]                           Au202_0_0       none         79       188098            0
+1000792030             Au203[0.0]                           Au203_0_0       none         79       189030            0
+1000792040             Au204[0.0]                           Au204_0_0       none         79       189964            0
+1000792050             Au205[0.0]                           Au205_0_0       none         79       190898            0
+1000801710             Hg171[0.0]                           Hg171_0_0       none         80       159249            0
+1000801720             Hg172[0.0]                           Hg172_0_0       none         80       160176            0
+1000801730             Hg173[0.0]                           Hg173_0_0       none         80       161106            0
+1000801740             Hg174[0.0]                           Hg174_0_0       none         80       162033            0
+1000801750             Hg175[0.0]                           Hg175_0_0       none         80       162963            0
+1000801760             Hg176[0.0]                           Hg176_0_0       none         80       163891            0
+1000801770             Hg177[0.0]                           Hg177_0_0       none         80       164821            0
+1000801780             Hg178[0.0]                           Hg178_0_0       none         80       165749            0
+1000801790             Hg179[0.0]                           Hg179_0_0       none         80       166680            0
+1000801800             Hg180[0.0]                           Hg180_0_0       none         80       167608            0
+1000801810             Hg181[0.0]                           Hg181_0_0       none         80       168539            0
+1000801820             Hg182[0.0]                           Hg182_0_0       none         80       169468            0
+1000801830             Hg183[0.0]                           Hg183_0_0       none         80       170399            0
+1000801840             Hg184[0.0]                           Hg184_0_0       none         80       171328            0
+1000801850             Hg185[0.0]                           Hg185_0_0       none         80       172260            0
+1000801860             Hg186[0.0]                           Hg186_0_0       none         80       173189            0
+1000801870             Hg187[0.0]                           Hg187_0_0       none         80       174121            0
+1000801880             Hg188[0.0]                           Hg188_0_0       none         80       175050            0
+1000801890             Hg189[0.0]                           Hg189_0_0       none         80       175982            0
+1000801900             Hg190[0.0]                           Hg190_0_0       none         80       176912            0
+1000801910             Hg191[0.0]                           Hg191_0_0       none         80       177844            0
+1000801920             Hg192[0.0]                           Hg192_0_0       none         80       178774            0
+1000801930             Hg193[0.0]                           Hg193_0_0       none         80       179707            0
+1000801940             Hg194[0.0]                           Hg194_0_0       none         80       180637            0
+1000801950             Hg195[0.0]                           Hg195_0_0       none         80       181570            0
+1000801960             Hg196[0.0]                           Hg196_0_0       none         80       182501            0
+1000801970             Hg197[0.0]                           Hg197_0_0       none         80       183433            0
+1000801980             Hg198[0.0]                           Hg198_0_0       none         80       184365            0
+1000801990             Hg199[0.0]                           Hg199_0_0       none         80       185297            0
+1000802000             Hg200[0.0]                           Hg200_0_0       none         80       186229            0
+1000802010             Hg201[0.0]                           Hg201_0_0       none         80       187162            0
+1000802020             Hg202[0.0]                           Hg202_0_0       none         80       188094            0
+1000802030             Hg203[0.0]                           Hg203_0_0       none         80       189028            0
+1000802040             Hg204[0.0]                           Hg204_0_0       none         80       189960            0
+1000802050             Hg205[0.0]                           Hg205_0_0       none         80       190894            0
+1000802060             Hg206[0.0]                           Hg206_0_0       none         80       191826            0
+1000802070             Hg207[0.0]                           Hg207_0_0       none         80       192763            0
+1000802080             Hg208[0.0]                           Hg208_0_0       none         80       193697            0
+1000802090             Hg209[0.0]                           Hg209_0_0       none         80       194634            0
+1000802100             Hg210[0.0]                           Hg210_0_0       none         80       195568            0
+1000811760             Tl176[0.0]                           Tl176_0_0       none         81       163903            0
+1000811770             Tl177[0.0]                           Tl177_0_0       none         81       164830            0
+1000811780             Tl178[0.0]                           Tl178_0_0       none         81       165760            0
+1000811790             Tl179[0.0]                           Tl179_0_0       none         81       166688            0
+1000811800             Tl180[0.0]                           Tl180_0_0       none         81       167619            0
+1000811810             Tl181[0.0]                           Tl181_0_0       none         81       168547            0
+1000811820             Tl182[0.0]                           Tl182_0_0       none         81       169478            0
+1000811830             Tl183[0.0]                           Tl183_0_0       none         81       170406            0
+1000811840             Tl184[0.0]                           Tl184_0_0       none         81       171337            0
+1000811850             Tl185[0.0]                           Tl185_0_0       none         81       172266            0
+1000811860             Tl186[0.0]                           Tl186_0_0       none         81       173197            0
+1000811870             Tl187[0.0]                           Tl187_0_0       none         81       174126            0
+1000811880             Tl188[0.0]                           Tl188_0_0       none         81       175058            0
+1000811890             Tl189[0.0]                           Tl189_0_0       none         81       175987            0
+1000811900             Tl190[0.0]                           Tl190_0_0       none         81       176919            0
+1000811910             Tl191[0.0]                           Tl191_0_0       none         81       177848            0
+1000811920             Tl192[0.0]                           Tl192_0_0       none         81       178780            0
+1000811930             Tl193[0.0]                           Tl193_0_0       none         81       179710            0
+1000811940             Tl194[0.0]                           Tl194_0_0       none         81       180642            0
+1000811950             Tl195[0.0]                           Tl195_0_0       none         81       181572            0
+1000811960             Tl196[0.0]                           Tl196_0_0       none         81       182504            0
+1000811970             Tl197[0.0]                           Tl197_0_0       none         81       183435            0
+1000811980             Tl198[0.0]                           Tl198_0_0       none         81       184367            0
+1000811990             Tl199[0.0]                           Tl199_0_0       none         81       185298            0
+1000812000             Tl200[0.0]                           Tl200_0_0       none         81       186231            0
+1000812010             Tl201[0.0]                           Tl201_0_0       none         81       187162            0
+1000812020             Tl202[0.0]                           Tl202_0_0       none         81       188095            0
+1000812030             Tl203[0.0]                           Tl203_0_0       none         81       189027            0
+1000812040             Tl204[0.0]                           Tl204_0_0       none         81       189960            0
+1000812050             Tl205[0.0]                           Tl205_0_0       none         81       190892            0
+1000812060             Tl206[0.0]                           Tl206_0_0       none         81       191825            0
+1000812070             Tl207[0.0]                           Tl207_0_0       none         81       192757            0
+1000812080             Tl208[0.0]                           Tl208_0_0       none         81       193693            0
+1000812090             Tl209[0.0]                           Tl209_0_0       none         81       194628            0
+1000812100             Tl210[0.0]                           Tl210_0_0       none         81       195564            0
+1000812110             Tl211[0.0]                           Tl211_0_0       none         81       196498            0
+1000812120             Tl212[0.0]                           Tl212_0_0       none         81       197434            0
+1000821780             Pb178[0.0]                           Pb178_0_0       none         82       165768            0
+1000821790             Pb179[0.0]                           Pb179_0_0       none         82       166698            0
+1000821800             Pb180[0.0]                           Pb180_0_0       none         82       167626            0
+1000821810             Pb181[0.0]                           Pb181_0_0       none         82       168556            0
+1000821820             Pb182[0.0]                           Pb182_0_0       none         82       169484            0
+1000821830             Pb183[0.0]                           Pb183_0_0       none         82       170415            0
+1000821840             Pb184[0.0]                           Pb184_0_0       none         82       171343            0
+1000821850             Pb185[0.0]                           Pb185_0_0       none         82       172274            0
+1000821860             Pb186[0.0]                           Pb186_0_0       none         82       173202            0
+1000821870             Pb187[0.0]                           Pb187_0_0       none         82       174133            0
+1000821880             Pb188[0.0]                           Pb188_0_0       none         82       175062            0
+1000821890             Pb189[0.0]                           Pb189_0_0       none         82       175993            0
+1000821900             Pb190[0.0]                           Pb190_0_0       none         82       176922            0
+1000821910             Pb191[0.0]                           Pb191_0_0       none         82       177854            0
+1000821920             Pb192[0.0]                           Pb192_0_0       none         82       178783            0
+1000821930             Pb193[0.0]                           Pb193_0_0       none         82       179715            0
+1000821940             Pb194[0.0]                           Pb194_0_0       none         82       180644            0
+1000821950             Pb195[0.0]                           Pb195_0_0       none         82       181576            0
+1000821960             Pb196[0.0]                           Pb196_0_0       none         82       182506            0
+1000821970             Pb197[0.0]                           Pb197_0_0       none         82       183438            0
+1000821980             Pb198[0.0]                           Pb198_0_0       none         82       184368            0
+1000821990             Pb199[0.0]                           Pb199_0_0       none         82       185301            0
+1000822000             Pb200[0.0]                           Pb200_0_0       none         82       186231            0
+1000822010             Pb201[0.0]                           Pb201_0_0       none         82       187164            0
+1000822020             Pb202[0.0]                           Pb202_0_0       none         82       188095            0
+1000822030             Pb203[0.0]                           Pb203_0_0       none         82       189027            0
+1000822040             Pb204[0.0]                           Pb204_0_0       none         82       189958            0
+1000822050             Pb205[0.0]                           Pb205_0_0       none         82       190891            0
+1000822060             Pb206[0.0]                           Pb206_0_0       none         82       191823            0
+1000822070             Pb207[0.0]                           Pb207_0_0       none         82       192755            0
+1000822080             Pb208[0.0]                           Pb208_0_0       none         82       193688            0
+1000822090             Pb209[0.0]                           Pb209_0_0       none         82       194623            0
+1000822100             Pb210[0.0]                           Pb210_0_0       none         82       195558            0
+1000822110             Pb211[0.0]                           Pb211_0_0       none         82       196493            0
+1000822120             Pb212[0.0]                           Pb212_0_0       none         82       197428            0
+1000822130             Pb213[0.0]                           Pb213_0_0       none         82       198364            0
+1000822140             Pb214[0.0]                           Pb214_0_0       none         82       199298            0
+1000822150             Pb215[0.0]                           Pb215_0_0       none         82       200234            0
+1000831840             Bi184[0.0]                           Bi184_0_0       none         83       171354            0
+1000831850             Bi185[0.0]                           Bi185_0_0       none         83       172282            0
+1000831860             Bi186[0.0]                           Bi186_0_0       none         83       173213            0
+1000831870             Bi187[0.0]                           Bi187_0_0       none         83       174141            0
+1000831880             Bi188[0.0]                           Bi188_0_0       none         83       175072            0
+1000831890             Bi189[0.0]                           Bi189_0_0       none         83       176000            0
+1000831900             Bi190[0.0]                           Bi190_0_0       none         83       176931            0
+1000831910             Bi191[0.0]                           Bi191_0_0       none         83       177860            0
+1000831920             Bi192[0.0]                           Bi192_0_0       none         83       178791            0
+1000831930             Bi193[0.0]                           Bi193_0_0       none         83       179721            0
+1000831940             Bi194[0.0]                           Bi194_0_0       none         83       180652            0
+1000831950             Bi195[0.0]                           Bi195_0_0       none         83       181581            0
+1000831960             Bi196[0.0]                           Bi196_0_0       none         83       182513            0
+1000831970             Bi197[0.0]                           Bi197_0_0       none         83       183443            0
+1000831980             Bi198[0.0]                           Bi198_0_0       none         83       184375            0
+1000831990             Bi199[0.0]                           Bi199_0_0       none         83       185305            0
+1000832000             Bi200[0.0]                           Bi200_0_0       none         83       186237            0
+1000832010             Bi201[0.0]                           Bi201_0_0       none         83       187167            0
+1000832020             Bi202[0.0]                           Bi202_0_0       none         83       188099            0
+1000832030             Bi203[0.0]                           Bi203_0_0       none         83       189030            0
+1000832040             Bi204[0.0]                           Bi204_0_0       none         83       189962            0
+1000832050             Bi205[0.0]                           Bi205_0_0       none         83       190893            0
+1000832060             Bi206[0.0]                           Bi206_0_0       none         83       191826            0
+1000832070             Bi207[0.0]                           Bi207_0_0       none         83       192757            0
+1000832080             Bi208[0.0]                           Bi208_0_0       none         83       193690            0
+1000832090             Bi209[0.0]                           Bi209_0_0       none         83       194622            0
+1000832100             Bi210[0.0]                           Bi210_0_0       none         83       195557            0
+1000832110             Bi211[0.0]                           Bi211_0_0       none         83       196492            0
+1000832120             Bi212[0.0]                           Bi212_0_0       none         83       197427            0
+1000832130             Bi213[0.0]                           Bi213_0_0       none         83       198361            0
+1000832140             Bi214[0.0]                           Bi214_0_0       none         83       199297            0
+1000832150             Bi215[0.0]                           Bi215_0_0       none         83       200231            0
+1000832160             Bi216[0.0]                           Bi216_0_0       none         83       201167            0
+1000832170             Bi217[0.0]                           Bi217_0_0       none         83       202101            0
+1000832180             Bi218[0.0]                           Bi218_0_0       none         83       203037            0
+1000841880             Po188[0.0]                           Po188_0_0       none         84       175078            0
+1000841890             Po189[0.0]                           Po189_0_0       none         84       176009            0
+1000841900             Po190[0.0]                           Po190_0_0       none         84       176937            0
+1000841910             Po191[0.0]                           Po191_0_0       none         84       177868            0
+1000841920             Po192[0.0]                           Po192_0_0       none         84       178796            0
+1000841930             Po193[0.0]                           Po193_0_0       none         84       179728            0
+1000841940             Po194[0.0]                           Po194_0_0       none         84       180657            0
+1000841950             Po195[0.0]                           Po195_0_0       none         84       181588            0
+1000841960             Po196[0.0]                           Po196_0_0       none         84       182517            0
+1000841970             Po197[0.0]                           Po197_0_0       none         84       183449            0
+1000841980             Po198[0.0]                           Po198_0_0       none         84       184378            0
+1000841990             Po199[0.0]                           Po199_0_0       none         84       185310            0
+1000842000             Po200[0.0]                           Po200_0_0       none         84       186240            0
+1000842010             Po201[0.0]                           Po201_0_0       none         84       187171            0
+1000842020             Po202[0.0]                           Po202_0_0       none         84       188102            0
+1000842030             Po203[0.0]                           Po203_0_0       none         84       189034            0
+1000842040             Po204[0.0]                           Po204_0_0       none         84       189964            0
+1000842050             Po205[0.0]                           Po205_0_0       none         84       190896            0
+1000842060             Po206[0.0]                           Po206_0_0       none         84       191827            0
+1000842070             Po207[0.0]                           Po207_0_0       none         84       192760            0
+1000842080             Po208[0.0]                           Po208_0_0       none         84       193691            0
+1000842090             Po209[0.0]                           Po209_0_0       none         84       194624            0
+1000842100             Po210[0.0]                           Po210_0_0       none         84       195555            0
+1000842110             Po211[0.0]                           Po211_0_0       none         84       196490            0
+1000842120             Po212[0.0]                           Po212_0_0       none         84       197424            0
+1000842130             Po213[0.0]                           Po213_0_0       none         84       198359            0
+1000842140             Po214[0.0]                           Po214_0_0       none         84       199293            0
+1000842150             Po215[0.0]                           Po215_0_0       none         84       200228            0
+1000842160             Po216[0.0]                           Po216_0_0       none         84       201162            0
+1000842170             Po217[0.0]                           Po217_0_0       none         84       202098            0
+1000842180             Po218[0.0]                           Po218_0_0       none         84       203032            0
+1000842190             Po219[0.0]                           Po219_0_0       none         84       203968            0
+1000842200             Po220[0.0]                           Po220_0_0       none         84       204902            0
+1000851930             At193[0.0]                           At193_0_0       none         85       179735            0
+1000851940             At194[0.0]                           At194_0_0       none         85       180666            0
+1000851950             At195[0.0]                           At195_0_0       none         85       181595            0
+1000851960             At196[0.0]                           At196_0_0       none         85       182526            0
+1000851970             At197[0.0]                           At197_0_0       none         85       183455            0
+1000851980             At198[0.0]                           At198_0_0       none         85       184386            0
+1000851990             At199[0.0]                           At199_0_0       none         85       185316            0
+1000852000             At200[0.0]                           At200_0_0       none         85       186247            0
+1000852010             At201[0.0]                           At201_0_0       none         85       187177            0
+1000852020             At202[0.0]                           At202_0_0       none         85       188108            0
+1000852030             At203[0.0]                           At203_0_0       none         85       189038            0
+1000852040             At204[0.0]                           At204_0_0       none         85       189970            0
+1000852050             At205[0.0]                           At205_0_0       none         85       190900            0
+1000852060             At206[0.0]                           At206_0_0       none         85       191833            0
+1000852070             At207[0.0]                           At207_0_0       none         85       192763            0
+1000852080             At208[0.0]                           At208_0_0       none         85       193695            0
+1000852090             At209[0.0]                           At209_0_0       none         85       194627            0
+1000852100             At210[0.0]                           At210_0_0       none         85       195559            0
+1000852110             At211[0.0]                           At211_0_0       none         85       196491            0
+1000852120             At212[0.0]                           At212_0_0       none         85       197425            0
+1000852130             At213[0.0]                           At213_0_0       none         85       198359            0
+1000852140             At214[0.0]                           At214_0_0       none         85       199294            0
+1000852150             At215[0.0]                           At215_0_0       none         85       200227            0
+1000852160             At216[0.0]                           At216_0_0       none         85       201162            0
+1000852170             At217[0.0]                           At217_0_0       none         85       202096            0
+1000852180             At218[0.0]                           At218_0_0       none         85       203031            0
+1000852190             At219[0.0]                           At219_0_0       none         85       203965            0
+1000852200             At220[0.0]                           At220_0_0       none         85       204900            0
+1000852210             At221[0.0]                           At221_0_0       none         85       205834            0
+1000852220             At222[0.0]                           At222_0_0       none         85       206770            0
+1000852230             At223[0.0]                           At223_0_0       none         85       207704            0
+1000861950             Rn195[0.0]                           Rn195_0_0       none         86       181603            0
+1000861960             Rn196[0.0]                           Rn196_0_0       none         86       182531            0
+1000861970             Rn197[0.0]                           Rn197_0_0       none         86       183462            0
+1000861980             Rn198[0.0]                           Rn198_0_0       none         86       184391            0
+1000861990             Rn199[0.0]                           Rn199_0_0       none         86       185322            0
+1000862000             Rn200[0.0]                           Rn200_0_0       none         86       186251            0
+1000862010             Rn201[0.0]                           Rn201_0_0       none         86       187183            0
+1000862020             Rn202[0.0]                           Rn202_0_0       none         86       188112            0
+1000862030             Rn203[0.0]                           Rn203_0_0       none         86       189044            0
+1000862040             Rn204[0.0]                           Rn204_0_0       none         86       189973            0
+1000862050             Rn205[0.0]                           Rn205_0_0       none         86       190905            0
+1000862060             Rn206[0.0]                           Rn206_0_0       none         86       191835            0
+1000862070             Rn207[0.0]                           Rn207_0_0       none         86       192767            0
+1000862080             Rn208[0.0]                           Rn208_0_0       none         86       193698            0
+1000862090             Rn209[0.0]                           Rn209_0_0       none         86       194630            0
+1000862100             Rn210[0.0]                           Rn210_0_0       none         86       195561            0
+1000862110             Rn211[0.0]                           Rn211_0_0       none         86       196493            0
+1000862120             Rn212[0.0]                           Rn212_0_0       none         86       197425            0
+1000862130             Rn213[0.0]                           Rn213_0_0       none         86       198359            0
+1000862140             Rn214[0.0]                           Rn214_0_0       none         86       199292            0
+1000862150             Rn215[0.0]                           Rn215_0_0       none         86       200227            0
+1000862160             Rn216[0.0]                           Rn216_0_0       none         86       201160            0
+1000862170             Rn217[0.0]                           Rn217_0_0       none         86       202095            0
+1000862180             Rn218[0.0]                           Rn218_0_0       none         86       203028            0
+1000862190             Rn219[0.0]                           Rn219_0_0       none         86       203963            0
+1000862200             Rn220[0.0]                           Rn220_0_0       none         86       204896            0
+1000862210             Rn221[0.0]                           Rn221_0_0       none         86       205831            0
+1000862220             Rn222[0.0]                           Rn222_0_0       none         86       206765            0
+1000862230             Rn223[0.0]                           Rn223_0_0       none         86       207700            0
+1000862240             Rn224[0.0]                           Rn224_0_0       none         86       208634            0
+1000862250             Rn225[0.0]                           Rn225_0_0       none         86       209569            0
+1000862260             Rn226[0.0]                           Rn226_0_0       none         86       210503            0
+1000862270             Rn227[0.0]                           Rn227_0_0       none         86       211439            0
+1000862280             Rn228[0.0]                           Rn228_0_0       none         86       212373            0
+1000871990             Fr199[0.0]                           Fr199_0_0       none         87       185330            0
+1000872000             Fr200[0.0]                           Fr200_0_0       none         87       186261            0
+1000872010             Fr201[0.0]                           Fr201_0_0       none         87       187190            0
+1000872020             Fr202[0.0]                           Fr202_0_0       none         87       188121            0
+1000872030             Fr203[0.0]                           Fr203_0_0       none         87       189050            0
+1000872040             Fr204[0.0]                           Fr204_0_0       none         87       189982            0
+1000872050             Fr205[0.0]                           Fr205_0_0       none         87       190911            0
+1000872060             Fr206[0.0]                           Fr206_0_0       none         87       191843            0
+1000872070             Fr207[0.0]                           Fr207_0_0       none         87       192773            0
+1000872080             Fr208[0.0]                           Fr208_0_0       none         87       193704            0
+1000872090             Fr209[0.0]                           Fr209_0_0       none         87       194635            0
+1000872100             Fr210[0.0]                           Fr210_0_0       none         87       195567            0
+1000872110             Fr211[0.0]                           Fr211_0_0       none         87       196497            0
+1000872120             Fr212[0.0]                           Fr212_0_0       none         87       197429            0
+1000872130             Fr213[0.0]                           Fr213_0_0       none         87       198361            0
+1000872140             Fr214[0.0]                           Fr214_0_0       none         87       199295            0
+1000872150             Fr215[0.0]                           Fr215_0_0       none         87       200228            0
+1000872160             Fr216[0.0]                           Fr216_0_0       none         87       201162            0
+1000872170             Fr217[0.0]                           Fr217_0_0       none         87       202095            0
+1000872180             Fr218[0.0]                           Fr218_0_0       none         87       203029            0
+1000872190             Fr219[0.0]                           Fr219_0_0       none         87       203962            0
+1000872200             Fr220[0.0]                           Fr220_0_0       none         87       204896            0
+1000872210             Fr221[0.0]                           Fr221_0_0       none         87       205830            0
+1000872220             Fr222[0.0]                           Fr222_0_0       none         87       206764            0
+1000872230             Fr223[0.0]                           Fr223_0_0       none         87       207698            0
+1000872240             Fr224[0.0]                           Fr224_0_0       none         87       208633            0
+1000872250             Fr225[0.0]                           Fr225_0_0       none         87       209566            0
+1000872260             Fr226[0.0]                           Fr226_0_0       none         87       210501            0
+1000872270             Fr227[0.0]                           Fr227_0_0       none         87       211435            0
+1000872280             Fr228[0.0]                           Fr228_0_0       none         87       212370            0
+1000872290             Fr229[0.0]                           Fr229_0_0       none         87       213304            0
+1000872300             Fr230[0.0]                           Fr230_0_0       none         87       214239            0
+1000872310             Fr231[0.0]                           Fr231_0_0       none         87       215174            0
+1000872320             Fr232[0.0]                           Fr232_0_0       none         87       216109            0
+1000882020             Ra202[0.0]                           Ra202_0_0       none         88       188127            0
+1000882030             Ra203[0.0]                           Ra203_0_0       none         88       189058            0
+1000882040             Ra204[0.0]                           Ra204_0_0       none         88       189987            0
+1000882050             Ra205[0.0]                           Ra205_0_0       none         88       190918            0
+1000882060             Ra206[0.0]                           Ra206_0_0       none         88       191847            0
+1000882070             Ra207[0.0]                           Ra207_0_0       none         88       192779            0
+1000882080             Ra208[0.0]                           Ra208_0_0       none         88       193708            0
+1000882090             Ra209[0.0]                           Ra209_0_0       none         88       194640            0
+1000882100             Ra210[0.0]                           Ra210_0_0       none         88       195570            0
+1000882110             Ra211[0.0]                           Ra211_0_0       none         88       196502            0
+1000882120             Ra212[0.0]                           Ra212_0_0       none         88       197432            0
+1000882130             Ra213[0.0]                           Ra213_0_0       none         88       198364            0
+1000882140             Ra214[0.0]                           Ra214_0_0       none         88       199296            0
+1000882150             Ra215[0.0]                           Ra215_0_0       none         88       200229            0
+1000882160             Ra216[0.0]                           Ra216_0_0       none         88       201162            0
+1000882170             Ra217[0.0]                           Ra217_0_0       none         88       202096            0
+1000882180             Ra218[0.0]                           Ra218_0_0       none         88       203028            0
+1000882190             Ra219[0.0]                           Ra219_0_0       none         88       203962            0
+1000882200             Ra220[0.0]                           Ra220_0_0       none         88       204895            0
+1000882210             Ra221[0.0]                           Ra221_0_0       none         88       205829            0
+1000882220             Ra222[0.0]                           Ra222_0_0       none         88       206762            0
+1000882230             Ra223[0.0]                           Ra223_0_0       none         88       207696            0
+1000882240             Ra224[0.0]                           Ra224_0_0       none         88       208629            0
+1000882250             Ra225[0.0]                           Ra225_0_0       none         88       209564            0
+1000882260             Ra226[0.0]                           Ra226_0_0       none         88       210497            0
+1000882270             Ra227[0.0]                           Ra227_0_0       none         88       211432            0
+1000882280             Ra228[0.0]                           Ra228_0_0       none         88       212365            0
+1000882290             Ra229[0.0]                           Ra229_0_0       none         88       213300            0
+1000882300             Ra230[0.0]                           Ra230_0_0       none         88       214234            0
+1000882310             Ra231[0.0]                           Ra231_0_0       none         88       215169            0
+1000882320             Ra232[0.0]                           Ra232_0_0       none         88       216103            0
+1000882330             Ra233[0.0]                           Ra233_0_0       none         88       217039            0
+1000882340             Ra234[0.0]                           Ra234_0_0       none         88       217973            0
+1000892060             Ac206[0.0]                           Ac206_0_0       none         89       191857            0
+1000892070             Ac207[0.0]                           Ac207_0_0       none         89       192786            0
+1000892080             Ac208[0.0]                           Ac208_0_0       none         89       193717            0
+1000892090             Ac209[0.0]                           Ac209_0_0       none         89       194646            0
+1000892100             Ac210[0.0]                           Ac210_0_0       none         89       195578            0
+1000892110             Ac211[0.0]                           Ac211_0_0       none         89       196508            0
+1000892120             Ac212[0.0]                           Ac212_0_0       none         89       197439            0
+1000892130             Ac213[0.0]                           Ac213_0_0       none         89       198370            0
+1000892140             Ac214[0.0]                           Ac214_0_0       none         89       199301            0
+1000892150             Ac215[0.0]                           Ac215_0_0       none         89       200232            0
+1000892160             Ac216[0.0]                           Ac216_0_0       none         89       201166            0
+1000892170             Ac217[0.0]                           Ac217_0_0       none         89       202098            0
+1000892180             Ac218[0.0]                           Ac218_0_0       none         89       203032            0
+1000892190             Ac219[0.0]                           Ac219_0_0       none         89       203964            0
+1000892200             Ac220[0.0]                           Ac220_0_0       none         89       204898            0
+1000892210             Ac221[0.0]                           Ac221_0_0       none         89       205830            0
+1000892220             Ac222[0.0]                           Ac222_0_0       none         89       206764            0
+1000892230             Ac223[0.0]                           Ac223_0_0       none         89       207696            0
+1000892240             Ac224[0.0]                           Ac224_0_0       none         89       208630            0
+1000892250             Ac225[0.0]                           Ac225_0_0       none         89       209563            0
+1000892260             Ac226[0.0]                           Ac226_0_0       none         89       210497            0
+1000892270             Ac227[0.0]                           Ac227_0_0       none         89       211430            0
+1000892280             Ac228[0.0]                           Ac228_0_0       none         89       212365            0
+1000892290             Ac229[0.0]                           Ac229_0_0       none         89       213298            0
+1000892300             Ac230[0.0]                           Ac230_0_0       none         89       214233            0
+1000892310             Ac231[0.0]                           Ac231_0_0       none         89       215166            0
+1000892320             Ac232[0.0]                           Ac232_0_0       none         89       216101            0
+1000892330             Ac233[0.0]                           Ac233_0_0       none         89       217035            0
+1000892340             Ac234[0.0]                           Ac234_0_0       none         89       217970            0
+1000892350             Ac235[0.0]                           Ac235_0_0       none         89       218904            0
+1000892360             Ac236[0.0]                           Ac236_0_0       none         89       219839            0
+1000902090             Th209[0.0]                           Th209_0_0       none         90       194653            0
+1000902100             Th210[0.0]                           Th210_0_0       none         90       195583            0
+1000902110             Th211[0.0]                           Th211_0_0       none         90       196514            0
+1000902120             Th212[0.0]                           Th212_0_0       none         90       197444            0
+1000902130             Th213[0.0]                           Th213_0_0       none         90       198375            0
+1000902140             Th214[0.0]                           Th214_0_0       none         90       199305            0
+1000902150             Th215[0.0]                           Th215_0_0       none         90       200237            0
+1000902160             Th216[0.0]                           Th216_0_0       none         90       201168            0
+1000902170             Th217[0.0]                           Th217_0_0       none         90       202101            0
+1000902180             Th218[0.0]                           Th218_0_0       none         90       203033            0
+1000902190             Th219[0.0]                           Th219_0_0       none         90       203966            0
+1000902200             Th220[0.0]                           Th220_0_0       none         90       204898            0
+1000902210             Th221[0.0]                           Th221_0_0       none         90       205832            0
+1000902220             Th222[0.0]                           Th222_0_0       none         90       206764            0
+1000902230             Th223[0.0]                           Th223_0_0       none         90       207697            0
+1000902240             Th224[0.0]                           Th224_0_0       none         90       208629            0
+1000902250             Th225[0.0]                           Th225_0_0       none         90       209563            0
+1000902260             Th226[0.0]                           Th226_0_0       none         90       210496            0
+1000902270             Th227[0.0]                           Th227_0_0       none         90       211430            0
+1000902280             Th228[0.0]                           Th228_0_0       none         90       212362            0
+1000902290             Th229[0.0]                           Th229_0_0       none         90       213296            0
+1000902300             Th230[0.0]                           Th230_0_0       none         90       214229            0
+1000902310             Th231[0.0]                           Th231_0_0       none         90       215164            0
+1000902320             Th232[0.0]                           Th232_0_0       none         90       216097            0
+1000902330             Th233[0.0]                           Th233_0_0       none         90       217032            0
+1000902340             Th234[0.0]                           Th234_0_0       none         90       217965            0
+1000902350             Th235[0.0]                           Th235_0_0       none         90       218900            0
+1000902360             Th236[0.0]                           Th236_0_0       none         90       219834            0
+1000902370             Th237[0.0]                           Th237_0_0       none         90       220769            0
+1000902380             Th238[0.0]                           Th238_0_0       none         90       221703            0
+1000912120             Pa212[0.0]                           Pa212_0_0       none         91       197453            0
+1000912130             Pa213[0.0]                           Pa213_0_0       none         91       198382            0
+1000912140             Pa214[0.0]                           Pa214_0_0       none         91       199313            0
+1000912150             Pa215[0.0]                           Pa215_0_0       none         91       200243            0
+1000912160             Pa216[0.0]                           Pa216_0_0       none         91       201175            0
+1000912170             Pa217[0.0]                           Pa217_0_0       none         91       202106            0
+1000912180             Pa218[0.0]                           Pa218_0_0       none         91       203039            0
+1000912190             Pa219[0.0]                           Pa219_0_0       none         91       203970            0
+1000912200             Pa220[0.0]                           Pa220_0_0       none         91       204903            0
+1000912210             Pa221[0.0]                           Pa221_0_0       none         91       205835            0
+1000912220             Pa222[0.0]                           Pa222_0_0       none         91       206768            0
+1000912230             Pa223[0.0]                           Pa223_0_0       none         91       207700            0
+1000912240             Pa224[0.0]                           Pa224_0_0       none         91       208633            0
+1000912250             Pa225[0.0]                           Pa225_0_0       none         91       209565            0
+1000912260             Pa226[0.0]                           Pa226_0_0       none         91       210498            0
+1000912270             Pa227[0.0]                           Pa227_0_0       none         91       211430            0
+1000912280             Pa228[0.0]                           Pa228_0_0       none         91       212364            0
+1000912290             Pa229[0.0]                           Pa229_0_0       none         91       213296            0
+1000912300             Pa230[0.0]                           Pa230_0_0       none         91       214230            0
+1000912310             Pa231[0.0]                           Pa231_0_0       none         91       215163            0
+1000912320             Pa232[0.0]                           Pa232_0_0       none         91       216097            0
+1000912330             Pa233[0.0]                           Pa233_0_0       none         91       217030            0
+1000912340             Pa234[0.0]                           Pa234_0_0       none         91       217964            0
+1000912350             Pa235[0.0]                           Pa235_0_0       none         91       218898            0
+1000912360             Pa236[0.0]                           Pa236_0_0       none         91       219832            0
+1000912370             Pa237[0.0]                           Pa237_0_0       none         91       220766            0
+1000912380             Pa238[0.0]                           Pa238_0_0       none         91       221701            0
+1000912390             Pa239[0.0]                           Pa239_0_0       none         91       222635            0
+1000912400             Pa240[0.0]                           Pa240_0_0       none         91       223570            0
+1000922170              U217[0.0]                            U217_0_0       none         92       202111            0
+1000922180              U218[0.0]                            U218_0_0       none         92       203041            0
+1000922190              U219[0.0]                            U219_0_0       none         92       203974            0
+1000922200              U220[0.0]                            U220_0_0       none         92       204905            0
+1000922210              U221[0.0]                            U221_0_0       none         92       205839            0
+1000922220              U222[0.0]                            U222_0_0       none         92       206770            0
+1000922230              U223[0.0]                            U223_0_0       none         92       207703            0
+1000922240              U224[0.0]                            U224_0_0       none         92       208634            0
+1000922250              U225[0.0]                            U225_0_0       none         92       209567            0
+1000922260              U226[0.0]                            U226_0_0       none         92       210499            0
+1000922270              U227[0.0]                            U227_0_0       none         92       211432            0
+1000922280              U228[0.0]                            U228_0_0       none         92       212364            0
+1000922290              U229[0.0]                            U229_0_0       none         92       213297            0
+1000922300              U230[0.0]                            U230_0_0       none         92       214229            0
+1000922310              U231[0.0]                            U231_0_0       none         92       215163            0
+1000922320              U232[0.0]                            U232_0_0       none         92       216095            0
+1000922330              U233[0.0]                            U233_0_0       none         92       217029            0
+1000922340              U234[0.0]                            U234_0_0       none         92       217961            0
+1000922350              U235[0.0]                            U235_0_0       none         92       218896            0
+1000922360              U236[0.0]                            U236_0_0       none         92       219829            0
+1000922370              U237[0.0]                            U237_0_0       none         92       220763            0
+1000922380              U238[0.0]                            U238_0_0       none         92       221697            0
+1000922390              U239[0.0]                            U239_0_0       none         92       222631            0
+1000922400              U240[0.0]                            U240_0_0       none         92       223565            0
+1000922410              U241[0.0]                            U241_0_0       none         92       224500            0
+1000922420              U242[0.0]                            U242_0_0       none         92       225434            0
+1000932250             Np225[0.0]                           Np225_0_0       none         93       209571            0
+1000932260             Np226[0.0]                           Np226_0_0       none         93       210504            0
+1000932270             Np227[0.0]                           Np227_0_0       none         93       211435            0
+1000932280             Np228[0.0]                           Np228_0_0       none         93       212368            0
+1000932290             Np229[0.0]                           Np229_0_0       none         93       213299            0
+1000932300             Np230[0.0]                           Np230_0_0       none         93       214232            0
+1000932310             Np231[0.0]                           Np231_0_0       none         93       215164            0
+1000932320             Np232[0.0]                           Np232_0_0       none         93       216097            0
+1000932330             Np233[0.0]                           Np233_0_0       none         93       217029            0
+1000932340             Np234[0.0]                           Np234_0_0       none         93       217963            0
+1000932350             Np235[0.0]                           Np235_0_0       none         93       218895            0
+1000932360             Np236[0.0]                           Np236_0_0       none         93       219829            0
+1000932370             Np237[0.0]                           Np237_0_0       none         93       220762            0
+1000932380             Np238[0.0]                           Np238_0_0       none         93       221696            0
+1000932390             Np239[0.0]                           Np239_0_0       none         93       222630            0
+1000932400             Np240[0.0]                           Np240_0_0       none         93       223564            0
+1000932410             Np241[0.0]                           Np241_0_0       none         93       224498            0
+1000932420             Np242[0.0]                           Np242_0_0       none         93       225432            0
+1000932430             Np243[0.0]                           Np243_0_0       none         93       226366            0
+1000932440             Np244[0.0]                           Np244_0_0       none         93       227301            0
+1000942280             Pu228[0.0]                           Pu228_0_0       none         94       212369            0
+1000942290             Pu229[0.0]                           Pu229_0_0       none         94       213302            0
+1000942300             Pu230[0.0]                           Pu230_0_0       none         94       214233            0
+1000942310             Pu231[0.0]                           Pu231_0_0       none         94       215166            0
+1000942320             Pu232[0.0]                           Pu232_0_0       none         94       216098            0
+1000942330             Pu233[0.0]                           Pu233_0_0       none         94       217031            0
+1000942340             Pu234[0.0]                           Pu234_0_0       none         94       217963            0
+1000942350             Pu235[0.0]                           Pu235_0_0       none         94       218896            0
+1000942360             Pu236[0.0]                           Pu236_0_0       none         94       219828            0
+1000942370             Pu237[0.0]                           Pu237_0_0       none         94       220762            0
+1000942380             Pu238[0.0]                           Pu238_0_0       none         94       221695            0
+1000942390             Pu239[0.0]                           Pu239_0_0       none         94       222628            0
+1000942400             Pu240[0.0]                           Pu240_0_0       none         94       223561            0
+1000942410             Pu241[0.0]                           Pu241_0_0       none         94       224496            0
+1000942420             Pu242[0.0]                           Pu242_0_0       none         94       225429            0
+1000942430             Pu243[0.0]                           Pu243_0_0       none         94       226364            0
+1000942440             Pu244[0.0]                           Pu244_0_0       none         94       227297            0
+1000942450             Pu245[0.0]                           Pu245_0_0       none         94       228232            0
+1000942460             Pu246[0.0]                           Pu246_0_0       none         94       229166            0
+1000942470             Pu247[0.0]                           Pu247_0_0       none         94       230101            0
+1000952310             Am231[0.0]                           Am231_0_0       none         95       215170            0
+1000952320             Am232[0.0]                           Am232_0_0       none         95       216102            0
+1000952330             Am233[0.0]                           Am233_0_0       none         95       217034            0
+1000952340             Am234[0.0]                           Am234_0_0       none         95       217966            0
+1000952350             Am235[0.0]                           Am235_0_0       none         95       218898            0
+1000952360             Am236[0.0]                           Am236_0_0       none         95       219831            0
+1000952370             Am237[0.0]                           Am237_0_0       none         95       220763            0
+1000952380             Am238[0.0]                           Am238_0_0       none         95       221696            0
+1000952390             Am239[0.0]                           Am239_0_0       none         95       222629            0
+1000952400             Am240[0.0]                           Am240_0_0       none         95       223562            0
+1000952410             Am241[0.0]                           Am241_0_0       none         95       224495            0
+1000952420             Am242[0.0]                           Am242_0_0       none         95       225429            0
+1000952430             Am243[0.0]                           Am243_0_0       none         95       226363            0
+1000952440             Am244[0.0]                           Am244_0_0       none         95       227297            0
+1000952450             Am245[0.0]                           Am245_0_0       none         95       228230            0
+1000952460             Am246[0.0]                           Am246_0_0       none         95       229165            0
+1000952470             Am247[0.0]                           Am247_0_0       none         95       230098            0
+1000952480             Am248[0.0]                           Am248_0_0       none         95       231033            0
+1000952490             Am249[0.0]                           Am249_0_0       none         95       231967            0
+1000962330             Cm233[0.0]                           Cm233_0_0       none         96       217037            0
+1000962340             Cm234[0.0]                           Cm234_0_0       none         96       217968            0
+1000962350             Cm235[0.0]                           Cm235_0_0       none         96       218901            0
+1000962360             Cm236[0.0]                           Cm236_0_0       none         96       219832            0
+1000962370             Cm237[0.0]                           Cm237_0_0       none         96       220765            0
+1000962380             Cm238[0.0]                           Cm238_0_0       none         96       221697            0
+1000962390             Cm239[0.0]                           Cm239_0_0       none         96       222630            0
+1000962400             Cm240[0.0]                           Cm240_0_0       none         96       223562            0
+1000962410             Cm241[0.0]                           Cm241_0_0       none         96       224496            0
+1000962420             Cm242[0.0]                           Cm242_0_0       none         96       225428            0
+1000962430             Cm243[0.0]                           Cm243_0_0       none         96       226362            0
+1000962440             Cm244[0.0]                           Cm244_0_0       none         96       227295            0
+1000962450             Cm245[0.0]                           Cm245_0_0       none         96       228229            0
+1000962460             Cm246[0.0]                           Cm246_0_0       none         96       229162            0
+1000962470             Cm247[0.0]                           Cm247_0_0       none         96       230096            0
+1000962480             Cm248[0.0]                           Cm248_0_0       none         96       231030            0
+1000962490             Cm249[0.0]                           Cm249_0_0       none         96       231965            0
+1000962500             Cm250[0.0]                           Cm250_0_0       none         96       232898            0
+1000962510             Cm251[0.0]                           Cm251_0_0       none         96       233833            0
+1000962520             Cm252[0.0]                           Cm252_0_0       none         96       234767            0
+1000972350             Bk235[0.0]                           Bk235_0_0       none         97       218905            0
+1000972360             Bk236[0.0]                           Bk236_0_0       none         97       219837            0
+1000972370             Bk237[0.0]                           Bk237_0_0       none         97       220768            0
+1000972380             Bk238[0.0]                           Bk238_0_0       none         97       221701            0
+1000972390             Bk239[0.0]                           Bk239_0_0       none         97       222633            0
+1000972400             Bk240[0.0]                           Bk240_0_0       none         97       223566            0
+1000972410             Bk241[0.0]                           Bk241_0_0       none         97       224497            0
+1000972420             Bk242[0.0]                           Bk242_0_0       none         97       225431            0
+1000972430             Bk243[0.0]                           Bk243_0_0       none         97       226363            0
+1000972440             Bk244[0.0]                           Bk244_0_0       none         97       227297            0
+1000972450             Bk245[0.0]                           Bk245_0_0       none         97       228229            0
+1000972460             Bk246[0.0]                           Bk246_0_0       none         97       229163            0
+1000972470             Bk247[0.0]                           Bk247_0_0       none         97       230096            0
+1000972480             Bk248[0.0]                           Bk248_0_0       none         97       231030            0
+1000972490             Bk249[0.0]                           Bk249_0_0       none         97       231963            0
+1000972500             Bk250[0.0]                           Bk250_0_0       none         97       232898            0
+1000972510             Bk251[0.0]                           Bk251_0_0       none         97       233832            0
+1000972520             Bk252[0.0]                           Bk252_0_0       none         97       234766            0
+1000972530             Bk253[0.0]                           Bk253_0_0       none         97       235700            0
+1000972540             Bk254[0.0]                           Bk254_0_0       none         97       236635            0
+1000982370             Cf237[0.0]                           Cf237_0_0       none         98       220773            0
+1000982380             Cf238[0.0]                           Cf238_0_0       none         98       221704            0
+1000982390             Cf239[0.0]                           Cf239_0_0       none         98       222636            0
+1000982400             Cf240[0.0]                           Cf240_0_0       none         98       223567            0
+1000982410             Cf241[0.0]                           Cf241_0_0       none         98       224500            0
+1000982420             Cf242[0.0]                           Cf242_0_0       none         98       225432            0
+1000982430             Cf243[0.0]                           Cf243_0_0       none         98       226365            0
+1000982440             Cf244[0.0]                           Cf244_0_0       none         98       227297            0
+1000982450             Cf245[0.0]                           Cf245_0_0       none         98       228230            0
+1000982460             Cf246[0.0]                           Cf246_0_0       none         98       229162            0
+1000982470             Cf247[0.0]                           Cf247_0_0       none         98       230096            0
+1000982480             Cf248[0.0]                           Cf248_0_0       none         98       231029            0
+1000982490             Cf249[0.0]                           Cf249_0_0       none         98       231963            0
+1000982500             Cf250[0.0]                           Cf250_0_0       none         98       232895            0
+1000982510             Cf251[0.0]                           Cf251_0_0       none         98       233830            0
+1000982520             Cf252[0.0]                           Cf252_0_0       none         98       234763            0
+1000982530             Cf253[0.0]                           Cf253_0_0       none         98       235698            0
+1000982540             Cf254[0.0]                           Cf254_0_0       none         98       236632            0
+1000982550             Cf255[0.0]                           Cf255_0_0       none         98       237567            0
+1000982560             Cf256[0.0]                           Cf256_0_0       none         98       238500            0
+1000992400             Es240[0.0]                           Es240_0_0       none         99       223573            0
+1000992410             Es241[0.0]                           Es241_0_0       none         99       224504            0
+1000992420             Es242[0.0]                           Es242_0_0       none         99       225437            0
+1000992430             Es243[0.0]                           Es243_0_0       none         99       226368            0
+1000992440             Es244[0.0]                           Es244_0_0       none         99       227301            0
+1000992450             Es245[0.0]                           Es245_0_0       none         99       228233            0
+1000992460             Es246[0.0]                           Es246_0_0       none         99       229166            0
+1000992470             Es247[0.0]                           Es247_0_0       none         99       230098            0
+1000992480             Es248[0.0]                           Es248_0_0       none         99       231031            0
+1000992490             Es249[0.0]                           Es249_0_0       none         99       231964            0
+1000992500             Es250[0.0]                           Es250_0_0       none         99       232897            0
+1000992510             Es251[0.0]                           Es251_0_0       none         99       233830            0
+1000992520             Es252[0.0]                           Es252_0_0       none         99       234764            0
+1000992530             Es253[0.0]                           Es253_0_0       none         99       235697            0
+1000992540             Es254[0.0]                           Es254_0_0       none         99       236632            0
+1000992550             Es255[0.0]                           Es255_0_0       none         99       237565            0
+1000992560             Es256[0.0]                           Es256_0_0       none         99       238500            0
+1000992570             Es257[0.0]                           Es257_0_0       none         99       239434            0
+1000992580             Es258[0.0]                           Es258_0_0       none         99       240368            0
+1001002420             Fm242[0.0]                           Fm242_0_0       none        100       225440            0
+1001002430             Fm243[0.0]                           Fm243_0_0       none        100       226372            0
+1001002440             Fm244[0.0]                           Fm244_0_0       none        100       227303            0
+1001002450             Fm245[0.0]                           Fm245_0_0       none        100       228236            0
+1001002460             Fm246[0.0]                           Fm246_0_0       none        100       229168            0
+1001002470             Fm247[0.0]                           Fm247_0_0       none        100       230100            0
+1001002480             Fm248[0.0]                           Fm248_0_0       none        100       231032            0
+1001002490             Fm249[0.0]                           Fm249_0_0       none        100       231965            0
+1001002500             Fm250[0.0]                           Fm250_0_0       none        100       232897            0
+1001002510             Fm251[0.0]                           Fm251_0_0       none        100       233831            0
+1001002520             Fm252[0.0]                           Fm252_0_0       none        100       234763            0
+1001002530             Fm253[0.0]                           Fm253_0_0       none        100       235697            0
+1001002540             Fm254[0.0]                           Fm254_0_0       none        100       236630            0
+1001002550             Fm255[0.0]                           Fm255_0_0       none        100       237565            0
+1001002560             Fm256[0.0]                           Fm256_0_0       none        100       238498            0
+1001002570             Fm257[0.0]                           Fm257_0_0       none        100       239432            0
+1001002580             Fm258[0.0]                           Fm258_0_0       none        100       240366            0
+1001002590             Fm259[0.0]                           Fm259_0_0       none        100       241301            0
+1001002600             Fm260[0.0]                           Fm260_0_0       none        100       242234            0
+1001012450             Md245[0.0]                           Md245_0_0       none        101       228241            0
+1001012460             Md246[0.0]                           Md246_0_0       none        101       229173            0
+1001012470             Md247[0.0]                           Md247_0_0       none        101       230104            0
+1001012480             Md248[0.0]                           Md248_0_0       none        101       231037            0
+1001012490             Md249[0.0]                           Md249_0_0       none        101       231969            0
+1001012500             Md250[0.0]                           Md250_0_0       none        101       232902            0
+1001012510             Md251[0.0]                           Md251_0_0       none        101       233833            0
+1001012520             Md252[0.0]                           Md252_0_0       none        101       234766            0
+1001012530             Md253[0.0]                           Md253_0_0       none        101       235699            0
+1001012540             Md254[0.0]                           Md254_0_0       none        101       236632            0
+1001012550             Md255[0.0]                           Md255_0_0       none        101       237565            0
+1001012560             Md256[0.0]                           Md256_0_0       none        101       238499            0
+1001012570             Md257[0.0]                           Md257_0_0       none        101       239432            0
+1001012580             Md258[0.0]                           Md258_0_0       none        101       240367            0
+1001012590             Md259[0.0]                           Md259_0_0       none        101       241300            0
+1001012600             Md260[0.0]                           Md260_0_0       none        101       242234            0
+1001012610             Md261[0.0]                           Md261_0_0       none        101       243168            0
+1001012620             Md262[0.0]                           Md262_0_0       none        101       244102            0
+1001022480             No248[0.0]                           No248_0_0       none        102       231040            0
+1001022490             No249[0.0]                           No249_0_0       none        102       231973            0
+1001022500             No250[0.0]                           No250_0_0       none        102       232904            0
+1001022510             No251[0.0]                           No251_0_0       none        102       233837            0
+1001022520             No252[0.0]                           No252_0_0       none        102       234768            0
+1001022530             No253[0.0]                           No253_0_0       none        102       235701            0
+1001022540             No254[0.0]                           No254_0_0       none        102       236633            0
+1001022550             No255[0.0]                           No255_0_0       none        102       237567            0
+1001022560             No256[0.0]                           No256_0_0       none        102       238499            0
+1001022570             No257[0.0]                           No257_0_0       none        102       239433            0
+1001022580             No258[0.0]                           No258_0_0       none        102       240366            0
+1001022590             No259[0.0]                           No259_0_0       none        102       241300            0
+1001022600             No260[0.0]                           No260_0_0       none        102       242233            0
+1001022610             No261[0.0]                           No261_0_0       none        102       243167            0
+1001022620             No262[0.0]                           No262_0_0       none        102       244100            0
+1001022630             No263[0.0]                           No263_0_0       none        102       245035            0
+1001022640             No264[0.0]                           No264_0_0       none        102       245968            0
+1001032510             Lr251[0.0]                           Lr251_0_0       none        103       233841            0
+1001032520             Lr252[0.0]                           Lr252_0_0       none        103       234774            0
+1001032530             Lr253[0.0]                           Lr253_0_0       none        103       235705            0
+1001032540             Lr254[0.0]                           Lr254_0_0       none        103       236638            0
+1001032550             Lr255[0.0]                           Lr255_0_0       none        103       237569            0
+1001032560             Lr256[0.0]                           Lr256_0_0       none        103       238503            0
+1001032570             Lr257[0.0]                           Lr257_0_0       none        103       239435            0
+1001032580             Lr258[0.0]                           Lr258_0_0       none        103       240369            0
+1001032590             Lr259[0.0]                           Lr259_0_0       none        103       241301            0
+1001032600             Lr260[0.0]                           Lr260_0_0       none        103       242235            0
+1001032610             Lr261[0.0]                           Lr261_0_0       none        103       243168            0
+1001032620             Lr262[0.0]                           Lr262_0_0       none        103       244102            0
+1001032630             Lr263[0.0]                           Lr263_0_0       none        103       245035            0
+1001032640             Lr264[0.0]                           Lr264_0_0       none        103       245969            0
+1001032650             Lr265[0.0]                           Lr265_0_0       none        103       246902            0
+1001032660             Lr266[0.0]                           Lr266_0_0       none        103       247837            0
+1001042530             Rf253[0.0]                           Rf253_0_0       none        104       235710            0
+1001042540             Rf254[0.0]                           Rf254_0_0       none        104       236641            0
+1001042550             Rf255[0.0]                           Rf255_0_0       none        104       237573            0
+1001042560             Rf256[0.0]                           Rf256_0_0       none        104       238505            0
+1001042570             Rf257[0.0]                           Rf257_0_0       none        104       239438            0
+1001042580             Rf258[0.0]                           Rf258_0_0       none        104       240370            0
+1001042590             Rf259[0.0]                           Rf259_0_0       none        104       241303            0
+1001042600             Rf260[0.0]                           Rf260_0_0       none        104       242236            0
+1001042610             Rf261[0.0]                           Rf261_0_0       none        104       243169            0
+1001042620             Rf262[0.0]                           Rf262_0_0       none        104       244102            0
+1001042630             Rf263[0.0]                           Rf263_0_0       none        104       245036            0
+1001042640             Rf264[0.0]                           Rf264_0_0       none        104       245969            0
+1001042650             Rf265[0.0]                           Rf265_0_0       none        104       246903            0
+1001042660             Rf266[0.0]                           Rf266_0_0       none        104       247835            0
+1001042670             Rf267[0.0]                           Rf267_0_0       none        104       248770            0
+1001042680             Rf268[0.0]                           Rf268_0_0       none        104       249703            0
+1001052550             Db255[0.0]                           Db255_0_0       none        105       237578            0
+1001052560             Db256[0.0]                           Db256_0_0       none        105       238511            0
+1001052570             Db257[0.0]                           Db257_0_0       none        105       239442            0
+1001052580             Db258[0.0]                           Db258_0_0       none        105       240375            0
+1001052590             Db259[0.0]                           Db259_0_0       none        105       241306            0
+1001052600             Db260[0.0]                           Db260_0_0       none        105       242240            0
+1001052610             Db261[0.0]                           Db261_0_0       none        105       243172            0
+1001052620             Db262[0.0]                           Db262_0_0       none        105       244105            0
+1001052630             Db263[0.0]                           Db263_0_0       none        105       245037            0
+1001052640             Db264[0.0]                           Db264_0_0       none        105       245971            0
+1001052650             Db265[0.0]                           Db265_0_0       none        105       246904            0
+1001052660             Db266[0.0]                           Db266_0_0       none        105       247838            0
+1001052670             Db267[0.0]                           Db267_0_0       none        105       248770            0
+1001052680             Db268[0.0]                           Db268_0_0       none        105       249705            0
+1001052690             Db269[0.0]                           Db269_0_0       none        105       250638            0
+1001052700             Db270[0.0]                           Db270_0_0       none        105       251573            0
+1001062580             Sg258[0.0]                           Sg258_0_0       none        106       240378            0
+1001062590             Sg259[0.0]                           Sg259_0_0       none        106       241311            0
+1001062600             Sg260[0.0]                           Sg260_0_0       none        106       242242            0
+1001062610             Sg261[0.0]                           Sg261_0_0       none        106       243175            0
+1001062620             Sg262[0.0]                           Sg262_0_0       none        106       244107            0
+1001062630             Sg263[0.0]                           Sg263_0_0       none        106       245040            0
+1001062640             Sg264[0.0]                           Sg264_0_0       none        106       245972            0
+1001062650             Sg265[0.0]                           Sg265_0_0       none        106       246906            0
+1001062660             Sg266[0.0]                           Sg266_0_0       none        106       247838            0
+1001062670             Sg267[0.0]                           Sg267_0_0       none        106       248772            0
+1001062680             Sg268[0.0]                           Sg268_0_0       none        106       249704            0
+1001062690             Sg269[0.0]                           Sg269_0_0       none        106       250639            0
+1001062700             Sg270[0.0]                           Sg270_0_0       none        106       251572            0
+1001062710             Sg271[0.0]                           Sg271_0_0       none        106       252506            0
+1001062720             Sg272[0.0]                           Sg272_0_0       none        106       253439            0
+1001062730             Sg273[0.0]                           Sg273_0_0       none        106       254374            0
+1001072600             Bh260[0.0]                           Bh260_0_0       none        107       242249            0
+1001072610             Bh261[0.0]                           Bh261_0_0       none        107       243180            0
+1001072620             Bh262[0.0]                           Bh262_0_0       none        107       244112            0
+1001072630             Bh263[0.0]                           Bh263_0_0       none        107       245044            0
+1001072640             Bh264[0.0]                           Bh264_0_0       none        107       245977            0
+1001072650             Bh265[0.0]                           Bh265_0_0       none        107       246909            0
+1001072660             Bh266[0.0]                           Bh266_0_0       none        107       247842            0
+1001072670             Bh267[0.0]                           Bh267_0_0       none        107       248774            0
+1001072680             Bh268[0.0]                           Bh268_0_0       none        107       249708            0
+1001072690             Bh269[0.0]                           Bh269_0_0       none        107       250640            0
+1001072700             Bh270[0.0]                           Bh270_0_0       none        107       251574            0
+1001072710             Bh271[0.0]                           Bh271_0_0       none        107       252507            0
+1001072720             Bh272[0.0]                           Bh272_0_0       none        107       253441            0
+1001072730             Bh273[0.0]                           Bh273_0_0       none        107       254374            0
+1001082630             Hs263[0.0]                           Hs263_0_0       none        108       245049            0
+1001082640             Hs264[0.0]                           Hs264_0_0       none        108       245980            0
+1001082650             Hs265[0.0]                           Hs265_0_0       none        108       246913            0
+1001082660             Hs266[0.0]                           Hs266_0_0       none        108       247845            0
+1001082670             Hs267[0.0]                           Hs267_0_0       none        108       248778            0
+1001082680             Hs268[0.0]                           Hs268_0_0       none        108       249709            0
+1001082690             Hs269[0.0]                           Hs269_0_0       none        108       250643            0
+1001082700             Hs270[0.0]                           Hs270_0_0       none        108       251575            0
+1001082710             Hs271[0.0]                           Hs271_0_0       none        108       252509            0
+1001082720             Hs272[0.0]                           Hs272_0_0       none        108       253442            0
+1001082730             Hs273[0.0]                           Hs273_0_0       none        108       254376            0
+1001092650             Mt265[0.0]                           Mt265_0_0       none        109       246918            0
+1001092660             Mt266[0.0]                           Mt266_0_0       none        109       247851            0
+1001092670             Mt267[0.0]                           Mt267_0_0       none        109       248782            0
+1001092680             Mt268[0.0]                           Mt268_0_0       none        109       249715            0
+1001092690             Mt269[0.0]                           Mt269_0_0       none        109       250647            0
+1001092700             Mt270[0.0]                           Mt270_0_0       none        109       251580            0
+1001092710             Mt271[0.0]                           Mt271_0_0       none        109       252512            0
+1001092720             Mt272[0.0]                           Mt272_0_0       none        109       253446            0
+1001092730             Mt273[0.0]                           Mt273_0_0       none        109       254378            0
+1001102670             Ds267[0.0]                           Ds267_0_0       none        110       248788            0
+1001102680             Ds268[0.0]                           Ds268_0_0       none        110       249719            0
+1001102690             Ds269[0.0]                           Ds269_0_0       none        110       250652            0
+1001102700             Ds270[0.0]                           Ds270_0_0       none        110       251583            0
+1001102710             Ds271[0.0]                           Ds271_0_0       none        110       252516            0
+1001102720             Ds272[0.0]                           Ds272_0_0       none        110       253448            0
+1001102730             Ds273[0.0]                           Ds273_0_0       none        110       254382            0

--- a/GlobalConstantsService/data/globalConstants_01.txt
+++ b/GlobalConstantsService/data/globalConstants_01.txt
@@ -4,6 +4,7 @@ int    physicsParams.verbosityLevel = 0;
 
 // Primary particle data table and the auxillary table.
 string particleDataTable.filename          = "Offline/GlobalConstantsService/data/particle.tbl";
+string particleDataList.filename          = "Offline/GlobalConstantsService/data/ParticleList.txt";
 string particleDataTable.auxillaryFilename = "Offline/GlobalConstantsService/data/mass_width_2008.mc";
 
 // Physical constants

--- a/GlobalConstantsService/inc/ParticleData.hh
+++ b/GlobalConstantsService/inc/ParticleData.hh
@@ -38,12 +38,7 @@ namespace mu2e {
     float mass() const { return _mass; }
     float lifetime() const { return _lifetime; }
 
-    void print( std::ostream& ostr=std::cout) const {
-      ostr << *this;
-    }
-
-    friend std::ostream& operator<<( std::ostream& output, 
-                                     const ParticleData& pd );
+    void print( std::ostream& ostr=std::cout) const;
 
   private:
     int _id;
@@ -54,6 +49,11 @@ namespace mu2e {
     float _lifetime;
 
   };  // ParticleData
+
+
+  std::ostream& operator<<( std::ostream& output, 
+                            const ParticleData& pd );
+
 
 } //end namespace mu2e
 

--- a/GlobalConstantsService/inc/ParticleData.hh
+++ b/GlobalConstantsService/inc/ParticleData.hh
@@ -1,0 +1,63 @@
+#ifndef GlobalConstantsService_ParticleData_hh
+#define GlobalConstantsService_ParticleData_hh
+//
+// Partcile data loaded from ParticleDataList
+//
+// the content is
+//  - PDG ID
+//  - displayname (includes special chars like +-*)
+//  - progamming name (includes only alphanumeric and _)
+//        this should be the same as  DataProducts/inc/PDGCode.hh
+//  - charge (units of electron charge)
+//  - mass (MeV)
+//  - lifetime (ns)
+//
+
+#include <iostream>
+#include <iomanip>
+
+#include "Offline/GlobalConstantsService/inc/ParticleData.hh"
+
+namespace mu2e {
+
+
+  class ParticleData {
+
+  public:
+
+    ParticleData(int id, const std::string& name, const std::string& codeName,
+                 float charge, float mass, float lifetime): 
+      _id(id),_name(name),_codeName(codeName),_charge(charge),
+      _mass(mass),_lifetime(lifetime) {}
+
+    int id() const { return _id; }
+    const std::string& name() const { return _name; }
+    const std::string& displayName() const { return _name; }
+    const std::string& codeName() const { return _codeName; }
+    float charge() const { return _charge; }
+    float mass() const { return _mass; }
+    float lifetime() const { return _lifetime; }
+
+    void print( std::ostream& ostr=std::cout) const {
+      ostr << std::setw(11) << _id;
+      ostr << std::setw(22) << _name;
+      ostr << std::setw(35) << _codeName;
+      ostr << std::setw(10) << _charge;
+      ostr << std::setw(12) << _mass;
+      ostr << std::setw(12) << _lifetime;
+      ostr << std::endl;
+    }
+
+  private:
+    int _id;
+    std::string _name;
+    std::string _codeName;
+    float _charge;
+    float _mass;
+    float _lifetime;
+
+  };  // ParticleData
+
+} //end namespace mu2e
+
+#endif /* GlobalConstantsService_ParticleData_hh */

--- a/GlobalConstantsService/inc/ParticleData.hh
+++ b/GlobalConstantsService/inc/ParticleData.hh
@@ -8,7 +8,7 @@
 //  - displayname (includes special chars like +-*)
 //  - progamming name (includes only alphanumeric and _)
 //        this should be the same as  DataProducts/inc/PDGCode.hh
-//  - charge (units of electron charge)
+//  - charge (units of proton charge)
 //  - mass (MeV)
 //  - lifetime (ns)
 //
@@ -39,14 +39,11 @@ namespace mu2e {
     float lifetime() const { return _lifetime; }
 
     void print( std::ostream& ostr=std::cout) const {
-      ostr << std::setw(11) << _id;
-      ostr << std::setw(22) << _name;
-      ostr << std::setw(35) << _codeName;
-      ostr << std::setw(10) << _charge;
-      ostr << std::setw(12) << _mass;
-      ostr << std::setw(12) << _lifetime;
-      ostr << std::endl;
+      ostr << *this;
     }
+
+    friend std::ostream& operator<<( std::ostream& output, 
+                                     const ParticleData& pd );
 
   private:
     int _id;

--- a/GlobalConstantsService/inc/ParticleDataList.hh
+++ b/GlobalConstantsService/inc/ParticleDataList.hh
@@ -1,0 +1,69 @@
+#ifndef GlobalConstantsService_ParticleDataList_hh
+#define GlobalConstantsService_ParticleDataList_hh
+//
+// A simple particle data list
+//
+// this list was created from 
+// - HepPDT list
+// - mass_width_2008.mc
+// - g4nuclei.tbl
+// - aspects of the geant particle list
+// - aspects of DataProducts/inc/PDGCode.hh
+//
+// Units are standard units: electron_charge, MeV, and ns
+//
+// the text file columns and accessors are
+//  1) PDG ID
+//  2) displayname (includes special chars like +-*)
+//  3) code name (includes only alphanumeric and _)
+//         this should be the same as  DataProducts/inc/PDGCode.hh
+//  4) alias - another common name that can be used to look up the particle
+//  5) charge (units of electron charge)
+//  6) mass (MeV)
+//  7) lifetime (ns)
+//
+
+
+#include <string>
+#include <iostream>
+#include <map>
+
+#include "Offline/Mu2eInterfaces/inc/ConditionsEntity.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleData.hh"
+
+namespace mu2e {
+
+  class SimpleConfig;
+
+  class ParticleDataList : virtual public ConditionsEntity{
+
+  public:
+
+    ParticleDataList( SimpleConfig const& config );
+
+    //lookup by PDG ID
+    const ParticleData& particle( int id ) const;
+    // lookup by name - the display name, code name or alias
+    const ParticleData& particle( std::string const& name ) const;
+
+    // the entire table as a map with pdgID as key
+    std::map<int,ParticleData> const& list() const { return _list;}
+    // the name lookup map with name as key and PDG id as mapped_type
+    std::map<std::string,int> const& names() const { return _names;}
+
+    void printTable( std::ostream& ostr=std::cout);
+
+  private:
+
+    // The actual particle data table.
+    // we add an entry if the particle id corresponds to a nonexistent nuclei
+    mutable std::map<int,ParticleData> _list;
+
+    // map for lookup by name
+    mutable std::map<std::string,int> _names;
+
+  };  // ParticleDataList
+
+} //end namespace mu2e
+
+#endif /* GlobalConstantsService_ParticleDataList_hh */

--- a/GlobalConstantsService/inc/ParticleDataList.hh
+++ b/GlobalConstantsService/inc/ParticleDataList.hh
@@ -10,7 +10,7 @@
 // - aspects of the geant particle list
 // - aspects of DataProducts/inc/PDGCode.hh
 //
-// Units are standard units: electron_charge, MeV, and ns
+// Units are standard units: proton_charge, MeV, and ns
 //
 // the text file columns and accessors are
 //  1) PDG ID
@@ -18,7 +18,7 @@
 //  3) code name (includes only alphanumeric and _)
 //         this should be the same as  DataProducts/inc/PDGCode.hh
 //  4) alias - another common name that can be used to look up the particle
-//  5) charge (units of electron charge)
+//  5) charge (units of proton charge)
 //  6) mass (MeV)
 //  7) lifetime (ns)
 //

--- a/GlobalConstantsService/src/GlobalConstantsService.cc
+++ b/GlobalConstantsService/src/GlobalConstantsService.cc
@@ -19,6 +19,7 @@
 
 #include "Offline/GlobalConstantsService/inc/ParticleDataTable.hh"
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 
 namespace mu2e {
 
@@ -50,7 +51,7 @@ namespace mu2e {
 
     makers_[typeid(mu2e::ParticleDataTable).name()] = &makeT<mu2e::ParticleDataTable>;
     makers_[typeid(mu2e::PhysicsParams).name()]     = &makeT<mu2e::PhysicsParams>;
-
+    makers_[typeid(mu2e::ParticleDataList).name()] = &makeT<mu2e::ParticleDataList>;
 
     //preloadAllEntities();
   }
@@ -98,6 +99,7 @@ namespace mu2e {
   // Explicitly instantiate getElement() for all types we handle rather than exposing all the code in the header.
   template const ParticleDataTable* GlobalConstantsService::getElement<ParticleDataTable>(const std::string&, const std::string&) const;
   template const PhysicsParams* GlobalConstantsService::getElement<PhysicsParams>(const std::string&, const std::string&) const;
+  template const ParticleDataList* GlobalConstantsService::getElement<ParticleDataList>(const std::string&, const std::string&) const;
 
   //================================================================
   void GlobalConstantsService::preloadAllEntities() {

--- a/GlobalConstantsService/src/ParticleData.cc
+++ b/GlobalConstantsService/src/ParticleData.cc
@@ -1,0 +1,18 @@
+
+#include "Offline/GlobalConstantsService/inc/ParticleData.hh"
+
+namespace mu2e {
+
+std::ostream& operator<<( std::ostream& output, 
+                          const ParticleData& pd ) {
+  output << std::setw(11) << pd._id;
+  output << std::setw(22) << pd._name;
+  output << std::setw(35) << pd._codeName;
+  output << std::setw(10) << pd._charge;
+  output << std::setw(12) << pd._mass;
+  output << std::setw(12) << pd._lifetime;
+  output << std::endl;
+  return output;            
+}
+
+}

--- a/GlobalConstantsService/src/ParticleData.cc
+++ b/GlobalConstantsService/src/ParticleData.cc
@@ -3,16 +3,19 @@
 
 namespace mu2e {
 
-std::ostream& operator<<( std::ostream& output, 
-                          const ParticleData& pd ) {
-  output << std::setw(11) << pd._id;
-  output << std::setw(22) << pd._name;
-  output << std::setw(35) << pd._codeName;
-  output << std::setw(10) << pd._charge;
-  output << std::setw(12) << pd._mass;
-  output << std::setw(12) << pd._lifetime;
-  output << std::endl;
-  return output;            
-}
+  std::ostream& operator<<(std::ostream& output, const ParticleData& pd) {
+    output << std::setw(11) << pd.id();
+    output << std::setw(22) << pd.name();
+    output << std::setw(35) << pd.codeName();
+    output << std::setw(10) << pd.charge();
+    output << std::setw(12) << pd.mass();
+    output << std::setw(12) << pd.lifetime();
+    output << std::endl;
+    return output;
+  }
 
-}
+  void ParticleData::print(std::ostream& ostr) const { 
+    ostr << *this; 
+  }
+
+} // namespace mu2e

--- a/GlobalConstantsService/src/ParticleDataList.cc
+++ b/GlobalConstantsService/src/ParticleDataList.cc
@@ -20,8 +20,7 @@ namespace mu2e {
     ConfigFileLookupPolicy findConfig;
     
     std::string tableFilename = findConfig(
-                    config.getString("particleDataList.filename",
-                   "Offline/GlobalConstantsService/data/ParticleList.txt") );
+                    config.getString("particleDataList.filename") );
     if( tableFilename.empty() ) {
       throw cet::exception("PARTICLELIST_NO_FILE") 
         << "ParticleDataList: file name not found\n";
@@ -34,25 +33,28 @@ namespace mu2e {
           << tableFilename << "\n";
     }
 
+    // input text file words on a row
+    constexpr int nWords = 7;
+
     std::string line;
     std::string str;
-    std::vector<std::string> words;
+    std::vector<std::string> words(nWords);
     while ( std::getline(in,line) ) {
       std::istringstream iss(line);
       while (iss >> str) {
         words.emplace_back(str);
       }
-      if ( words.size() != 7 ) {
+      if ( words.size() != nWords ) {
         throw cet::exception("PARTICLELIST_BAD_LINE")
-          << "ParticleList: Not 7 words on line: "
+          << "ParticleList: Not " << nWords << " words on line: "
           << line << "\n";
       }
       int id = std::stoi(words[0]);
       _list.try_emplace(id, id, words[1], words[2], 
          std::stof(words[4]), std::stof(words[5]), std::stof(words[6]) );
       _names.try_emplace(words[1],id);
-      if( words[2] != "none" ) _names.emplace(words[2],id);
-      if( words[3] != "none" ) _names.emplace(words[3],id);
+      if( words[2] != "none" ) _names.try_emplace(words[2],id);
+      if( words[3] != "none" ) _names.try_emplace(words[3],id);
       words.clear();
     }
 

--- a/GlobalConstantsService/src/ParticleDataList.cc
+++ b/GlobalConstantsService/src/ParticleDataList.cc
@@ -34,11 +34,13 @@ namespace mu2e {
     }
 
     // input text file words on a row
-    constexpr int nWords = 7;
+    constexpr size_t nWords = 7;
 
     std::string line;
     std::string str;
-    std::vector<std::string> words(nWords);
+    std::vector<std::string> words;
+    words.reserve(nWords);
+
     while ( std::getline(in,line) ) {
       std::istringstream iss(line);
       while (iss >> str) {

--- a/GlobalConstantsService/src/ParticleDataList.cc
+++ b/GlobalConstantsService/src/ParticleDataList.cc
@@ -1,0 +1,121 @@
+
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+
+#include "cetlib_except/exception.h"
+
+#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+#include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
+#include "Offline/ConfigTools/inc/SimpleConfig.hh"
+#include "Offline/DataProducts/inc/PDGCode.hh"
+
+
+namespace mu2e {
+
+  // *************************************************************
+
+  ParticleDataList::ParticleDataList( SimpleConfig const& config ) {
+
+    ConfigFileLookupPolicy findConfig;
+    
+    std::string tableFilename = findConfig(
+                    config.getString("particleDataList.filename",
+                   "Offline/GlobalConstantsService/data/ParticleList.txt") );
+    if( tableFilename.empty() ) {
+      throw cet::exception("PARTICLELIST_NO_FILE") 
+        << "ParticleDataList: file name not found\n";
+    }
+
+    std::ifstream in(tableFilename.c_str());
+    if ( !in ) {
+      throw cet::exception("PARTICLELIST_OPEN_FAIL")
+          << "Unable to open particle data file: "
+          << tableFilename << "\n";
+    }
+
+    std::string line;
+    std::string str;
+    std::vector<std::string> words;
+    while ( std::getline(in,line) ) {
+      std::istringstream iss(line);
+      while (iss >> str) {
+        words.emplace_back(str);
+      }
+      if ( words.size() != 7 ) {
+        throw cet::exception("PARTICLELIST_BAD_LINE")
+          << "ParticleList: Not 7 words on line: "
+          << line << "\n";
+      }
+      int id = std::stoi(words[0]);
+      _list.try_emplace(id, id, words[1], words[2], 
+         std::stof(words[4]), std::stof(words[5]), std::stof(words[6]) );
+      _names.try_emplace(words[1],id);
+      if( words[2] != "none" ) _names.emplace(words[2],id);
+      if( words[3] != "none" ) _names.emplace(words[3],id);
+      words.clear();
+    }
+
+
+  }
+
+  // *************************************************************
+
+  const ParticleData& ParticleDataList::particle( int id ) const {
+
+    auto it = _list.find(id);
+    if( it != _list.end() ) {
+      return it->second;
+    }
+
+    if ( id <= PDGCode::G4Threshold ){    
+      throw cet::exception("PARTICLELIST_BAD_ID")
+        << "ParticleList: Failed to look up id: "
+        << id << "\n";
+    }
+
+    // this is a unknown geant nucleus, add it to the list
+
+    int pA = (std::abs(id)/10)%1000;
+    int pZ = (std::abs(id)/10000)%1000;
+
+    // the nuclear excitation level
+    int exc = id%10;
+    float protonMass = particle(PDGCode::p_plus).mass();
+    float mass = (pA+exc)*protonMass;
+
+    std::ostringstream pName;
+    pName << "Mu2e_" << id;
+    std::string name = pName.str();
+
+    _list.try_emplace(id,id, name, name, float(pZ), mass, 0.0);
+
+    return _list.at(id);
+    
+  }
+
+  // *************************************************************
+
+  const ParticleData& ParticleDataList::particle( 
+                                    const std::string& name ) const {
+    auto it = _names.find(name);
+    if( it == _names.end() ) {
+      throw cet::exception("PARTICLELIST_BAD_NAME")
+        << "ParticleList: Failed to look up name: "
+        << name << "\n";
+    }
+    return particle(it->second);
+    
+  }
+
+  // *************************************************************
+
+  void ParticleDataList::printTable( std::ostream& ostr) {
+
+    for(auto const& pp: _list) {
+      auto const& p = pp.second;
+      p.print(ostr);
+    }
+  }
+
+}  // end namespace mu2e


### PR DESCRIPTION
- The previous code read from 3 tables, combined and modfied data.  This code simply captured the output of that process as the basis of the new table.
- mass is in MeV, lifetime is in ns (was MeV, ks)
- Rob needs to update doc 1120
- there were HepPDT names, geant names and PDGCode.hh names, this list uses primarily geant names and adds the concept of "code names" which don't contain any special characters so they can be used in code
- once this service passes review, we will migrate the use cases from the old service to the new service and then remove the old
