### PR TITLE
add connection to EPICS replica

### DIFF
--- a/DbService/data/connections.txt
+++ b/DbService/data/connections.txt
@@ -16,17 +16,23 @@ database mu2e_conditions_prd
     host ifdb08
     port 5448
     cache      https://dbdata0vm.fnal.gov:8444/QE/mu2e/prod/app/SQ/query?
-    nocache  https://dbdata0vm.fnal.gov:9443/QE/mu2e/prod/app/SQ/query?
+    nocache    https://dbdata0vm.fnal.gov:9443/QE/mu2e/prod/app/SQ/query?
 
 database mu2e_conditions_dev
     host ifdb07
     port 5444
-    cache     https://dbdata0vm.fnal.gov:8444/QE/mu2e/dev/app/SQ/query?
-    nocache https://dbdata0vm.fnal.gov:9443/QE/mu2e/dev/app/SQ/query?
+    cache      https://dbdata0vm.fnal.gov:8444/QE/mu2e/dev/app/SQ/query?
+    nocache    https://dbdata0vm.fnal.gov:9443/QE/mu2e/dev/app/SQ/query?
 
 database mu2e_dqm_prd
     host ifdb08
     port 5459
+    cache      https://dbdata0vm.fnal.gov:8444/QE/mu2e/prod/app/SQ/query?
+    nocache    https://dbdata0vm.fnal.gov:9443/QE/mu2e/prod/app/SQ/query?
+
+database dcs_archive
+    host ifdb09
+    port 5457
     cache      https://dbdata0vm.fnal.gov:8444/QE/mu2e/prod/app/SQ/query?
     nocache    https://dbdata0vm.fnal.gov:9443/QE/mu2e/prod/app/SQ/query?
 


### PR DESCRIPTION
Add connection to EPICS archiver.  The file is updated on cvmfs.  There should be no effect on validation. 