### PR TITLE
add option to match to the nearest calibration

### DIFF
--- a/DbService/inc/DbEngine.hh
+++ b/DbService/inc/DbEngine.hh
@@ -18,7 +18,8 @@ namespace mu2e {
   class DbEngine {
   public:
 
-    DbEngine():_verbose(0),_saveCsv(true),_initialized(false),
+    DbEngine():_verbose(0),_saveCsv(true),_nearestMatch(false),
+               _initialized(false),
 	       _lockWaitTime(0),_lockTime(0) {}
     // the big read of the IOV structure is done in beginJob
     int beginJob();
@@ -33,6 +34,8 @@ namespace mu2e {
     void setVerbose(int verbose = 0) { _verbose = verbose; }
     // whether to save the csv text content when loading a table
     void setSaveCsv(bool saveCsv) { _saveCsv = saveCsv; }
+    // whether, if no perfect match, accept neaby data
+    void setNearestMatch(bool nearestMatch) { _nearestMatch = nearestMatch; }
     // these should only be called in single-threaded startup
     std::shared_ptr<DbValCache>& valCache() {return _vcache;}
     std::vector<int> gids() { return _gids; }
@@ -71,6 +74,7 @@ namespace mu2e {
     DbVersion _version;
     int _verbose;
     bool _saveCsv;
+    bool _nearestMatch; // match to nearby data, without proper IOV
     DbTableCollection _override;
     DbCache _cache;
     std::shared_ptr<DbValCache> _vcache;

--- a/DbService/inc/DbService.hh
+++ b/DbService/inc/DbService.hh
@@ -36,11 +36,13 @@ namespace mu2e {
       fhicl::Atom<bool> saveCsv{Name("saveCsv"), 
 	  Comment("save csv content in tables, default false"),false};
       fhicl::OptionalAtom<bool> fastStart{Name("fastStart"), 
-	  Comment("read the DB immedatiately, not on first use")};
+	  Comment("read the DB immediately, not on first use")};
       fhicl::OptionalAtom<int> cacheLifetime{Name("cacheLifetime"), 
 	  Comment("if >0, read IoV from cache, but renew each lifetime (s)")};
       fhicl::OptionalAtom<int> retryTimeout{Name("retryTimeout"), 
 	  Comment("how long to keep retrying to read database (3600s)")};
+      fhicl::Atom<bool> nearestMatch{Name("nearestMatch"), 
+	  Comment("if no proper IoV, accept nearby calibrations, default false"),false};
     };
 
     // this line is required by art to allow the command line help print

--- a/DbService/src/DbEngine.cc
+++ b/DbService/src/DbEngine.cc
@@ -357,7 +357,28 @@ mu2e::DbEngine::Row mu2e::DbEngine::findTable(
 	return r; // return iov and cid in a Row
       }
     } // loop over Rows for table type
-  }  
+
+    // if no return above, then find a nearby entry, if requested
+    if(_nearestMatch) {
+      Row br(DbIoV(),-1);
+      int brr=br.iov().maxRun(), bsr=br.iov().maxSubrun();
+      for(auto const& r : iter->second) { // find closest entry
+        int dr = run - r.iov().endRun();
+        int ds = subrun + r.iov().maxSubrun() - r.iov().endSubrun();
+        if(dr==0) ds = subrun - r.iov().endSubrun();
+        if( dr>0 && ds>0 && (dr<brr || ( dr==brr && ds<bsr) ) ) {
+          brr = dr;
+          bsr = ds;
+          br = r;
+        }
+      } // loop over Rows for table type
+      if(br.cid()>0) { // then something was found
+        return br;
+      }
+    } // try nearest match
+
+  } // tid found in lookup
+
   return DbEngine::Row(DbIoV(),-1); // not found
 }
 

--- a/DbService/src/DbService_service.cc
+++ b/DbService/src/DbService_service.cc
@@ -4,6 +4,7 @@
 #include "Offline/DbTables/inc/DbUtil.hh"
 #include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
 #include "art/Framework/Services/Registry/ServiceDefinitionMacros.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
 
 
 namespace mu2e {
@@ -36,6 +37,12 @@ namespace mu2e {
     // the engine which will read db, hold calibrations, deliver them
     _engine.setVerbose(_verbose);
     _engine.setSaveCsv(_config.saveCsv());
+    if(_config.nearestMatch()) {
+      _engine.setNearestMatch(true);
+      mf::LogWarning warn("DbService");
+      warn<<"WARNING: setting DbService nearestMatch true will probably result "
+          <<"in approximate or unreproducible results\n";
+    }
 
     DbIdList idList; // read file of db connection details
     _engine.setDbId( idList.getDbId(_config.dbName()) );


### PR DESCRIPTION
From time to time a user might want to run reco on a run before the formal calibration set is prepared, or perhaps a bad run or a test run where the formal calibration will never be prepared.  Turning this option on will cause the code to accept the calibration from the nearest available earlier run.  A messagelogger warning saying the result may be unreliable and unreproducible, is printed.