### PR TITLE
fixed issue: https://github.com/art-framework-suite/art/issues/112

### DIFF
--- a/Mu2eG4/inc/MTMasterThread.hh
+++ b/Mu2eG4/inc/MTMasterThread.hh
@@ -36,7 +36,6 @@ namespace mu2e {
 
     void beginRun() const;
     void endRun() const;
-    void stopThread();
     void storeRunNumber(int art_runnumber);
     void readRunData(PhysicalVolumeHelper* phys_vol_help) const;
 
@@ -65,6 +64,10 @@ namespace mu2e {
     mutable bool m_stopped;
 
     int run_number;
+
+    void storeCleanUp();
+    void stopThread();
+
 
   };
 

--- a/Mu2eG4/inc/Mu2eG4ActionInitialization.hh
+++ b/Mu2eG4/inc/Mu2eG4ActionInitialization.hh
@@ -64,9 +64,9 @@ namespace mu2e {
 
     std::vector<double> timeVDtimes_;
 
-    SensitiveDetectorHelper* sensitiveDetectorHelper_;
-    Mu2eG4PerThreadStorage*  perThreadStorage_;
-    PhysicalVolumeHelper* physVolHelper_;
+    SensitiveDetectorHelper* sensitiveDetectorHelper_ = nullptr;
+    Mu2eG4PerThreadStorage*  perThreadStorage_ = nullptr;
+    PhysicalVolumeHelper* physVolHelper_ = nullptr;
 
     mutable PhysicsProcessInfo physicsProcessInfo_;
 

--- a/Mu2eG4/inc/Mu2eG4EventAction.hh
+++ b/Mu2eG4/inc/Mu2eG4EventAction.hh
@@ -73,14 +73,14 @@ namespace mu2e {
     Mu2eG4TrackingAction* _trackingAction;
     Mu2eG4SteppingAction* _steppingAction;
 
-    SensitiveDetectorHelper* _sensitiveDetectorHelper;
+    SensitiveDetectorHelper* _sensitiveDetectorHelper = nullptr;
 
     const CLHEP::Hep3Vector& _originInWorld;
 
     // local Mu2e per Geant4 event timer
     std::unique_ptr<G4Timer> _timer;
 
-    PhysicsProcessInfo *_processInfo;
+    PhysicsProcessInfo *_processInfo = nullptr;
 
     bool _g4InternalFiltering;
 

--- a/Mu2eG4/inc/Mu2eG4MTRunManager.hh
+++ b/Mu2eG4/inc/Mu2eG4MTRunManager.hh
@@ -60,10 +60,10 @@ namespace mu2e {
     bool m_managerInitialized;
     bool m_runTerminated;
 
-    PhysicalVolumeHelper* physVolHelper_;
+    PhysicalVolumeHelper* physVolHelper_ = nullptr;
     SensitiveDetectorHelper sensitiveDetectorHelper_;
-    Mu2eG4MasterRunAction* masterRunAction_;
-    G4VUserPhysicsList* physicsList_;
+    Mu2eG4MasterRunAction* masterRunAction_ = nullptr;
+    G4VUserPhysicsList* physicsList_ = nullptr;
 
     int rmvlevel_;
   };

--- a/Mu2eG4/inc/Mu2eG4MasterRunAction.hh
+++ b/Mu2eG4/inc/Mu2eG4MasterRunAction.hh
@@ -39,7 +39,7 @@ namespace mu2e {
   private:
     //data members
     int diagLevel_;
-    PhysicalVolumeHelper* physVolHelper_;
+    PhysicalVolumeHelper* physVolHelper_ = nullptr;
 
   };
 

--- a/Mu2eG4/inc/Mu2eG4PerThreadStorage.hh
+++ b/Mu2eG4/inc/Mu2eG4PerThreadStorage.hh
@@ -88,16 +88,16 @@ namespace mu2e {
     // output data products
     std::unique_ptr<StatusG4> statG4{nullptr};
     std::unique_ptr<SimParticleCollection> simPartCollection = nullptr;
-    std::unique_ptr<StepPointMCCollection> tvd_collection;
+    std::unique_ptr<StepPointMCCollection> tvd_collection = nullptr;
     std::unique_ptr<MCTrajectoryCollection> mcTrajectories = nullptr;
     std::unique_ptr<SimParticleRemapping> simRemapping = nullptr;
     std::unique_ptr<ExtMonFNALSimHitCollection> extMonFNALHits = nullptr;
 
     std::unordered_map< std::string, std::unique_ptr<StepPointMCCollection> > sensitiveDetectorSteps;
 
-    std::unique_ptr<IMu2eG4Cut> stackingCuts;
-    std::unique_ptr<IMu2eG4Cut> steppingCuts;
-    std::unique_ptr<IMu2eG4Cut> commonCuts;
+    std::unique_ptr<IMu2eG4Cut> stackingCuts = nullptr;
+    std::unique_ptr<IMu2eG4Cut> steppingCuts = nullptr;
+    std::unique_ptr<IMu2eG4Cut> commonCuts = nullptr;
   };
 
 }  // end namespace mu2e

--- a/Mu2eG4/inc/Mu2eG4PrimaryGeneratorAction.hh
+++ b/Mu2eG4/inc/Mu2eG4PrimaryGeneratorAction.hh
@@ -46,7 +46,7 @@ namespace mu2e {
     // a flag used to enable the above testing
     const bool testPDGIdToGenerate_;
 
-    Mu2eG4PerThreadStorage* perThreadObjects_;
+    Mu2eG4PerThreadStorage* perThreadObjects_ = nullptr;
 
   };
 

--- a/Mu2eG4/inc/Mu2eG4RunAction.hh
+++ b/Mu2eG4/inc/Mu2eG4RunAction.hh
@@ -51,12 +51,12 @@ namespace mu2e {
     Mu2eG4Config::Debug debug_;
     CLHEP::Hep3Vector const& originInWorld;
 
-    PhysicalVolumeHelper* _physVolHelper;
-    PhysicsProcessInfo* _processInfo;
-    Mu2eG4TrackingAction* _trackingAction;
-    Mu2eG4SteppingAction* _steppingAction;
+    PhysicalVolumeHelper* _physVolHelper = nullptr;
+    PhysicsProcessInfo* _processInfo = nullptr;
+    Mu2eG4TrackingAction* _trackingAction = nullptr;
+    Mu2eG4SteppingAction* _steppingAction = nullptr;
 
-    SensitiveDetectorHelper* _sensitiveDetectorHelper;
+    SensitiveDetectorHelper* _sensitiveDetectorHelper = nullptr;
 
   };
 

--- a/Mu2eG4/inc/Mu2eG4SensitiveDetector.hh
+++ b/Mu2eG4/inc/Mu2eG4SensitiveDetector.hh
@@ -45,10 +45,10 @@ namespace mu2e {
   protected:
 
     // Non-owning pointer to the  collection into which hits will be added.
-    StepPointMCCollection* _collection;
+    StepPointMCCollection* _collection = nullptr;
 
     // Non-ownning pointer and object that returns code describing physics processes.
-    PhysicsProcessInfo* _processInfo;
+    PhysicsProcessInfo* _processInfo = nullptr;
 
     // Mu2e point of origin
     G4ThreeVector _mu2eOrigin;
@@ -61,7 +61,7 @@ namespace mu2e {
     int _currentSize;
 
     // A helper to create pointers to SimParticles
-    const SimParticleHelper *_spHelper;
+    const SimParticleHelper *_spHelper = nullptr;
   };
 
 } // namespace mu2e

--- a/Mu2eG4/inc/Mu2eG4StackingAction.hh
+++ b/Mu2eG4/inc/Mu2eG4StackingAction.hh
@@ -18,8 +18,8 @@ namespace mu2e {
 
   private:
     // owned by Mu2eG4 module.
-    IMu2eG4Cut* stackingCuts_;
-    IMu2eG4Cut* commonCuts_;
+    IMu2eG4Cut* stackingCuts_ = nullptr;
+    IMu2eG4Cut* commonCuts_ = nullptr;
   };
 
 } // end namespace mu2e

--- a/Mu2eG4/inc/Mu2eG4SteppingAction.hh
+++ b/Mu2eG4/inc/Mu2eG4SteppingAction.hh
@@ -77,10 +77,10 @@ namespace mu2e {
 
   private:
     // owned by Mu2eG4 module.
-    IMu2eG4Cut* steppingCuts_;
-    IMu2eG4Cut* commonCuts_;
+    IMu2eG4Cut* steppingCuts_ = nullptr;
+    IMu2eG4Cut* commonCuts_ = nullptr;
 
-    const Mu2eG4ResourceLimits *mu2elimits_;
+    const Mu2eG4ResourceLimits *mu2elimits_ = nullptr;
 
     // Protection against "too complicated" events
     unsigned numTrackSteps_;
@@ -88,11 +88,11 @@ namespace mu2e {
 
     // List of times for time virtual detector
     std::vector<double> tvd_time_;
-    StepPointMCCollection* tvd_collection_;
+    StepPointMCCollection* tvd_collection_ = nullptr;
     bool tvd_warning_printed_;
 
     // MCTrajectory point filtering cuts
-    const Mu2eG4TrajectoryControl* trajectoryControl_;
+    const Mu2eG4TrajectoryControl* trajectoryControl_ = nullptr;
     typedef std::map<const G4VPhysicalVolume*, double> VolumeCutMap;
     VolumeCutMap mcTrajectoryVolumePtDistances_;
     // Store trajectory parameters at each G4Step; cleared at beginOfTrack time.
@@ -103,11 +103,11 @@ namespace mu2e {
     EventNumberList _debugTrackList;
 
     // Information about the SimParticleCollection, needed to instantiate art::Ptr.
-    const SimParticleHelper *_spHelper;
+    const SimParticleHelper *_spHelper = nullptr;
 
     // Non-owning pointer to the information about physical processes;
     // lifetime of pointee is one run.
-    PhysicsProcessInfo *  _processInfo;
+    PhysicsProcessInfo *  _processInfo = nullptr;
 
     // Origin of Mu2e Coordinate system in the G4 world system.
     CLHEP::Hep3Vector _mu2eOrigin;

--- a/Mu2eG4/src/ConstructMaterials.cc
+++ b/Mu2eG4/src/ConstructMaterials.cc
@@ -39,9 +39,8 @@
 
 // G4 includes
 #include "Geant4/G4GeometryManager.hh"
-#include "Geant4/G4PhysicalVolumeStore.hh"
-#include "Geant4/G4LogicalVolumeStore.hh"
-#include "Geant4/G4SolidStore.hh"
+//#include "Geant4/G4PhysicalVolumeStore.hh"
+//#include "Geant4/G4LogicalVolumeStore.hh"
 
 #include "Geant4/G4Material.hh"
 #include "Geant4/G4Box.hh"

--- a/Mu2eG4/src/MTMasterThread.cc
+++ b/Mu2eG4/src/MTMasterThread.cc
@@ -11,6 +11,7 @@
 
 //G4 includes
 #include "Geant4/G4PhysicalVolumeStore.hh"
+#include "Geant4/G4LogicalVolumeStore.hh"
 
 //art includes
 #include "art/Framework/Principal/Run.h"
@@ -107,7 +108,7 @@ namespace mu2e {
         }
 
         masterRunManager.reset();
-        G4PhysicalVolumeStore::Clean();
+        storeCleanUp();
 
         if (m_mtDebugOutput > 0) {
           G4cout << "Master thread: reset shared_ptr" << G4endl;
@@ -182,6 +183,25 @@ namespace mu2e {
   }
 
 
+  void MTMasterThread::storeRunNumber(int art_runnumber) {
+    run_number = art_runnumber;
+  }
+
+
+  void MTMasterThread::readRunData(PhysicalVolumeHelper* phys_vol_help) const {
+
+    m_masterRunManager->setPhysVolumeHelper(phys_vol_help);
+
+  }
+
+  void MTMasterThread::storeCleanUp() {
+
+    G4PhysicalVolumeStore::GetInstance()->Clean();
+    G4LogicalVolumeStore::GetInstance()->Clean();
+
+  }
+
+
   void MTMasterThread::stopThread() {
     if (m_stopped) {
       return;
@@ -217,17 +237,5 @@ namespace mu2e {
     m_stopped = true;
   }
 
-
-  void MTMasterThread::storeRunNumber(int art_runnumber)
-  {
-    run_number = art_runnumber;
-  }
-
-
-  void MTMasterThread::readRunData(PhysicalVolumeHelper* phys_vol_help) const {
-
-    m_masterRunManager->setPhysVolumeHelper(phys_vol_help);
-
-  }
 
 }// end namespace mu2e

--- a/Mu2eG4/src/MTMasterThread.cc
+++ b/Mu2eG4/src/MTMasterThread.cc
@@ -9,6 +9,9 @@
 #include "Offline/Mu2eG4/inc/MTMasterThread.hh"
 #include "Offline/Mu2eG4/inc/Mu2eG4MTRunManager.hh"
 
+//G4 includes
+#include "Geant4/G4PhysicalVolumeStore.hh"
+
 //art includes
 #include "art/Framework/Principal/Run.h"
 
@@ -104,7 +107,7 @@ namespace mu2e {
         }
 
         masterRunManager.reset();
-        //G4PhysicalVolumeStore::Clean();
+        G4PhysicalVolumeStore::Clean();
 
         if (m_mtDebugOutput > 0) {
           G4cout << "Master thread: reset shared_ptr" << G4endl;


### PR DESCRIPTION
The issue described in https://github.com/art-framework-suite/art/issues/112 occurs when the G4 geometry is setup in MT mode (this is done in the BeginRun() call) but produce() is not called due to e.g. a failure in the produce() call of a module that runs before G4 causing art to exit the job. When this situation occurs, it is the main thread, not the master thread, that calls the destructor of the geometry. In a very specific geometry setup*, we get a seg fault at the line https://geant4.kek.jp/lxr/source/geometry/volumes/src/G4PVPlacement.cc?v=10.7.p2#L78 because the main thread does not have access to the rotation defined by https://geant4.kek.jp/lxr/source/geometry/management/src/G4VPhysicalVolume.cc?v=10.7.p2#L46.

By calling the destruction of the geometry explicitly in the the master thread with the call "G4PhysicalVolumeStore::Clean();"
we guarantee that access to the rotation at destruction is available.


*The specific geometry setup mentioned is one in which a G4VPlacement object is defined by either the 2nd or 4th constructor in https://geant4.kek.jp/lxr/source//geometry/volumes/src/G4PVPlacement.cc?v=10.7.p2 which takes in a G4Transform3D object rather than a G4RotationMatrix and G4ThreeVector. The caloBuildFEB() function in the constructDiskCalorimeter.cc file is the only place in the Mu2eG4 code that a G4VPlacement object is defined in this way.
