### PR TITLE
Revert from a ReplicatedProducer to a legacy EDProducer

### DIFF
--- a/EventGenerator/src/PrimaryProtonGun_module.cc
+++ b/EventGenerator/src/PrimaryProtonGun_module.cc
@@ -1,6 +1,6 @@
 
 /*
-  This was a Replicated Module and was reverted to Legacy on Mar 27, 2002
+  This was a Replicated Module and was reverted to Legacy on Mar 27, 2022
   until GitHub issues #744 and #745 can be resolved.
 
   A plug-in for running PrimaryProtonGun-based event generator for running in MT art.


### PR DESCRIPTION
This is a, hopefully, temporary solution to Offline issues #744 and #745  that were uncovered when working on issue #482.

Using Production/JobConfig/validation/stoppedMuonsSingleStageMT.fcl  I ran 4 test jobs, 2 with the original code and with this PR.  All were 250000 events.  The two with this PR produced identical results while the two originals differed as described in issue #482 .

This PR could slow down the real time performance of the two jobs because of less parallelism.  So I did a measurement and the change is not large enough to be important.    The execution times for the 4 jobs were

Before this PR:
TimeReport CPU = 9158.873317 Real = 1878.142641
TimeReport CPU = 9288.815459 Real = 1904.679477

 Mean and standard deviation:  1891 +/- 23

After this PR:
TimeReport CPU = 9301.399397 Real = 1906.883257
TimeReport CPU = 9358.623558 Real = 1916.216917

 Mean and standard deviation:   1911 +/- 7

The difference between the two means is about 1%, with a significance of about 1 sigma.  I believe this is acceptable.


