### PR TITLE
added missing parameter configuration

### DIFF
--- a/Mu2eG4/geom/bfgeom_DS70_no_tsu_ps_v01.txt
+++ b/Mu2eG4/geom/bfgeom_DS70_no_tsu_ps_v01.txt
@@ -23,6 +23,7 @@ vector<string> bfield.innerMaps = {
   "BFieldMaps/Mau13/DSExtension.header"
 };
 
+double bfield.scaleFactor = 0.7;
 
 //
 // This tells emacs to view this file in c++ mode.


### PR DESCRIPTION
Working with a student, we found out that the SeedFit (aka the tack Kalman-based fit with no material nor BField correction) uses a constant BField assumption and that we need to use this parameter to set it properly.