### PR TITLE
epicsTool missing case 

### DIFF
--- a/DbService/src/EpicsTool.cc
+++ b/DbService/src/EpicsTool.cc
@@ -101,6 +101,11 @@ EpicsVar::EpicsVec EpicsTool::get(std::string const& name,
     return ev;
   }
 
+  // if no constraints, return the whole list
+  if ( time.empty() && daysAgo<=0.0 ) {
+    return ev;
+  }
+
   EpicsVar::EpicsVec evt;
   if (time.find('/') != std::string::npos) {
     // time interval


### PR DESCRIPTION
There was a missing case in the parsing of the inputs.  This change is ~zero risk, and will not affect validation.
