### PR TITLE
Restore the Mu2e-specific artapp() parameter report_unused=false

### DIFF
--- a/Mu2e/src/mu2e_main.cc
+++ b/Mu2e/src/mu2e_main.cc
@@ -55,7 +55,7 @@ int
 main(int argc, char* argv[])
 {
   mu2eBanner();
-  p = artapp(argc, argv);
+  p = artapp(argc, argv, false);
   mf::EndMessageFacility();
   return p.exitcode();
 }


### PR DESCRIPTION
This is to stop the reporting of unused modules by art.