### PR TITLE
turn off Trigger pycache

### DIFF
--- a/Trigger/python/SConscript
+++ b/Trigger/python/SConscript
@@ -3,6 +3,11 @@
 # Original author Rob Kutschke.
 #
 
+# prevent creating pycache in repo area
+import sys
+wrtSave = sys.dont_write_bytecode
+sys.dont_write_bytecode = True
+
 import os
 Import('env')
 
@@ -11,12 +16,16 @@ helper = mu2e_helper(env)
 
 # this python code generates Trigger fcl in gen/fcl/Trigger
 import genTriggerFcl
+
+sys.dont_write_bytecode = wrtSave
+
 # run like this, it just generates the source and target file listss
 menus=["OnSpillTrigMenu","OffSpillTrigMenu","ExtrPosTrigMenu"]
 for m in menus:
     sources,targets,command = genTriggerFcl.generate(m, False, False)
     # this schedules it to run again to make the files
     helper.make_generic(sources,targets,command+" -c "+m)
+
 
 # this tells emacs to view this file in python mode.
 # Local Variables:


### PR DESCRIPTION
importing Offline/Trigger/genTriggerFcl.py in SConscript was creating a pycache in the same directory.  This PR turns that off to keep the repo area clean.  Since this python is relatively simple and runs only in the build, it doesn't matter whether it caches the pyc.  If we develop a large python base used in a production or analysis procedure, where it is re-started or imported many times, then saving the pyc can make a difference.  At that time, we can make it part of the build and steer the pyc to the build subdirectory.  PyWrap python is already in the build area, and gains pyc there, as needed.