### PR TITLE
Add TrackerBFieldInfo.

### DIFF
--- a/Mu2eUtilities/inc/TrackerBFieldInfo.hh
+++ b/Mu2eUtilities/inc/TrackerBFieldInfo.hh
@@ -13,8 +13,8 @@
 //
 // To use this to look at limits of a map:
 // TrackerBFieldInfo info
-//  cout << info.xmin() << " " << info.xmax() << endl;  // and so on
-//  cout << info.getKey() << endl;                      // name of the map that was selected
+//  cout << info.map().xmin() << " " << info.map().xmax() << endl;  // and so on
+//  cout << info.map().getKey() << endl;                            // name of the map that was selected
 //
 // Original author Rob Kutschke
 //

--- a/Mu2eUtilities/inc/TrackerBFieldInfo.hh
+++ b/Mu2eUtilities/inc/TrackerBFieldInfo.hh
@@ -1,0 +1,44 @@
+#ifndef Mu2eUtilities_TrackerBFieldInfo_hh
+#define Mu2eUtilities_TrackerBFieldInfo_hh
+//
+// Find the magnetic field map that contains the tracker origin.
+// Return the map on request.
+//
+// I made this a class so that we can add other accessors that
+// transform the information received from the map.
+//
+// If a map cannot be located it throws an exception.
+// If there is more than one map among the BField innerMaps, it
+// also throws and exception.
+//
+// To use this to look at limits of a map:
+// TrackerBFieldInfo info
+//  cout << info.xmin() << " " << info.xmax() << endl;  // and so on
+//  cout << info.getKey() << endl;                      // name of the map that was selected
+//
+// Original author Rob Kutschke
+//
+
+#include "Offline/BFieldGeom/inc/BFMap.hh"
+
+#include <iosfwd>
+
+namespace mu2e {
+
+
+  class TrackerBFieldInfo {
+  public:
+
+    TrackerBFieldInfo();
+
+    BFMap const& map() const { return *_map; }
+
+  private:
+
+    BFMap const* _map = nullptr;
+
+  };
+
+} // end of namespace mu2e
+
+#endif /* Mu2eUtilities_TrackerBFieldInfo_hh */

--- a/Mu2eUtilities/src/TrackerBFieldInfo.cc
+++ b/Mu2eUtilities/src/TrackerBFieldInfo.cc
@@ -1,0 +1,32 @@
+// See header file for description.
+
+#include "Offline/BFieldGeom/inc/BFieldManager.hh"
+#include "Offline/BFieldGeom/inc/BFMap.hh"
+#include "Offline/GeometryService/inc/DetectorSystem.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
+#include "Offline/Mu2eUtilities/inc/TrackerBFieldInfo.hh"
+
+#include <iostream>
+
+mu2e::TrackerBFieldInfo::TrackerBFieldInfo(){
+  BFieldManager  const& bfm    = *GeomHandle<BFieldManager>();
+  DetectorSystem const& detsys = *GeomHandle<DetectorSystem>();
+
+  CLHEP::Hep3Vector trackerOriginWorld = detsys.toMu2e( CLHEP::Hep3Vector() );
+
+  unsigned count{0};
+  for ( auto m : bfm.getInnerMaps() ){
+    if ( m->isValid( trackerOriginWorld ) ){
+      _map = m.get();
+      ++count;
+    }
+  }
+
+  if ( count != 1 ){
+    throw cet::exception("BField")
+      << "TrackerBFieldInfo: could not locate exactly one BField innerMap containing the tracker origin. Number found: "
+      << count
+      << "\n Tracker origin in World: " << trackerOriginWorld;
+  }
+
+}


### PR DESCRIPTION
The the comments in  Mu2eUtilities/inc/TrackerBFieldInfo.hh for usage.  The class is designed so that we can do transformations to other coordinate systems in the class in order to clean up client code.