### PR TITLE
Poly cone fix

### DIFF
--- a/GeometryService/src/MBSMaker.cc
+++ b/GeometryService/src/MBSMaker.cc
@@ -262,7 +262,7 @@ namespace mu2e {
                       _CLV2MaterialName));
       
     } else if ( _MBSVersion >= 2 ) {
-      
+
       mbs._zMax = _MBSCZ+_BSTSZ+_BSTSHLength;
       mbs._rMax = _SPBSCOuterRadius;
       //mbs._rMin = *std::min_element(_CLV2InnerRadii.begin(), _CLV2InnerRadii.end());
@@ -335,7 +335,11 @@ namespace mu2e {
 	BSTSInRads.push_back(_BSTSInnRadii[iSeg]);
 	BSTSOutRads.push_back(_BSTSOutRadii[iSeg]);
 	zpos += _BSTSZLengths[iSeg];
-	BSTSPlanes.push_back(zpos - _BSTSHLength + _BSTSZ);
+
+        // Fixme: ensure that zplanes in the BSTS polycone are not coincident.
+        const double epsilon = (iSeg<_BSTSZLengths.size()-1 )? 0.1 : 0.0;
+
+	BSTSPlanes.push_back(zpos - _BSTSHLength + _BSTSZ - epsilon);
 	BSTSInRads.push_back(_BSTSInnRadii[iSeg]);
 	BSTSOutRads.push_back(_BSTSOutRadii[iSeg]);
       }
@@ -407,7 +411,11 @@ namespace mu2e {
 	BSTCCornersInnRadii.push_back(_BSTCInnerRadii.at(isurf));
 	BSTCCornersOutRadii.push_back(_BSTCOuterRadii.at(isurf));
 	tmpBSTCPntZ+=_BSTCLengths.at(isurf);
-	BSTCCornersZ.push_back(tmpBSTCPntZ);
+
+        // Fixme: ensure that zplanes in the BSTC polycone are not coincident.
+        const double epsilon = (isurf<nBSTCSurfs-1 )? 0.1 : 0.0;
+
+	BSTCCornersZ.push_back(tmpBSTCPntZ-epsilon);
 	BSTCCornersInnRadii.push_back(_BSTCInnerRadii.at(isurf));
 	BSTCCornersOutRadii.push_back(_BSTCOuterRadii.at(isurf));
       }

--- a/GeometryService/src/MBSMaker.cc
+++ b/GeometryService/src/MBSMaker.cc
@@ -331,15 +331,17 @@ namespace mu2e {
 
       double zpos = 0.0;
       for ( unsigned int iSeg = 0; iSeg < _BSTSZLengths.size(); iSeg++ ) {
-	BSTSPlanes.push_back(zpos - _BSTSHLength + _BSTSZ);
+
+        // Fixme: ensure that zplanes in the BSTS polycone are not coincident.
+        // Be sure to stay inside the MBS mother.
+        const double epsilon = (iSeg>0 )? 0.1 : 0.0;
+
+	BSTSPlanes.push_back(zpos - _BSTSHLength + _BSTSZ + epsilon);
 	BSTSInRads.push_back(_BSTSInnRadii[iSeg]);
 	BSTSOutRads.push_back(_BSTSOutRadii[iSeg]);
 	zpos += _BSTSZLengths[iSeg];
 
-        // Fixme: ensure that zplanes in the BSTS polycone are not coincident.
-        const double epsilon = (iSeg<_BSTSZLengths.size()-1 )? 0.1 : 0.0;
-
-	BSTSPlanes.push_back(zpos - _BSTSHLength + _BSTSZ - epsilon);
+	BSTSPlanes.push_back(zpos - _BSTSHLength + _BSTSZ);
 	BSTSInRads.push_back(_BSTSInnRadii[iSeg]);
 	BSTSOutRads.push_back(_BSTSOutRadii[iSeg]);
       }
@@ -407,15 +409,17 @@ namespace mu2e {
       }
       double tmpBSTCPntZ=/*_BSTCZ*/-0.5*BSTCtotLength;
       for (std::size_t isurf=0; isurf<nBSTCSurfs; ++isurf) {
-	BSTCCornersZ.push_back(tmpBSTCPntZ);
+
+        // Fixme: ensure that zplanes in the BSTC polycone are not coincident.
+        // No overlap issues here.
+        const double epsilon = (isurf>0 )? 0.1 : 0.0;
+
+	BSTCCornersZ.push_back(tmpBSTCPntZ+epsilon);
 	BSTCCornersInnRadii.push_back(_BSTCInnerRadii.at(isurf));
 	BSTCCornersOutRadii.push_back(_BSTCOuterRadii.at(isurf));
 	tmpBSTCPntZ+=_BSTCLengths.at(isurf);
 
-        // Fixme: ensure that zplanes in the BSTC polycone are not coincident.
-        const double epsilon = (isurf<nBSTCSurfs-1 )? 0.1 : 0.0;
-
-	BSTCCornersZ.push_back(tmpBSTCPntZ-epsilon);
+	BSTCCornersZ.push_back(tmpBSTCPntZ);
 	BSTCCornersInnRadii.push_back(_BSTCInnerRadii.at(isurf));
 	BSTCCornersOutRadii.push_back(_BSTCOuterRadii.at(isurf));
       }

--- a/Mu2eG4/geom/PSShield_v06.txt
+++ b/Mu2eG4/geom/PSShield_v06.txt
@@ -36,7 +36,7 @@ vector<double> PSShield.color4 = { 0.1, 0.1, 0.1};
 vector<double> PSShield.r5 = { 736.6, 736.6, 736.6, 736.6, 736.6 };
 
 // The endRings for the HRS.  
-vector<double> PSShield.frontRing.zPlane = { 1023.5 ,1074.2, 1074.2, 1083.7, 1086.8, 1086.8, 1120.0, 1120.0, 1124.0, 1124.0, 1150.0, 1210.0 };
+vector<double> PSShield.frontRing.zPlane = { 1023.5 ,1074.2, 1074.3, 1083.7, 1086.8, 1086.8, 1120.0, 1120.0, 1124.0, 1124.0, 1150.0, 1210.0 };
 vector<double> PSShield.frontRing.rIn =    { 719.9, 700.9, 700.9, 697.36, 696.2, 696.2, 683.75, 683.75, 682.25, 682.25, 672.5, 650.0 };
 vector<double> PSShield.frontRing.rOut =   { 750.0, 750.0, 750., 750., 746.3, 736.6, 736.6, 723.5, 723.5, 709., 700.0, 700.0 }; 
 string PSShield.frontRing.material = "StainlessSteel";

--- a/Mu2eG4/src/constructExtMonFNALBuilding.cc
+++ b/Mu2eG4/src/constructExtMonFNALBuilding.cc
@@ -100,7 +100,10 @@ namespace mu2e {
                                            std::pow(boxdz * abs(tan(collimator.angleH())) + dr/abs(cos(collimator.angleH())), 2)
                                            );
 
-    double zPlane[] = {-cylHalfLength, -0.5*collimator.radiusTransitiondZ(), +0.5*collimator.radiusTransitiondZ(), +cylHalfLength };
+    // Fixme: protect against two planes at the same value of z.
+    double const epsilon= ( collimator.radiusTransitiondZ() == 0. ) ? 0.1 : 0.;
+
+    double zPlane[] = {-cylHalfLength, -0.5*collimator.radiusTransitiondZ()-epsilon, +0.5*collimator.radiusTransitiondZ()+epsilon, +cylHalfLength };
     double rzero[] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 
     //----------------------------------------------------------------
@@ -205,6 +208,7 @@ namespace mu2e {
     VolumeInfo channel(collimator.name()+"Channel",
                        CLHEP::Hep3Vector(0,0,0),
                        alignmentHole.centerInWorld);
+
 
     channel.solid = new G4IntersectionSolid(channel.name,
                                             parent.solid,


### PR DESCRIPTION
In the following I ask the reviewers to approve if the fixes to the code are good enough for now.  If they prefer a better solution for the longer term, I prefer that they submit a separate PR to address it.

For some time now the gdml file generated by the head of Offline has broken both the TEve and REve based event displays.  The issue is the following: we have several polycones in our geometry in which two planes have identical values for all three of (z, rmin and rmax).   The G4 experts tell me that this silently produces undefined behaviour in G4.  The ROOT graphics experts tell me that having two identical planes in a poly cone is illegal.

For the event displays we produce a gdml file from our G4 geometry and then read it into a TGeometry object.  There are errors when reading the gdml file into the TGeometry.   In a TEve or REve based event display the job crashes.  If I read the gdml file in a standalone module that does nothing else, I see printed error messages about the identical planes.  The error message mentions 4 polycones, given below along with the person I believe is responsible for that section of the geometry
 
 collimator1channel   ( Andrei )
 BSTS                         ( Dave (Kentucky) )
 BSTC                         ( Dave (Kentucky) )
 PSShieldEndRing1   ( Dave (Kentucky) )

I wrote code to walk the G4SolidStore and identify all G4PolyCones that have this problem.  There are only the four illegal polycones, the four mentioned above.  In a separate PR I will add this code to Offline .

The Root and G4 people say that it is OK if two planes have the same value of z so long as at least one of rmin or rmax changes.

I have verified that the standalone test works with a gdml file made from this geometry (no  printed warnings) and that the TEve event display works with this geometry.  The TEve event display seg faulted on exit; I don't know if that is related to this and I have informed Sophie.

After my changes, the root overlap check passes and the G4 surface check passed with 6 different random numbers.

