### PR TITLE
Use STM Pedestals

### DIFF
--- a/STMReco/fcl/plotSTMWaveformDigis.fcl
+++ b/STMReco/fcl/plotSTMWaveformDigis.fcl
@@ -11,12 +11,8 @@ source : {
 }
 
 services : {
-  message : { @table::Services.Core.message }
+  @table::Services.Core
   TFileService : { fileName : "stmWaveformDigis.root" }
-  GeometryService : { @table::Services.Core.GeometryService }
-  GlobalConstantsService : { @table::Services.Core.GlobalConstantsService }
-  DbService : { @table::Services.Core.DbService }
-  ProditionsService : { @table::Services.Core.ProditionsService }
 }
 
 physics: {

--- a/STMReco/fcl/plotSTMWaveformDigis.fcl
+++ b/STMReco/fcl/plotSTMWaveformDigis.fcl
@@ -11,8 +11,12 @@ source : {
 }
 
 services : {
-  message : @local::Services.Core.message
+  message : { @table::Services.Core.message }
   TFileService : { fileName : "stmWaveformDigis.root" }
+  GeometryService : { @table::Services.Core.GeometryService }
+  GlobalConstantsService : { @table::Services.Core.GlobalConstantsService }
+  DbService : { @table::Services.Core.DbService }
+  ProditionsService : { @table::Services.Core.ProditionsService }
 }
 
 physics: {
@@ -22,10 +26,14 @@ physics: {
     plotHPGeWaveformDigis : {
       module_type : PlotSTMWaveformDigis
       stmWaveformDigisTag : "FromSTMTestBeamData:HPGe"
+      subtractPedestal : false
+      verbosityLevel : 0
     }
     plotLaBrWaveformDigis : {
       module_type : PlotSTMWaveformDigis
       stmWaveformDigisTag : "FromSTMTestBeamData:LaBr"
+      subtractPedestal : false
+      verbosityLevel : 0
     }
   }
   # setup paths
@@ -33,3 +41,6 @@ physics: {
   anaPath : [ plotHPGeWaveformDigis, plotLaBrWaveformDigis ]
   end_paths: [anaPath]
 }
+
+# Can define pedestals in fcl like the commented line below
+# services.ProditionsService.stmEnergyCalib.pedestals : [ ["HPGe",100.0], ["LaBr",2000.0] ]

--- a/STMReco/src/PlotSTMWaveformDigis_module.cc
+++ b/STMReco/src/PlotSTMWaveformDigis_module.cc
@@ -53,8 +53,7 @@ namespace mu2e {
     art::EDAnalyzer{config},
     _stmWaveformDigisTag(config().stmWaveformDigisTag()),
     _subtractPedestal(config().subtractPedestal()),
-    _verbosityLevel(config().verbosityLevel()),
-    _stmEnergyCalib_h()
+    _verbosityLevel(config().verbosityLevel())
   {
     consumes<STMWaveformDigiCollection>(_stmWaveformDigisTag);
     _channel = STMUtils::getChannel(_stmWaveformDigisTag);

--- a/STMReco/src/PlotSTMWaveformDigis_module.cc
+++ b/STMReco/src/PlotSTMWaveformDigis_module.cc
@@ -22,6 +22,8 @@
 #include "Offline/RecoDataProducts/inc/STMWaveformDigi.hh"
 #include "Offline/DataProducts/inc/STMChannel.hh"
 #include "Offline/Mu2eUtilities/inc/STMUtils.hh"
+#include "Offline/ProditionsService/inc/ProditionsHandle.hh"
+#include "Offline/STMConditions/inc/STMEnergyCalib.hh"
 
 namespace mu2e {
 
@@ -31,6 +33,8 @@ namespace mu2e {
       using Comment=fhicl::Comment;
       struct Config {
         fhicl::Atom<art::InputTag> stmWaveformDigisTag{ Name("stmWaveformDigisTag"), Comment("InputTag for STMWaveformDigiCollection")};
+        fhicl::Atom<bool> subtractPedestal{ Name("subtractPedestal"), Comment("True/False whether to subtract the pedestal before plotting")};
+        fhicl::Atom<int> verbosityLevel{ Name("verbosityLevel"), Comment("Verbosity level")};
       };
       using Parameters = art::EDAnalyzer::Table<Config>;
       explicit PlotSTMWaveformDigis(const Parameters& conf);
@@ -39,12 +43,18 @@ namespace mu2e {
     void analyze(const art::Event& e) override;
 
     art::InputTag _stmWaveformDigisTag;
+    bool _subtractPedestal;
+    int _verbosityLevel;
+    ProditionsHandle<STMEnergyCalib> _stmEnergyCalib_h;
     STMChannel _channel;
   };
 
   PlotSTMWaveformDigis::PlotSTMWaveformDigis(const Parameters& config )  :
     art::EDAnalyzer{config},
-    _stmWaveformDigisTag(config().stmWaveformDigisTag())
+    _stmWaveformDigisTag(config().stmWaveformDigisTag()),
+    _subtractPedestal(config().subtractPedestal()),
+    _verbosityLevel(config().verbosityLevel()),
+    _stmEnergyCalib_h()
   {
     consumes<STMWaveformDigiCollection>(_stmWaveformDigisTag);
     _channel = STMUtils::getChannel(_stmWaveformDigisTag);
@@ -57,6 +67,12 @@ namespace mu2e {
 
     std::stringstream histname, histtitle;
     int count = 0;
+    STMEnergyCalib const& stmEnergyCalib = _stmEnergyCalib_h.get(event.id()); // get prodition
+    const auto pedestal = stmEnergyCalib.pedestal(_channel);
+    if (_verbosityLevel > 0) {
+      std::cout << _channel.name() << " Pedestal = " << pedestal << std::endl;
+    }
+
     for (const auto& waveform : *waveformsHandle) {
       histname.str("");
       histname << "evt" << event.event() << "_waveform" << count;
@@ -65,7 +81,13 @@ namespace mu2e {
       TH1F* _hWaveform = tfs->make<TH1F>(histname.str().c_str(), histtitle.str().c_str(), waveform.adcs().size(),0,waveform.adcs().size());
       for (size_t i_adc = 0; i_adc < waveform.adcs().size(); ++i_adc) {
         const auto adc = waveform.adcs().at(i_adc);
-        _hWaveform->SetBinContent(i_adc+1, adc); // bins start numbering at 1
+
+        auto content = adc;
+        if (_subtractPedestal) {
+          content -= pedestal;
+        }
+
+        _hWaveform->SetBinContent(i_adc+1, content); // bins start numbering at 1
       }
       ++count;
     }

--- a/STMReco/src/SConscript
+++ b/STMReco/src/SConscript
@@ -41,6 +41,7 @@ helper.make_plugins( [ mainlib,
                        'cetlib_except',
                        'mu2e_Mu2eUtilities',
                        'mu2e_DataProducts',
+                       'mu2e_DbTables',
                        rootlibs
                      ] )
 


### PR DESCRIPTION
Hi Everyone,

This is just a smal PR to make use of the STM pedestals that Ray added to the Proditions Service in PR #869. I added an option to the PlotSTMWaveformDigis module for plotting pedestal-subtracted waveforms. This option is off by default and the default pedestal value is 0.

This PR doesn't add any scripts to extract the pedestal values that we would put in the database. I guess this will be in a different repository but I don't know

Cheers,
Andy