### PR TITLE
protect against empty select statement

### DIFF
--- a/DbService/src/DbReader.cc
+++ b/DbService/src/DbReader.cc
@@ -265,8 +265,10 @@ int mu2e::DbReader::queryCore(std::string& csv,
   url.append("dbname="+_id.name());
   url.append("&t=");
   url.append(table);
-  url.append("&c=");
-  url.append(select);
+  if(!select.empty()) {
+    url.append("&c=");
+    url.append(select);
+  }
   for(auto const& ww : where) {
     url.append("&w="+ww);
   }


### PR DESCRIPTION
present, but empty, select clause leads to incorrect results.  Recent dqm work was the first test of this case..