### PR TITLE
prototype for using particle names in fhicl

### DIFF
--- a/Analyses/src/ReadVirtualDetector_module.cc
+++ b/Analyses/src/ReadVirtualDetector_module.cc
@@ -127,6 +127,7 @@ namespace mu2e {
   class ReadVirtualDetector : public art::EDAnalyzer {
 
     typedef vector<int> Vint;
+    typedef vector<string> Sint;
     typedef SimParticleCollection::key_type key_type;
 
     // Name of the VD and TVD StepPoint collections
@@ -198,6 +199,8 @@ namespace mu2e {
     // real parent, navigating through the staged SimParticles
     bool _navigate_to_parent;
 
+    GlobalConstantsHandle<ParticleDataList> pdt;
+
   public:
 
     explicit ReadVirtualDetector(fhicl::ParameterSet const& pset);
@@ -247,12 +250,13 @@ namespace mu2e {
     if (_debugout > 1){
       std::cout << "_vd_required = " << _vd_required << std::endl;
     }
-    Vint const & pdg_ids = pset.get<Vint>("savePDG", Vint());
+    Sint const & pdg_names = pset.get<Sint>("savePDG", Sint());
+    vector<PDGCode::type> const & pdg_ids = pdt->pdgId(pdg_names);
     if( pdg_ids.size()>0 ) {
       cout << "ReadVirtualDetector: save following particle types in the ntuple: ";
       for( size_t i=0; i<pdg_ids.size(); ++i ) {
         pdg_save.insert(pdg_ids[i]);
-        cout << pdg_ids[i] << ", ";
+        cout << pdg_names[i] << "("<<pdg_ids[i]<<"), ";
       }
       cout << endl;
     }
@@ -423,7 +427,6 @@ namespace mu2e {
     }
     GeomHandle<VirtualDetector> vdg;
     if( vdg->nDet()<=0 ) return;
-    GlobalConstantsHandle<ParticleDataList> pdt;
 
     // Ask the event to give us a "handle" to the requested hits.
     art::Handle<StepPointMCCollection> hits;

--- a/Analyses/test/vd_readback.fcl
+++ b/Analyses/test/vd_readback.fcl
@@ -5,6 +5,7 @@
 
 #include "Offline/fcl/minimalMessageService.fcl"
 #include "Offline/fcl/standardProducers.fcl"
+#include "Offline/fcl/standardServices.fcl"
 
 #include "Offline/Analyses/fcl/prolog.fcl"
 
@@ -19,28 +20,7 @@ source :
   maxEvents : -1
 }
 
-services :
-{
-  message : @local::default_message
-
-  TFileService :
-  {
-    fileName : "vd_readback.root"
-  }
-
-  GeometryService :
-  {
-    inputFile : "Offline/Mu2eG4/geom/geom_common.txt"
-  }
-
-  ConditionsService :
-  {
-    conditionsfile : "Offline/ConditionsService/data/conditions_01.txt"
-  }
-
-  GlobalConstantsService : { inputFile : "Offline/GlobalConstantsService/data/globalConstants_01.txt" }
-
-}
+services : { @table::Services.Core }
 
 physics :
 {
@@ -63,5 +43,5 @@ physics :
 }
 
 physics.analyzers.readvd.debugOutput : 0
-physics.analyzers.readvd.savePDG     : [11, -11, 13, -13, 22, 111, 211, -211, 321, -321, 2112, 2212, -2212]
+physics.analyzers.readvd.savePDG     : [electron, positron, muon, antimuon, photon, pi0, pi_plus, pi_minus, K_minus, K_plus, proton, anti_proton, neutron]
 physics.analyzers.readvd.maxPrint    : 10

--- a/GlobalConstantsService/inc/ParticleDataList.hh
+++ b/GlobalConstantsService/inc/ParticleDataList.hh
@@ -27,9 +27,12 @@
 #include <string>
 #include <iostream>
 #include <map>
+#include <vector>
+#include <array>
 
 #include "Offline/Mu2eInterfaces/inc/ConditionsEntity.hh"
 #include "Offline/GlobalConstantsService/inc/ParticleData.hh"
+#include "Offline/DataProducts/inc/PDGCode.hh"
 
 namespace mu2e {
 
@@ -45,6 +48,14 @@ namespace mu2e {
     const ParticleData& particle( int id ) const;
     // lookup by name - the display name, code name or alias
     const ParticleData& particle( std::string const& name ) const;
+
+    // name to ID conversions
+    PDGCode::type pdgId( std::string const& name) const;
+    std::vector<PDGCode::type>
+           pdgId( std::vector<std::string> const& names) const;
+    template<std::size_t N> std::array<PDGCode::type,N>
+           pdgId( std::array<std::string,N> const& names) const;
+
 
     // the entire table as a map with pdgID as key
     std::map<int,ParticleData> const& list() const { return _list;}

--- a/GlobalConstantsService/src/ParticleDataList.cc
+++ b/GlobalConstantsService/src/ParticleDataList.cc
@@ -8,7 +8,6 @@
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
 #include "Offline/ConfigTools/inc/SimpleConfig.hh"
-#include "Offline/DataProducts/inc/PDGCode.hh"
 
 
 namespace mu2e {
@@ -109,6 +108,34 @@ namespace mu2e {
     }
     return particle(it->second);
 
+  }
+
+  // *************************************************************
+
+  PDGCode::type ParticleDataList::pdgId( std::string const& name) const {
+    return PDGCode::type(particle(name).id());
+  }
+
+  // *************************************************************
+
+  std::vector<PDGCode::type>
+  ParticleDataList::pdgId( std::vector<std::string> const& names) const {
+    std::vector<PDGCode::type> vv;
+    for(auto const& name : names) {
+      vv.emplace_back(PDGCode::type(particle(name).id()));
+    }
+    return vv;
+  }
+
+  // *************************************************************
+
+  template<std::size_t N> std::array<PDGCode::type,N>
+  ParticleDataList::pdgId( std::array<std::string,N> const& names) const {
+    std::array<PDGCode::type,N> aa;
+    for(std::size_t i=0; i<N; i++) {
+      aa[i] = PDGCode::type(particle(names[i]).id());
+    }
+    return aa;
   }
 
   // *************************************************************


### PR DESCRIPTION
Running vd_readback.fcl with fhicl:
`physics.analyzers.readvd.savePDG     : [electron, positron, muon, antimuon, photon, pi0, pi_plus, pi_minus, K_minus, K_plus, proton, anti_proton, neutron]
`
on a file like ceSimReco output results in 
`ReadVirtualDetector: save following particle types in the ntuple: electron(11), positron(-11), muon(13), antimuon(-13), photon(22), pi0(111), pi_plus(211), pi_minus(-211), K_minus(-321), K_plus(321), proton(2212), anti_proton(-2212), neutron(2112), 
`
All Additions are production and validation-safe