### PR TITLE
Updated the clustering process of the Crv coincidence finder

### DIFF
--- a/CRVResponse/fcl/prolog_v10.fcl
+++ b/CRVResponse/fcl/prolog_v10.fcl
@@ -158,8 +158,6 @@ BEGIN_PROLOG
       crvRecoPulsesModuleLabel         : "CrvRecoPulses"
       #cluster settings
       clusterMaxDistance               : 250 //mm
-      clusterMaxTimeDifference         : 20  //20ns (same as max time difference in coincidence setting) //when overlap option is not used
-      clusterMinOverlapTime            : 30  //30ns (=at least 3 ADC samples, same as coincidence setting) //when overlap option is used
       #sector-specific coincidence settings
       sectorConfig :
       [

--- a/CRVResponse/fcl/prolog_v10.fcl
+++ b/CRVResponse/fcl/prolog_v10.fcl
@@ -157,7 +157,9 @@ BEGIN_PROLOG
       verboseLevel                     : 0
       crvRecoPulsesModuleLabel         : "CrvRecoPulses"
       #cluster settings
-      clusterMaxDistance               : 250 //mm
+      initialClusterMaxDistance        : 250 //mm
+      clusterMaxTimeDifference         : 60  //60ns //cluster time values are set to allow hits from SiPMs of opposite counter ends to be included
+      clusterMinOverlapTime            : 10  //10ns (=at least 1 ADC sample) //when pulse overlap is used
       #sector-specific coincidence settings
       sectorConfig :
       [

--- a/CRVResponse/fcl/prolog_v10.fcl
+++ b/CRVResponse/fcl/prolog_v10.fcl
@@ -158,8 +158,9 @@ BEGIN_PROLOG
       crvRecoPulsesModuleLabel         : "CrvRecoPulses"
       #cluster settings
       initialClusterMaxDistance        : 250 //mm
-      clusterMaxTimeDifference         : 60  //60ns //cluster time values are set to allow hits from SiPMs of opposite counter ends to be included
-      clusterMinOverlapTime            : 10  //10ns (=at least 1 ADC sample) //when pulse overlap is used
+      clusterMaxTimeDifference         : 60  //ns                               //use looser cut for cluster time values
+      clusterMinOverlapTime            : 10  //ns //when pulse overlap is used  //to allow hits from SiPMs of opposite
+                                                                                //counter ends to be included
       #sector-specific coincidence settings
       sectorConfig :
       [

--- a/CRVResponse/src/CrvCoincidenceFinder_module.cc
+++ b/CRVResponse/src/CrvCoincidenceFinder_module.cc
@@ -122,7 +122,11 @@ namespace mu2e
       double _maxTimeDifference;
       double _maxSlope, _maxSlopeDifference;
       int    _coincidenceLayers;
-      mutable double _maxDistance; //initially set to initialClusterMaxDistance, updated when the coindidences are checked
+      mutable double _maxDistance; //initially set to initialClusterMaxDistance, which is just an estimate 
+                                   //used for the initial clustering process (to keep the number of 
+                                   //hit combinations down that need to be checked for coincidendes).
+                                   //_maxDistance is updated when the coindidences are checked
+                                   //(used for the final clustering process)
 
       CrvHit(const art::Ptr<CrvRecoPulse> crvRecoPulse, const CLHEP::Hep3Vector &pos, 
              double x, double y, double time, double timePulseStart, double timePulseEnd,
@@ -165,7 +169,8 @@ namespace mu2e
     _totalEventsCoincidence(0)
   {
     produces<CrvCoincidenceClusterCollection>();
-    //get cluster time parameters from coincidence parameters
+    //get initial cluster time parameters from coincidence parameters
+    //initial clustering is done to keep the number of hit combinations down that need to be checked for coincidences
     _initialClusterMaxTimeDifference=std::max_element(_sectorConfig.begin(), _sectorConfig.end(),
                               [](const SectorConfig &a, const SectorConfig &b)
                               {return a.maxTimeDifference() < b.maxTimeDifference();})->maxTimeDifference();
@@ -303,6 +308,7 @@ namespace mu2e
       filterHits(hitsUnfiltered, hitsFiltered);
 
       //distribute the hits into clusters
+      //initial clustering is done to keep the number of hit combinations down that need to be checked for coincidences
       std::vector<std::vector<CrvHit> > clusters;
       findClusters(hitsFiltered, clusters, _initialClusterMaxTimeDifference, _initialClusterMinOverlapTime);
 


### PR DESCRIPTION
- added different cuts for the initial clustering (to keep the number of hits combinations down that need to be checked for coincidences) and the final clustering (based only on coincidence hits).
- used a better solution to keep hits from opposite counter ends in one coincidence cluster.
- added a protection to prevent hits from coincidence groups to be broken apart at the final clustering.