### PR TITLE
Removing unneeded destructor from Mu2eG4DecayMuonsWithSpinPhysicsConstructor

### DIFF
--- a/Mu2eG4/inc/Mu2eG4DecayMuonsWithSpinPhysicsConstructor.hh
+++ b/Mu2eG4/inc/Mu2eG4DecayMuonsWithSpinPhysicsConstructor.hh
@@ -47,7 +47,7 @@ class Mu2eG4DecayMuonsWithSpinPhysicsConstructor : public G4VPhysicsConstructor
   public:
     Mu2eG4DecayMuonsWithSpinPhysicsConstructor(G4int ver = 1);
     Mu2eG4DecayMuonsWithSpinPhysicsConstructor(const G4String& name, G4int ver = 1);
-    virtual ~Mu2eG4DecayMuonsWithSpinPhysicsConstructor();
+    virtual ~Mu2eG4DecayMuonsWithSpinPhysicsConstructor() = default;
     Mu2eG4DecayMuonsWithSpinPhysicsConstructor(const Mu2eG4DecayMuonsWithSpinPhysicsConstructor &) = delete;
     Mu2eG4DecayMuonsWithSpinPhysicsConstructor & operator=(const Mu2eG4DecayMuonsWithSpinPhysicsConstructor &) = delete;
     Mu2eG4DecayMuonsWithSpinPhysicsConstructor & operator=( Mu2eG4DecayMuonsWithSpinPhysicsConstructor && ) = delete;
@@ -61,10 +61,8 @@ class Mu2eG4DecayMuonsWithSpinPhysicsConstructor : public G4VPhysicsConstructor
     // registered to the process manager of each particle type
   virtual void ConstructProcess();
 
-  virtual G4Decay* GetDecayProcess() { return fDecayWithSpinProcess; }
-
 private:
-  G4Decay* fDecayWithSpinProcess;
+
   G4int    verbose;
 };
 

--- a/Mu2eG4/src/Mu2eG4DecayMuonsWithSpinPhysicsConstructor.cc
+++ b/Mu2eG4/src/Mu2eG4DecayMuonsWithSpinPhysicsConstructor.cc
@@ -65,20 +65,11 @@ G4_DECLARE_PHYSCONSTR_FACTORY(Mu2eG4DecayMuonsWithSpinPhysicsConstructor);
 
 Mu2eG4DecayMuonsWithSpinPhysicsConstructor::Mu2eG4DecayMuonsWithSpinPhysicsConstructor(G4int ver)
   :  G4VPhysicsConstructor("Decay"), verbose(ver)
-{
-  fDecayWithSpinProcess = nullptr;
-}
+{}
 
 Mu2eG4DecayMuonsWithSpinPhysicsConstructor::Mu2eG4DecayMuonsWithSpinPhysicsConstructor(const G4String& name, G4int ver)
   :  G4VPhysicsConstructor(name), verbose(ver)
-{
-  fDecayWithSpinProcess = nullptr;
-}
-
-Mu2eG4DecayMuonsWithSpinPhysicsConstructor::~Mu2eG4DecayMuonsWithSpinPhysicsConstructor()
-{
-  delete fDecayWithSpinProcess;
-}
+{}
 
 void Mu2eG4DecayMuonsWithSpinPhysicsConstructor::ConstructParticle()
 {
@@ -117,7 +108,8 @@ void Mu2eG4DecayMuonsWithSpinPhysicsConstructor::ConstructProcess()
 {
 
   // Add Decay With Spin Process
-  fDecayWithSpinProcess = new G4DecayWithSpin();
+  // the process table takes ownership of it
+  G4Decay* fDecayWithSpinProcess = new G4DecayWithSpin();
 
   G4ProcessTable* processTable = G4ProcessTable::GetProcessTable();
 


### PR DESCRIPTION
This PR removes the specialized destructor which is not needed because the process it deletes is deleted using the G4ProcessTable anyway;
No visible result changes are expected.