### PR TITLE
Fix bug in the registration of Logical Volume Sensitive Detectors

### DIFF
--- a/Mu2eG4/src/SensitiveDetectorHelper.cc
+++ b/Mu2eG4/src/SensitiveDetectorHelper.cc
@@ -137,9 +137,9 @@ namespace mu2e {
     art::ServiceHandle<Mu2eG4Helper> helper;
 
     for(auto& iter : lvsd_) {
-      iter.second.sensitiveDetector = new Mu2eG4SensitiveDetector(iter.first, config);
-      SDman->AddNewDetector(iter.second.sensitiveDetector);
-      helper->locateVolInfo(iter.first).logical->SetSensitiveDetector(iter.second.sensitiveDetector);
+      auto sd = new Mu2eG4SensitiveDetector(iter.first, config);
+      SDman->AddNewDetector(sd);
+      helper->locateVolInfo(iter.first).logical->SetSensitiveDetector(sd);
     }
   }
 
@@ -149,6 +149,8 @@ namespace mu2e {
   void SensitiveDetectorHelper::registerSensitiveDetectors(){
     G4SDManager* sdManager = G4SDManager::GetSDMpointer();
 
+    const bool printWarnings = (verbosityLevel_ > -1) ? true : false;
+
     for ( InstanceMap::iterator i=stepInstances_.begin();
           i != stepInstances_.end(); ++i ) {
       StepInstance& step(i->second);
@@ -156,7 +158,6 @@ namespace mu2e {
         std::cout << __func__ << " looking for sd with name: "
                   << step.stepName << std::endl;
             }
-      bool printWarnings = (verbosityLevel_ > -1) ? true : false;
       step.sensitiveDetector =
         dynamic_cast<Mu2eG4SensitiveDetector*>(sdManager->FindSensitiveDetector(step.stepName.c_str(),printWarnings));
     }
@@ -165,6 +166,17 @@ namespace mu2e {
       dynamic_cast<ExtMonFNALPixelSD*>(sdManager->
                                        FindSensitiveDetector(SensitiveDetectorName::ExtMonFNAL()))
       : nullptr;
+
+    // Logical volume SDs, it any.
+    for ( auto& i : lvsd_ ){
+      StepInstance& step(i.second);
+      if (verbosityLevel_ > 0 ) {
+        std::cout << __func__ << " looking for lvsd with name: "
+                  << step.stepName << "   " << this << std::endl;
+      }
+       step.sensitiveDetector =
+         dynamic_cast<Mu2eG4SensitiveDetector*>(sdManager->FindSensitiveDetector(step.stepName.c_str(),printWarnings));
+    }
 
   }
 


### PR DESCRIPTION
Logical Volume Sensitive Detectors (LVSD) have never worked correctly in MT mode.  This commit fixes the immediate problem but the code remains fragile.  Issue #690 in the Offline GitHub issue tracker has been created to remove the fragility.

The immediate problem is that in MT mode there are many SensitiveDetectorHelper objects and the member function:

   void SensitiveDetectorHelper::instantiateLVSDs(const SimpleConfig& config);

correctly instantiates the objects but stores the pointers in the wrong SensitiveDetectorHelper object.  They are stored in the instance that lives in the Mu2eG4MTRunManager object, not in the object that lives in the appropriate Mu2eG4WorkerRunManager instance.

The solution is to leave the instantation as is but to move the storage of pointers into:

  void SensitiveDetectorHelper::registerSensitiveDetectors();

which is called at the right time using the right SensitiveDetectorHelper instance.

As part of the fix I made it manifest that instantiateLVSDs does not register any pointers; I also  moved an invariant computation out of a loop.
