### PR TITLE
Hold B fields with const pointers

### DIFF
--- a/Analyses/src/BFieldPlotter_module.cc
+++ b/Analyses/src/BFieldPlotter_module.cc
@@ -113,13 +113,13 @@ namespace mu2e {
     const BFieldManager::MapContainerType& outerMaps = bf->getOuterMaps();
 
     //plot inner maps
-    for(std::shared_ptr<BFMap> const & map : innerMaps) {
-      fillHistogram(map.get(), tfs);
+    for(auto const & mapptr : innerMaps) {
+      fillHistogram(mapptr.get(), tfs);
     }
 
     //plot outer maps
-    for(std::shared_ptr<BFMap> const & map : outerMaps) {
-      fillHistogram(map.get(), tfs);
+    for(auto const & mapptr : outerMaps) {
+      fillHistogram(mapptr.get(), tfs);
     }
 
     //plot the default field returned from the manager

--- a/BFieldGeom/inc/BFCacheManager.hh
+++ b/BFieldGeom/inc/BFCacheManager.hh
@@ -28,9 +28,9 @@ namespace mu2e {
     //
 
     class BFCacheManager {
-        // typedef std::vector<const BFMap*> SequenceType;
-        // typedef std::vector<std::shared_ptr<const BFMap>> SequenceType;
-        typedef std::vector<std::shared_ptr<BFMap>> MapContainerType;
+
+        typedef std::vector<std::shared_ptr<const BFMap>> MapContainerType;
+
         struct MapList : public MapContainerType {
             // return the first matching map or 0
             std::shared_ptr<const BFMap> findMap(const CLHEP::Hep3Vector& x) const {

--- a/BFieldGeom/inc/BFieldManager.hh
+++ b/BFieldGeom/inc/BFieldManager.hh
@@ -36,7 +36,7 @@ namespace mu2e {
         friend class BFieldManagerMaker;
 
         // Maps for various parts of the detector.
-        typedef std::vector<std::shared_ptr<BFMap>> MapContainerType;
+        typedef std::vector<std::shared_ptr<const BFMap>> MapContainerType;
 
         // Get field at an arbitrary point.
         bool getBFieldWithStatus(const CLHEP::Hep3Vector&, CLHEP::Hep3Vector&) const;
@@ -84,7 +84,8 @@ namespace mu2e {
        private:
         // Private ctr.  An instance of BFieldManager should be obtained
         // via the BFieldManagerMaker class.
-        BFieldManager() {}
+        BFieldManager(MapContainerType const& innerMaps,
+                      MapContainerType const& outerMaps);
 
         // This class could support copying but it is not really needed and
         // I would like to prevent unintended copies ( people forgetting to
@@ -92,39 +93,9 @@ namespace mu2e {
         BFieldManager(const BFieldManager&);
         BFieldManager& operator=(const BFieldManager&);
 
-        // Make sure map names are unique on the union of inner and outer maps
-        std::set<std::string> mapKeys_;
-
         MapContainerType innerMaps_;
         MapContainerType outerMaps_;
 
-        // Add an empty grid-like map to the list.  Used by BFieldManagerMaker.
-        std::shared_ptr<BFGridMap> addBFGridMap(MapContainerType* whichMap,
-                                                const std::string& key,
-                                                int nx,
-                                                double xmin,
-                                                double dx,
-                                                int ny,
-                                                double ymin,
-                                                double dy,
-                                                int nz,
-                                                double zmin,
-                                                double dz,
-                                                BFMapType::enum_type type,
-                                                double scaleFactor,
-                                                BFInterpolationStyle interpStyle);
-
-        // Add an empty parametric map to the list.  Used by BFieldManagerMaker.
-        std::shared_ptr<BFParamMap> addBFParamMap(MapContainerType* whichMap,
-                                                  const std::string& key,
-                                                  double xmin,
-                                                  double xmax,
-                                                  double ymin,
-                                                  double ymax,
-                                                  double zmin,
-                                                  double zmax,
-                                                  BFMapType::enum_type type,
-                                                  double scaleFactor);
 
         // Handles caching and overlap resolution logic
         BFCacheManager cm_;

--- a/BFieldGeom/src/BFieldManager.cc
+++ b/BFieldGeom/src/BFieldManager.cc
@@ -42,61 +42,12 @@ namespace mu2e {
     }
 
 
-    std::shared_ptr<BFGridMap> BFieldManager::addBFGridMap(MapContainerType* mapContainer,
-                                                           const std::string& key,
-                                                           int nx,
-                                                           double xmin,
-                                                           double dx,
-                                                           int ny,
-                                                           double ymin,
-                                                           double dy,
-                                                           int nz,
-                                                           double zmin,
-                                                           double dz,
-                                                           BFMapType::enum_type type,
-                                                           double scaleFactor,
-                                                           BFInterpolationStyle interpStyle) {
-        // If there already was another Map with the same key, then it is a hard error.
-        if (!mapKeys_.insert(key).second) {
-            throw cet::exception("GEOM")
-                << "Trying to add a new magnetic field when the named field map already exists: "
-                << key << "\n";
-        }
+  BFieldManager::BFieldManager(MapContainerType const& innerMaps,
+                               MapContainerType const& outerMaps):
+    innerMaps_(innerMaps),outerMaps_(outerMaps) {
+    cm_.setMaps(innerMaps, outerMaps);
 
-        // Add an empty BFMap.
-        auto new_map = std::make_shared<BFGridMap>(key, nx, xmin, dx, ny, ymin, dy, nz, zmin, dz,
-                                                   type, scaleFactor, interpStyle);
-        mapContainer->push_back(new_map);
-
-        return new_map;
-    }
-
-    // Create a new BFGridMap in the container of BFMaps.
-    std::shared_ptr<BFParamMap> BFieldManager::addBFParamMap(MapContainerType* mapContainer,
-                                                             const std::string& key,
-                                                             double xmin,
-                                                             double xmax,
-                                                             double ymin,
-                                                             double ymax,
-                                                             double zmin,
-                                                             double zmax,
-                                                             BFMapType::enum_type type,
-                                                             double scaleFactor) {
-        // If there already was another Map with the same key, then it is a hard error.
-        if (!mapKeys_.insert(key).second) {
-            throw cet::exception("GEOM")
-                << "Trying to add a new magnetic field when the named field map already exists: "
-                << key << "\n";
-        }
-
-        // Add an empty BFMap.
-        auto new_map = std::make_shared<BFParamMap>(key, xmin, xmax, ymin, ymax, zmin, zmax, type,
-                                                    scaleFactor);
-        mapContainer->push_back(new_map);
-
-        return new_map;
-    }
-
+  }
     void BFieldManager::print(ostream& out) const {
         out << "================ BFieldManager: innerMaps ================\n";
         for (auto i = innerMaps_.begin(); i != innerMaps_.end(); ++i) {

--- a/GeometryService/inc/BFieldManagerMaker.hh
+++ b/GeometryService/inc/BFieldManagerMaker.hh
@@ -42,41 +42,28 @@ namespace mu2e {
         // Hold the object while we are creating it. The GeometryService will take ownership.
         std::unique_ptr<BFieldManager> _bfmgr;
 
-        // Hold the types of the inner and outer maps (if they differ)
-        std::vector<BFMapType> _innerTypes;
-        std::vector<BFMapType> _outerTypes;
-
-        // Load a series of parametric magnetic field maps.
-        void loadParam(MapContainerType& whichMap,
+        // Load a series of G4BL or parametric magnetic field maps.
+        void loadMaps(MapContainerType& whichMap,
                        const BFieldConfig::FileSequenceType& files,
                        std::vector<BFMapType> mapTypeList,
-                       BFInterpolationStyle interpStyle,
-                       double scaleFactor,
-                       bool flipBFieldMap);
+                      const BFieldConfig& config);
+
 
         // Create a new parametric magnetic field map, get information from config file.
         void loadParam(MapContainerType& whichMap,
                        const std::string& key,
                        const std::string& resolvedFileName,
-                       double scaleFactor);
-
-        // Load a series of G4BL magnetic field maps.
-        void loadG4BL(MapContainerType& whichMap,
-                      const BFieldConfig::FileSequenceType& files,
-                      double scaleFactor,
-                      BFInterpolationStyle interpStyle,
-                      bool flipBFieldMap);
+                       const BFieldConfig& config);
 
         // Create a new magnetic field map, get information from config file.
         void loadG4BL(MapContainerType& whichMap,
                       const std::string& key,
                       const std::string& resolvedFileName,
-                      double scaleFactor,
-                      BFInterpolationStyle interpStyle,
-                      bool flipBFieldMap);
+                      const BFieldConfig& config);
 
         // Read a G4BL text format map.
-        void readG4BLMap(const std::string& filename, BFGridMap& bfmap, CLHEP::Hep3Vector offset);
+        void readG4BLMap(const std::string& filename, BFGridMap& bfmap,
+                         CLHEP::Hep3Vector offset);
 
         // Read a G4BL map that was stored using writeG4BLBinary.
         void readG4BLBinary(const std::string& headerFilename, BFGridMap& bfmap);

--- a/GeometryService/inc/BFieldManagerMaker.hh
+++ b/GeometryService/inc/BFieldManagerMaker.hh
@@ -28,6 +28,8 @@ namespace mu2e {
     class BFieldManagerMaker {
        public:
 
+        typedef std::vector<std::shared_ptr<BFMap>> MapContainerType;
+
         explicit BFieldManagerMaker(const BFieldConfig& config);
 
         // Transfer ownership of the BFManager.
@@ -45,30 +47,33 @@ namespace mu2e {
         std::vector<BFMapType> _outerTypes;
 
         // Load a series of parametric magnetic field maps.
-        void loadParam(BFieldManager::MapContainerType* whichMap,
+        void loadParam(MapContainerType& whichMap,
                        const BFieldConfig::FileSequenceType& files,
                        std::vector<BFMapType> mapTypeList,
                        BFInterpolationStyle interpStyle,
-                       double scaleFactor);
+                       double scaleFactor,
+                       bool flipBFieldMap);
 
         // Create a new parametric magnetic field map, get information from config file.
-        void loadParam(BFieldManager::MapContainerType* whichMap,
+        void loadParam(MapContainerType& whichMap,
                        const std::string& key,
                        const std::string& resolvedFileName,
                        double scaleFactor);
 
         // Load a series of G4BL magnetic field maps.
-        void loadG4BL(BFieldManager::MapContainerType* whichMap,
+        void loadG4BL(MapContainerType& whichMap,
                       const BFieldConfig::FileSequenceType& files,
                       double scaleFactor,
-                      BFInterpolationStyle interpStyle);
+                      BFInterpolationStyle interpStyle,
+                      bool flipBFieldMap);
 
         // Create a new magnetic field map, get information from config file.
-        void loadG4BL(BFieldManager::MapContainerType* whichMap,
+        void loadG4BL(MapContainerType& whichMap,
                       const std::string& key,
                       const std::string& resolvedFileName,
                       double scaleFactor,
-                      BFInterpolationStyle interpStyle);
+                      BFInterpolationStyle interpStyle,
+                      bool flipBFieldMap);
 
         // Read a G4BL text format map.
         void readG4BLMap(const std::string& filename, BFGridMap& bfmap, CLHEP::Hep3Vector offset);


### PR DESCRIPTION
Changes to implement #155
- BFieldManager now holds maps with a const pointer

Cleanups:
- maps are now made and checked in the maker, which is more appropriate
- BFieldManager now is constructed with maps, instead of setting later
- loadParam could load both param and G4BL, so only it is needed
  (renamed loadMaps, always use vector of map types)
- pass config instead of parts of it
- moved config field flip (not By flip) to eliminate cast
- moved write maps to G4BL method to eliminate cast

validated with ceSimReco, potSim and cosmicSimReco.  
Should have no effect on nightly validation.
