### PR TITLE
fetching pre step point times for particles born at rest

### DIFF
--- a/Mu2eG4/src/Mu2eG4TrackingAction.cc
+++ b/Mu2eG4/src/Mu2eG4TrackingAction.cc
@@ -661,6 +661,17 @@ namespace mu2e {
 
     ProcessCode stoppingCode(_processInfo->findAndCount(pname));
 
+
+    //Get kinematics just before the post step doit process acted (e.g., decay, annihilation, etc.)
+    //note that while we have the intermediate position we use it only for diagnostic printouts
+    double endKE = Mu2eG4UserHelpers::getEndKE(trk);
+    CLHEP::HepLorentzVector endMomentum =  Mu2eG4UserHelpers::getEndMomentum(trk);
+    double endGlobalTime = Mu2eG4UserHelpers::getEndGlobalTime(trk);
+    double endProperTime = Mu2eG4UserHelpers::getEndProperTime(trk);
+
+    //Get number of steps the track is made of
+    int nSteps = Mu2eG4UserHelpers::getNSteps(trk);
+
     if (trackingVerbosityLevel > 1 ) {
       G4int prec = G4cout.precision(15);
       const G4DynamicParticle*  pParticle = trk->GetDynamicParticle();
@@ -687,31 +698,23 @@ namespace mu2e {
              << " Global time            " << trk->GetGlobalTime()
              << " Proper time            " << trk->GetProperTime()
              << G4endl;
+      G4cout << __func__ << " KE stored     " << endKE
+             << " G4 Position stored  " << trk->GetPosition()
+             << " Global time stored     " << endGlobalTime
+             << " Proper time stored     " << endProperTime
+             << G4endl;
       G4cout.precision(prec);
     }
 
-
-    //Get kinematics just before the post step doit process acted (e.g., decay, annihilation, etc.)
-    //note that while we have the intermediate position we use it only for diagnostic printouts
-    double endKE = Mu2eG4UserHelpers::getEndKE(trk);
-    CLHEP::HepLorentzVector endMomentum =  Mu2eG4UserHelpers::getEndMomentum(trk);
-    double preLastStepGlobalTime = Mu2eG4UserHelpers::getEndGlobalTime(trk);
-    double preLastStepProperTime = Mu2eG4UserHelpers::getEndProperTime(trk);
-
-    //Get number od steps the track is made of
-    int nSteps = Mu2eG4UserHelpers::getNSteps(trk);
-
     // Add info about the end of the track.  Throw if SimParticle not already there.
     i->second.addEndInfo( trk->GetPosition()-_mu2eOrigin,
-                          endMomentum, // from pre last step
-                          // trk->GetGlobalTime(),
-                          // trk->GetProperTime(),
-                          preLastStepGlobalTime,
-                          preLastStepProperTime,
+                          endMomentum, // based on pre last step
+                          endGlobalTime, // based on pre last step
+                          endProperTime, // based on pre last step
                           _physVolHelper->index(trk),
                           trk->GetTrackStatus(),
                           stoppingCode,
-                          endKE, // from pre last step
+                          endKE, // based on pre last step
                           nSteps,
                           trk->GetTrackLength()
                           );

--- a/Mu2eG4/src/Mu2eG4TrackingAction.cc
+++ b/Mu2eG4/src/Mu2eG4TrackingAction.cc
@@ -668,6 +668,13 @@ namespace mu2e {
       const G4ThreeVector& theMomentumDirection = pParticle->GetMomentumDirection();
       Mu2eG4UserTrackInformation* uti =
         (dynamic_cast<Mu2eG4UserTrackInformation*>(trk->GetUserInformation()));
+      G4StepPoint const* lastPreStepPoint = trk->GetStep()->GetPreStepPoint();
+      G4cout << __func__ << " KE pre step   "  << lastPreStepPoint->GetKineticEnergy()
+             << " Momentum direction pre step   " << lastPreStepPoint->GetMomentumDirection()
+             << " Position pre step   " << lastPreStepPoint->GetPosition()
+             << " Global time pre step   " << lastPreStepPoint->GetGlobalTime()
+             << " Proper time pre step   " << lastPreStepPoint->GetProperTime()
+             << G4endl;
       G4cout << __func__ << " KE before int " << uti->GetKineticEnergy()
              << " Momentum direction before int " << uti->GetMomentumDirection()
              << " Position before int " << uti->GetPosition()

--- a/Mu2eG4/src/Mu2eG4UserHelpers.cc
+++ b/Mu2eG4/src/Mu2eG4UserHelpers.cc
@@ -73,7 +73,9 @@ namespace mu2e {
     // pre step point. Note that for the particles decaying in flight,
     // the end times are the ones after they decay, while for the ones
     // decaying at rest, the recorded times are the ones before they
-    // decay
+    // decay. Also note, that while the particle decays at rest the
+    // track length is not changing, so no special treatment is needed.
+    // Similarly, when the KE is zero, the momentum direction does not matter
 
     // global time at the point of interaction/decay
     double getEndGlobalTime(G4Track const* const trk) {

--- a/Mu2eG4/src/Mu2eG4UserHelpers.cc
+++ b/Mu2eG4/src/Mu2eG4UserHelpers.cc
@@ -64,15 +64,28 @@ namespace mu2e {
 
     }
 
+    // The following functions attempt to get the particle end
+    // parameters. For the one which have a chance to travel, the
+    // Mu2eRecorderProcess stores the information in the
+    // Mu2eG4UserTrackInformation just before they interact
+    // inelastically or decay. For the particles born at rest, such
+    // information is not provided and their times are taken from the
+    // pre step point. Note that for the particles decaying in flight,
+    // the end times are the ones after they decay, while for the ones
+    // decaying at rest, the recorded times are the ones before they
+    // decay
+
     // global time at the point of interaction/decay
     double getEndGlobalTime(G4Track const* const trk) {
       auto const* uti = dynamic_cast<Mu2eG4UserTrackInformation*>(trk->GetUserInformation());
-      return (uti->GetGlobalTime() >= 0.) ? uti->GetGlobalTime() : trk->GetGlobalTime();
+      return (uti->GetGlobalTime() >= 0.) ? uti->GetGlobalTime() :
+        trk->GetStep()->GetPreStepPoint()->GetGlobalTime();
     }
     // proper time at the point of interaction/decay
     double getEndProperTime(G4Track const* const trk) {
       auto const* uti = dynamic_cast<Mu2eG4UserTrackInformation*>(trk->GetUserInformation());
-      return (uti->GetProperTime() >= 0.) ? uti->GetProperTime() : trk->GetProperTime();
+      return (uti->GetProperTime() >= 0.) ? uti->GetProperTime() :
+        trk->GetStep()->GetPreStepPoint()->GetProperTime();
     }
     // kinetic energy at the point of interaction/decay
     double getEndKE(G4Track const* const trk) {

--- a/Mu2eG4/src/Mu2eRecorderProcess.cc
+++ b/Mu2eG4/src/Mu2eRecorderProcess.cc
@@ -43,6 +43,7 @@ namespace mu2e{
              << trk.GetParticleDefinition()->GetParticleName()
              << " totE deposit " << std::fixed << trk.GetStep()->GetTotalEnergyDeposit()
              << " NonIonE deposit " << std::fixed << trk.GetStep()->GetNonIonizingEnergyDeposit()
+             << std::defaultfloat
              << " in " << trk.GetVolume()->GetName()
              << " material " << trk.GetMaterial()->GetName()
              << G4endl;


### PR DESCRIPTION
This PR should improve the code created in PR#821 to more consistently handle the case of particles created at rest
and adds clarifying comments