### PR TITLE
enabling forcing specific muon decay proper time

### DIFF
--- a/Mu2eG4/fcl/prolog.fcl
+++ b/Mu2eG4/fcl/prolog.fcl
@@ -47,6 +47,9 @@ mu2eg4DefaultPhysics: {
 
     // mscModelTransitionEnergy: 115. // MeV uncomment to change the Geant4 deafult
 
+    // muonPreAssignedDecayProperTime: 200.0 // ns uncomment and set specific time,
+                                             // to activate seting muon fixed decay proper time
+
     useEmOption4InTracker: false // to use that option in the tracker only if not using _EMZ;
                                  // does not seem to work all that well in geant4 10.4
     addProcesses: []

--- a/Mu2eG4/inc/Mu2eG4Config.hh
+++ b/Mu2eG4/inc/Mu2eG4Config.hh
@@ -142,6 +142,7 @@ namespace mu2e {
           };
 
       fhicl::OptionalAtom<double> mscModelTransitionEnergy {Name("mscModelTransitionEnergy")};
+      fhicl::OptionalAtom<double> muonPreAssignedDecayProperTime {Name("muonPreAssignedDecayProperTime")};
 
       OptionalDelegatedParameter BirksConsts {Name("BirksConsts")};
       OptionalDelegatedParameter minRangeRegionCuts {Name("minRangeRegionCuts")};

--- a/Mu2eG4/inc/Mu2eG4TrackingAction.hh
+++ b/Mu2eG4/inc/Mu2eG4TrackingAction.hh
@@ -127,6 +127,9 @@ namespace mu2e {
     // trajectory information to the output data product.
     void swapTrajectory( const G4Track* trk );
 
+    // the muon specific decay proper time; it is ignored if set to a negative value
+    double _muonPreAssignedDecayProperTime;
+
   };
 
 } // end namespace mu2e

--- a/Mu2eG4/src/Mu2eG4TrackingAction.cc
+++ b/Mu2eG4/src/Mu2eG4TrackingAction.cc
@@ -191,7 +191,7 @@ namespace mu2e {
 
     // Need to cast away const-ness to do this.
     const_cast<G4Track*>(trk)->SetUserInformation(ti);
-    if (_muonPreAssignedDecayProperTime>0) {
+    if (_muonPreAssignedDecayProperTime>=0.0) {
       const G4DynamicParticle* dynPart = trk->GetDynamicParticle();
       if (dynPart->GetPDGcode() == 13) {
         // if track is a muon and preassigned proper time is set, assing it

--- a/Mu2eG4/src/Mu2eG4TrackingAction.cc
+++ b/Mu2eG4/src/Mu2eG4TrackingAction.cc
@@ -36,6 +36,7 @@
 #include "Offline/Mu2eG4/inc/Mu2eG4ResourceLimits.hh"
 #include "Offline/Mu2eG4/inc/Mu2eG4TrajectoryControl.hh"
 #include "Offline/Mu2eG4/inc/Mu2eG4PerThreadStorage.hh"
+#include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/SimParticle.hh"
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
 #include "Offline/MCDataProducts/inc/ProcessCode.hh"
@@ -193,7 +194,7 @@ namespace mu2e {
     const_cast<G4Track*>(trk)->SetUserInformation(ti);
     if (_muonPreAssignedDecayProperTime>=0.0) {
       const G4DynamicParticle* dynPart = trk->GetDynamicParticle();
-      if (dynPart->GetPDGcode() == 13) {
+      if (dynPart->GetPDGcode() == PDGCode::mu_minus) {
         // if track is a muon and preassigned proper time is set, assing it
         if (trackingVerbosityLevel>0) {
           G4cout << __func__
@@ -546,8 +547,8 @@ namespace mu2e {
     if (pname == "Transportation" &&
         Mu2eG4UserHelpers::isTrackKilledByFieldPropagator(trk, trVerbosity)) {
       pname = G4String("mu2eFieldPropagator");
-      if ( !(trk->GetDefinition()->GetPDGEncoding() == 11 || // electron & proton codes hardcoded for now
-             trk->GetDefinition()->GetPDGEncoding() == 2212 ) ||
+      if ( !(trk->GetDefinition()->GetPDGEncoding() == PDGCode::e_minus ||
+             trk->GetDefinition()->GetPDGEncoding() == PDGCode::proton ) ||
            G4LossTableManager::Instance()->
            GetRange(trk->GetDefinition(),
                     trk->GetKineticEnergy(),


### PR DESCRIPTION
The PR enables forcing specific muon decay proper time 
(if the decay process is the one which ends the track, and not, e.g., 
a capture at rest often seen in case of low energy muons).

The setting is inactive by default, so no changes in behavior are expected when merging this PR.

There is a negligible CPU penalty to check if a double is greater or equal zero in the tracking action.

The PR is a proof of concept, which can form a basis for a more elaborate solution.