### PR TITLE
Geometry files for positive muon beam and 50% DS field

### DIFF
--- a/Mu2eG4/geom/RotatedColl3.txt
+++ b/Mu2eG4/geom/RotatedColl3.txt
@@ -1,0 +1,11 @@
+//
+// To generate a positive muon beam in Mu2e, we need to
+// rotate the collimator in TS3
+//
+
+double ts.coll3.rotationAngle    = 180.0;
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/bfgeom_DS50_no_ds_v01.txt
+++ b/Mu2eG4/geom/bfgeom_DS50_no_ds_v01.txt
@@ -1,6 +1,6 @@
 //
-// Variant of the B field maps used for reconstruction.  All B field maps
-// not needed for reconstruction have been removed.
+// Variant of the bfield maps with the DS field scaled down to 50% of nominal
+// and with the DS field map removed for production jobs
 //
 // Warning:
 //  There are multiple points of maintenance when you change any bfield maps.
@@ -15,13 +15,15 @@
 //
 //  If more variants are added, update the comments in all relevant files.
 
-#include "Offline/Mu2eG4/geom/bfgeom_v01.txt"
+#include "Mu2eG4/geom/bfgeom_no_ds_v01.txt"
 
 vector<string> bfield.innerMaps = {
-  "BFieldMaps/Mau13/DSMap.header"
+  "BFieldMaps/Mau13/PSMap.header",
+  "BFieldMaps/Mau13/TSuMap_fix.header",
+  "BFieldMaps/Mau13/TSdMap_DS50.header",
+  "BFieldMaps/Mau13/PStoDumpAreaMap.header",
+  "BFieldMaps/Mau13/ProtonDumpAreaMap.header"
 };
-
-vector<string> bfield.outerMaps = {};
 
 
 //

--- a/Mu2eG4/geom/bfgeom_DS50_no_ds_v01.txt
+++ b/Mu2eG4/geom/bfgeom_DS50_no_ds_v01.txt
@@ -8,14 +8,14 @@
 //    - bfgeom_no_ds_v01.txt     ( DS map removed     )
 //    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
 //    - bfgeom_no_tsu_ps_v01.txt ( PS and TSu maps removed.
-//    - bfgeam_DS50_v01.txt      ( DS field reduced to 50% )
-//    - bfgeam_DS50_no_ds_v01.txt ( DS field reduced to 50% and with DS map removed ) 
-//    - bfgeam_DS50_no_tsu_ps_v01.txt ( DS field reduced to 50% and with PS and TSu maps removed ) 
-//    - bfgeam_DS50_reco_v01.txt ( DS field reduced to 50% and only maps needed for reconstrucion ) 
+//    - bfgeom_DS50_v01.txt      ( DS field reduced to 50% )
+//    - bfgeom_DS50_no_ds_v01.txt ( DS field reduced to 50% and with DS map removed ) 
+//    - bfgeom_DS50_no_tsu_ps_v01.txt ( DS field reduced to 50% and with PS and TSu maps removed ) 
+//    - bfgeom_DS50_reco_v01.txt ( DS field reduced to 50% and only maps needed for reconstrucion ) 
 //
 //  If more variants are added, update the comments in all relevant files.
 
-#include "Mu2eG4/geom/bfgeom_no_ds_v01.txt"
+#include "Offline/Mu2eG4/geom/bfgeom_no_ds_v01.txt"
 
 vector<string> bfield.innerMaps = {
   "BFieldMaps/Mau13/PSMap.header",

--- a/Mu2eG4/geom/bfgeom_DS50_no_tsu_ps_v01.txt
+++ b/Mu2eG4/geom/bfgeom_DS50_no_tsu_ps_v01.txt
@@ -8,14 +8,14 @@
 //    - bfgeom_no_ds_v01.txt     ( DS map removed     )
 //    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
 //    - bfgeom_no_tsu_ps_v01.txt ( PS and TSu maps removed.
-//    - bfgeam_DS50_v01.txt      ( DS field reduced by 50% )
-//    - bfgeam_DS50_no_ds_v01.txt ( DS field reduced to 50% and with DS map removed ) 
-//    - bfgeam_DS50_no_tsu_ps_v01.txt ( DS field reduced to 50% and with PS and TSu maps removed ) 
-//    - bfgeam_DS50_reco_v01.txt ( DS field reduced to 50% and only maps needed for reconstrucion ) 
+//    - bfgeom_DS50_v01.txt      ( DS field reduced by 50% )
+//    - bfgeom_DS50_no_ds_v01.txt ( DS field reduced to 50% and with DS map removed ) 
+//    - bfgeom_DS50_no_tsu_ps_v01.txt ( DS field reduced to 50% and with PS and TSu maps removed ) 
+//    - bfgeom_DS50_reco_v01.txt ( DS field reduced to 50% and only maps needed for reconstrucion ) 
 //
 //  If more variants are added, update the comments in all relevant files.
 
-#include "Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
+#include "Offline/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 
 vector<string> bfield.innerMaps = {
   "BFieldMaps/Mau13/DSMap50.header",

--- a/Mu2eG4/geom/bfgeom_DS50_no_tsu_ps_v01.txt
+++ b/Mu2eG4/geom/bfgeom_DS50_no_tsu_ps_v01.txt
@@ -1,6 +1,6 @@
 //
-// Variant of the B field maps used for reconstruction.  All B field maps
-// not needed for reconstruction have been removed.
+// Variant of the bfield maps with the DS field scaled down to 50% of nominal
+// and with the PS and TSu maps removed
 //
 // Warning:
 //  There are multiple points of maintenance when you change any bfield maps.
@@ -8,20 +8,20 @@
 //    - bfgeom_no_ds_v01.txt     ( DS map removed     )
 //    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
 //    - bfgeom_no_tsu_ps_v01.txt ( PS and TSu maps removed.
-//    - bfgeam_DS50_v01.txt      ( DS field reduced to 50% )
+//    - bfgeam_DS50_v01.txt      ( DS field reduced by 50% )
 //    - bfgeam_DS50_no_ds_v01.txt ( DS field reduced to 50% and with DS map removed ) 
 //    - bfgeam_DS50_no_tsu_ps_v01.txt ( DS field reduced to 50% and with PS and TSu maps removed ) 
 //    - bfgeam_DS50_reco_v01.txt ( DS field reduced to 50% and only maps needed for reconstrucion ) 
 //
 //  If more variants are added, update the comments in all relevant files.
 
-#include "Offline/Mu2eG4/geom/bfgeom_v01.txt"
+#include "Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt"
 
 vector<string> bfield.innerMaps = {
-  "BFieldMaps/Mau13/DSMap.header"
+  "BFieldMaps/Mau13/DSMap50.header",
+  "BFieldMaps/Mau13/TSdMap_DS50.header",
+  "BFieldMaps/Mau13/DSExtension.header"
 };
-
-vector<string> bfield.outerMaps = {};
 
 
 //

--- a/Mu2eG4/geom/bfgeom_DS50_reco_v01.txt
+++ b/Mu2eG4/geom/bfgeom_DS50_reco_v01.txt
@@ -1,6 +1,6 @@
 //
-// Variant of the B field maps used for reconstruction.  All B field maps
-// not needed for reconstruction have been removed.
+// Variant of the bfield maps with the DS field scaled down to 50% of nominal
+// and with only the field maps needed for the reconstruction
 //
 // Warning:
 //  There are multiple points of maintenance when you change any bfield maps.
@@ -15,13 +15,11 @@
 //
 //  If more variants are added, update the comments in all relevant files.
 
-#include "Offline/Mu2eG4/geom/bfgeom_v01.txt"
+#include "Mu2eG4/geom/bfgeom_reco_v01.txt"
 
 vector<string> bfield.innerMaps = {
-  "BFieldMaps/Mau13/DSMap.header"
+  "BFieldMaps/Mau13/DSMap50.header"
 };
-
-vector<string> bfield.outerMaps = {};
 
 
 //

--- a/Mu2eG4/geom/bfgeom_DS50_v01.txt
+++ b/Mu2eG4/geom/bfgeom_DS50_v01.txt
@@ -7,14 +7,14 @@
 //    - bfgeom_no_ds_v01.txt     ( DS map removed     )
 //    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
 //    - bfgeom_no_tsu_ps_v01.txt ( PS and TSu maps removed.
-//    - bfgeam_DS50_v01.txt      ( DS field reduced by 50% )
-//    - bfgeam_DS50_no_ds_v01.txt ( DS field reduced to 50% and with DS map removed ) 
-//    - bfgeam_DS50_no_tsu_ps_v01.txt ( DS field reduced to 50% and with PS and TSu maps removed ) 
-//    - bfgeam_DS50_reco_v01.txt ( DS field reduced to 50% and only maps needed for reconstrucion ) 
+//    - bfgeom_DS50_v01.txt      ( DS field reduced by 50% )
+//    - bfgeom_DS50_no_ds_v01.txt ( DS field reduced to 50% and with DS map removed ) 
+//    - bfgeom_DS50_no_tsu_ps_v01.txt ( DS field reduced to 50% and with PS and TSu maps removed ) 
+//    - bfgeom_DS50_reco_v01.txt ( DS field reduced to 50% and only maps needed for reconstrucion ) 
 //
 //  If more variants are added, update the comments in all relevant files.
 
-#include "Mu2eG4/geom/bfgeom_v01.txt"
+#include "Offline/Mu2eG4/geom/bfgeom_v01.txt"
 
 vector<string> bfield.innerMaps = {
   "BFieldMaps/Mau13/DSMap50.header",

--- a/Mu2eG4/geom/bfgeom_DS50_v01.txt
+++ b/Mu2eG4/geom/bfgeom_DS50_v01.txt
@@ -1,6 +1,5 @@
 //
-// Variant of the B field maps used for reconstruction.  All B field maps
-// not needed for reconstruction have been removed.
+// Variant of the bfield maps with the DS field scaled down to 50% of nominal.
 //
 // Warning:
 //  There are multiple points of maintenance when you change any bfield maps.
@@ -8,20 +7,24 @@
 //    - bfgeom_no_ds_v01.txt     ( DS map removed     )
 //    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
 //    - bfgeom_no_tsu_ps_v01.txt ( PS and TSu maps removed.
-//    - bfgeam_DS50_v01.txt      ( DS field reduced to 50% )
+//    - bfgeam_DS50_v01.txt      ( DS field reduced by 50% )
 //    - bfgeam_DS50_no_ds_v01.txt ( DS field reduced to 50% and with DS map removed ) 
 //    - bfgeam_DS50_no_tsu_ps_v01.txt ( DS field reduced to 50% and with PS and TSu maps removed ) 
 //    - bfgeam_DS50_reco_v01.txt ( DS field reduced to 50% and only maps needed for reconstrucion ) 
 //
 //  If more variants are added, update the comments in all relevant files.
 
-#include "Offline/Mu2eG4/geom/bfgeom_v01.txt"
+#include "Mu2eG4/geom/bfgeom_v01.txt"
 
 vector<string> bfield.innerMaps = {
-  "BFieldMaps/Mau13/DSMap.header"
+  "BFieldMaps/Mau13/DSMap50.header",
+  "BFieldMaps/Mau13/PSMap.header",
+  "BFieldMaps/Mau13/TSuMap_fix.header",
+  "BFieldMaps/Mau13/TSdMap_DS50.header",
+  "BFieldMaps/Mau13/PStoDumpAreaMap.header",
+  "BFieldMaps/Mau13/ProtonDumpAreaMap.header",
+  "BFieldMaps/Mau13/DSExtension.header"
 };
-
-vector<string> bfield.outerMaps = {};
 
 
 //

--- a/Mu2eG4/geom/bfgeom_no_ds_v01.txt
+++ b/Mu2eG4/geom/bfgeom_no_ds_v01.txt
@@ -11,6 +11,10 @@
 //    - bfgeom_no_ds_v01.txt     ( DS map removed     )
 //    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
 //    - bfgeom_no_tsu_ps_v01.txt ( PS and TSu maps removed.
+//    - bfgeam_DS50_v01.txt      ( DS field reduced to 50% )
+//    - bfgeam_DS50_no_ds_v01.txt ( DS field reduced to 50% and with DS map removed ) 
+//    - bfgeam_DS50_no_tsu_ps_v01.txt ( DS field reduced to 50% and with PS and TSu maps removed ) 
+//    - bfgeam_DS50_reco_v01.txt ( DS field reduced to 50% and only maps needed for reconstrucion ) 
 //
 //  If more variants are added, update the comments in all relevant files.
 

--- a/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt
+++ b/Mu2eG4/geom/bfgeom_no_tsu_ps_v01.txt
@@ -22,6 +22,10 @@
 //    - bfgeom_no_ds_v01.txt     ( DS map removed     )
 //    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
 //    - bfgeom_no_tsu_ps_v01.txt ( PS and TSu maps removed.
+//    - bfgeam_DS50_v01.txt      ( DS field reduced to 50% )
+//    - bfgeam_DS50_no_ds_v01.txt ( DS field reduced to 50% and with DS map removed ) 
+//    - bfgeam_DS50_no_tsu_ps_v01.txt ( DS field reduced to 50% and with PS and TSu maps removed ) 
+//    - bfgeam_DS50_reco_v01.txt ( DS field reduced to 50% and only maps needed for reconstrucion ) 
 //
 //  If more variants are added, update the comments in all relevant files.
 

--- a/Mu2eG4/geom/bfgeom_v01.txt
+++ b/Mu2eG4/geom/bfgeom_v01.txt
@@ -8,6 +8,10 @@
 //    - bfgeom_no_ds_v01.txt     ( DS map removed     )
 //    - bfgeom_reco_v01.txt      ( only maps needed for reconstruction )
 //    - bfgeom_no_tsu_ps_v01.txt ( PS and TSu maps removed.
+//    - bfgeam_DS50_v01.txt      ( DS field reduced to 50% )
+//    - bfgeam_DS50_no_ds_v01.txt ( DS field reduced to 50% and with DS map removed ) 
+//    - bfgeam_DS50_no_tsu_ps_v01.txt ( DS field reduced to 50% and with PS and TSu maps removed ) 
+//    - bfgeam_DS50_reco_v01.txt ( DS field reduced to 50% and only maps needed for reconstrucion ) 
 //
 
 // Form of DS field: 0 is full field;

--- a/Mu2eG4/geom/geom_common_DS50.txt
+++ b/Mu2eG4/geom/geom_common_DS50.txt
@@ -3,7 +3,7 @@
 //
 
 #include "Offline/Mu2eG4/geom/geom_common.txt"
-#include "Offline/Mu2eG4/geom/bfgeom_DS50_v01.txt
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_v01.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/geom_common_DS50.txt
+++ b/Mu2eG4/geom/geom_common_DS50.txt
@@ -1,0 +1,11 @@
+//
+// Variant on geom_common.txt for DS field scaled to 50%
+//
+
+#include "Offline/Mu2eG4/geom/geom_common.txt"
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_v01.txt
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_DS50_no_ds.txt
+++ b/Mu2eG4/geom/geom_common_DS50_no_ds.txt
@@ -4,7 +4,7 @@
 //
 
 #include "Offline/Mu2eG4/geom/geom_common_no_ds.txt"
-#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_ds_v01.txt
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_ds_v01.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/geom_common_DS50_no_ds.txt
+++ b/Mu2eG4/geom/geom_common_DS50_no_ds.txt
@@ -1,0 +1,12 @@
+//
+// Variant on geom_common.txt for DS field scaled to 50%
+// and DS field map removed
+//
+
+#include "Offline/Mu2eG4/geom/geom_common_no_ds.txt"
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_ds_v01.txt
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_DS50_no_tsu_ps.txt
+++ b/Mu2eG4/geom/geom_common_DS50_no_tsu_ps.txt
@@ -1,0 +1,12 @@
+//
+// Variant on geom_common.txt for DS field scaled to 50%
+// and TSu and PS field maps removed
+//
+
+#include "Offline/Mu2eG4/geom/geom_common_no_tsu_ps.txt"
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_tsu_ps_v01.txt
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_DS50_no_tsu_ps.txt
+++ b/Mu2eG4/geom/geom_common_DS50_no_tsu_ps.txt
@@ -4,7 +4,7 @@
 //
 
 #include "Offline/Mu2eG4/geom/geom_common_no_tsu_ps.txt"
-#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_tsu_ps_v01.txt
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_tsu_ps_v01.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/geom_common_DS50_reco.txt
+++ b/Mu2eG4/geom/geom_common_DS50_reco.txt
@@ -1,0 +1,12 @@
+//
+// Variant on geom_common.txt for DS field scaled to 50%
+// and only with field maps needed for reconstruction
+//
+
+#include "Offline/Mu2eG4/geom/geom_common_reco.txt"
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_reco_v01.txt
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_muplus.txt
+++ b/Mu2eG4/geom/geom_common_muplus.txt
@@ -1,0 +1,11 @@
+//
+// Variant on geom_common.txt for positive muon running
+//
+
+#include "Offline/Mu2eG4/geom/geom_common.txt"
+#include "Offline/Mu2eG4/geom/RotatedColl3.txt"
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_muplus_DS50.txt
+++ b/Mu2eG4/geom/geom_common_muplus_DS50.txt
@@ -1,0 +1,12 @@
+//
+// Variant on geom_common.txt for positive muon running
+// and with DS field scaled to 50%
+//
+
+#include "Offline/Mu2eG4/geom/geom_common_muplus.txt"
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_v01.txt
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_muplus_DS50.txt
+++ b/Mu2eG4/geom/geom_common_muplus_DS50.txt
@@ -4,7 +4,7 @@
 //
 
 #include "Offline/Mu2eG4/geom/geom_common_muplus.txt"
-#include "Offline/Mu2eG4/geom/bfgeom_DS50_v01.txt
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_v01.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/geom_common_muplus_DS50_no_ds.txt
+++ b/Mu2eG4/geom/geom_common_muplus_DS50_no_ds.txt
@@ -5,7 +5,7 @@
 //
 
 #include "Offline/Mu2eG4/geom/geom_common_muplus.txt"
-#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_ds_v01.txt
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_ds_v01.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/geom_common_muplus_DS50_no_ds.txt
+++ b/Mu2eG4/geom/geom_common_muplus_DS50_no_ds.txt
@@ -1,0 +1,13 @@
+//
+// Variant on geom_common.txt for positive muon running
+// and with DS field scaled to 50%
+// and with DS field map removed
+//
+
+#include "Offline/Mu2eG4/geom/geom_common_muplus.txt"
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_ds_v01.txt
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_muplus_DS50_no_tsu_ps.txt
+++ b/Mu2eG4/geom/geom_common_muplus_DS50_no_tsu_ps.txt
@@ -1,0 +1,13 @@
+//
+// Variant on geom_common.txt for positive muon running
+// and with DS field scaled to 50%
+// and withTSu and PSS field maps removed
+//
+
+#include "Offline/Mu2eG4/geom/geom_common_muplus.txt"
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_tsu_ps_v01.txt
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_muplus_DS50_no_tsu_ps.txt
+++ b/Mu2eG4/geom/geom_common_muplus_DS50_no_tsu_ps.txt
@@ -5,7 +5,7 @@
 //
 
 #include "Offline/Mu2eG4/geom/geom_common_muplus.txt"
-#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_tsu_ps_v01.txt
+#include "Offline/Mu2eG4/geom/bfgeom_DS50_no_tsu_ps_v01.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/geom_common_muplus_no_ds.txt
+++ b/Mu2eG4/geom/geom_common_muplus_no_ds.txt
@@ -1,0 +1,12 @@
+//
+// Variant on geom_common.txt for positive muon running
+// and with DS field map removed
+//
+
+#include "Offline/Mu2eG4/geom/geom_common_no_ds.txt"
+#include "Offline/Mu2eG4/geom/RotatedColl3.txt"
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_common_muplus_no_tsu_ps.txt
+++ b/Mu2eG4/geom/geom_common_muplus_no_tsu_ps.txt
@@ -1,0 +1,12 @@
+//
+// Variant on geom_common.txt for positive muon running
+// and with TSu and PS field maps removed
+//
+
+#include "Offline/Mu2eG4/geom/geom_common_no_tsu_ps.txt"
+#include "Offline/Mu2eG4/geom/RotatedColl3.txt"
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:


### PR DESCRIPTION
Hi Everyone,

I've added the geometry files for:
 - negative muon beam running and 50% DS field,
 - positive muon beam running and 100% DS field, and
 - positive muon beam running and 50% DS field

I added standard, ```_no_ds```, and ```_no_tsu_ps``` versions for all geometries but I did not add ```_reco_``` geometries for the positive muon beam since the rotated collimator shouldn't have an effect during the reconstruction. I'm happy to add these if we want consistency. I'm also happy to rename anything if the names I've used don't quite work

I am creating this as a draft pull request because I would like to look at the overlap checks for the rotated collimator geometry, and make sure I haven't got any typos by trying to run a single event with each of the new geom_common files. I will also put in a PR to the Production repository with related fcl scripts

Cheers,
Andy