### PR TITLE
Merge helices improvement

### DIFF
--- a/TrkReco/fcl/prolog.fcl
+++ b/TrkReco/fcl/prolog.fcl
@@ -121,8 +121,12 @@ TrkReco: { @table::TrkReco
     maxMeanResidual                     : 0.8
   }
   producers : {
-    MergeHelices : {
-      module_type : MergeHelices
+    MergeHelices : { module_type : MergeHelices
+      debugLevel                 : 0
+      deltanh                    : 5     # if the difference in the strawHit counts between the helices 
+                                         # is less than deltanh, use the chisq of the helices to select the better helix
+      scaleXY                    : 1.1.  # scale the weight for having chi2XY/ndof distribution peaking at 1
+      scaleZPhi                  : 0.75  # scale the weight for having chi2ZPhi/ndof distribution peaking at 1
     }
   }
 }

--- a/TrkReco/fcl/prolog.fcl
+++ b/TrkReco/fcl/prolog.fcl
@@ -125,7 +125,7 @@ TrkReco: { @table::TrkReco
       debugLevel                 : 0
       deltanh                    : 5     # if the difference in the strawHit counts between the helices 
                                          # is less than deltanh, use the chisq of the helices to select the better helix
-      scaleXY                    : 1.1.  # scale the weight for having chi2XY/ndof distribution peaking at 1
+      scaleXY                    : 1.1   # scale the weight for having chi2XY/ndof distribution peaking at 1
       scaleZPhi                  : 0.75  # scale the weight for having chi2ZPhi/ndof distribution peaking at 1
     }
   }

--- a/TrkReco/fcl/prolog_trigger.fcl
+++ b/TrkReco/fcl/prolog_trigger.fcl
@@ -13,62 +13,62 @@ TrkRecoTrigger : {
     # from the output of the helix finders.
     # We need an instance for each track trigger sequence
     TTHelixMergerUeM : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TThelixFinderUe:Negative" ]
     }
 
     TTHelixMergerUeP : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TThelixFinderUe:Positive" ]
     }
 
     TTHelixMergerDeM : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TThelixFinder:Positive" ]
     }
 
     TTHelixMergerDeP : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TThelixFinder:Negative" ]
     }
 
     TTHelixUCCMergerDeM : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TThelixFinderUCC:Positive" ]
     }
 
     TTHelixUCCMergerDeP : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TThelixFinderUCC:Negative" ]
     }
 
     TTCalHelixMergerDeM : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TTCalHelixFinderDe:Positive" ]
     }
 
     TTCalHelixMergerDeP : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TTCalHelixFinderDe:Negative" ]
     }
 
     TTCalHelixMergerUeM : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TTCalHelixFinderUe:Negative" ]
     }
 
     TTCalHelixMergerUeP : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TTCalHelixFinderUe:Positive" ]
     }
 
     TTCalHelixUCCMergerDeM : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TTCalHelixFinderUCCDe:Positive" ]
     }
 
     TTCalHelixUCCMergerDeP : {
-      module_type : MergeHelices
+      @table::TrkReco.producers.MergeHelices
       HelixFinders  : [ "TTCalHelixFinderUCCDe:Negative" ]
     }
   }

--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -10,11 +10,26 @@
 #include "art/Framework/Principal/Selector.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
+
+#include "Offline/GeometryService/inc/GeometryService.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
+#include "Offline/GeometryService/inc/DetectorSystem.hh"
+#include "Offline/CalorimeterGeom/inc/DiskCalorimeter.hh"
+#include "Offline/CalorimeterGeom/inc/Calorimeter.hh"
+#include "Offline/CalPatRec/inc/CalTimePeakFinder_types.hh"
+
 // mu2e data products
 #include "Offline/RecoDataProducts/inc/HelixSeed.hh"
 #include "Offline/RecoDataProducts/inc/TimeCluster.hh"
+
+#include "Offline/RecoDataProducts/inc/CaloCluster.hh"
+
 // utilities
 #include "Offline/TrkReco/inc/TrkUtilities.hh"
+
+#include "Offline/Mu2eUtilities/inc/LsqSums2.hh"
+#include "Offline/Mu2eUtilities/inc/LsqSums4.hh"
+#include "Offline/Mu2eUtilities/inc/polyAtan2.hh"
 // C++
 #include <vector>
 #include <memory>
@@ -22,50 +37,53 @@
 #include <forward_list>
 #include <string>
 
+using CLHEP::Hep3Vector;
 
 namespace mu2e {
   class MergeHelices : public art::EDProducer {
-    public:
-      using Name=fhicl::Name;
-      using Comment=fhicl::Comment;
-      struct Config {
-        fhicl::Atom<int> debug{ Name("debugLevel"),
-          Comment("Debug Level"), 0};
-        fhicl::Atom<bool> selectbest{ Name("SelectBest"),
-          Comment("Select best overlapping helices for output"), true};
-        fhicl::Atom<bool> usecalo{ Name("UseCalo"),
-          Comment("Use CaloCluster info in comparison"), true};
-        fhicl::Atom<unsigned> minnover{ Name("MinNHitOverlap"),
-          Comment("Minimum number of common hits to consider helices to be 'the same'"), 10};
-        fhicl::Atom<float> minoverfrac{ Name("MinHitOverlapFraction"),
-          Comment("Minimum fraction of common hits to consider helices to be 'the same'"), 0.5};
-        fhicl::Sequence<std::string> BadHitFlags { Name("BadHitFlags"),
-          Comment("HelixHit flag bits to exclude from counting"),std::vector<std::string>{"Outlier"}};
-        fhicl::Sequence<std::string> HelixFinders { Name("HelixFinders"),
-          Comment("HelixSeed producers to merge")};
-      };
-      using Parameters = art::EDProducer::Table<Config>;
-      explicit MergeHelices(const Parameters& conf);
-      void produce(art::Event& evt) override;
-    private:
-      enum HelixComp{unique=-1,first=0,second=1};
-      int _debug;
-      unsigned _minnover;
-      float _minoverfrac;
-      bool _selectbest, _usecalo;
-      std::vector<std::string> _hfs;
-      StrawHitFlag _badhit;
-      // helper functions
-      typedef std::vector<StrawHitIndex> SHIV;
-      HelixComp compareHelices(art::Event const& evt,
-          HelixSeed const& h1, HelixSeed const& h2);
-      void countHits(art::Event const& evt,
-          HelixSeed const& h1, HelixSeed const& h2,
-          unsigned& nh1, unsigned& nh2, unsigned& nover);
-      unsigned countOverlaps(SHIV const& s1, SHIV const& s2);
+  public:
+    using Name=fhicl::Name;
+    using Comment=fhicl::Comment;
+    struct Config {
+      fhicl::Atom<int> debug{ Name("debugLevel"),
+	      Comment("Debug Level"), 0};
+      fhicl::Atom<bool> selectbest{ Name("SelectBest"),
+	      Comment("Select best overlapping helices for output"), true};
+      fhicl::Atom<bool> usecalo{ Name("UseCalo"),
+	      Comment("Use CaloCluster info in comparison"), true};
+      fhicl::Atom<unsigned> minnover{ Name("MinNHitOverlap"),
+	      Comment("Minimum number of common hits to consider helices to be 'the same'"), 10};
+      fhicl::Atom<float> minoverfrac{ Name("MinHitOverlapFraction"),
+	      Comment("Minimum fraction of common hits to consider helices to be 'the same'"), 0.5};
+      fhicl::Sequence<std::string> BadHitFlags { Name("BadHitFlags"),
+	      Comment("HelixHit flag bits to exclude from counting"),std::vector<std::string>{"Outlier"}}; 
+      fhicl::Sequence<std::string> HelixFinders { Name("HelixFinders"),
+	      Comment("HelixSeed producers to merge")};
+    };
+    using Parameters = art::EDProducer::Table<Config>;
+    explicit MergeHelices(const Parameters& conf);
+    void produce(art::Event& evt) override;
+  private:
+    enum HelixComp{unique=-1,first=0,second=1};
+    int _debug;
+    unsigned _minnover;
+    float _minoverfrac;
+    bool _selectbest, _usecalo;
+    std::vector<std::string> _hfs;
+    StrawHitFlag _badhit;
+    // helper functions
+    typedef std::vector<StrawHitIndex> SHIV;
+    HelixComp compareHelices(art::Event const& evt,
+	      HelixSeed const& h1, HelixSeed const& h2);
+    void countHits(art::Event const& evt,
+	      HelixSeed const& h1, HelixSeed const& h2,
+	      unsigned& nh1, unsigned& nh2, unsigned& nover);
+    unsigned countOverlaps(SHIV const& s1, SHIV const& s2);
+    void findchisq(art::Event const& evt,
+        HelixSeed const& h2, float& chixy, float& chizphi);
   };
 
-  MergeHelices::MergeHelices(const Parameters& config) :
+  MergeHelices::MergeHelices(const Parameters& config) : 
     art::EDProducer{config},
     _debug(config().debug()),
     _minnover(config().minnover()),
@@ -89,36 +107,36 @@ namespace mu2e {
     auto TimeClusterCollectionGetter = event.productGetter(TimeClusterCollectionPID);
     // loop over helix products and flatten the helix collections into a single collection
     std::list<const HelixSeed*> hseeds;
-    for (auto const& hf : _hfs) {
+    for(auto const& hf : _hfs) {
       art::InputTag hsct(hf);
       auto hsch = event.getValidHandle<HelixSeedCollection>(hsct);
       auto const& hsc = *hsch;
       for(auto const&  hs : hsc) {
-        hseeds.insert(hseeds.end(),&hs);
+	      hseeds.insert(hseeds.end(),&hs);
       }
     }
     // now loop over all combinations
     for(auto ihel = hseeds.begin(); ihel != hseeds.end();) {
       auto jhel = ihel; jhel++;
       while( jhel != hseeds.end()){
-        // compare the helice
-        auto hcomp = compareHelices(event, **ihel, **jhel);
-        if(hcomp == unique) {
-          // both helices are unique: simply advance the iterator to keep both
-          jhel++;
-        } else if(hcomp == first) {
-          // the first helix is 'better'; remove the second
-          jhel = hseeds.erase(jhel);
-        } else if(hcomp == second) {
-          // the second helix is better; remove the first and restart the loop
-          ihel = hseeds.erase(ihel);
-          break;
-        }
+	      // compare the helices
+       	auto hcomp = compareHelices(event, **ihel, **jhel);
+	     if(hcomp == unique) {
+	       // both helices are unique: simply advance the iterator to keep both
+	       jhel++;
+	     } else if(hcomp == first) {
+	        // the first helix is 'better'; remove the second
+	        jhel = hseeds.erase(jhel);
+	     } else if(hcomp == second) {
+	       // the second helix is better; remove the first and restart the loop
+	       ihel = hseeds.erase(ihel);
+	       break;
+	     }
       }
       // only advance the outer loop if we exhausted the inner one
       if(jhel == hseeds.end())ihel++;
     }
-    // now hseeds contains only pointers to unique and best helices: use them to
+    // now hseeds contains only pointers to unique and best helices: use them to 
     // create the output, which must be deep-copy, including the time cluster
     for(auto ihel = hseeds.begin(); ihel != hseeds.end(); ihel++){
       // copy the time cluster first
@@ -127,6 +145,13 @@ namespace mu2e {
       auto tcptr = art::Ptr<TimeCluster>(TimeClusterCollectionPID,tcs->size()-1,TimeClusterCollectionGetter);
       // copy the Helix Seed and point its TimeCluster to the copy
       HelixSeed hs(**ihel);
+      hs._timeCluster = tcptr;
+      float chixy(0),chizphi(0);
+      // Calculate the XY and ZPhi chisquared of the helix
+      findchisq(event,**ihel,chixy,chizphi); 
+      // Replace the helix seed chisquared with the new values   
+      hs._helix._chi2dXY = chixy;
+      hs._helix._chi2dZPhi = chizphi;
       hs._timeCluster = tcptr;
       mhels->push_back(hs);
     }
@@ -141,25 +166,28 @@ namespace mu2e {
     unsigned nh1, nh2, nover;
     countHits(evt,h1,h2, nh1, nh2, nover);
     unsigned minh = std::min(nh1, nh2);
+    float chih1xy(0),chih1zphi(0),chih2xy(0),chih2zphi(0);
+    int deltanh = 5; 
+    // Calculate the chi-sq of the helices
+    findchisq(evt,h1,chih1xy,chih1zphi);
+    findchisq(evt,h2,chih2xy,chih2zphi);
     if(nover >= _minnover && nover/float(minh) > _minoverfrac) {
       // overlapping helices: decide which is best
-      // this should be a neural net FIXME!
-      // Pick the one with a CaloCluster first
+      // Pick the one with a CaloCluster first	    
       if(h1.caloCluster().isNonnull() && h2.caloCluster().isNull())
-        retval = first;
+	      retval = first;
       else if( h2.caloCluster().isNonnull() && h1.caloCluster().isNull())
-        retval = second;
-      // then compare active StrawHit counts
-      else if(nh1 > nh2)
-        retval = first;
-      else if(nh2 > nh1)
-        retval = second;
-      // finally compare chisquared: sum xy and fz for now
-      else if(h1.helix().chi2dXY() + h1.helix().chi2dZPhi()  <
-          h2.helix().chi2dXY() + h2.helix().chi2dZPhi() )
-        retval = first;
+	      retval = second;
+	    // then compare active StrawHit counts and if difference of the StrawHit counts greater than deltanh 
+      else if((nh1 > nh2) && (nh1-nh2) > deltanh)
+	      retval = first;
+      else if((nh2 > nh1) && (nh2-nh1) > deltanh)
+	      retval = second;
+	    // finally compare chisquared: sum xy and fz 
+      else if(chih1xy+chih1zphi  < chih2xy+chih2zphi)
+	      retval = first;
       else
-        retval = second;
+	      retval = second;
     }
     return retval;
   }
@@ -172,24 +200,57 @@ namespace mu2e {
     for(size_t ihit=0;ihit < h1.hits().size(); ihit++){
       auto const& hh = h1.hits()[ihit];
       if(!hh.flag().hasAnyProperty(_badhit))
-        h1.hits().fillStrawHitIndices(evt,ihit,shiv1);
+	    h1.hits().fillStrawHitIndices(evt,ihit,shiv1);
     }
     for(size_t ihit=0;ihit < h2.hits().size(); ihit++){
       auto const& hh = h2.hits()[ihit];
       if(!hh.flag().hasAnyProperty(_badhit))
-        h2.hits().fillStrawHitIndices(evt,ihit,shiv2);
+	   h2.hits().fillStrawHitIndices(evt,ihit,shiv2);
     }
     nh1 = shiv1.size();
     nh2 = shiv2.size();
     nover = countOverlaps(shiv1,shiv2);
   }
-
+	
+  // The chisquared calculation method used here is 
+  // taken from the LsqSums approach followed in CalPatRec
+  void MergeHelices::findchisq(art::Event const& evt,
+      HelixSeed const& h1,float& chixy, float& chizphi) {
+    ::LsqSums4 sxy;
+    ::LsqSums4 szphi;
+    for(size_t ihit=0;ihit < h1.hits().size(); ihit++) {
+      auto const& hh = h1.hits()[ihit];
+      float transErr = 5./sqrt(12.);
+      if(!hh.flag().hasAnyProperty(_badhit)){
+	      // Calculate the transverse and z-phi weights of the hits
+        if(hh.nStrawHits() > 1) transErr *= 1.5;
+	      float transErr2 = transErr*transErr;
+        float dx  = hh.pos().x() - h1.helix().center().x();
+        float dy  = hh.pos().y() - h1.helix().center().y();
+        float dxn = dx*hh._sdir.x()+dy*hh._sdir.y();
+        float costh2 = dxn*dxn/(dx*dx+dy*dy);
+        float sinth2 = 1-costh2;
+        float e2xy     = hh.wireErr2()*sinth2+transErr2*costh2;
+        float wtxy     = 1./e2;
+        float e2zphi     = hh.wireErr2()*costh2+hh.transErr2()*sinth2;        
+        float wtzphi     = h1.helix().radius()*h1.helix().radius()/e2zphi;
+        wtxy      *=1.1;
+        wtzphi  *=0.75;        
+        sxy.addPoint(hh.pos().x(),hh.pos().y(),wtxy);
+        szphi.addPoint(hh.pos().z(),hh.helixPhi(),wtzphi);
+      }
+    }
+    chixy = sxy.chi2DofCircle();
+    chizphi = szphi.chi2DofLine();
+  }
+  
   unsigned MergeHelices::countOverlaps(SHIV const& shiv1, SHIV const& shiv2) {
     unsigned retval(0);
     for(auto shi1 : shiv1)
       for(auto shi2 : shiv2)
-        if(shi1 == shi2)retval++;
+	      if(shi1 == shi2)retval++;
     return retval;
   }
 }
 DEFINE_ART_MODULE(mu2e::MergeHelices)
+

--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -214,9 +214,8 @@ namespace mu2e {
       HelixSeed const& h1,float& chixy, float& chizphi) {
     ::LsqSums4 sxy;
     ::LsqSums4 szphi;
-    for(size_t ihit=0;ihit < h1.hits().size(); ihit++) {
+    for(auto const& hh : h1.hits()) {
       auto const& hh = h1.hits()[ihit];
-      float transErr = 5./sqrt(12.);
       if(!hh.flag().hasAnyProperty(_badhit)){
         // Calculate the transverse and z-phi weights of the hits
         float dx = hh.pos().x() - h1.helix().center().x();

--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -231,7 +231,7 @@ namespace mu2e {
         float costh2 = dxn*dxn/(dx*dx+dy*dy);
         float sinth2 = 1-costh2;
         float e2xy     = hh.wireErr2()*sinth2+transErr2*costh2;
-        float wtxy     = 1./e2;
+        float wtxy     = 1./e2xy;
         float e2zphi     = hh.wireErr2()*costh2+hh.transErr2()*sinth2;        
         float wtzphi     = h1.helix().radius()*h1.helix().radius()/e2zphi;
         wtxy      *=1.1;

--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -32,11 +32,11 @@ namespace mu2e {
       struct Config {
         fhicl::Atom<int> debug{ Name("debugLevel"),
 	  Comment("Debug Level"), 0};
-	fhicl::Atom<unsigned> deltanh{ Name("DeltanHits"),
+	fhicl::Atom<unsigned> deltanh{ Name("deltanh"),
 	  Comment("difference in the active StrawHit counts")};
-        fhicl::Atom<float> scaleXY{ Name("ScaleFactorXY"),
+        fhicl::Atom<float> scaleXY{ Name("scaleXY"),
 	  Comment("scaling factor to get chi2XY/ndof distribution peak at 1")};
-        fhicl::Atom<float> scaleZPhi{ Name("ScaleFactorZPhi"),
+        fhicl::Atom<float> scaleZPhi{ Name("scaleZPhi"),
 	  Comment("scaling factor to get chi2ZPhi/ndof distribution peak at 1")};
         fhicl::Atom<bool> selectbest{ Name("SelectBest"),
 	  Comment("Select best overlapping helices for output"), true};

--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -33,11 +33,11 @@ namespace mu2e {
         fhicl::Atom<int> debug{ Name("debugLevel"),
 	  Comment("Debug Level"), 0};
 	fhicl::Atom<unsigned> deltanh{ Name("DeltanHits"),
-	  Comment("difference in the active StrawHit counts"),5};
+	  Comment("difference in the active StrawHit counts")};
         fhicl::Atom<float> scaleXY{ Name("ScaleFactorXY"),
-	  Comment("scaling factor to have chi2XY/ndof distribution peak at 1"), 1.1};
+	  Comment("scaling factor to get chi2XY/ndof distribution peak at 1")};
         fhicl::Atom<float> scaleZPhi{ Name("ScaleFactorZPhi"),
-	  Comment("scaling factor to have chi2ZPhi/ndof distribution peak at 1"),0.75};
+	  Comment("scaling factor to get chi2ZPhi/ndof distribution peak at 1")};
         fhicl::Atom<bool> selectbest{ Name("SelectBest"),
 	  Comment("Select best overlapping helices for output"), true};
         fhicl::Atom<bool> usecalo{ Name("UseCalo"),
@@ -73,7 +73,7 @@ namespace mu2e {
 	  unsigned& nh1, unsigned& nh2, unsigned& nover);
       unsigned countOverlaps(SHIV const& s1, SHIV const& s2);
       void findchisq(art::Event const& evt,
-          HelixSeed const& h2, float& chixy, float& chizphi);
+          HelixSeed const& h2, float& chixy, float& chizphi) const;
     };
 
   MergeHelices::MergeHelices(const Parameters& config) : 
@@ -211,7 +211,7 @@ namespace mu2e {
   // The chisquared calculation method used here is 
   // taken from the LsqSums approach followed in CalPatRec
   void MergeHelices::findchisq(art::Event const& evt,
-      HelixSeed const& h1,float& chixy, float& chizphi) {
+      HelixSeed const& h1,float& chixy, float& chizphi) const{
     ::LsqSums4 sxy;
     ::LsqSums4 szphi;
     for(auto const& hh : h1.hits()) {

--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -10,23 +10,11 @@
 #include "art/Framework/Principal/Selector.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
-
-#include "Offline/GeometryService/inc/GeometryService.hh"
-#include "Offline/GeometryService/inc/GeomHandle.hh"
-#include "Offline/GeometryService/inc/DetectorSystem.hh"
-#include "Offline/CalorimeterGeom/inc/DiskCalorimeter.hh"
-#include "Offline/CalorimeterGeom/inc/Calorimeter.hh"
-#include "Offline/CalPatRec/inc/CalTimePeakFinder_types.hh"
-
 // mu2e data products
 #include "Offline/RecoDataProducts/inc/HelixSeed.hh"
 #include "Offline/RecoDataProducts/inc/TimeCluster.hh"
-
-#include "Offline/RecoDataProducts/inc/CaloCluster.hh"
-
 // utilities
 #include "Offline/TrkReco/inc/TrkUtilities.hh"
-
 #include "Offline/Mu2eUtilities/inc/LsqSums2.hh"
 #include "Offline/Mu2eUtilities/inc/LsqSums4.hh"
 #include "Offline/Mu2eUtilities/inc/polyAtan2.hh"

--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -167,7 +167,7 @@ namespace mu2e {
     countHits(evt,h1,h2, nh1, nh2, nover);
     unsigned minh = std::min(nh1, nh2);
     float chih1xy(0),chih1zphi(0),chih2xy(0),chih2zphi(0);
-    int deltanh = 5; 
+    unsigned deltanh = 5; 
     // Calculate the chi-sq of the helices
     findchisq(evt,h1,chih1xy,chih1zphi);
     findchisq(evt,h2,chih2xy,chih2zphi);

--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -17,15 +17,12 @@
 #include "Offline/TrkReco/inc/TrkUtilities.hh"
 #include "Offline/Mu2eUtilities/inc/LsqSums2.hh"
 #include "Offline/Mu2eUtilities/inc/LsqSums4.hh"
-#include "Offline/Mu2eUtilities/inc/polyAtan2.hh"
 // C++
 #include <vector>
 #include <memory>
 #include <iostream>
 #include <forward_list>
 #include <string>
-
-using CLHEP::Hep3Vector;
 
 namespace mu2e {
   class MergeHelices : public art::EDProducer {
@@ -236,7 +233,7 @@ namespace mu2e {
     unsigned retval(0);
     for(auto shi1 : shiv1)
       for(auto shi2 : shiv2)
-	      if(shi1 == shi2)retval++;
+	if(shi1 == shi2)retval++;
     return retval;
   }
 }

--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -107,16 +107,16 @@ namespace mu2e {
 	// compare the helices
        	auto hcomp = compareHelices(event, **ihel, **jhel);
 	if(hcomp == unique) {
-	// both helices are unique: simply advance the iterator to keep both
-	 jhel++;
-	     } else if(hcomp == first) {
-	        // the first helix is 'better'; remove the second
-	        jhel = hseeds.erase(jhel);
-	     } else if(hcomp == second) {
-	       // the second helix is better; remove the first and restart the loop
-	       ihel = hseeds.erase(ihel);
-	       break;
-	     }
+	  // both helices are unique: simply advance the iterator to keep both
+	  jhel++;
+	}else if(hcomp == first) {
+	   // the first helix is 'better'; remove the second
+	   jhel = hseeds.erase(jhel);
+	 }else if(hcomp == second) {
+	    // the second helix is better; remove the first and restart the loop
+	    ihel = hseeds.erase(ihel);
+	    break;
+	  }
       }
       // only advance the outer loop if we exhausted the inner one
       if(jhel == hseeds.end())ihel++;

--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -163,7 +163,6 @@ namespace mu2e {
     countHits(evt,h1,h2, nh1, nh2, nover);
     unsigned minh = std::min(nh1, nh2);
     float chih1xy(0),chih1zphi(0),chih2xy(0),chih2zphi(0);
-    unsigned deltanh = 5; 
     // Calculate the chi-sq of the helices
     findchisq(evt,h1,chih1xy,chih1zphi);
     findchisq(evt,h2,chih2xy,chih2zphi);
@@ -215,7 +214,6 @@ namespace mu2e {
     ::LsqSums4 sxy;
     ::LsqSums4 szphi;
     for(auto const& hh : h1.hits()) {
-      auto const& hh = h1.hits()[ihit];
       if(!hh.flag().hasAnyProperty(_badhit)){
         // Calculate the transverse and z-phi weights of the hits
         float dx = hh.pos().x() - h1.helix().center().x();


### PR DESCRIPTION
- A uniform chi-squared calculation for all helices, irrespective of the source (TrkPatRe or CalPatRec) is implemented and used for the comparison of the helices. 
- The "greater the number of active StrawHits, better the helix" criteria relaxed to if "the difference in the number of active StrawHits between the two helix candidates < 5, select the helix with the better chi-squared value".