### PR TITLE
adding options to set min max muon proper time

### DIFF
--- a/Mu2eG4/fcl/prolog.fcl
+++ b/Mu2eG4/fcl/prolog.fcl
@@ -42,13 +42,18 @@ mu2eg4DefaultPhysics: {
       "Inconel718","MBSCalShieldRing","MBSSupportMix","NbTi","NbTiCu",
       "ProductionTargetTungstenLa2_O3",
       "RackSteel","StainlessSteel","StainlessSteel316","StainlessSteel316L","StoppingTarget_Al"]
-    // comma separated list used when the above is set to true 
+    // comma separated list used when the above is set to true
     // e.g., ["StainlessSteel", "StainlessSteel316"]
 
     // mscModelTransitionEnergy: 115. // MeV uncomment to change the Geant4 deafult
 
     // muonPreAssignedDecayProperTime: 200.0 // ns uncomment and set specific time,
                                              // to activate seting muon fixed decay proper time
+
+    // muonMinPreAssignedDecayProperTime: 100.0 // ns uncomment and set the min proper time
+    // muonMaxPreAssignedDecayProperTime: 200.0 // ns uncomment and set the max proper time
+    // to activate seting muon random, fixed (from min up to the max value) decay proper time
+    // either the specific or one or both min, max options above can be activated at a time
 
     useEmOption4InTracker: false // to use that option in the tracker only if not using _EMZ;
                                  // does not seem to work all that well in geant4 10.4

--- a/Mu2eG4/inc/Mu2eG4Config.hh
+++ b/Mu2eG4/inc/Mu2eG4Config.hh
@@ -143,6 +143,8 @@ namespace mu2e {
 
       fhicl::OptionalAtom<double> mscModelTransitionEnergy {Name("mscModelTransitionEnergy")};
       fhicl::OptionalAtom<double> muonPreAssignedDecayProperTime {Name("muonPreAssignedDecayProperTime")};
+      fhicl::OptionalAtom<double> muonMaxPreAssignedDecayProperTime {Name("muonMaxPreAssignedDecayProperTime")};
+      fhicl::OptionalAtom<double> muonMinPreAssignedDecayProperTime {Name("muonMinPreAssignedDecayProperTime")};
 
       OptionalDelegatedParameter BirksConsts {Name("BirksConsts")};
       OptionalDelegatedParameter minRangeRegionCuts {Name("minRangeRegionCuts")};

--- a/Mu2eG4/inc/Mu2eG4TrackingAction.hh
+++ b/Mu2eG4/inc/Mu2eG4TrackingAction.hh
@@ -129,6 +129,11 @@ namespace mu2e {
 
     // the muon specific decay proper time; it is ignored if set to a negative value
     double _muonPreAssignedDecayProperTime;
+    // the maximum specific decay proper time; the specific time above excludes
+    // the min max time use
+    double _muonMinPreAssignedDecayProperTime;
+    // the minimum specific decay proper time;
+    double _muonMaxPreAssignedDecayProperTime;
 
   };
 


### PR DESCRIPTION
This PR builds upon and extends PR https://github.com/Mu2e/Offline/pull/753

The settings are inactive by default, so no changes in behavior are expected when merging this PR.

One can activate them by using one or both lines below in an fcl file:
physics.producers.g4run.physics.muonMinPreAssignedDecayProperTime: 100. // ns
physics.producers.g4run.physics.muonMaxPreAssignedDecayProperTime: 300. // ns
