### PR TITLE
Using physics constructors in the Minimal physics list etc.

### DIFF
--- a/Mu2eG4/inc/Mu2eG4CustomizationPhysicsConstructor.hh
+++ b/Mu2eG4/inc/Mu2eG4CustomizationPhysicsConstructor.hh
@@ -23,15 +23,13 @@ namespace mu2e {
 
     Mu2eG4CustomizationPhysicsConstructor();
 
-    virtual ~Mu2eG4CustomizationPhysicsConstructor();
+    virtual ~Mu2eG4CustomizationPhysicsConstructor() = default;
 
     virtual void ConstructParticle();
 
     virtual void ConstructProcess();
 
   private:
-
-    static G4ThreadLocal G4bool wasActivated;
 
     // non owning pointer
     // can't be ref due to the default constructor factory requirement

--- a/Mu2eG4/inc/Mu2eG4CustomizationPhysicsConstructor.hh
+++ b/Mu2eG4/inc/Mu2eG4CustomizationPhysicsConstructor.hh
@@ -24,7 +24,9 @@ namespace mu2e {
     Mu2eG4CustomizationPhysicsConstructor();
 
     virtual ~Mu2eG4CustomizationPhysicsConstructor() = default;
-
+    Mu2eG4CustomizationPhysicsConstructor(const Mu2eG4CustomizationPhysicsConstructor &) = delete;
+    Mu2eG4CustomizationPhysicsConstructor & operator=(const Mu2eG4CustomizationPhysicsConstructor &) = delete;
+    Mu2eG4CustomizationPhysicsConstructor & operator=( Mu2eG4CustomizationPhysicsConstructor && ) = delete;
     virtual void ConstructParticle();
 
     virtual void ConstructProcess();

--- a/Mu2eG4/inc/Mu2eG4DecayMuonsWithSpinPhysicsConstructor.hh
+++ b/Mu2eG4/inc/Mu2eG4DecayMuonsWithSpinPhysicsConstructor.hh
@@ -64,7 +64,6 @@ class Mu2eG4DecayMuonsWithSpinPhysicsConstructor : public G4VPhysicsConstructor
 private:
   G4Decay* fDecayWithSpinProcess;
   G4int    verbose;
-  G4bool   wasActivated;
 };
 
 

--- a/Mu2eG4/inc/Mu2eG4DecayMuonsWithSpinPhysicsConstructor.hh
+++ b/Mu2eG4/inc/Mu2eG4DecayMuonsWithSpinPhysicsConstructor.hh
@@ -48,7 +48,9 @@ class Mu2eG4DecayMuonsWithSpinPhysicsConstructor : public G4VPhysicsConstructor
     Mu2eG4DecayMuonsWithSpinPhysicsConstructor(G4int ver = 1);
     Mu2eG4DecayMuonsWithSpinPhysicsConstructor(const G4String& name, G4int ver = 1);
     virtual ~Mu2eG4DecayMuonsWithSpinPhysicsConstructor();
-
+    Mu2eG4DecayMuonsWithSpinPhysicsConstructor(const Mu2eG4DecayMuonsWithSpinPhysicsConstructor &) = delete;
+    Mu2eG4DecayMuonsWithSpinPhysicsConstructor & operator=(const Mu2eG4DecayMuonsWithSpinPhysicsConstructor &) = delete;
+    Mu2eG4DecayMuonsWithSpinPhysicsConstructor & operator=( Mu2eG4DecayMuonsWithSpinPhysicsConstructor && ) = delete;
   public:
     // This method will be invoked in the Construct() method.
     // each particle type will be instantiated

--- a/Mu2eG4/inc/Mu2eG4MinDEDXPhysicsConstructor.hh
+++ b/Mu2eG4/inc/Mu2eG4MinDEDXPhysicsConstructor.hh
@@ -47,7 +47,10 @@ class Mu2eG4MinDEDXPhysicsConstructor : public G4VPhysicsConstructor
 public:
   Mu2eG4MinDEDXPhysicsConstructor(G4int ver = 0);
 
-  virtual ~Mu2eG4MinDEDXPhysicsConstructor();
+  virtual ~Mu2eG4MinDEDXPhysicsConstructor() = default;
+  Mu2eG4MinDEDXPhysicsConstructor(const Mu2eG4MinDEDXPhysicsConstructor &) = delete;
+  Mu2eG4MinDEDXPhysicsConstructor & operator=(const Mu2eG4MinDEDXPhysicsConstructor &) = delete;
+  Mu2eG4MinDEDXPhysicsConstructor & operator=( Mu2eG4MinDEDXPhysicsConstructor && ) = delete;
 
   virtual void ConstructParticle();
   virtual void ConstructProcess();

--- a/Mu2eG4/inc/Mu2eG4MinimalModularPhysicsList.hh
+++ b/Mu2eG4/inc/Mu2eG4MinimalModularPhysicsList.hh
@@ -1,8 +1,8 @@
 #ifndef Mu2eG4_Mu2eG4MinimalModularPhysicsList_hh
 #define Mu2eG4_Mu2eG4MinimalModularPhysicsList_hh
 //
-// Define a minimal physics list for G4, just transportation.
-// Used for debugging geometry.
+// Define a minimal physics list for Geant4
+// Used for debugging geometry etc.
 //
 //
 // Original author Rob Kutschke
@@ -14,19 +14,12 @@ namespace mu2e {
   class Mu2eG4MinimalModularPhysicsList: public G4VModularPhysicsList{
   public:
     Mu2eG4MinimalModularPhysicsList();
-    ~Mu2eG4MinimalModularPhysicsList();
-
-  protected:
-
-    // These methods are called by G4 not by users.
-    void ConstructParticle();
-    void ConstructProcess();
-    void SetCuts();
-
+    virtual ~Mu2eG4MinimalModularPhysicsList() = default;
+    Mu2eG4MinimalModularPhysicsList(const Mu2eG4MinimalModularPhysicsList &) = delete;
+    Mu2eG4MinimalModularPhysicsList & operator=(const Mu2eG4MinimalModularPhysicsList &) = delete;
+    Mu2eG4MinimalModularPhysicsList & operator=( Mu2eG4MinimalModularPhysicsList && ) = delete;
   };
 
 }  // end namespace mu2e
 
 #endif /* Mu2eG4_Mu2eG4MinimalModularPhysicsList_hh */
-
-

--- a/Mu2eG4/inc/Mu2eG4MinimalPhysicsConstructor.hh
+++ b/Mu2eG4/inc/Mu2eG4MinimalPhysicsConstructor.hh
@@ -16,6 +16,9 @@ namespace mu2e {
     Mu2eG4MinimalPhysicsConstructor();
 
     virtual ~Mu2eG4MinimalPhysicsConstructor() = default;
+    Mu2eG4MinimalPhysicsConstructor(const Mu2eG4MinimalPhysicsConstructor &) = delete;
+    Mu2eG4MinimalPhysicsConstructor & operator=(const Mu2eG4MinimalPhysicsConstructor &) = delete;
+    Mu2eG4MinimalPhysicsConstructor & operator=( Mu2eG4MinimalPhysicsConstructor && ) = delete;
 
     void ConstructParticle();
 

--- a/Mu2eG4/inc/Mu2eG4MinimalPhysicsConstructor.hh
+++ b/Mu2eG4/inc/Mu2eG4MinimalPhysicsConstructor.hh
@@ -1,0 +1,28 @@
+#ifndef Mu2eG4_Mu2eG4MinimalPhysicsConstructor_hh
+#define Mu2eG4_Mu2eG4MinimalPhysicsConstructor_hh
+//
+// A Physics constructor that defines the minimal physics
+//
+// Original author KLG inspired by Rob Kutschke Minimal physics list
+//
+#include "Geant4/G4VPhysicsConstructor.hh"
+
+namespace mu2e {
+
+  class  Mu2eG4MinimalPhysicsConstructor: public G4VPhysicsConstructor {
+
+  public:
+
+    Mu2eG4MinimalPhysicsConstructor();
+
+    virtual ~Mu2eG4MinimalPhysicsConstructor() = default;
+
+    void ConstructParticle();
+
+    void ConstructProcess();
+
+  };
+
+} // end namespace mu2e
+
+#endif /* Mu2eG4_Mu2eG4MinimalPhysicsConstructor_hh */

--- a/Mu2eG4/inc/Mu2eG4StepLimiterPhysicsConstructor.hh
+++ b/Mu2eG4/inc/Mu2eG4StepLimiterPhysicsConstructor.hh
@@ -15,6 +15,9 @@ namespace mu2e {
   public:
     Mu2eG4StepLimiterPhysicsConstructor();
     virtual ~Mu2eG4StepLimiterPhysicsConstructor() = default;
+    Mu2eG4StepLimiterPhysicsConstructor(const Mu2eG4StepLimiterPhysicsConstructor &) = delete;
+    Mu2eG4StepLimiterPhysicsConstructor & operator=(const Mu2eG4StepLimiterPhysicsConstructor &) = delete;
+    Mu2eG4StepLimiterPhysicsConstructor & operator=( Mu2eG4StepLimiterPhysicsConstructor && ) = delete;
 
     void ConstructParticle();
     void ConstructProcess();

--- a/Mu2eG4/inc/Mu2eG4StepLimiterPhysicsConstructor.hh
+++ b/Mu2eG4/inc/Mu2eG4StepLimiterPhysicsConstructor.hh
@@ -14,7 +14,7 @@ namespace mu2e {
 
   public:
     Mu2eG4StepLimiterPhysicsConstructor();
-    ~Mu2eG4StepLimiterPhysicsConstructor();
+    virtual ~Mu2eG4StepLimiterPhysicsConstructor() = default;
 
     void ConstructParticle();
     void ConstructProcess();

--- a/Mu2eG4/src/Mu2eG4CustomizationPhysicsConstructor.cc
+++ b/Mu2eG4/src/Mu2eG4CustomizationPhysicsConstructor.cc
@@ -21,8 +21,6 @@ namespace mu2e {
 
   G4_DECLARE_PHYSCONSTR_FACTORY(Mu2eG4CustomizationPhysicsConstructor);
 
-  G4ThreadLocal G4bool Mu2eG4CustomizationPhysicsConstructor::wasActivated = false;
-
   Mu2eG4CustomizationPhysicsConstructor::
   Mu2eG4CustomizationPhysicsConstructor(const Mu2eG4Config::Physics* phys
                                         , const Mu2eG4Config::Debug* debug
@@ -44,9 +42,6 @@ namespace mu2e {
     , mu2elimits_(nullptr)
   {}
 
-  Mu2eG4CustomizationPhysicsConstructor::~Mu2eG4CustomizationPhysicsConstructor()
-  {}
-
   void Mu2eG4CustomizationPhysicsConstructor::ConstructParticle()
   {
     // Empty on purpose, for now
@@ -54,8 +49,6 @@ namespace mu2e {
 
   void Mu2eG4CustomizationPhysicsConstructor::ConstructProcess()
   {
-    if(wasActivated) { return; }
-    wasActivated = true;
 
     if (debug_->diagLevel()>0) {
       G4cout << "Mu2eG4CustomizationPhysicsConstructor::"

--- a/Mu2eG4/src/Mu2eG4DecayMuonsWithSpinPhysicsConstructor.cc
+++ b/Mu2eG4/src/Mu2eG4DecayMuonsWithSpinPhysicsConstructor.cc
@@ -64,15 +64,15 @@
 G4_DECLARE_PHYSCONSTR_FACTORY(Mu2eG4DecayMuonsWithSpinPhysicsConstructor);
 
 Mu2eG4DecayMuonsWithSpinPhysicsConstructor::Mu2eG4DecayMuonsWithSpinPhysicsConstructor(G4int ver)
-  :  G4VPhysicsConstructor("Decay"), verbose(ver), wasActivated(false)
+  :  G4VPhysicsConstructor("Decay"), verbose(ver)
 {
-  fDecayWithSpinProcess = 0;
+  fDecayWithSpinProcess = nullptr;
 }
 
 Mu2eG4DecayMuonsWithSpinPhysicsConstructor::Mu2eG4DecayMuonsWithSpinPhysicsConstructor(const G4String& name, G4int ver)
-  :  G4VPhysicsConstructor(name), verbose(ver), wasActivated(false)
+  :  G4VPhysicsConstructor(name), verbose(ver)
 {
-  fDecayWithSpinProcess = 0;
+  fDecayWithSpinProcess = nullptr;
 }
 
 Mu2eG4DecayMuonsWithSpinPhysicsConstructor::~Mu2eG4DecayMuonsWithSpinPhysicsConstructor()
@@ -115,8 +115,6 @@ void Mu2eG4DecayMuonsWithSpinPhysicsConstructor::ConstructParticle()
 
 void Mu2eG4DecayMuonsWithSpinPhysicsConstructor::ConstructProcess()
 {
-  if(wasActivated) { return; }
-  wasActivated = true;
 
   // Add Decay With Spin Process
   fDecayWithSpinProcess = new G4DecayWithSpin();

--- a/Mu2eG4/src/Mu2eG4MinDEDXPhysicsConstructor.cc
+++ b/Mu2eG4/src/Mu2eG4MinDEDXPhysicsConstructor.cc
@@ -103,11 +103,6 @@ Mu2eG4MinDEDXPhysicsConstructor::Mu2eG4MinDEDXPhysicsConstructor(G4int ver)
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-Mu2eG4MinDEDXPhysicsConstructor::~Mu2eG4MinDEDXPhysicsConstructor()
-{}
-
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-
 void Mu2eG4MinDEDXPhysicsConstructor::ConstructParticle()
 {
   // gamma

--- a/Mu2eG4/src/Mu2eG4MinimalModularPhysicsList.cc
+++ b/Mu2eG4/src/Mu2eG4MinimalModularPhysicsList.cc
@@ -1,6 +1,6 @@
 //
 // Define a minimal physics list.
-// Just transportation; used for debugging geometry.
+// Just transportation plus step limiters; used for debugging geometry etc.
 //
 //
 // Original author Rob Kutschke
@@ -11,45 +11,19 @@
 
 // Geant4 includes
 #include "Offline/Mu2eG4/inc/Mu2eG4MinimalModularPhysicsList.hh"
-#include "Offline/Mu2eG4/inc/addStepLimiter.hh"
-
-#include "Geant4/G4ParticleTypes.hh"
-#include "Geant4/G4ProcessManager.hh"
-#include "Geant4/G4StepLimiter.hh"
-#include "Geant4/G4ParticleTable.hh"
+#include "Offline/Mu2eG4/inc/Mu2eG4MinimalPhysicsConstructor.hh"
+#include "Offline/Mu2eG4/inc/Mu2eG4StepLimiterPhysicsConstructor.hh"
+//#include "Geant4/G4DecayPhysics.hh"
 
 namespace mu2e {
-  Mu2eG4MinimalModularPhysicsList::Mu2eG4MinimalModularPhysicsList():  G4VModularPhysicsList(){
+  Mu2eG4MinimalModularPhysicsList::Mu2eG4MinimalModularPhysicsList():
+    G4VModularPhysicsList() {
     defaultCutValue = 1.0*CLHEP::cm;
     SetVerboseLevel(1);
-  }
-
-  Mu2eG4MinimalModularPhysicsList::~Mu2eG4MinimalModularPhysicsList(){
-  }
-
-  void Mu2eG4MinimalModularPhysicsList::ConstructParticle(){
-
-    G4ChargedGeantino::Definition();
-    G4Electron::Definition();
-    G4Positron::Definition();
-    G4MuonPlus::Definition();
-    G4MuonMinus::Definition();
-    G4Gamma::Definition();
-    G4Proton::Definition();
-    G4AntiProton::Definition();
-    G4GenericIon::Definition();
-
-  }
-
-  void Mu2eG4MinimalModularPhysicsList::ConstructProcess(){
-    AddTransportation();
-
-    // Add step limiters to a standard list of particles.
-    addStepLimiter();
-
-  }
-
-  void Mu2eG4MinimalModularPhysicsList::SetCuts(){
+    RegisterPhysics( new Mu2eG4MinimalPhysicsConstructor() );
+    RegisterPhysics( new Mu2eG4StepLimiterPhysicsConstructor() );
+    // An example how to add Decays
+    // RegisterPhysics( new G4DecayPhysics(verboseLevel) );
   }
 
 }  // end namespace mu2e

--- a/Mu2eG4/src/Mu2eG4MinimalPhysicsConstructor.cc
+++ b/Mu2eG4/src/Mu2eG4MinimalPhysicsConstructor.cc
@@ -1,0 +1,47 @@
+//
+// A PhysicsConstructor that implements the Minimal physics
+//
+// Original author KLG inspired by Rob Kutschke's Minimal Physics list
+//
+// Mu2e includes
+#include "Offline/Mu2eG4/inc/Mu2eG4MinimalPhysicsConstructor.hh"
+// G4 includes
+#include "Geant4/G4ParticleTypes.hh"
+#include "Geant4/G4PhysicsConstructorFactory.hh"
+
+namespace mu2e {
+
+  G4_DECLARE_PHYSCONSTR_FACTORY(Mu2eG4MinimalPhysicsConstructor);
+
+  // The unused second parameter (physics type) defaults to bUnknown =0
+  Mu2eG4MinimalPhysicsConstructor::Mu2eG4MinimalPhysicsConstructor():
+    G4VPhysicsConstructor("Mu2eG4MinimalPhysicsConstructor"){
+  }
+
+  void Mu2eG4MinimalPhysicsConstructor::ConstructParticle(){
+
+    G4ChargedGeantino::Definition();
+    G4Electron::Definition();
+    G4Positron::Definition();
+    G4MuonPlus::Definition();
+    G4MuonMinus::Definition();
+    G4Gamma::Definition();
+    G4Proton::Definition();
+    G4AntiProton::Definition();
+    G4GenericIon::Definition();
+
+   }
+
+  void Mu2eG4MinimalPhysicsConstructor::ConstructProcess(){
+
+    // planing to add the use Mu2eG4Config in future to be able to
+    // control the printout
+    // if (debug_->diagLevel()>0) {
+    //   G4cout << "Mu2eG4MinimalPhysicsConstructor::"
+    //          << __func__ << " Called" << G4endl;
+    // }
+
+  }
+
+
+}  // end namespace mu2e

--- a/Mu2eG4/src/Mu2eG4StepLimiterPhysicsConstructor.cc
+++ b/Mu2eG4/src/Mu2eG4StepLimiterPhysicsConstructor.cc
@@ -14,15 +14,15 @@
 #include "Offline/Mu2eG4/inc/Mu2eG4StepLimiterPhysicsConstructor.hh"
 #include "Offline/Mu2eG4/inc/addStepLimiter.hh"
 
-using namespace std;
+// G4 includes
+#include "Geant4/G4PhysicsConstructorFactory.hh"
 
 namespace mu2e {
 
+  G4_DECLARE_PHYSCONSTR_FACTORY(Mu2eG4StepLimiterPhysicsConstructor);
+
   Mu2eG4StepLimiterPhysicsConstructor::Mu2eG4StepLimiterPhysicsConstructor():
     G4VPhysicsConstructor("Mu2eG4StepLimiterPhysicsConstructor"){
-  }
-
-  Mu2eG4StepLimiterPhysicsConstructor::~Mu2eG4StepLimiterPhysicsConstructor(){
   }
 
   void Mu2eG4StepLimiterPhysicsConstructor::ConstructParticle(){


### PR DESCRIPTION
This pull request rewrites the Minimal physics list using a more current approach using physics constructors,
making it easier to expand it by adding other constructors if desired, e.g. for tests.
It also makes physics constructors consistent with more recent versions of Geant4.
No change in the results is expected.