### PR TITLE
remove reference to null pointer

### DIFF
--- a/CaloMC/src/CaloClusterTruthMatch_module.cc
+++ b/CaloMC/src/CaloClusterTruthMatch_module.cc
@@ -82,7 +82,7 @@ namespace mu2e {
 
       const auto  caloClusterHandle = event.getValidHandle(caloClusterToken_);
       const auto& caloClusters(*caloClusterHandle);
-      const auto* caloClusterBase = &caloClusters.front();
+      const auto* caloClusterBase = caloClusters.data();
 
       const auto  CaloHitMCHandle = event.getValidHandle(caloHitMCTruthToken_);
       const auto& caloHitTruth(*CaloHitMCHandle);


### PR DESCRIPTION
This should remove the last "reference to null pointer" warning in Offline sanitize.  The functionality is identical, just without going through the intermediate step of making a null reference.  Verified and validated with 500 events of ceSimReco (where the warning originally appeared).