### PR TITLE
Making the code compatible with Geant4 v11

### DIFF
--- a/MCDataProducts/inc/ProcessCode.hh
+++ b/MCDataProducts/inc/ProcessCode.hh
@@ -87,7 +87,7 @@ namespace mu2e {
       mu2eExternalRMC,         mu2eFlateMinus,      mu2eFlatePlus, mu2eFlatPhoton, // 175
       mu2eCePlusLeadingLog, mu2ePionCaptureAtRest, mu2eExternalRPC, mu2eInternalRPC, 
       mu2eunused5, mu2eunused6, mu2eunused7, mu2eunused8, 
-      uninitialized,
+      uninitialized, NoProcess,
       lastEnum,
       // An alias for backward compatibility
       mu2eHallAir = mu2eKillerVolume
@@ -143,7 +143,7 @@ namespace mu2e {
     "mu2eExternalRMC",  "mu2eFlateMinus",      "mu2eFlatePlus", "mu2eFlatPhoton", \
     "mu2eCePlusLeadingLog", "mu2ePionCaptureAtRest", "mu2eExternalRPC", "mu2eInternalRPC", \
     "mu2eunused5", "mu2eunused6", "mu2eunused7", "mu2eunused8", \
-    "uninitialized"
+    "uninitialized", "NoProcess"
 #endif
 
   public:

--- a/Mu2eG4/inc/PhysicsProcessInfo.hh
+++ b/Mu2eG4/inc/PhysicsProcessInfo.hh
@@ -35,7 +35,11 @@ namespace mu2e {
     // Locate a process by its name, return the corresponding process code and
     // increment the counter.
     ProcessCode findAndCount( G4String const& name );
-      
+
+    // helper function to insert process and add particle name to ProcInfo;
+    // return non zero if process is unknown
+
+    int insertIfNotFound( G4String const& processName, G4String const& particleName );
     void printAll ( std::ostream& os) const;
     void printSummary ( std::ostream& os) const;
 
@@ -69,4 +73,3 @@ namespace mu2e {
 } // end namespace mu2e
 
 #endif /* Mu2eG4_PhysicsProcessInfo_hh */
-

--- a/Mu2eG4/src/ConstructMaterials.cc
+++ b/Mu2eG4/src/ConstructMaterials.cc
@@ -917,7 +917,7 @@ namespace mu2e {
                        kStateGas, temperature, pressure);
 
       for (size_t i = 0 ; i < StrawLeak->GetNumberOfElements(); ++i) {
-        DSVacuum->AddElement(StrawLeak->GetElementVector()->at(i), StrawLeak->GetFractionVector()[i]);
+        DSVacuum->AddElement(const_cast<G4Element*>(StrawLeak->GetElementVector()->at(i)), StrawLeak->GetFractionVector()[i]);
       }
 
     }
@@ -943,7 +943,7 @@ namespace mu2e {
                        kStateGas, temperature, pressure);
 
       for (size_t i = 0 ; i < gas->GetNumberOfElements(); ++i) {
-        PSVacuum->AddElement(gas->GetElementVector()->at(i), gas->GetFractionVector()[i]);
+        PSVacuum->AddElement(const_cast<G4Element*>(gas->GetElementVector()->at(i)), gas->GetFractionVector()[i]);
       }
 
     }

--- a/Mu2eG4/src/Mu2eG4MinDEDXPhysicsConstructor.cc
+++ b/Mu2eG4/src/Mu2eG4MinDEDXPhysicsConstructor.cc
@@ -62,7 +62,6 @@
 
 #include "Geant4/G4hIonisation.hh"
 #include "Geant4/G4ionIonisation.hh"
-#include "Geant4/G4alphaIonisation.hh"
 
 #include "Geant4/G4Gamma.hh"
 #include "Geant4/G4Electron.hh"

--- a/Mu2eG4/src/Mu2eG4TrackingAction.cc
+++ b/Mu2eG4/src/Mu2eG4TrackingAction.cc
@@ -429,8 +429,7 @@ namespace mu2e {
              << ", " << pG4Ion->GetIsomerLevel()
              << ", " << flbi
         //   << ", " << static_cast<G4int>(pG4Ion->GetFloatLevelBase())
-             << ", " << G4String(G4Ions::FloatLevelBaseChar(G4Ions::FloatLevelBase(flbi)))
-        //   << ", " << G4String(G4Ions::FloatLevelBaseChar(pG4Ion->GetFloatLevelBase()))
+             << ", " << std::string(1,G4Ions::FloatLevelBaseChar(G4Ions::FloatLevelBase(flbi)))
              << G4endl;
       Mu2eG4UserHelpers::printTrackInfo( trk, " Ion:          ", _transientMap,
                                          _timer, _mu2eOrigin);
@@ -651,7 +650,7 @@ namespace mu2e {
                << " with excitaion energy: "
                << pG4Ion->GetExcitationEnergy()
                << " with float level base: "
-               << G4String(G4Ions::FloatLevelBaseChar(G4Ions::FloatLevelBase(flbi))) << " " << flbi
+               << std::string(1,G4Ions::FloatLevelBaseChar(G4Ions::FloatLevelBase(flbi))) << " " << flbi
                << G4endl;
       }
       G4cout.precision(prec);

--- a/Mu2eG4/src/SConscript
+++ b/Mu2eG4/src/SConscript
@@ -178,7 +178,6 @@ G4GLOBALIBS = [
               'libG4track',
               'libG4tracking',
               'libG4visHepRep',
-              'libG4visXXX',
               'libG4vis_management',
               'libG4zlib'
               ]


### PR DESCRIPTION
This pull request makes changes enabling the use of Geant4 v11.0 while preserving compatibility with the current,
10.7, version of Geant4

Changes in the first commit add a newly introduced process name "NoProcess" which was added for accounting 
purposes and is not assigned to any of Geant4 particle process managers, but is used to acknowledge, that
in certain situations, no process has acted, therefore we need to add it to all particles here.
While adding it in PhysicsProcessInfo the class was refactored, which was long overdue.
While refactoring a small logic error was corrected. It will result in more particles to be added to the ProcInfo in it,
but it seems that that information was not relied upon, so it will likely not change any of the current results.
Two of the following commits remove obsolete entities, and another one adapts the code to the Geant4 code evolution, 
neither of which should result in any change of functionality.
