### PR TITLE
STMChannel enum class

### DIFF
--- a/DataProducts/inc/STMChannel.hh
+++ b/DataProducts/inc/STMChannel.hh
@@ -1,0 +1,129 @@
+#ifndef DataProducts_STMChannel_hh
+#define DataProducts_STMChannel_hh
+//
+// An enum-matched-to-names class for generator Id's.
+// based on GenId.hh
+//
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace mu2e {
+
+  class STMChannel {
+
+  public:
+
+    // Need to keep the enum and the _name member in sync.
+    // Also, restrict to 8-bits because we will never need that many
+    // and this may be in every STMDigi
+    enum enum_type : int8_t { HPGe, LaBr, unknown, lastEnum };
+
+#ifndef SWIG
+    // Keep this in sync with the enum. Used in STMChannel.cc
+#define STMCHANNEL_NAMES \
+    "HPGe", "LaBr", "unknown"
+#endif
+
+  public:
+
+    // The most important c'tor and accessor methods are first.
+    STMChannel( enum_type id):
+      _id(id)
+    {}
+
+    enum_type id() const { return _id;}
+
+    const std::string name() const {
+      return std::string( _name[_id] );
+    }
+
+    // ROOT requires a default c'tor.
+    STMChannel():
+      _id(unknown){
+    }
+
+    virtual ~STMChannel(){}
+
+    bool operator==(const STMChannel g) const{
+      return ( _id == g._id );
+    }
+
+    bool operator==(const STMChannel::enum_type g) const{
+      return ( _id == g );
+    }
+
+    bool operator!=(const STMChannel::enum_type g) const{
+      return ( _id != g );
+    }
+
+    bool operator!=(const STMChannel g) const{
+      return ( _id != g._id );
+    }
+
+    // Accessor for the version.
+    static int version() { return _version; }
+
+    // Static version of the name method.
+    static const std::string name( enum_type id ){
+      return std::string( _name[id] );
+    }
+
+    // Check validity of an Id. Unknown is defined to be valid.
+    static bool isValid( enum_type id){
+      if ( id <  unknown  ) return false;
+      if ( id >= lastEnum ) return false;
+      return true;
+    }
+
+    // Return the STMChannel that corresponds to this name.
+    static STMChannel findByName ( std::string const& name);
+
+    static void printAll( std::ostream& ost);
+
+    static void printAll(){
+      printAll(std::cout);
+    }
+
+    // Member function version of static functions.
+    bool isValid() const{
+      return isValid(_id);
+    }
+
+#ifndef SWIG
+    // List of names corresponding to the enum.
+    const static char* _name[];
+#endif
+
+    // Number of valid codes, not including lastEnum, but including "unknown".
+    static std::size_t size(){
+      return lastEnum;
+    }
+
+  private:
+
+    // The one and only per-instance member datum.
+    enum_type _id;
+
+    // Can this make sense?  What happens if I read in two different
+    // files that have different versions?  Should I use cvs version instead?
+    // This is really an edm question not a question for the class itself.
+    static const unsigned _version = 1000;
+
+  };
+
+  // Shift left (printing) operator.
+  inline std::ostream& operator<<(std::ostream& ost,
+                                  const STMChannel& id ){
+    ost << "( "
+        << id.id() << ": "
+        << id.name()
+        << " )";
+    return ost;
+  }
+
+}
+
+#endif /* DataProducts_STMChannel_hh */

--- a/DataProducts/inc/STMChannel.hh
+++ b/DataProducts/inc/STMChannel.hh
@@ -1,7 +1,7 @@
 #ifndef DataProducts_STMChannel_hh
 #define DataProducts_STMChannel_hh
 //
-// An enum-matched-to-names class for generator Id's.
+// An enum-matched-to-names class for STM channels
 // based on GenId.hh
 //
 

--- a/DataProducts/inc/STMChannel.hh
+++ b/DataProducts/inc/STMChannel.hh
@@ -17,8 +17,8 @@ namespace mu2e {
   public:
 
     // Need to keep the enum and the _name member in sync.
-    // Also, restrict to 8-bits because we will never need that many
-    // and this may be in every STMDigi
+    // Note 1. Unknown has a non-standard numerica value since we start channel numbering at 0
+    // Note 2. We restrict to 8-bits because this may be in every STMDigi
     enum enum_type : int8_t { HPGe, LaBr, unknown, lastEnum };
 
 #ifndef SWIG
@@ -72,6 +72,7 @@ namespace mu2e {
     }
 
     // Check validity of an Id. Unknown is defined to be valid.
+    // Unknown has a non-standard numeric value
     static bool isValid( enum_type id){
       if ( id <  0  ) return false;
       if ( id >= unknown ) return false;

--- a/DataProducts/inc/STMChannel.hh
+++ b/DataProducts/inc/STMChannel.hh
@@ -73,8 +73,8 @@ namespace mu2e {
 
     // Check validity of an Id. Unknown is defined to be valid.
     static bool isValid( enum_type id){
-      if ( id <  unknown  ) return false;
-      if ( id >= lastEnum ) return false;
+      if ( id <  0  ) return false;
+      if ( id >= unknown ) return false;
       return true;
     }
 

--- a/DataProducts/src/STMChannel.cc
+++ b/DataProducts/src/STMChannel.cc
@@ -1,5 +1,5 @@
 //
-// An enum-matched-to-names class for generator Id's.
+// An enum-matched-to-names class for STM channels
 // based on GenId.cc
 #include <iomanip>
 #include <iostream>

--- a/DataProducts/src/STMChannel.cc
+++ b/DataProducts/src/STMChannel.cc
@@ -1,0 +1,38 @@
+//
+// An enum-matched-to-names class for generator Id's.
+// based on GenId.cc
+#include <iomanip>
+#include <iostream>
+
+#include "Offline/DataProducts/inc/STMChannel.hh"
+
+#include <boost/static_assert.hpp>
+
+using namespace std;
+
+namespace mu2e {
+
+  const char* STMChannel::_name[] = { STMCHANNEL_NAMES };
+
+  BOOST_STATIC_ASSERT(sizeof(STMChannel::_name)/sizeof(char*) == STMChannel::lastEnum);
+
+  void STMChannel::printAll( std::ostream& ost){
+    ost << "List of STM channels: " << endl;
+    for ( int i=0; i<lastEnum; ++i){
+      ost << setw(2) << i << " " << _name[i] << std::endl;
+    }
+  }
+
+  STMChannel STMChannel::findByName ( std::string const& name){
+
+    // Size must be at least 2 (for unknown and lastEnum).
+    for ( size_t i=0; i<size(); ++i ){
+      if ( _name[i] == name ){
+        return STMChannel(enum_type(i));
+      }
+    }
+    return STMChannel(unknown);
+  }
+
+
+}

--- a/STMReco/test/testSTMChannel.C
+++ b/STMReco/test/testSTMChannel.C
@@ -21,65 +21,38 @@ void testSTMChannel() {
 
   std::cout << std::endl;
 
-  mu2e::STMChannel ch_HPGe(mu2e::STMChannel::HPGe);
-  std::cout << "This should be \"HPGe\": " << ch_HPGe << " : ";
-  if (ch_HPGe.name().find("HPGe") != std::string::npos) {
-    std::cout << "OK" << std::endl;
-  }
-  else {
-    std::cout << "FAILED" << std::endl;
-    return -1;
-  }
-  std::cout << "and isValid() should be true: isValid() = " << std::boolalpha << ch_HPGe.isValid() << " : ";
-  if (ch_HPGe.isValid() == true) {
-    std::cout << "OK" << std::endl;
-  }
-  else {
-    std::cout << "FAILED" << std::endl;
-    return -1;
-  }
+  // Test findByName()
+  const int n_channels = 4;
+  std::string names[n_channels] = {"HPGe", "LaBr", "unknown", "a channel that does not exist"};
+  mu2e::STMChannel expectedChannels[n_channels] = {mu2e::STMChannel::HPGe, mu2e::STMChannel::LaBr, mu2e::STMChannel::unknown, mu2e::STMChannel::unknown};
+  bool expectedValids[n_channels] = {true, true, false, false};
+  for (int i_channel = 0; i_channel < n_channels; ++i_channel) {
+    std::string name = names[i_channel];
+    mu2e::STMChannel expectedChannel = expectedChannels[i_channel];
+    bool expectedValid = expectedValids[i_channel];
 
-  std::cout << std::endl;
+    std::cout << "Looking for \"" << name << "\"... " << std::endl;
+    mu2e::STMChannel ch = mu2e::STMChannel::findByName(name);
+    std::cout << "Expecting to find " << expectedChannel << " and found: " << ch << " : ";
+    if (ch == expectedChannel) {
+      std::cout << "OK" << std::endl;
+    }
+    else {
+      std::cout << "FAILED" << std::endl;
+      return -1;
+    }
 
-  mu2e::STMChannel ch_LaBr(mu2e::STMChannel::LaBr);
-  std::cout << "This should be \"LaBr\": " << ch_LaBr << " : ";
-  if (ch_LaBr.name().find("LaBr") != std::string::npos) {
-    std::cout << "OK" << std::endl;
-  }
-  else {
-    std::cout << "FAILED" << std::endl;
-    return -1;
-  }
-  std::cout << "and isValid() should be true: isValid() = " << std::boolalpha << ch_LaBr.isValid() << " : ";
-  if (ch_LaBr.isValid() == true) {
-    std::cout << "OK" << std::endl;
-  }
-  else {
-    std::cout << "FAILED" << std::endl;
-    return -1;
-  }
+    std::cout << "isValid() should be " << std::boolalpha << expectedValid << ": isValid() = " << ch.isValid() << " : ";
+    if (ch.isValid() == expectedValid) {
+      std::cout << "OK" << std::endl;
+    }
+    else {
+      std::cout << "FAILED" << std::endl;
+      return -1;
+    }
 
-  std::cout << std::endl;
-
-  mu2e::STMChannel ch_unknown(mu2e::STMChannel::unknown);
-  std::cout << "This should be \"unknown\": " << ch_unknown << " : ";
-  if (ch_unknown.name().find("unknown") != std::string::npos) {
-    std::cout << "OK" << std::endl;
+    std::cout << std::endl;
   }
-  else {
-    std::cout << "FAILED" << std::endl;
-    return -1;
-  }
-  std::cout << "and isValid() should be false: isValid() = " << std::boolalpha << ch_unknown.isValid() << " : ";
-  if (ch_unknown.isValid() == false) {
-    std::cout << "OK" << std::endl;
-  }
-  else {
-    std::cout << "FAILED" << std::endl;
-    return -1;
-  }
-
-  std::cout << std::endl;
 
   std::cout << "All tests passed" << std::endl;
 }

--- a/STMReco/test/testSTMChannel.C
+++ b/STMReco/test/testSTMChannel.C
@@ -10,6 +10,16 @@ void testSTMChannel() {
     std::cout << "FAILED" << std::endl;
     return -1;
   }
+  std::cout << "and isValid() should be false: isValid() = " << std::boolalpha << ch_default.isValid() << " : ";
+  if (ch_default.isValid() == false) {
+    std::cout << "OK" << std::endl;
+  }
+  else {
+    std::cout << "FAILED" << std::endl;
+    return -1;
+  }
+
+  std::cout << std::endl;
 
   mu2e::STMChannel ch_HPGe(mu2e::STMChannel::HPGe);
   std::cout << "This should be \"HPGe\": " << ch_HPGe << " : ";
@@ -20,6 +30,16 @@ void testSTMChannel() {
     std::cout << "FAILED" << std::endl;
     return -1;
   }
+  std::cout << "and isValid() should be true: isValid() = " << std::boolalpha << ch_HPGe.isValid() << " : ";
+  if (ch_HPGe.isValid() == true) {
+    std::cout << "OK" << std::endl;
+  }
+  else {
+    std::cout << "FAILED" << std::endl;
+    return -1;
+  }
+
+  std::cout << std::endl;
 
   mu2e::STMChannel ch_LaBr(mu2e::STMChannel::LaBr);
   std::cout << "This should be \"LaBr\": " << ch_LaBr << " : ";
@@ -30,6 +50,16 @@ void testSTMChannel() {
     std::cout << "FAILED" << std::endl;
     return -1;
   }
+  std::cout << "and isValid() should be true: isValid() = " << std::boolalpha << ch_LaBr.isValid() << " : ";
+  if (ch_LaBr.isValid() == true) {
+    std::cout << "OK" << std::endl;
+  }
+  else {
+    std::cout << "FAILED" << std::endl;
+    return -1;
+  }
+
+  std::cout << std::endl;
 
   mu2e::STMChannel ch_unknown(mu2e::STMChannel::unknown);
   std::cout << "This should be \"unknown\": " << ch_unknown << " : ";
@@ -40,4 +70,16 @@ void testSTMChannel() {
     std::cout << "FAILED" << std::endl;
     return -1;
   }
+  std::cout << "and isValid() should be false: isValid() = " << std::boolalpha << ch_unknown.isValid() << " : ";
+  if (ch_unknown.isValid() == false) {
+    std::cout << "OK" << std::endl;
+  }
+  else {
+    std::cout << "FAILED" << std::endl;
+    return -1;
+  }
+
+  std::cout << std::endl;
+
+  std::cout << "All tests passed" << std::endl;
 }

--- a/STMReco/test/testSTMChannel.C
+++ b/STMReco/test/testSTMChannel.C
@@ -1,0 +1,43 @@
+#include "DataProducts/inc/STMChannel.hh"
+
+void testSTMChannel() {
+  mu2e::STMChannel ch_default;
+  std::cout << "Default constructor should be \"unknown\": " << ch_default << " : ";
+  if (ch_default.name().find("unknown") != std::string::npos) {
+    std::cout << "OK" << std::endl;
+  }
+  else {
+    std::cout << "FAILED" << std::endl;
+    return -1;
+  }
+
+  mu2e::STMChannel ch_HPGe(mu2e::STMChannel::HPGe);
+  std::cout << "This should be \"HPGe\": " << ch_HPGe << " : ";
+  if (ch_HPGe.name().find("HPGe") != std::string::npos) {
+    std::cout << "OK" << std::endl;
+  }
+  else {
+    std::cout << "FAILED" << std::endl;
+    return -1;
+  }
+
+  mu2e::STMChannel ch_LaBr(mu2e::STMChannel::LaBr);
+  std::cout << "This should be \"LaBr\": " << ch_LaBr << " : ";
+  if (ch_LaBr.name().find("LaBr") != std::string::npos) {
+    std::cout << "OK" << std::endl;
+  }
+  else {
+    std::cout << "FAILED" << std::endl;
+    return -1;
+  }
+
+  mu2e::STMChannel ch_unknown(mu2e::STMChannel::unknown);
+  std::cout << "This should be \"unknown\": " << ch_unknown << " : ";
+  if (ch_unknown.name().find("unknown") != std::string::npos) {
+    std::cout << "OK" << std::endl;
+  }
+  else {
+    std::cout << "FAILED" << std::endl;
+    return -1;
+  }
+}

--- a/STMReco/test/testSTMChannel.C
+++ b/STMReco/test/testSTMChannel.C
@@ -54,5 +54,20 @@ void testSTMChannel() {
     std::cout << std::endl;
   }
 
+  std::string expected_all_printed = "List of STM channels: \n 0 HPGe\n 1 LaBr\n 2 unknown\n";
+  std::stringstream all_printed;
+  mu2e::STMChannel::printAll(all_printed);
+  std::cout << "Output of printAll(): " << std::endl;
+  std::cout << all_printed.str();
+  std::cout << "Is it what we expected? : ";
+  if (all_printed.str().compare(expected_all_printed) == 0) {
+    std::cout << "YES" << std::endl;
+  }
+  else {
+    std::cout << "NO" << std::endl;
+    return -1;
+  }
+  std::cout << std::endl;
+
   std::cout << "All tests passed" << std::endl;
 }


### PR DESCRIPTION
Hi Everyone,

I will break down the big PR #829 into smaller PRs as I can / when it's needed. This PR adds an enum class for the STMChannel. This is needed to start work on the proditions interface (which Ray has kindly agreed to work on) since we will index the rows in the conditions database to the channel number.

I copied the code from the GenId class and made any necessary changes. One non-obvious change is that the "unknown" member is not at position 0. I did this because we want to start the channel numbering at 0. Let me know if there is a better way to do this.

Thanks,
Andy