### PR TITLE
replace 3.14 with M_PI

### DIFF
--- a/Analyses/src/CaloClusterCompare_module.cc
+++ b/Analyses/src/CaloClusterCompare_module.cc
@@ -19,6 +19,8 @@
 #include "TLegend.h"
 #include "TTree.h"
 
+#include <cmath>
+
 using namespace std;
 
 namespace mu2e
@@ -78,7 +80,7 @@ namespace mu2e
                 _EnergyErr->GetXaxis()->SetTitle("EDepErr");
                 _TimeErr= tfs->make<TH1F>("TimeErr","TimeErr" ,50,0,50);
                 _TimeErr->GetXaxis()->SetTitle("TimeErr");
-                _Angle= tfs->make<TH1F>("Angle","Angle " ,50,-3.1415, 3.1415);
+                _Angle= tfs->make<TH1F>("Angle","Angle " ,50,-M_PI, M_PI);
                 _Angle->GetXaxis()->SetTitle("Angle");
                 _PosX= tfs->make<TH1F>("PosX","Pos X" ,50,-650,650);
                 _PosX->GetXaxis()->SetTitle("X Pos");

--- a/Analyses/src/KineticFracAnalysis_module.cc
+++ b/Analyses/src/KineticFracAnalysis_module.cc
@@ -979,7 +979,7 @@ namespace mu2e {
         double tanDip = sqrt( 1. - tCosDip*tCosDip)/tCosDip;
 
 
-        double angleWrtZ = acos(trkMomentum.z()/trkMomentum.mag())*(180/3.14159);
+        double angleWrtZ = acos(trkMomentum.z()/trkMomentum.mag())*(180/M_PI);
 
         std::cout << "delta time = " << _cluTime[bestCluster[trackNumber]] << " " << trkArrivalTime << " " << deltaTime << std::endl;
         //        if (deltaTime > -4){break;}

--- a/CaloFilters/src/FilterEcalMixedTrigger_module.cc
+++ b/CaloFilters/src/FilterEcalMixedTrigger_module.cc
@@ -47,6 +47,7 @@
 
 // C++ includes
 #include <vector>
+#include <cmath>
 
 //using namespace std;
 
@@ -490,9 +491,9 @@ namespace mu2e {
             // ANGULAR VELOCITY SELECTION (ANGLES AT THE CIRCUMFERENCE)
             alphastraw=atan2(ystraw,xstraw);
             dalpha=2.*(alphastraw-alphapeak);
-            if (dalpha>0) dalpha-=6.2832;
-            n2pi=(int)((dalpha-DAPAR0-DAPAR1*zstraw)/6.2832+1.5);
-            dalpha-=6.2832*(float)(n2pi-1);
+            if (dalpha>0) dalpha-=(2.0*M_PI);
+            n2pi=(int)((dalpha-DAPAR0-DAPAR1*zstraw)/(2.0*M_PI)+1.5);
+            dalpha-=(2.0*M_PI)*(float)(n2pi-1);
             //
             dz=zstraw-zpeak;
             dalphadz=dalpha/dz;
@@ -604,9 +605,9 @@ namespace mu2e {
           zstraw=shit.z;
           phistraw=atan2(ystraw-ymax,xstraw-xmax);
           dphi=phistraw-phipeak;
-          if (dphi>0) dphi-=6.2832;
-          n2pi=(int)((dphi-DAPAR0-dalphadzbest*zstraw)/6.2832+1.5);
-          dphi-=6.2832*(float)(n2pi-1);
+          if (dphi>0) dphi-=(2.0*M_PI);
+          n2pi=(int)((dphi-DAPAR0-dalphadzbest*zstraw)/(2.0*M_PI)+1.5);
+          dphi-=(2.0*M_PI)*(float)(n2pi-1);
           dz=zstraw-zpeak;
           dphidz=dphi/dz;
           dfdzbin=(int)((dphidz-0.003)/dfdzbinwidth);
@@ -671,11 +672,11 @@ namespace mu2e {
         rstraw=sqrt(xstraw*xstraw+ystraw*ystraw);
         zstraw=shit.z;
         dphipeak=(dphidz-dphidzbest)*(zstraw-zpeak);
-        if (dphipeak<-3.1416) dphipeak+=3.1416;
-        if (dphipeak>3.1416) dphipeak-=3.1416;
+        if (dphipeak<-M_PI) dphipeak+=M_PI;
+        if (dphipeak>M_PI) dphipeak-=M_PI;
         dphi=dphidz*(zstraw-zpeak);
-        n2pi=(int)(dphi/6.2832+7.5);
-        dphi-=6.2832*(float)(n2pi-7);
+        n2pi=(int)(dphi/(2.0*M_PI)+7.5);
+        dphi-=(2.0*M_PI)*(float)(n2pi-7);
         if (abs(dphipeak)< 0.08){
           ndphicpeak++;
         }

--- a/CosmicReco/src/CosmicAnalyzer_module.cc
+++ b/CosmicReco/src/CosmicAnalyzer_module.cc
@@ -2,7 +2,6 @@
 //Date: April 2019
 //Purpose: (DEPRECATED - Almost!) Not very nice analyzer for Cosmics. Would be better to use the CosmicTrackDetails. This will be removed soon but might be useful for comparison with old code.
 
-#define _USE_MATH_DEFINES
 #include <iostream>
 #include <string>
 #include <cmath>
@@ -315,10 +314,10 @@ namespace mu2e
                 _trueb1XYZ->SetStats();
 
 
-                _mc_phi_angle = tfs->make<TH1F>("#phi_{true, fit}","#phi_{true, fit}" ,100,-3.141529,3.141529);
+                _mc_phi_angle = tfs->make<TH1F>("#phi_{true, fit}","#phi_{true, fit}" ,100,-M_PI,M_PI);
                 _mc_phi_angle->GetXaxis()->SetTitle("#phi_{true, fit} [rad]");
 
-                _mc_theta_angle = tfs->make<TH1F>("#theta_{true, fit}","#theta_{true, fit}" ,20,0,3.141529);
+                _mc_theta_angle = tfs->make<TH1F>("#theta_{true, fit}","#theta_{true, fit}" ,20,0,M_PI);
                 _mc_theta_angle->GetXaxis()->SetTitle("#theta_{true, fit} [rad]");
 
                 _AMBIG = tfs->make<TH2F>("True v Reco", "True v Reco", 2,-2,2,2,-2,2);
@@ -333,19 +332,19 @@ namespace mu2e
                 _TrueTimeResiduals->GetXaxis()->SetTitle("True Time Res [ns]");
                 _TrueTimeResiduals->SetStats();
 
-                _A0pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull A_{0} v #theta_{true,fit}  ","Seed Parameter Pull A_{0} v #theta_{true,fit} ",100,0,3.141529,-200,200);
+                _A0pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull A_{0} v #theta_{true,fit}  ","Seed Parameter Pull A_{0} v #theta_{true,fit} ",100,0,M_PI,-200,200);
                 _A0pull_v_theta_true->GetXaxis()->SetTitle("#theta_{true}");
                 _A0pull_v_theta_true->GetYaxis()->SetTitle("Parameter Pull A_{0}");
 
-                _B0pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull B_{0} v #theta_{true,fit}  ","Seed Parameter Pull B_{0} v #theta_{true,fit} ",100,0,3.141529,-200,200);
+                _B0pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull B_{0} v #theta_{true,fit}  ","Seed Parameter Pull B_{0} v #theta_{true,fit} ",100,0,M_PI,-200,200);
                 _B0pull_v_theta_true->GetXaxis()->SetTitle("#theta_{true}");
                 _B0pull_v_theta_true->GetYaxis()->SetTitle("Parameter Pull B_{0}");
 
-                _A1pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull A_{1} v #theta_{true,fit}  ","Seed Parameter Pull A_{1} v #theta_{true,fit} ",100,0,3.141529,-10,10);
+                _A1pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull A_{1} v #theta_{true,fit}  ","Seed Parameter Pull A_{1} v #theta_{true,fit} ",100,0,M_PI,-10,10);
                 _A1pull_v_theta_true->GetXaxis()->SetTitle("#theta_{true}");
                 _A1pull_v_theta_true->GetYaxis()->SetTitle("Parameter Pull A_{1}");
 
-                _B1pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull B_{1} v #theta_{true,fit}  ","Seed Parameter Pull B_{1} v #theta_{true,fit} ",100,0,3.141529,-10,10);
+                _B1pull_v_theta_true= tfs->make<TProfile>("Seed Parameter Pull B_{1} v #theta_{true,fit}  ","Seed Parameter Pull B_{1} v #theta_{true,fit} ",100,0,M_PI,-10,10);
                 _B1pull_v_theta_true->GetXaxis()->SetTitle("#theta_{true}");
                 _B1pull_v_theta_true->GetYaxis()->SetTitle("Parameter Pull B_{1}");
 
@@ -397,7 +396,7 @@ namespace mu2e
                 _seedDeltaB1_v_minuitB1->GetXaxis()->SetTitle("#Delta B^{seed-MC}_{1}");
                 _seedDeltaB1_v_minuitB1->GetYaxis()->SetTitle("B^{straw}_{1}");
         }
-        _reco_phi_angle = tfs->make<TH1F>("#phi Angle of Reconstructred Track","#phi_{reco} Angle of Tracl " ,20,0,3.141529);
+        _reco_phi_angle = tfs->make<TH1F>("#phi Angle of Reconstructred Track","#phi_{reco} Angle of Tracl " ,20,0,M_PI);
         _reco_phi_angle->GetXaxis()->SetTitle("#phi_{reco} [rad]");
         _reco_phi_angle->SetStats();
 

--- a/CosmicReco/src/CosmicMCRecoDiff_module.cc
+++ b/CosmicReco/src/CosmicMCRecoDiff_module.cc
@@ -2,7 +2,6 @@
 //Date:  2021
 //Purpose: For getting seed cov estimates
 
-#define _USE_MATH_DEFINES
 #include <iostream>
 #include <string>
 #include <cmath>

--- a/CosmicReco/src/CosmicMuonInfo_module.cc
+++ b/CosmicReco/src/CosmicMuonInfo_module.cc
@@ -18,6 +18,7 @@
 #include "art/Framework/Principal/Handle.h"
 #include "art_root_io/TFileService.h"
 #include "fhiclcpp/ParameterSet.h"
+#include <cmath>
 #include <iostream>
 #include <map>
 #include <set>
@@ -222,10 +223,10 @@ mu2e::CosmicMuonInfo::CosmicMuonInfo(fhicl::ParameterSet const& pset):
 
   art::ServiceHandle<art::TFileService> tfs;
 
-  _phiMC          = tfs->make<TH1D>( "#phi_{MC}",   "Angle #phi_{MC} of Muon MC tracks All",  100, -3.141529,      3.141529 );
-  _thetaMC        = tfs->make<TH1D>( "#theta_{MC}",   "Angle #theta_{MC} of Muon MC tracks All",  20, 0,      3.141529 );
-  _phiMCcuts          = tfs->make<TH1D>( "#phi_after_cuts_{MC}",   "Angle #phi_{MC} of Muon MC tracks after MC cuts",  100, -3.141529,      3.141529 );
-  _thetaMCcuts        = tfs->make<TH1D>( "#theta_after_cuts{MC}",   "Angle #theta_{MC} of Muon MC tracks aft MC cuts",  20, 0,      3.141529 );
+  _phiMC          = tfs->make<TH1D>( "#phi_{MC}",   "Angle #phi_{MC} of Muon MC tracks All",  100, -M_PI,      M_PI );
+  _thetaMC        = tfs->make<TH1D>( "#theta_{MC}",   "Angle #theta_{MC} of Muon MC tracks All",  20, 0,      M_PI );
+  _phiMCcuts          = tfs->make<TH1D>( "#phi_after_cuts_{MC}",   "Angle #phi_{MC} of Muon MC tracks after MC cuts",  100, -M_PI,      M_PI );
+  _thetaMCcuts        = tfs->make<TH1D>( "#theta_after_cuts{MC}",   "Angle #theta_{MC} of Muon MC tracks aft MC cuts",  20, 0,      M_PI );
   _hNStrawHits    = tfs->make<TH1D>( "hNStrawHits",   "Number of Straw Hits",         100,  0.,       100. );
   _hNPanelHits    = tfs->make<TH1D>( "hNPanelHits",   "Number of Panel Hits",         100,  0.,       100. );
   _hUniquePanel   = tfs->make<TH1D>( "hUniquePanel",  "Unique Panel ID",              216,  0.,       216. );

--- a/CosmicReco/src/CosmicTrackDetails_module.cc
+++ b/CosmicReco/src/CosmicTrackDetails_module.cc
@@ -2,7 +2,6 @@
 //Date: Oct 2019
 //Purpose: An improved analyzer for Cosmics
 
-#define _USE_MATH_DEFINES
 #include <iostream>
 #include <string>
 #include <cmath>

--- a/CosmicReco/src/CosmicTrackDiag_module.cc
+++ b/CosmicReco/src/CosmicTrackDiag_module.cc
@@ -1,4 +1,3 @@
-#define _USE_MATH_DEFINES
 #include <iostream>
 #include <string>
 #include <cmath>

--- a/EventGenerator/src/CaloTBGun_module.cc
+++ b/EventGenerator/src/CaloTBGun_module.cc
@@ -24,6 +24,8 @@
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
 #include "Offline/CalorimeterGeom/inc/DiskCalorimeter.hh"
 
+#include <cmath>
+
 namespace mu2e {
 
   //================================================================
@@ -60,7 +62,7 @@ namespace mu2e {
   {
        const Calorimeter& cal = *(GeomHandle<Calorimeter>());
 
-       double                  angleRad = angle_*3.1415926/180;
+       double                  angleRad = angle_*M_PI/180;
        double                  Zbuffer  = cal.disk(0).crystal(400).position().z()-cal.disk(0).geomInfo().origin().z()+cal.disk(0).geomInfo().size().z()/2.0+1;
        double                  dz       = (frontVD_)? Zbuffer : 0;
        CLHEP::Hep3Vector       pos      = cal.disk(0).crystal(400).position() - CLHEP::Hep3Vector(tan(angleRad)*dz,0,dz);

--- a/GeometryService/src/DiskCalorimeterMaker.cc
+++ b/GeometryService/src/DiskCalorimeterMaker.cc
@@ -359,7 +359,7 @@ namespace mu2e {
             if (verbosityLevel_ > 2)
             {
                 double espace          = thisDisk->estimateEmptySpace();
-                double diskVolume    = 3.1415926*(thisDisk->outerRadius()*thisDisk->outerRadius()-thisDisk->innerRadius()*thisDisk->innerRadius());
+                double diskVolume    = M_PI*(thisDisk->outerRadius()*thisDisk->outerRadius()-thisDisk->innerRadius()*thisDisk->innerRadius());
                 double crystalVolume = 3.4641016*crystalCellRadius*crystalCellRadius*thisDisk->nCrystals();
 
                 std::cout<<"Estimated empty space between the disks and the crystals "<<std::endl;

--- a/Mu2eG4/src/generateFieldMap.cc
+++ b/Mu2eG4/src/generateFieldMap.cc
@@ -55,7 +55,7 @@ namespace mu2e {
     StraightSection const * ts3in =beamg->getTS().getTSCryo<StraightSection>( TransportSolenoid::TSRegion::TS3,
                                                                               TransportSolenoid::TSRadialPart::IN );
     double L = ts3in->getHalfLength();
-    double Lturn = L + 3.14159/2*R;
+    double Lturn = L + M_PI/2*R;
 
     for( int i=-1100; i<2200; i++ ) {
 

--- a/TrackerMC/src/MakeStrawGasSteps_module.cc
+++ b/TrackerMC/src/MakeStrawGasSteps_module.cc
@@ -34,6 +34,8 @@
 #include "TH1F.h"
 #include "TTree.h"
 
+#include <cmath>
+
 using namespace std;
 using CLHEP::Hep3Vector;
 namespace mu2e {
@@ -143,7 +145,7 @@ namespace mu2e {
     art::ServiceHandle<art::TFileService> tfs;
     if(_diag > 0){
       _hendrad = tfs->make<TH1F>("endrad","EndStep Radius",100,2.0,3.0);
-      _hphi = tfs->make<TH1F>("phi","Step rotation angle",100,0.0,3.14);
+      _hphi = tfs->make<TH1F>("phi","Step rotation angle",100,0.0,M_PI);
       if(_diag > 1) {
         _sgsdiag=tfs->make<TTree>("sgsdiag","StrawGasStep diagnostics");
         _sgsdiag->Branch("prilen",&_prilen,"prilen/F");

--- a/TrkReco/src/RobustHelixFit.cc
+++ b/TrkReco/src/RobustHelixFit.cc
@@ -769,7 +769,7 @@ void RobustHelixFit::findHistPeaks(std::vector<int>&hist_sum, int binWidth,
   int    bin_index(0);
 
   for (int ipeak=0; ipeak<_initFZFrequencyNMaxPeaks; ++ipeak){
-    //      if (ipeak>0) bin_index = (xmp[ipeak-1] + 0.4*lambda[ipeak-1]*6.28 - start_dz)/bin_size;//shifting the starting pos 1/2 pitch from the previous peak
+    //      if (ipeak>0) bin_index = (xmp[ipeak-1] + 0.4*lambda[ipeak-1]*(2.0*M_PI) - start_dz)/bin_size;//shifting the starting pos 1/2 pitch from the previous peak
     if (ipeak>0) bin_index = (xmp[ipeak-1] + _initFZFrequencyNSigma*sigma[ipeak-1])/binWidth;//shifting the starting pos 1/2 pitch from the previous peak
 
     if (bin_index >= _initFZFrequencyArraySize-_initFZFrequencyBinsToIntegrate)       break;
@@ -790,9 +790,9 @@ void RobustHelixFit::findHistPeaks(std::vector<int>&hist_sum, int binWidth,
         xmp[ipeak]  += shift_dz;
         indexPeak[ipeak] = ix;
         // if (ipeak ==0 )
-        //   lambda[ipeak] = xmp[ipeak]/(6.28*(peaks_found+1));//ipeak!=0 ? xmp[ipeak]/(6.28*(ipeak)) : xmp[ipeak]/(6.28);
+        //   lambda[ipeak] = xmp[ipeak]/((2.0*M_PI)*(peaks_found+1));//ipeak!=0 ? xmp[ipeak]/((2.0*M_PI)*(ipeak)) : xmp[ipeak]/(2.0*M_PI);
         // else {
-        //   lambda[ipeak] = (xmp[ipeak] - xmp[ipeak-1])/6.28;
+        //   lambda[ipeak] = (xmp[ipeak] - xmp[ipeak-1])/(2.0*M_PI);
         // }
         swmax[ipeak] = sw;
       }
@@ -892,14 +892,14 @@ bool RobustHelixFit::initFZ_from_dzFrequency(RobustHelixFinderData& HelixData, i
     if (swmax[i]>minNCounts){
       if ( (xmp[i] - _initFZFrequencyNSigma*sigma[i]>0) && (xmp[i-1] - _initFZFrequencyNSigma*sigma[i-1]>0)){
         double   wg = sqrt(swmax[i]*swmax[i-1]);
-        weight_lambda += wg*(xmp[i] - xmp[i-1])/6.28;//(lambda[i]*swmax[i]);
+        weight_lambda += wg*(xmp[i] - xmp[i-1])/(2.0*M_PI);//(lambda[i]*swmax[i]);
         total_wg   += wg;
       }
     }
   }
   weight_lambda /= total_wg;
 
-  if (peaks_found == 1) weight_lambda = xmp[first_peak]/6.28;
+  if (peaks_found == 1) weight_lambda = xmp[first_peak]/(2.0*M_PI);
 
   float lambda_final = weight_lambda*dzdphisign;
 


### PR DESCRIPTION
per #235 replace 3.14 literal with M_PI. It is possible that some of these uses for histogram boundaries were strategically just not quite pi, so they should be reviewed.  Tested identical with validation 1K ceSimReco and 200 reco.