### PR TITLE
add links for sanitize

### DIFF
--- a/CaloConditions/src/SConscript
+++ b/CaloConditions/src/SConscript
@@ -28,6 +28,7 @@ mainlib = helper.make_mainlib ( [
     'art_Utilities',
     'canvas',
     'fhiclcpp',
+    'fhiclcpp_types',
     'cetlib',
     'cetlib_except',
     #'CLHEP',

--- a/DAQConditions/src/SConscript
+++ b/DAQConditions/src/SConscript
@@ -34,6 +34,7 @@ mainlib = helper.make_mainlib ( [
                                   'art_Utilities',
                                   'canvas',
                                   'fhiclcpp',
+                                  'fhiclcpp_types',
                                   'cetlib',
                                   'cetlib_except',
                                   'CLHEP',


### PR DESCRIPTION
Compiling and linking for the gnu sanitize tests is a little more demanding than our standard linking.  We fixed this issue before, but I think these additions were probably triggered by recent changes in fhiclcpp product.