### PR TITLE
Check Geometry

### DIFF
--- a/Mu2eG4/inc/validGeometryOrThrow.hh
+++ b/Mu2eG4/inc/validGeometryOrThrow.hh
@@ -1,0 +1,15 @@
+#ifndef Mu2eG4_validGeometryOrThrow_hh
+#define Mu2eG4_validGeometryOrThrow_hh
+//
+// Called after the G4 geometry has been instantiated.
+// Inspect the stores of the geometry objects to check for a valid geometry.
+// If the geometry is invalid, throw an exception.
+//
+// Original author Rob Kutschke
+//
+
+namespace mu2e {
+  void validGeometryOrThrow ( int printLevel );
+}
+
+#endif /* Mu2eG4_validGeometryOrThrow_hh */

--- a/Mu2eG4/inc/validPolyCones.hh
+++ b/Mu2eG4/inc/validPolyCones.hh
@@ -1,0 +1,19 @@
+#ifndef Mu2eG4_validPolyCones_hh
+#define Mu2eG4_validPolyCones_hh
+//
+// Called after the G4 geometry has been instantiated.
+// Check all PolyCones in the G4SolidStore.
+//   - Return true if the Polycone geometry is valid.
+//   - Return false if any PolyCone has an invalid geometry
+//
+// Conditions checked for:
+//  1) The geometry is invalid if any two planes have identical ( z, rmin, rmax).
+//
+// Original author Rob Kutschke
+//
+
+namespace mu2e {
+  bool validPolyCones ( int printLevel );
+}
+
+#endif /* Mu2eG4_validPolyCones_hh */

--- a/Mu2eG4/src/Mu2eG4MT_module.cc
+++ b/Mu2eG4/src/Mu2eG4MT_module.cc
@@ -24,6 +24,7 @@
 #include "Offline/Mu2eG4/inc/Mu2eG4IOConfigHelper.hh"
 #include "Offline/Mu2eG4/inc/writePhysicalVolumes.hh"
 #include "Offline/Mu2eG4/inc/Mu2eG4MTRunManager.hh"
+#include "Offline/Mu2eG4/inc/validGeometryOrThrow.hh"
 
 // Data products that will be produced by this module.
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
@@ -212,8 +213,12 @@ namespace mu2e {
       }
     }
 
-    if ( ncalls == 1 && _exportPDTStart) {
-      exportG4PDT( "Start:" );//once per job
+    // Some end-of-begin run things that need to be done only once per job.
+    if ( ncalls == 1 ){
+      validGeometryOrThrow( _rmvlevel );
+      if ( _exportPDTStart) {
+        exportG4PDT( "Start:" );
+      }
     }
 
   }//Mu2eG4MT::beginRun

--- a/Mu2eG4/src/Mu2eG4_module.cc
+++ b/Mu2eG4/src/Mu2eG4_module.cc
@@ -36,6 +36,7 @@
 #include "Offline/Mu2eG4/inc/Mu2eG4PerThreadStorage.hh"
 #include "Offline/Mu2eG4/inc/Mu2eG4Config.hh"
 #include "Offline/Mu2eG4/inc/Mu2eG4IOConfigHelper.hh"
+#include "Offline/Mu2eG4/inc/validGeometryOrThrow.hh"
 #include "Offline/Mu2eG4/inc/writePhysicalVolumes.hh"
 #if ( defined G4VIS_USE_OPENGLX || defined G4VIS_USE_OPENGL || defined G4VIS_USE_OPENGLQT )
 #include "Offline/Mu2eG4/inc/Mu2eG4VisCommands.hh"
@@ -267,7 +268,9 @@ namespace mu2e {
     if ( ncalls == 1 ) {
       if( _checkFieldMap>0 ) generateFieldMap(_originInWorld,_checkFieldMap);
       if ( _exportPDTStart ) exportG4PDT( "Start:" );//once per job
+      validGeometryOrThrow( _rmvlevel );
     }
+
   }
 
 

--- a/Mu2eG4/src/validGeometryOrThrow.cc
+++ b/Mu2eG4/src/validGeometryOrThrow.cc
@@ -1,0 +1,22 @@
+//
+// Master function for checking for a valid geometry.
+//
+#include "Offline/Mu2eG4/inc/validGeometryOrThrow.hh"
+#include "Offline/Mu2eG4/inc/validPolyCones.hh"
+
+#include "cetlib_except/exception.h"
+
+
+void mu2e::validGeometryOrThrow( int printLevel ){
+
+  // Calls to individual tests; add more here as needed.
+  bool pConesOK = validPolyCones( printLevel );
+
+  // Throw an exception if any test fails.
+  // Put detailed printout in the indvidual test functions.
+  if ( !pConesOK ){
+    throw cet::exception("GEOM")
+      << "Mu2eG4::validGeometryOrThrow Error: inconsistent geometry\n";
+  }
+
+}

--- a/Mu2eG4/src/validPolyCones.cc
+++ b/Mu2eG4/src/validPolyCones.cc
@@ -1,0 +1,100 @@
+//
+// Check all PolyCones in the G4SolidStore for a valid geometry.
+//
+#include "Offline/Mu2eG4/inc/validPolyCones.hh"
+
+#include "Geant4/G4Polycone.hh"
+#include "Geant4/G4SolidStore.hh"
+#include "Geant4/G4VSolid.hh"
+
+#include <set>
+
+namespace {
+
+  //  Helper class that represents one plane of a polycone
+  struct pConePlane {
+
+    // Parameters of one plane
+    double z;
+    double rmin;
+    double rmax;
+
+    pConePlane( double az, double armin, double armax):
+      z(az), rmin(armin), rmax(armax){
+    }
+
+    // Operators needed for use with std::set and std::map
+    bool operator==(pConePlane const& a) const{
+      return ( z==a.z && rmin==a.rmin && rmax==a.rmax);
+    }
+
+    bool operator<(pConePlane const& a) const{
+      if ( z    < a.z    ) return true;
+      if ( rmin < a.rmin ) return true;
+      if ( rmax < a.rmax ) return true;
+      return false;
+    }
+  };
+
+}
+
+bool mu2e::validPolyCones( int printLevel ){
+
+  // Return value defaults to the geometry being valid.
+  bool retval=true;
+
+  G4SolidStore* sstore = G4SolidStore::GetInstance();
+  if ( printLevel >  0 ){
+    G4cout << "Physical volume store size: " << sstore->size() << G4endl;
+  }
+
+  for ( auto i=sstore->begin(); i!=sstore->end(); ++i){
+
+    G4VSolid* vsolid = *i;
+
+    if ( vsolid->GetEntityType() != "G4Polycone" ){
+      continue;
+    }
+
+    // Extract parameters from polycone
+    G4Polycone const* tmp = static_cast<G4Polycone const *>(vsolid);
+    G4PolyconeHistorical const* pcon = tmp->GetOriginalParameters();
+    double* z    = pcon->Z_values;
+    double* rmin = pcon->Rmin;
+    double* rmax = pcon->Rmax;
+
+    // Count the number of unique planes in this polycone.
+    std::set<pConePlane> uniquePlanes;
+    for ( int i=0; i<pcon->Num_z_planes; ++i ){
+      uniquePlanes.emplace(z[i], rmin[i], rmax[i] );
+    }
+
+    if ( printLevel > 1 ) {
+      G4cout << "Polycone: "
+           << vsolid->GetName() << " "
+           << vsolid->GetEntityType() << " "
+           << pcon->Num_z_planes << " "
+           << uniquePlanes.size()
+           << G4endl;
+    }
+
+    // This polycone is invalid; it has at least two identical planes.
+    if ( int(uniquePlanes.size()) != pcon->Num_z_planes ){
+      retval = false;
+      G4cout << "\nError: Polycone has identical planes.  Name of polycone:  " << vsolid->GetName() << G4endl;
+      G4cout << "Number of planes: " << pcon->Num_z_planes << "   Number of unique planes: " << uniquePlanes.size() << G4endl;
+      G4cout << "Polycone planes ( plane number, z, rmin, rmax): " << G4endl;
+      for ( int i=0; i<pcon->Num_z_planes; ++i ){
+        G4cout << "  "    << i
+             << " z: "    << z[i]
+             << " rmin: " << rmin[i]
+             << " rmax: " << rmax[i]
+             << G4endl;
+      }
+    }
+
+  } // end loop over G4SolidStore
+
+  G4cout << "Retval: " << retval << G4endl;
+  return retval;
+}

--- a/Mu2eG4/src/validPolyCones.cc
+++ b/Mu2eG4/src/validPolyCones.cc
@@ -95,6 +95,5 @@ bool mu2e::validPolyCones( int printLevel ){
 
   } // end loop over G4SolidStore
 
-  G4cout << "Retval: " << retval << G4endl;
   return retval;
 }


### PR DESCRIPTION
Create an infrastructure to do validity checks on the G4 geometry after the geometry has been created.  

Added the first check: Mu2eG4/src/validPolyCones.cc .  This checks all polycones in the G4SolidStore and issues an error if any two planes in one polycone have identical values of (z,rmin,rmax).  This will catch problems of the type that were fixed in PR #678 .

This PR has to be tested with PR #678 and cannot be merged until #678  has been merged.