### PR TITLE
Enabling optional use of density effect in ionization loss calculations

### DIFF
--- a/Mu2eG4/fcl/prolog.fcl
+++ b/Mu2eG4/fcl/prolog.fcl
@@ -26,6 +26,25 @@ mu2eg4DefaultPhysics: {
     setMuHadLateralDisplacement: true // improves accuracy of boundary
                                       // crossing for muons and common charged hadrons
 
+    useDensityEffectInIonizationLossCalc: false // improves accuracy of energy loss calculations;
+                                                // done for the materials listed below, for now
+                                                // to be used with Geant4 10.7.p03 and above
+
+    conductingMaterials : ["A1100","A95083","AL999Ni001","AluminumHoneycomb","BrassC360",
+      "BronzeC608","BronzeC642","BronzeC938","BronzeC943","BronzeC945",
+      "CollCu","CuW1090","DS1CoilMix","DS2CoilMix","G4_Al",
+      "G4_Al_Double","G4_Al_Half","G4_Al_Quarter","G4_Al_Standard","G4_Al_Triple",
+      "G4_As","G4_Au","G4_Be_Double","G4_Be_Half","G4_Be_Quarter",
+      "G4_Be_Standard","G4_Be_Triple","G4_Co","G4_Cr","G4_Cu",
+      "G4_Fe","G4_Li","G4_Mg","G4_Mn","G4_Mo",
+      "G4_Nb","G4_Ni","G4_Pb","G4_Sb","G4_Sn",
+      "G4_Ti","G4_W","G4_W_Hayman","G4_Zn","HRSBronze",
+      "Inconel718","MBSCalShieldRing","MBSSupportMix","NbTi","NbTiCu",
+      "ProductionTargetTungstenLa2_O3",
+      "RackSteel","StainlessSteel","StainlessSteel316","StainlessSteel316L","StoppingTarget_Al"]
+    // comma separated list used when the above is set to true 
+    // e.g., ["StainlessSteel", "StainlessSteel316"]
+
     // mscModelTransitionEnergy: 115. // MeV uncomment to change the Geant4 deafult
 
     useEmOption4InTracker: false // to use that option in the tracker only if not using _EMZ;

--- a/Mu2eG4/inc/ConstructMaterials.hh
+++ b/Mu2eG4/inc/ConstructMaterials.hh
@@ -59,6 +59,10 @@ namespace mu2e {
     // Check that a material name is not already in use.
     CheckedG4String uniqueMaterialOrThrow( G4String const& name);
 
+    // Turning on density effect correction in ionization loss calculations
+    // for selected materials deemed conductors
+    void useDensityEffectInIonizationLossCorrectionIfRequested();
+
   };
 
 } // end namespace mu2e

--- a/Mu2eG4/inc/Mu2eG4Config.hh
+++ b/Mu2eG4/inc/Mu2eG4Config.hh
@@ -126,6 +126,10 @@ namespace mu2e {
 
       fhicl::Atom<bool> setMuHadLateralDisplacement {Name("setMuHadLateralDisplacement"), false};
 
+      fhicl::Atom<bool> useDensityEffectInIonizationLossCalc {Name("useDensityEffectInIonizationLossCalc"), false};
+      fhicl::Sequence<std::string> conductingMaterials {Name("conductingMaterials"),
+          Comment("List of materials which are electrical conductors.")};
+
       fhicl::Sequence<int> noDecay {Name("noDecay"), Comment("List of PDG IDs that for which to turn decays off.")};
 
       fhicl::Atom<std::string> captureDModel {Name("captureDModel")};


### PR DESCRIPTION
Added code, to be used with Geant4 10.7.p03 and above, to enable a future use of more accurate energy loss calculations,
esp. in metals, which may affect, e.g., muons stops. TBD.