### PR TITLE
Fix santize errors: binding a nullptr to a reference. 

### DIFF
--- a/Analyses/src/CosmicAnalysis_module.cc
+++ b/Analyses/src/CosmicAnalysis_module.cc
@@ -470,7 +470,7 @@ namespace mu2e
             std::string productionVolumeName="unknown volume";
             if(hasPhysicalVolumes && physicalVolumesMulti.product()!=NULL)
             {
-              mu2e::PhysicalVolumeMultiHelper volumeMultiHelper(*physicalVolumesMulti);
+              mu2e::PhysicalVolumeMultiHelper volumeMultiHelper(physicalVolumesMulti.product());
               productionVolumeName=volumeMultiHelper.startVolume(*matchingSimparticle).name();
             }
             strncpy(_eventinfo.simreco_production_volume, productionVolumeName.c_str(),99);

--- a/CaloMC/src/CaloShowerStepMaker_module.cc
+++ b/CaloMC/src/CaloShowerStepMaker_module.cc
@@ -137,7 +137,7 @@ namespace mu2e {
          bool                                     compressData_;
          double                                   eDepThreshold_;
          int                                      diagLevel_;
-         const PhysicalVolumeInfoMultiCollection* vols_;
+         const PhysicalVolumeInfoMultiCollection* vols_ = nullptr;
          double                                   zSliceSize_;
 
          diagSummary                              diagSummary_;
@@ -246,7 +246,7 @@ namespace mu2e {
   void CaloShowerStepMaker::makeCompressedHits(const HandleVector& crystalStepsHandle, 
                                                CaloShowerStepCollection& caloShowerStepMCs,SimParticlePtrCollection& simsToKeep)
   {
-      PhysicalVolumeMultiHelper vi(*vols_);
+      PhysicalVolumeMultiHelper vi(vols_);
 
       const Calorimeter& cal = *(GeomHandle<Calorimeter>());
       zSliceSize_            = cal.caloInfo().getDouble("crystalZLength")/float(numZSlices_)+1e-5;

--- a/CommonMC/src/StoppedParticlesFinder_module.cc
+++ b/CommonMC/src/StoppedParticlesFinder_module.cc
@@ -102,7 +102,7 @@ namespace mu2e {
 
     TH1* hStopMaterials_;
 
-    const PhysicalVolumeInfoMultiCollection *vols_;
+    const PhysicalVolumeInfoMultiCollection *vols_ = nullptr;
 
     bool isStopped(const SimParticle& particle) const;
     bool materialAccepted(const std::string& material) const;
@@ -208,7 +208,7 @@ namespace mu2e {
 
     std::unique_ptr<SimParticlePtrCollection> output(new SimParticlePtrCollection());
 
-    PhysicalVolumeMultiHelper vi(*vols_);
+    PhysicalVolumeMultiHelper vi(vols_);
     auto ih = event.getValidHandle<SimParticleCollection>(particleInput_);
     numTotalParticles_ += ih->size();
     for(const auto& i : *ih) {

--- a/EventDisplay/src/DataInterface.cc
+++ b/EventDisplay/src/DataInterface.cc
@@ -1188,7 +1188,7 @@ void DataInterface::fillEvent(boost::shared_ptr<ContentSelector> const &contentS
       std::string endVolumeName="unknown volume";
       if(physicalVolumesMulti!=nullptr)
       {
-        mu2e::PhysicalVolumeMultiHelper volumeMultiHelper(*physicalVolumesMulti);
+        mu2e::PhysicalVolumeMultiHelper volumeMultiHelper(physicalVolumesMulti);
         startVolumeName=volumeMultiHelper.startVolume(particle).name();
         endVolumeName=volumeMultiHelper.endVolume(particle).name();
       }

--- a/Mu2eG4/inc/Mu2eG4SteppingAction.hh
+++ b/Mu2eG4/inc/Mu2eG4SteppingAction.hh
@@ -47,7 +47,7 @@ namespace mu2e {
 
     void UserSteppingAction(const G4Step*);
 
-    void BeginOfEvent(StepPointMCCollection& outputHits, const SimParticleHelper& spHelper);
+    void BeginOfEvent(StepPointMCCollection* outputHits, const SimParticleHelper& spHelper);
 
     void BeginOfTrack();
     void EndOfTrack();

--- a/Mu2eG4/src/Mu2eG4EventAction.cc
+++ b/Mu2eG4/src/Mu2eG4EventAction.cc
@@ -108,7 +108,7 @@ namespace mu2e {
 
     _trackingAction->beginEvent();
 
-    _steppingAction->BeginOfEvent(*perThreadObjects_->tvd_collection, *_spHelper);
+    _steppingAction->BeginOfEvent(perThreadObjects_->tvd_collection.get(), *_spHelper);
 
     _sensitiveDetectorHelper->updateSensitiveDetectors(*_processInfo, *_spHelper);
 

--- a/Mu2eG4/src/Mu2eG4SteppingAction.cc
+++ b/Mu2eG4/src/Mu2eG4SteppingAction.cc
@@ -108,9 +108,9 @@ namespace mu2e {
   }
 
 
-  void Mu2eG4SteppingAction::BeginOfEvent(StepPointMCCollection& outputHits,
+  void Mu2eG4SteppingAction::BeginOfEvent(StepPointMCCollection* outputHits,
                                           const SimParticleHelper& spHelper) {
-    tvd_collection_  = &outputHits;
+    tvd_collection_  = outputHits;
     tvd_warning_printed_ = false;
     _spHelper    = &spHelper;
   }

--- a/Mu2eUtilities/inc/PhysicalVolumeMultiHelper.hh
+++ b/Mu2eUtilities/inc/PhysicalVolumeMultiHelper.hh
@@ -19,7 +19,7 @@ struct PhysicalVolumeInfo;
   public:
     typedef PhysicalVolumeInfoMultiCollection::size_type size_type;
 
-    PhysicalVolumeMultiHelper(const PhysicalVolumeInfoMultiCollection& coll);
+    PhysicalVolumeMultiHelper(const PhysicalVolumeInfoMultiCollection* coll);
 
     // the volumes
     const PhysicalVolumeInfo& startVolume(const SimParticle& p) const;

--- a/Mu2eUtilities/src/PhysicalVolumeMultiHelper.cc
+++ b/Mu2eUtilities/src/PhysicalVolumeMultiHelper.cc
@@ -10,8 +10,8 @@
 namespace mu2e {
 struct PhysicalVolumeInfo;
 
-  PhysicalVolumeMultiHelper::PhysicalVolumeMultiHelper(const PhysicalVolumeInfoMultiCollection& coll)
-    : pi_(&coll)
+  PhysicalVolumeMultiHelper::PhysicalVolumeMultiHelper(const PhysicalVolumeInfoMultiCollection* coll)
+    : pi_(coll)
   {}
 
   const PhysicalVolumeInfo&


### PR DESCRIPTION
The sanitizer found two places in which a pointer with a value of nullptr was bound to a reference.  In both cases the caller held an object by pointer and dereferenced the pointer to pass the object by reference into a function;  the function immediately took the address of the argument and held it by pointer internally.

In some cases the original pointer is allowed to have a value of nullptr and the code handles this correctly.  However the sanitizer objected to binding a nullptr to a reference at the function call.  So I changed the argument type to pointer and made all of the needed follow-on changes in the callers.  This includes locations that had not yet had coverage by the sanitizer.
