### PR TITLE
added CrvCoincidenceFinder as replacement for CrvCoincidenceCheck/CrvCoincidenceClusterFinder

### DIFF
--- a/CRVResponse/fcl/prolog.fcl
+++ b/CRVResponse/fcl/prolog.fcl
@@ -1,1 +1,1 @@
-#include "Offline/CRVResponse/fcl/prolog_v09.fcl"
+#include "Offline/CRVResponse/fcl/prolog_v10.fcl"

--- a/CRVResponse/fcl/prolog_v10.fcl
+++ b/CRVResponse/fcl/prolog_v10.fcl
@@ -157,10 +157,8 @@ BEGIN_PROLOG
       verboseLevel                  : 0
       crvRecoPulsesModuleLabel      : "CrvRecoPulses"
       #cluster settings
-#      maxDistance                   : 1000 //mm
-#      maxTimeDifference             : 100  //ns
-      maxDistance                   : 100 //mm
-      maxTimeDifference             : 40  //ns
+      maxDistance                   : 400 //mm (up to 7 counters w/o offset) //was 1000 mm
+      maxTimeDifference             : 60  //ns (up to 4 ADC samples)         //was 100 ns
       #sector specific coincidence settings
       CRVSectors                       : ["R1","R2","R3","R4","R5","R6","L1","L2","T1","T2","T3","T4","E1","E2","U" ,"D1","D2","D3","D4","C1","C2","C3","C4"] //used only to match the vector entries below
       PEthresholds                     : [  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ]

--- a/CRVResponse/fcl/prolog_v10.fcl
+++ b/CRVResponse/fcl/prolog_v10.fcl
@@ -1,0 +1,243 @@
+//Use with Mu2eG4/geom/crv_counters_v08.txt (e.g. CRVResponse/test/CRVResponse.fcl)
+//The CRV-Cryo-Inner modules get a scintillation yield of 0 to disable these modules.
+//These modules cannot be removed from the geometry because it would make older files incompatible with the new geometry.
+//The geometry in Mu2eG4/geom/crv_counters_v08.txt uses a CRV counter cross section of 51.30mm x 19.80mm,
+//while the v6_0 lookup tables use a cross section of 51.34mm x 19.78mm.
+//The TiO2 coating of the CRV counters has a thickness of 0.25mm so that the active volume of the lookup table counters
+//is fully covered by the Offline counters.
+
+#include "Offline/CommonMC/fcl/prolog.fcl"
+BEGIN_PROLOG
+
+    CrvSteps:
+    {
+      module_type               : CrvStepsFromStepPointMCs
+      removeNeutralParticles    : true
+      debugLevel                : 0
+      diagLevel                 : 0
+      stepPointsInstance        : "CRV"
+      stepPointsModuleLabels    : @nil
+    }
+    CrvPhotons:
+    {
+      module_type               : CrvPhotonGenerator
+      crvStepModuleLabels       : @nil
+      crvStepProcessNames       : @nil
+      CRVSectors                : ["R1","R2","R3","R4","R5","R6","L1","L2","T1","T2","T3","T4","E1","E2","U" ,"D1","D2","D3","D4","C1","C2","C3","C4"] //used only to match the vector entries below
+      reflectors                : [  0 ,  0 , -1 ,  0 ,  0 ,  0 ,  0 ,  0 ,  1 ,  1 ,  0 ,  0 , -1 , -1 , 1  ,  0 ,  1 , -1 ,  0 ,  1 , -1 , -1 , -1 ]
+      lookupTableFileNames      : ["CRVConditions/v6_0/LookupTable_4550_0",  //R1
+                                   "CRVConditions/v6_0/LookupTable_4550_0",  //R2
+                                   "CRVConditions/v6_0/LookupTable_1045_1",  //R3
+                                   "CRVConditions/v6_0/LookupTable_3040_0",  //R4
+                                   "CRVConditions/v6_0/LookupTable_4550_0",  //R5
+                                   "CRVConditions/v6_0/LookupTable_3200_0",  //R6
+                                   "CRVConditions/v6_0/LookupTable_4550_0",  //L1
+                                   "CRVConditions/v6_0/LookupTable_3200_0",  //L2
+                                   "CRVConditions/v6_0/LookupTable_6000_1",  //T1
+                                   "CRVConditions/v6_0/LookupTable_6000_1",  //T2
+                                   "CRVConditions/v6_0/LookupTable_6000_0",  //T3
+                                   "CRVConditions/v6_0/LookupTable_6000_0",  //T4
+                                   "CRVConditions/v6_0/LookupTable_5000_1",  //E1
+                                   "CRVConditions/v6_0/LookupTable_5000_1",  //E2
+                                   "CRVConditions/v6_0/LookupTable_6900_1",  //U
+                                   "CRVConditions/v6_0/LookupTable_5700_0",  //D1
+                                   "CRVConditions/v6_0/LookupTable_2370_1",  //D2
+                                   "CRVConditions/v6_0/LookupTable_2370_1",  //D3
+                                   "CRVConditions/v6_0/LookupTable_5700_0",  //D4
+                                   "CRVConditions/v6_0/LookupTable_900_1",   //C1
+                                   "CRVConditions/v6_0/LookupTable_900_1",   //C2
+                                   "CRVConditions/v6_0/LookupTable_2100_1",  //C3
+                                   "CRVConditions/v6_0/LookupTable_1550_1"]  //C4
+
+                                //number of photons per MeV visible energy deposited
+                                //for 68 PE/SiPM @ 1 m away from SiPM (Test beam June 2017)
+                                //using the pulse height calibration, this value gives 45 PE/SiPM @ 1 m away from SiPM
+      scintillationYields       : [39400,39400,39400,39400,39400,39400,  //R1...6
+                                   39400,39400,                          //L1,L2
+                                   39400,39400,39400,39400,              //T1...4
+                                   39400,39400,                          //E1,E2
+                                   39400,                                //U
+                                   39400,39400,39400,39400,              //D1...4
+                                   0,0,39400,39400]                      //C1...4
+
+      scintillationYieldScaleFactor         : 0.42  //scale factor applied to scintillation yields to mimic aging
+                                                    //0.42 results in 28.6 PE/SiPM @ 1 m away from SiPM (expected in 2025)
+                                                    //used in SU2020
+      scintillationYieldVariation           : 0.1   //gaussian distribution with sigma equal to 10% of the mean
+                                                    //previously used 0.2 without upper limit
+      scintillationYieldVariationCutoffLow  : 0.7   //the scintillation yield variation is cut off at 70% below the mean
+      scintillationYieldVariationCutoffHigh : 1.2   //the scintillation yield variation is cut off at 120% above the mean
+      digitizationStart                     :  400.0    //400ns
+      digitizationEnd                       : 1750.0    //1750ns
+      digitizationStartMargin               :   50.0    //50ns
+      timeOffsets                           : [ @sequence::CommonMC.TimeMaps ]
+    }
+    CrvSiPMCharges:
+    {
+      module_type                  : CrvSiPMChargeGenerator
+      crvPhotonsModuleLabel        : "CrvPhotons"
+      digitizationStart            :  400.0    //400ns
+      digitizationEnd              : 1750.0    //1750ns
+      digitizationStartMargin      :   50.0    //50ns
+
+      deadSiPMProbability          : 0.01
+      nPixelsX                     : 40
+      nPixelsY                     : 40
+      inactivePixels               : [ [18,18], [18,19], [18,20], [18,21],
+                                       [19,18], [19,19], [19,20], [19,21],
+                                       [20,18], [20,19], [20,20], [20,21],
+                                       [21,18], [21,19], [21,20], [21,21] ]
+      photonMapFileName            : "CRVConditions/v6_0/photonMap.root"
+      overvoltage                  : 3.0        //V
+      timeConstant                 : 13.3       //ns  according to an Hamamatsu example with R_q=150kOhm --> tau=R_q*C=13.3ns
+      capacitance                  : 8.84e-14   //F   capacitance of one pixel according to specs
+
+      AvalancheProbParam1          : 0.607      // = p1
+      AvalancheProbParam2          : 2.7        // = p2
+                                                //Avalanche probability at over voltage v: p1*(1 - exp(-v/p2))
+
+      TrapType0Prob                : 0.0        //0.14 (Paul's number)  ????
+      TrapType1Prob                : 0.0        //0.06 (Paul's number)  ????
+      TrapType0Lifetime            : 5.0        //ns  ????
+      TrapType1Lifetime            : 50.0       //ns  ????
+
+      ThermalRate                  : 3.0e-4     //ns^-1     0.3MHz for entire SiPM 
+      CrossTalkProb                : 0.05       //
+    }
+    CrvWaveforms:
+    {
+      module_type                  : CrvWaveformsGenerator
+      crvSiPMChargesModuleLabel    : "CrvSiPMCharges"
+      digitizationStart            :  400.0    //400ns
+      digitizationEnd              : 1750.0    //1750ns
+      singlePEWaveformFileName     : "Offline/CRVResponse/fcl/singlePEWaveform_v3.txt"
+      singlePEWaveformPrecision    : 0.5    //0.5 ns
+      singlePEWaveformStretchFactor: 1.047  //1.047 for singlePEWaveform_v3.txt //from comparison with testbeam data
+      singlePEWaveformMaxTime      : 100    //100 ns
+      singlePEReferenceCharge      : 2.652e-13  //2.652e-13 C charge which was used to generate the above 1PE waveform
+                                                //capacitance of one pixel (8.84e-14C) * overvoltage (3.0V)
+      FEBtimeSpread                : 2.0    //2.0 ns
+      minVoltage                   : 0.0275  //27.5mV (corresponds to 5.5PE)
+      noise                        : 4.0e-4 //0.4mV
+    }
+    CrvDigi:
+    {
+      module_type                  : CrvDigitizer
+      crvWaveformsModuleLabel      : "CrvWaveforms"
+      ADCconversionFactor          : 2300      //2300 ADC/V
+      pedestal                     : 100       //ADC
+    }
+    CrvRecoPulses:
+    {
+      module_type               : CrvRecoPulsesFinder
+      crvDigiModuleLabel        : "CrvDigi"
+      minADCdifference          : 5     //minimum ADC difference above pedestal to be considered for reconstruction
+      defaultBeta               : 19.0  //19.0ns for regular pulses
+                                        //12.6ns for dark noise pulses used for calibration
+                                        //used for initialization of fit function
+                                        //and as default value for invalid fits
+      minBeta                   : 5.0   //5.0ns smallest accepted beta for valid fit
+      maxBeta                   : 40.0  //40.0ns largest accepted beta for valid fit
+      maxTimeDifference         : 15.0  //15.0ns largest accepted differences between
+                                        //time of largest ADC value and fitted peak
+      minPulseHeightRatio       : 0.7   //smallest accepted ratio between largest ADC value and fitted peak
+      maxPulseHeightRatio       : 1.5   //largest accepted ratio between largest ADC value and fitted peak
+      LEtimeFactor              : 0.985 //time of leading edge is peakTime-LEtimeFactor*beta
+                                        //e.g. 0.985 for a leading edge at 50% pulse height
+                                        //e.g. 1.385 for a leading edge at 20% pulse height
+                                        //e.g. 1.587 for a leading edge at 10% pulse height
+      allowDoubleGumbel         : false //tries fitting with two Gumbel functions (needs a very small "minPulseHeightRatio", e.g. 0.01)
+      doubleGumbelThreshold     : 2.0   //Chi2/#ADCsamples (based on a single Gumble fit) 
+                                        //at which a fit with two Gumbel functions should be attempted
+      minPEs                    : 0     //0 PEs
+    }
+    CrvCoincidenceClusterFinder:
+    {
+      module_type                   : CrvCoincidenceFinder
+      verboseLevel                  : 0
+      crvRecoPulsesModuleLabel      : "CrvRecoPulses"
+      #cluster settings
+#      maxDistance                   : 1000 //mm
+#      maxTimeDifference             : 100  //ns
+      maxDistance                   : 100 //mm
+      maxTimeDifference             : 40  //ns
+      #sector specific coincidence settings
+      CRVSectors                       : ["R1","R2","R3","R4","R5","R6","L1","L2","T1","T2","T3","T4","E1","E2","U" ,"D1","D2","D3","D4","C1","C2","C3","C4"] //used only to match the vector entries below
+      PEthresholds                     : [  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ,  8 ]
+      maxTimeDifferencesAdjacentPulses : [ 10 , 10 , 10 , 10 , 10 , 10 , 10 , 10 , 10 , 10 , 20 , 20 , 10 , 10 , 10 , 10 , 10 , 10 , 10 , 10 , 10 , 10 , 10 ] //ns
+      maxTimeDifferences               : [ 10 , 10 , 10 , 10 , 10 , 10 , 10 , 10 , 20 , 20 , 20 , 20 , 20 , 20 , 20 , 10 , 10 , 10 , 10 , 10 , 10 , 10 , 10 ] //ns
+      coincidenceLayers                : [  3 ,  3 ,  3 ,  3 ,  3 ,  3 ,  3 ,  3 ,  4 ,  3 ,  3 ,  3 ,  4 ,  4 ,  4 ,  4 ,  4 ,  4 ,  4 ,  3 ,  3 ,  3 ,  3 ]
+      #coincidence settings for overlap option
+      usePulseOverlaps              : true
+      minOverlapTimeAdjacentPulses  : 30     //30ns (=at least 2 ADC samples)
+      minOverlapTime                : 30     //30ns (=at least 2 ADC samples)
+      #other coincidence settings
+      useNoFitReco                  : true
+      usePEsPulseHeight             : false  //using the PEs which were calculated using the pulse height
+      maxSlope                      : 11.0   //11.0mm over 1mm, which is a little bit more than 6 counters per layer
+      maxSlopeDifference            : 4.0    //slope difference between layers
+    }
+    CrvCoincidenceClusterMatchMC:
+    {
+      module_type                            : CrvCoincidenceClusterMatchMC
+      crvCoincidenceClusterFinderModuleLabel : "CrvCoincidenceClusterFinder"
+      crvWaveformsModuleLabel                : "CrvWaveforms"
+      timeOffsets                            : { inputs : [ @sequence::CommonMC.TimeMaps ] }
+    }
+    CrvPlot:
+    {
+      module_type                    : CrvPlot
+      events                         : @nil
+      crvBarIndices                  : @nil
+      crvPhotonsModuleLabel          : CrvPhotons
+      crvSiPMChargesModuleLabel      : CrvSiPMCharges
+      crvDigiModuleLabel             : CrvDigi
+      crvRecoPulsesModuleLabel       : CrvRecoPulses
+      timeStart                      : 500
+      timeEnd                        : 1600
+    }
+
+CrvDAQPackage : 
+{
+   producers : 
+   {
+     CrvPhotons                  : @local::CrvPhotons
+     CrvSiPMCharges              : @local::CrvSiPMCharges
+     CrvWaveforms                : @local::CrvWaveforms
+     CrvDigi                     : @local::CrvDigi
+   }
+   CrvResponseSequence : [ CrvPhotons, CrvSiPMCharges, CrvWaveforms, CrvDigi ] //for backward compatibility
+   CrvDAQSequence : [ CrvPhotons, CrvSiPMCharges, CrvWaveforms, CrvDigi ]
+}
+
+CrvRecoPackage :
+{
+   producers :
+   {
+     CrvRecoPulses               : @local::CrvRecoPulses
+     CrvCoincidenceClusterFinder : @local::CrvCoincidenceClusterFinder
+   }
+   CrvRecoSequence : [ CrvRecoPulses, CrvCoincidenceClusterFinder]
+}
+
+CrvRecoMCPackage :
+{
+   producers :
+   {
+     @table::CrvRecoPackage.producers
+     CrvCoincidenceClusterMatchMC : @local::CrvCoincidenceClusterMatchMC
+   }
+   CrvRecoMCSequence : [ @sequence::CrvRecoPackage.CrvRecoSequence, CrvCoincidenceClusterMatchMC ]
+}
+
+CrvResponsePackage :
+{
+   producers :
+   {
+     @table::CrvDAQPackage.producers
+     @table::CrvRecoMCPackage.producers
+   }
+   CrvResponseSequence : [ @sequence::CrvDAQPackage.CrvDAQSequence, @sequence::CrvRecoMCPackage.CrvRecoMCSequence ]
+}
+
+END_PROLOG

--- a/CRVResponse/src/CrvCoincidenceFinder_module.cc
+++ b/CRVResponse/src/CrvCoincidenceFinder_module.cc
@@ -1,0 +1,591 @@
+//
+// A module to find clusters of coincidences of CRV pulses
+//
+// 
+// Original Author: Ralf Ehrlich
+
+#include "Offline/CosmicRayShieldGeom/inc/CosmicRayShield.hh"
+#include "Offline/DataProducts/inc/CRSScintillatorBarIndex.hh"
+
+#include "Offline/GeometryService/inc/GeomHandle.hh"
+#include "Offline/GeometryService/inc/GeometryService.hh"
+#include "Offline/RecoDataProducts/inc/CrvRecoPulse.hh"
+#include "Offline/RecoDataProducts/inc/CrvCoincidenceCluster.hh"
+#include "Offline/CRVResponse/inc/CrvHelper.hh"
+
+#include "canvas/Persistency/Common/Ptr.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/Sequence.h"
+
+#include <string>
+
+namespace mu2e 
+{
+  class CrvCoincidenceFinder : public art::EDProducer 
+  {
+    public:
+    struct Config
+    {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      fhicl::Atom<int> verboseLevel{Name("verboseLevel"), Comment("verbose level")};
+      fhicl::Atom<std::string> crvRecoPulsesModuleLabel{Name("crvRecoPulsesModuleLabel"), Comment("module label of CrvRecoPulses")};
+      //cluster settings
+      fhicl::Atom<double> maxDistance{Name("maxDistance"), Comment("maximum distance between hits to be considered for a hit cluster")};
+      fhicl::Atom<double> maxTimeDifference{Name("maxTimeDifference"), Comment("maximum time difference between hits to be considered for a hit cluster")};
+      //sector specific coincidence settings
+      fhicl::Sequence<std::string> CRVSectors{Name("CRVSectors"), Comment("CRV sectors")};
+      fhicl::Sequence<int> PEthresholds{Name("PEthresholds"), Comment("PE thresholds required for a coincidence")};
+      fhicl::Sequence<double> maxTimeDifferencesAdjacentPulses{Name("maxTimeDifferencesAdjacentPulses"), Comment("maximum time differences of pulses of adjacent channels considered for coincidences")};
+      fhicl::Sequence<double> maxTimeDifferences{Name("maxTimeDifferences"), Comment("maximum time differences of a coincidence hit combination")};
+      fhicl::Sequence<int> coincidenceLayers{Name("coincidenceLayers"), Comment("number of layers required for a coincidence")};
+      //coincidence settings for overlap option
+      fhicl::Atom<bool> usePulseOverlaps{Name("usePulseOverlaps"), Comment("use pulse overlaps instead of peak times to determine coincidences")};
+      fhicl::Atom<double> minOverlapTimeAdjacentPulses{Name("minOverlapTimeAdjacentPulses"), Comment("minimum overlap time between pulses of adjacent channels to be considered for coincidences")};
+      fhicl::Atom<double> minOverlapTime{Name("minOverlapTime"), Comment("minimum overlap time between pulses of a coincidence hit combination")};
+      //other coincidence settings
+      fhicl::Atom<bool> useNoFitReco{Name("useNoFitReco"), Comment("use pulse reco results not based on a Gumbel fit")};
+      fhicl::Atom<bool> usePEsPulseHeight{Name("usePEsPulseHeight"), Comment("use PEs determined by pulse height instead of pulse area")};
+      fhicl::Atom<double> maxSlope{Name("maxSlope"), Comment("maximum slope allowed for a coincidence")};
+      fhicl::Atom<double> maxSlopeDifference{Name("maxSlopeDifference"), Comment("maximum slope differences between layers allowed for a coincidence")};
+    };
+
+    typedef art::EDProducer::Table<Config> Parameters;
+
+    explicit CrvCoincidenceFinder(const Parameters& config);
+    void produce(art::Event& e);
+    void beginJob();
+    void beginRun(art::Run &run);
+    void endJob();
+
+    private:
+    int         _verboseLevel;
+    std::string _crvRecoPulsesModuleLabel;
+
+    double      _maxDistance;
+    double      _maxTimeDifference;
+
+    std::vector<std::string> _CRVSectors;
+    std::vector<int>         _PEthresholds;
+    std::vector<double>      _maxTimeDifferencesAdjacentPulses;
+    std::vector<double>      _maxTimeDifferences;
+    std::vector<int>         _coincidenceLayers;
+
+    bool        _usePulseOverlaps;
+    double      _minOverlapTimeAdjacentPulses;
+    double      _minOverlapTime;
+    bool        _useNoFitReco;
+    bool        _usePEsPulseHeight;
+    double      _maxSlope;
+    double      _maxSlopeDifference;
+
+    int         _totalEvents;
+    int         _totalEventsCoincidence;
+
+    struct sectorCoincidenceProperties
+    {
+      int  precedingCounters;
+      int  nCountersPerModule;
+      int  sectorType;
+      bool sipmsAtSide0;
+      bool sipmsAtSide1;
+      int  widthDirection, thicknessDirection;
+      std::string name;
+      int         PEthreshold;
+      double      maxTimeDifferenceAdjacentPulses;
+      double      maxTimeDifference;
+      int         coincidenceLayers;
+    };
+    std::map<int,sectorCoincidenceProperties> _sectorMap;
+
+    struct CrvHit
+    {
+      art::Ptr<CrvRecoPulse> _crvRecoPulse; 
+      CLHEP::Hep3Vector      _pos;
+      float  _x, _y;
+      double _time, _timePulseStart, _timePulseEnd;
+      double _PEs;
+      int    _layer;
+      int    _counter;
+      int    _SiPM;
+      int    _PEthreshold;
+      double _maxTimeDifferenceAdjacentPulses;
+      double _maxTimeDifference;
+      int    _coincidenceLayers;
+      CrvHit(const art::Ptr<CrvRecoPulse> crvRecoPulse, const CLHEP::Hep3Vector &pos,
+             double x, double y, double time, double timePulseStart, double timePulseEnd,
+             double PEs, int layer, int counter, int SiPM,
+             int PEthreshold, double maxTimeDifferenceAdjacentPulses, double maxTimeDifference, int coincidenceLayers) :
+               _crvRecoPulse(crvRecoPulse), _pos(pos),
+               _x(x), _y(y), _time(time), _timePulseStart(timePulseStart), _timePulseEnd(timePulseEnd), 
+               _PEs(PEs), _layer(layer), _counter(counter), _SiPM(SiPM), 
+               _PEthreshold(PEthreshold), _maxTimeDifferenceAdjacentPulses(maxTimeDifferenceAdjacentPulses),
+               _maxTimeDifference(maxTimeDifference), _coincidenceLayers(coincidenceLayers) {}
+    };
+
+    struct PosCompare
+    {
+      bool operator() (const CrvHit &lhs, const CrvHit &rhs) const 
+      {
+        return lhs._x < rhs._x; 
+      }
+    };
+
+    struct TimeCompare
+    {
+      bool operator() (const CrvHit &lhs, const CrvHit &rhs) const 
+      {
+        return lhs._time < rhs._time; 
+      }
+    };
+
+
+    bool checkCoincidence(const std::vector<CrvHit> &hits);
+    bool checkCombination(const std::vector<std::vector<CrvHit>::const_iterator> &layerIterators);
+  };
+
+  CrvCoincidenceFinder::CrvCoincidenceFinder(const Parameters& conf) :
+    art::EDProducer(conf),
+    _verboseLevel(conf().verboseLevel()),
+    _crvRecoPulsesModuleLabel(conf().crvRecoPulsesModuleLabel()),
+    _maxDistance(conf().maxDistance()),
+    _maxTimeDifference(conf().maxTimeDifference()),
+    _CRVSectors(conf().CRVSectors()),
+    _PEthresholds(conf().PEthresholds()),
+    _maxTimeDifferencesAdjacentPulses(conf().maxTimeDifferencesAdjacentPulses()),
+    _maxTimeDifferences(conf().maxTimeDifferences()),
+    _coincidenceLayers(conf().coincidenceLayers()),
+    _usePulseOverlaps(conf().usePulseOverlaps()),
+    _minOverlapTimeAdjacentPulses(conf().minOverlapTimeAdjacentPulses()),
+    _minOverlapTime(conf().minOverlapTime()),
+    _useNoFitReco(conf().useNoFitReco()),
+    _usePEsPulseHeight(conf().usePEsPulseHeight()),
+    _maxSlope(conf().maxSlope()),
+    _maxSlopeDifference(conf().maxSlopeDifference()),
+    _totalEvents(0),
+    _totalEventsCoincidence(0)
+  {
+    produces<CrvCoincidenceClusterCollection>();
+  }
+
+  void CrvCoincidenceFinder::beginJob()
+  {
+  }
+
+  void CrvCoincidenceFinder::endJob()
+  {
+    if(_verboseLevel>0)
+    {
+      std::cout<<"SUMMARY "<<moduleDescription().moduleLabel()<<"    "<<_totalEventsCoincidence<<" / "<<_totalEvents<<" events satisfied coincidence requirements"<<std::endl;
+    }
+  }
+
+  void CrvCoincidenceFinder::beginRun(art::Run &run)
+  {
+    //first get some properties of each CRV sector
+    //-from the geometry
+    //-from the fcl file settings
+    GeomHandle<CosmicRayShield> CRS;
+    const std::vector<CRSScintillatorShield> &sectors = CRS->getCRSScintillatorShields();
+    for(unsigned int i=0; i<sectors.size(); ++i)
+    {
+      sectorCoincidenceProperties s;
+      s.precedingCounters=0;
+      int precedingSector=sectors[i].getPrecedingSector();
+      while(precedingSector!=-1)
+      {
+        int nModules=sectors[precedingSector].nModules();
+        int nCountersPerModule=sectors[precedingSector].getCountersPerModule();
+        s.precedingCounters+=nModules*nCountersPerModule;
+        precedingSector=sectors[precedingSector].getPrecedingSector();
+      }
+
+      s.nCountersPerModule=sectors[i].getCountersPerModule();
+
+      s.sectorType=sectors[i].getSectorType();
+      s.name=sectors[i].getName();
+
+      s.sipmsAtSide0=sectors[i].getCRSScintillatorBarDetail().hasCMB(0);
+      s.sipmsAtSide1=sectors[i].getCRSScintillatorBarDetail().hasCMB(1);
+
+      s.widthDirection=sectors[i].getCRSScintillatorBarDetail().getWidthDirection();
+      s.thicknessDirection=sectors[i].getCRSScintillatorBarDetail().getThicknessDirection();
+
+      std::string sectorName = s.name.substr(4); //removes the "CRV_" part
+      std::vector<std::string>::iterator userPropertyIter=std::find(_CRVSectors.begin(), _CRVSectors.end(), sectorName);
+      if(userPropertyIter==_CRVSectors.end())
+        throw std::logic_error("CrvCoincidenceFinder: The geometry has a CRV sector for which no coincidence properties were defined in the fcl file.");
+      int userPropertyPosition = std::distance(_CRVSectors.begin(),userPropertyIter);  //that's the position of the vector in the fcl file which sets PE thresholds, time differences, etc.
+
+      s.PEthreshold = _PEthresholds[userPropertyPosition];
+      s.maxTimeDifferenceAdjacentPulses = _maxTimeDifferencesAdjacentPulses[userPropertyPosition];
+      s.maxTimeDifference = _maxTimeDifferences[userPropertyPosition];
+      s.coincidenceLayers = _coincidenceLayers[userPropertyPosition];
+
+      _sectorMap[i]=s;
+    }
+  }
+
+  void CrvCoincidenceFinder::produce(art::Event& event) 
+  {
+    std::unique_ptr<CrvCoincidenceClusterCollection> crvCoincidenceClusterCollection(new CrvCoincidenceClusterCollection);
+
+    GeomHandle<CosmicRayShield> CRS;
+
+    art::Handle<CrvRecoPulseCollection> crvRecoPulseCollection;
+    event.getByLabel(_crvRecoPulsesModuleLabel,"",crvRecoPulseCollection);
+
+    if(crvRecoPulseCollection.product()==NULL) return;
+
+    //loop through all reco pulses
+    //distribute them into the crv sector types
+    //and put them into a (x-pos ordered) multiset
+    std::map<int, std::multiset<CrvHit,PosCompare> > sectorTypeMap;
+    for(size_t recoPulseIndex=0; recoPulseIndex<crvRecoPulseCollection->size(); ++recoPulseIndex)
+    {
+      const art::Ptr<CrvRecoPulse> crvRecoPulse(crvRecoPulseCollection, recoPulseIndex);
+
+      //get information about the counter
+      const CRSScintillatorBarIndex &crvBarIndex = crvRecoPulse->GetScintillatorBarIndex();
+      int sectorNumber, moduleNumber, layerNumber, barNumber;
+      CrvHelper::GetCrvCounterInfo(CRS, crvBarIndex, sectorNumber, moduleNumber, layerNumber, barNumber);
+
+      //sector properties
+      std::map<int,sectorCoincidenceProperties>::const_iterator sIter = _sectorMap.find(sectorNumber);
+      if(sIter==_sectorMap.end()) throw std::logic_error("CrvCoincidenceFinder: Found a CRV hit at a CRV sector without properties.");
+      const sectorCoincidenceProperties &sector = sIter->second;
+
+      //counter number within the entire sector type (like CRV-T, CRV-R, ...)
+      int counterNumber = sector.precedingCounters + sector.nCountersPerModule*moduleNumber + barNumber;
+
+      CLHEP::Hep3Vector crvCounterPos=CrvHelper::GetCrvCounterPos(CRS, crvBarIndex);
+      double x=crvCounterPos[sector.widthDirection];
+      double y=crvCounterPos[sector.thicknessDirection];
+
+      //get the reco pulses information
+      int SiPM = crvRecoPulse->GetSiPMNumber();
+
+      //ignore SiPMs on counter sides which don't have SiPMs according to the geometry file
+      int counterSide=SiPM%2;
+      if(counterSide==0 && !sector.sipmsAtSide0) continue;
+      if(counterSide==1 && !sector.sipmsAtSide1) continue;
+
+      double time=crvRecoPulse->GetPulseTime();
+      double timePulseStart=crvRecoPulse->GetPulseStart();
+      double timePulseEnd=crvRecoPulse->GetPulseEnd();
+      float  PEs =crvRecoPulse->GetPEs();
+      if(_usePEsPulseHeight) PEs=crvRecoPulse->GetPEsPulseHeight();
+      if(_useNoFitReco) PEs=crvRecoPulse->GetPEsNoFit();
+      if(_useNoFitReco) time=crvRecoPulse->GetPulseTimeNoFit();
+
+      //don't split counter sides for the purpose of finding clusters
+      sectorTypeMap[sector.sectorType].emplace(crvRecoPulse, crvCounterPos,
+                                               x, y, time, timePulseStart, timePulseEnd, PEs,
+                                               layerNumber, counterNumber, SiPM,
+                                               sector.PEthreshold, sector.maxTimeDifferenceAdjacentPulses,
+                                               sector.maxTimeDifference, sector.coincidenceLayers);
+    }
+
+    //loop through all crv sectors types
+    std::map<int, std::multiset<CrvHit,PosCompare> >::const_iterator sectorTypeMapIter;
+    for(sectorTypeMapIter=sectorTypeMap.begin(); sectorTypeMapIter!=sectorTypeMap.end(); ++sectorTypeMapIter)
+    {
+      //each entry is a x-pos ordered multiset of hits
+      int crvSectorType = sectorTypeMapIter->first;
+      const std::multiset<CrvHit,PosCompare> &posOrderedHits = sectorTypeMapIter->second; 
+
+      //loop through the multiset of x-pos ordered hits for this particular crv sector type
+      std::multiset<CrvHit,PosCompare>::const_iterator hp=posOrderedHits.begin();
+      while(hp!=posOrderedHits.end())
+      {
+        //find clusters of x positions
+        //and fill their hits into a time ordered multiset for this cluster
+        std::multiset<CrvHit,TimeCompare> posCluster;  //time ordered hits of this x-position cluster
+        posCluster.insert(*hp);
+        double lastPos=hp->_x;
+        while(++hp!=posOrderedHits.end())
+        {
+          if(hp->_x-lastPos>_maxDistance) break;  //this x-position does not belong to this cluster anymore
+          posCluster.insert(*hp);
+          lastPos=hp->_x;
+        }
+        //filled one full x-position cluster
+
+        //loop through the vector of time ordered hits for this x-position cluster
+        std::multiset<CrvHit,TimeCompare>::const_iterator ht=posCluster.begin();
+        while(ht!=posCluster.end())
+        {
+          //find time cluster for this x-pos cluster
+          std::vector<CrvHit> posAndTimeCluster;   //cluster in position and time
+          std::vector<CrvHit> posAndTimeCluster0;  //cluster in position and time for SiPMs at negative end
+          std::vector<CrvHit> posAndTimeCluster1;  //cluster in position and time for SiPMs at positive end
+          posAndTimeCluster.push_back(*ht);
+          if(ht->_SiPM%2==0) posAndTimeCluster0.push_back(*ht); else posAndTimeCluster1.push_back(*ht);
+          double lastTime=ht->_time;
+          while(++ht!=posCluster.end())
+          {
+            if(ht->_time-lastTime>_maxTimeDifference) break;
+            posAndTimeCluster.push_back(*ht);
+            if(ht->_SiPM%2==0) posAndTimeCluster0.push_back(*ht); else posAndTimeCluster1.push_back(*ht);
+            lastTime=ht->_time;
+          }
+          //filled one full position&time cluster
+
+          //check whether this position&time cluster has at least one coincidence
+          //if not, try to find the next cluster
+          if(!checkCoincidence(posAndTimeCluster0))
+          {
+            if(!checkCoincidence(posAndTimeCluster1)) continue;
+          }
+
+          //calulcate properties of this cluster
+          std::vector<art::Ptr<CrvRecoPulse> > crvRecoPulses;
+          double startTime=posAndTimeCluster.front()._time;
+          double endTime=posAndTimeCluster.back()._time;
+          double PEs=0;
+          CLHEP::Hep3Vector avgCounterPos;  //PE-weighted average position
+          int nHits=posAndTimeCluster.size();
+          std::set<int> layerSet;
+          double sumX =0;
+          double sumY =0;
+          double sumYY=0;
+          double sumXY=0;
+          for(size_t i=0; i<posAndTimeCluster.size(); ++i)
+          {
+            const CrvHit &chit = posAndTimeCluster[i];
+            crvRecoPulses.push_back(chit._crvRecoPulse);
+            PEs+=chit._PEs;
+            avgCounterPos+=chit._pos*chit._PEs;
+            layerSet.insert(chit._layer);
+            sumX +=chit._x;
+            sumY +=chit._y;
+            sumYY+=chit._y*chit._y;
+            sumXY+=chit._x*chit._y;
+          }
+
+          //average counter position (PE weighted), slope, layers
+          avgCounterPos/=PEs;
+          double slope=(nHits*sumXY-sumX*sumY)/(nHits*sumYY-sumY*sumY);
+          std::vector<int> layers(layerSet.begin(), layerSet.end());
+
+          //insert the cluster information into the vector of the crv coincidence clusters
+          crvCoincidenceClusterCollection->emplace_back(crvSectorType, avgCounterPos, startTime, endTime, PEs, crvRecoPulses, slope, layers);
+
+        }//loop over all hits in position cluster
+      }//loop over all hits in sector
+    }//loop over all sector types
+
+    ++_totalEvents;
+    if(crvCoincidenceClusterCollection->size()>0) ++_totalEventsCoincidence;
+
+    if(_verboseLevel>1)
+    {
+      std::cout<<moduleDescription().moduleLabel()<<"   run "<<event.id().run()<<"  subrun "<<event.id().subRun()<<"  event "<<event.id().event();
+      std::cout<<"   Coincidence clusters found: "<<crvCoincidenceClusterCollection->size()<<std::endl;
+    }
+
+    event.put(std::move(crvCoincidenceClusterCollection));
+  } // end produce
+
+  bool CrvCoincidenceFinder::checkCoincidence(const std::vector<CrvHit> &hits)
+  {
+    //remove hits below the threshold
+    std::vector< std::vector<CrvHit> > hitsFiltered;  //separated by layers
+    hitsFiltered.resize(4); //for 4 layers
+    std::vector<CrvHit>::const_iterator iterHit;
+    for(iterHit=hits.begin(); iterHit!=hits.end(); ++iterHit)
+    {
+      int    layer=iterHit->_layer;
+      int    counter=iterHit->_counter;  //counter number in one layer counted from the beginning of the counter type
+      double time=iterHit->_time;
+      double timePulseStart=iterHit->_timePulseStart;
+      double timePulseEnd=iterHit->_timePulseEnd;
+
+      int    PEthreshold=iterHit->_PEthreshold;
+      double maxTimeDifferenceAdjacentPulses=iterHit->_maxTimeDifferenceAdjacentPulses;
+
+      //check other SiPM and the SiPMs at the adjacent counters
+      double PEs_thisCounter=0;
+      double PEs_adjacentCounter1=0;
+      double PEs_adjacentCounter2=0;
+      std::vector<CrvHit>::const_iterator iterHitAdjacent;
+      for(iterHitAdjacent=hits.begin(); iterHitAdjacent!=hits.end(); ++iterHitAdjacent)
+      {
+        //use hits of the same layer only
+        if(iterHitAdjacent->_layer!=layer) continue;
+
+        //use hits within a certain time window only
+        if(!_usePulseOverlaps)
+        {
+          if(fabs(iterHitAdjacent->_time-time)>maxTimeDifferenceAdjacentPulses) continue;
+        }
+        else
+        {
+          double overlapTime=std::min(iterHitAdjacent->_timePulseEnd,timePulseEnd)-std::max(iterHitAdjacent->_timePulseStart,timePulseStart);
+          if(overlapTime<_minOverlapTimeAdjacentPulses) continue; //no overlap or overlap time too short
+        }
+
+        //collect all PEs of this and the adjacent counters
+        int counterDiff=iterHitAdjacent->_counter-counter;
+        if(counterDiff==0) PEs_thisCounter+=iterHitAdjacent->_PEs;   //add PEs from the same counter (i.e. the "other" SiPM),
+                                                                     //if the "other" hit is within a certain time window (5ns)
+                                                                     //this will include PEs from the current pulse
+        if(counterDiff==-1) PEs_adjacentCounter1+=iterHitAdjacent->_PEs;  //add PEs from an adjacent counter,
+                                                                          //if these hits are within a certain time window (5ns)
+        if(counterDiff==1) PEs_adjacentCounter2+=iterHitAdjacent->_PEs;   //add PEs from an adjacent counter,
+                                                                          //if these hits are within a certain time window (5ns)
+      }
+
+      //if the number of PEs of this hit (plus the number of PEs of the same or one of the adjacent counter, if their time 
+      //difference is small enough) is above the PE threshold, add this hit to vector of filtered hits
+      if(PEs_thisCounter+PEs_adjacentCounter1>=PEthreshold || PEs_thisCounter+PEs_adjacentCounter2>=PEthreshold)
+         hitsFiltered[layer].push_back(*iterHit);
+    }
+
+    //***************************************************
+    //find coincidences using 2/4 coincidence requirement
+    for(int layer1=0; layer1<4; ++layer1)
+    for(int layer2=layer1+1; layer2<4; ++layer2)
+    {
+      const std::vector<CrvHit> &layer1Hits=hitsFiltered[layer1];
+      const std::vector<CrvHit> &layer2Hits=hitsFiltered[layer2];
+      std::vector<CrvHit>::const_iterator layer1Iter;
+      std::vector<CrvHit>::const_iterator layer2Iter;
+
+      //it will loop only, if both layers have hits
+      //loops will exit, if all three hits require a 3/4 or 4/4 coincidence
+      for(layer1Iter=layer1Hits.begin(); layer1Iter!=layer1Hits.end(); ++layer1Iter)
+      for(layer2Iter=layer2Hits.begin(); layer2Iter!=layer2Hits.end(); ++layer2Iter)
+      {
+        if(layer1Iter->_coincidenceLayers>2 && layer2Iter->_coincidenceLayers>2) continue; //all hits require at least a 3/4 coincidence
+
+        //add both hits into one vector
+        const std::vector<std::vector<CrvHit>::const_iterator> layerIterators={layer1Iter, layer2Iter};
+        //if one hit combination of this cluster satisfies the coincidence criteria, return true
+        //no need to check more combinations for this cluster
+        if(checkCombination(layerIterators)) return true;
+      }
+    }  //two layer coincidences
+
+    //***************************************************
+    //find coincidences using 3/4 coincidence requirement
+    for(int layer1=0; layer1<4; ++layer1)
+    for(int layer2=layer1+1; layer2<4; ++layer2)
+    for(int layer3=layer2+1; layer3<4; ++layer3)
+    {
+      const std::vector<CrvHit> &layer1Hits=hitsFiltered[layer1];
+      const std::vector<CrvHit> &layer2Hits=hitsFiltered[layer2];
+      const std::vector<CrvHit> &layer3Hits=hitsFiltered[layer3];
+      std::vector<CrvHit>::const_iterator layer1Iter;
+      std::vector<CrvHit>::const_iterator layer2Iter;
+      std::vector<CrvHit>::const_iterator layer3Iter;
+
+      //it will loop only, if all 3 layers have hits
+      //loops will exit, if all three hits require a 4/4 coincidence
+      for(layer1Iter=layer1Hits.begin(); layer1Iter!=layer1Hits.end(); ++layer1Iter)
+      for(layer2Iter=layer2Hits.begin(); layer2Iter!=layer2Hits.end(); ++layer2Iter)
+      for(layer3Iter=layer3Hits.begin(); layer3Iter!=layer3Hits.end(); ++layer3Iter)
+      {
+        if(layer1Iter->_coincidenceLayers>3 && layer2Iter->_coincidenceLayers>3 && layer3Iter->_coincidenceLayers>3) continue; //all hits require at 4/4 coincidence
+
+        //add all 3 hits into one vector
+        const std::vector<std::vector<CrvHit>::const_iterator> layerIterators={layer1Iter, layer2Iter, layer3Iter};
+        //if one hit combination of this cluster satisfies the coincidence criteria, return true
+        //no need to check more combinations for this cluster
+        if(checkCombination(layerIterators)) return true;
+      }
+    }  //three layer coincidences
+
+    //***************************************************
+    //find coincidences using 4/4 coincidence requirement
+    {
+      const std::vector<CrvHit> &layer0Hits=hitsFiltered[0];
+      const std::vector<CrvHit> &layer1Hits=hitsFiltered[1];
+      const std::vector<CrvHit> &layer2Hits=hitsFiltered[2];
+      const std::vector<CrvHit> &layer3Hits=hitsFiltered[3];
+      std::vector<CrvHit>::const_iterator layer0Iter;
+      std::vector<CrvHit>::const_iterator layer1Iter;
+      std::vector<CrvHit>::const_iterator layer2Iter;
+      std::vector<CrvHit>::const_iterator layer3Iter;
+
+      //it will loop only, if all 4 layers have hits
+      for(layer0Iter=layer0Hits.begin(); layer0Iter!=layer0Hits.end(); ++layer0Iter)
+      for(layer1Iter=layer1Hits.begin(); layer1Iter!=layer1Hits.end(); ++layer1Iter)
+      for(layer2Iter=layer2Hits.begin(); layer2Iter!=layer2Hits.end(); ++layer2Iter)
+      for(layer3Iter=layer3Hits.begin(); layer3Iter!=layer3Hits.end(); ++layer3Iter)
+      {
+        //add all 4 hits into one vector
+        const std::vector<std::vector<CrvHit>::const_iterator> layerIterators={layer0Iter, layer1Iter, layer2Iter, layer3Iter};
+        //if one hit combination of this cluster satisfies the coincidence criteria, return true
+        //no need to check more combinations for this cluster
+        if(checkCombination(layerIterators)) return true;
+      }
+    } // four layer coincidences
+
+    return false;  //no coincidences found
+  } //end check coincidence
+
+  bool CrvCoincidenceFinder::checkCombination(const std::vector<std::vector<CrvHit>::const_iterator> &layerIterators) 
+  {
+    size_t n=layerIterators.size();
+    if(n<2) return false;
+
+    double maxTimeDifferences[n];
+    double times[n];
+    double timesPulseStart[n], timesPulseEnd[n];
+    double x[n], y[n];
+    for(size_t i=0; i<n; ++i)
+    {
+      const std::vector<CrvHit>::const_iterator &iter=layerIterators[i];
+      maxTimeDifferences[i]=iter->_maxTimeDifference;
+      times[i]=iter->_time;
+      timesPulseStart[i]=iter->_timePulseStart;
+      timesPulseEnd[i]=iter->_timePulseEnd;
+      x[i]=iter->_x;
+      y[i]=iter->_y;
+    }
+
+    if(!_usePulseOverlaps)
+    {
+      double maxTimeDifference=*std::max_element(maxTimeDifferences,maxTimeDifferences+n);
+      double timeMin = *std::min_element(times,times+n);
+      double timeMax = *std::max_element(times,times+n);
+      if(timeMax-timeMin>maxTimeDifference) return false;  //hits don't fall within the time window
+    }
+    else
+    {
+      double timeMaxPulseStart = *std::max_element(timesPulseStart,timesPulseStart+n);
+      double timeMinPulseEnd = *std::min_element(timesPulseEnd,timesPulseEnd+n);
+      if(timeMinPulseEnd-timeMaxPulseStart<_minOverlapTime) return false;  //pulses don't overlap, or overlap time too short
+    }
+
+    std::vector<float> slopes;
+    for(size_t d=0; d<n-1; ++d)
+    {
+      slopes.push_back((x[d+1]-x[d])/(y[d+1]-y[d]));   //width direction / thickness direction
+      if(fabs(slopes.back())>_maxSlope) return false;  //not more than maxSlope allowed for coincidence;
+    }
+
+    if(n>2)
+    {
+      //slope must not change more than 2mm over 1mm (which is a little bit more than 1 counter per layer)
+      if(fabs(slopes[0]-slopes[1])>_maxSlopeDifference) return false;
+      if(n>3)
+      {
+        if(fabs(slopes[0]-slopes[2])>_maxSlopeDifference) return false;
+        if(fabs(slopes[1]-slopes[2])>_maxSlopeDifference) return false;
+      }
+    }
+
+    return true; //all coincidence criteria for this combination satisfied
+  } // end checkCombination
+
+} // end namespace mu2e
+
+using mu2e::CrvCoincidenceFinder;
+DEFINE_ART_MODULE(CrvCoincidenceFinder)


### PR DESCRIPTION
**Not ready for merging yet. Still requires some tests.**

See doc-db 40947 for details.
-CrvCoincidenceCheck and CrvCoincidenceClusterFinder modules will be replaced by CrvCoincidenceFinder module
-new module is faster than the previous two modules in certain circumstances
-new module uses CRV's prolog_v10; the old modules still run with prolog_v09 (switch happens automatically via CRV's prolog.fcl)
-requires some changes in Production