### PR TITLE
Update ups_install scripts

### DIFF
--- a/ups_install/install.sh
+++ b/ups_install/install.sh
@@ -6,12 +6,11 @@
 # same product+version+qualifiers: use with care.
 #
 
+export PACKAGE_VERSION="$1"
 export COMPILER_CODE=${MUSE_COMPILER_E}
-export ${MU2E_SETUP_BUILDOPTS}
 export DEBUG_LEVEL=${MUSE_BUILD}
 export PACKAGE_NAME=offline
 export PACKAGE_SOURCE=${MUSE_WORK_DIR}/Offline
-export PACKAGE_VERSION=d10_17_00
 
 # Check that the installation directoy has been defined.
 if [ "${PRODUCTS_INSTALL}" = '' ];then

--- a/ups_install/installTableFile.sh
+++ b/ups_install/installTableFile.sh
@@ -111,14 +111,6 @@ Qualifiers = "${qualifiers_value}:trig:${MUSE_BUILD}"
 EOG
 )
 
-echo
-echo '****************************************************************'
-echo
-echo "GROUP_DEFINITIONS variable is: ${GROUP_DEFINITIONS}"
-echo
-echo '****************************************************************'
-echo
-
 echo "$GROUP_DEFINITIONS"|sed -i "/Group:/r /dev/stdin" ${destination_file}
 
 unset art_ver


### PR DESCRIPTION
Make PACKAGE_VERSION and argument to the script install.sh ; previously was hard coded.
Remove reference to non-longer-existing environment variable.
Remove noisy printout.