### PR TITLE
Calofastfix

### DIFF
--- a/CalPatRec/fcl/prolog_trigger.fcl
+++ b/CalPatRec/fcl/prolog_trigger.fcl
@@ -111,7 +111,8 @@ CprTrigger : { @table::CprTrigger
             BackgroundSelectionBits                     : ["Background"]
             minClusterEnergy                            : 50.    # MeV
             minClusterSize                              : 2      # number of crystals
-            dtOffset                                    : -61. #FIXME! this is necessary because CaloClusterFast returns an uncalibrated time!
+            #            dtOffset                                    : -61. #FIXME! this is necessary because CaloClusterFast returns an uncalibrated time!
+            dtOffset                                    : 0
         }
 
 
@@ -124,7 +125,8 @@ CprTrigger : { @table::CprTrigger
             BackgroundSelectionBits                     : ["Background"]
             minClusterEnergy                            : 50.    # MeV
             minClusterSize                              : 2      # number of crystals
-            dtOffset                                    : -61. #-41.8 #FIXME! this is necessary because CaloClusterFast returns an uncalibrated time!
+            #            dtOffset                                    : -61. #-41.8 #FIXME! this is necessary because CaloClusterFast returns an uncalibrated time!
+            dtOffset                                    : 0
         }
 
         TTCalTimePeakFinderUe          : { @table::CalPatRec.filters.CalTimePeakFinder
@@ -168,7 +170,8 @@ CprTrigger : { @table::CprTrigger
             BackgroundSelectionBits                     : ["Background"]
             minClusterEnergy                            : 50.    # MeV
             minClusterSize                              : 2      # number of crystals
-            dtOffset                                    : -41.8 #FIXME! this is necessary because CaloClusterFast returns an uncalibrated time!
+            #            dtOffset                                    : -41.8 #FIXME! this is necessary because CaloClusterFast returns an uncalibrated time!
+            dtOffset                                    : 0.0
         }
 
         TTCalHelixFinderUCC          : { @table::CalPatRec.filters.CalHelixFinder

--- a/CaloCluster/fcl/prolog_trigger.fcl
+++ b/CaloCluster/fcl/prolog_trigger.fcl
@@ -16,6 +16,7 @@ CaloClusterFast:
    deltaTime              : 10
    minSiPMPerHit          : 2
    extendSearch           : true
+   timeOffset             : -61 #ns
    diagLevel              : 0
 }
 

--- a/CaloCluster/src/CaloClusterFast_module.cc
+++ b/CaloCluster/src/CaloClusterFast_module.cc
@@ -31,6 +31,7 @@ namespace mu2e {
             fhicl::Atom<double>         EnoiseCut         { Name("EnoiseCut"),         Comment("Minimum energy for a hit to be in a cluster") };
             fhicl::Atom<double>         ExpandCut         { Name("ExpandCut"),         Comment("Minimum energy for a hit to expand cluster") };
             fhicl::Atom<double>         deltaTime         { Name("deltaTime"),         Comment("Maximum time difference between seed and hit in cluster") };
+            fhicl::Atom<double>         timeOffset        { Name("timeOffset"),        Comment("Time offset to add to base cluster time") };
             fhicl::Atom<int>            minSiPMPerHit     { Name("minSiPMPerHit"),     Comment("Minimum number of SiPM contributing to the hit") };
             fhicl::Atom<bool>           extendSearch      { Name("extendSearch"),      Comment("Search next-next neighbors for clustering") };
             fhicl::Atom<int>            diagLevel         { Name("diagLevel"),         Comment("Diag level"),0 };
@@ -43,6 +44,7 @@ namespace mu2e {
           EnoiseCut_     (config().EnoiseCut()),
           ExpandCut_     (config().ExpandCut()),
           deltaTime_     (config().deltaTime()),
+          timeOffset_     (config().timeOffset()),
           minSiPMPerHit_ (config().minSiPMPerHit()),
           extendSearch_  (config().extendSearch()),
           diagLevel_     (config().diagLevel())
@@ -59,6 +61,7 @@ namespace mu2e {
         double            EnoiseCut_;
         double            ExpandCut_;
         double            deltaTime_;
+        double            timeOffset_;
         int               minSiPMPerHit_;
         bool              extendSearch_;
         int               diagLevel_;
@@ -177,7 +180,7 @@ namespace mu2e {
       yCOG /= totalEnergy;
 
       const CaloHit& seedHit = caloHits[clusterList[0]];
-      double time            = seedHit.time();
+      double time            = seedHit.time() + timeOffset_;
       int    iDisk           = cal.crystal(seedHit.crystalID()).diskID();
 
       caloClusters.emplace_back(CaloCluster(iDisk,time,0.0,totalEnergy,0.0,CLHEP::Hep3Vector(xCOG,yCOG,0),

--- a/Mu2eKinKal/data/LRDrift_S0.weights.xml
+++ b/Mu2eKinKal/data/LRDrift_S0.weights.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0"?>
+<MethodSetup Method="MLP::MLP">
+  <GeneralInfo>
+    <Info name="TMVA Release" value="4.2.1 [262657]"/>
+    <Info name="ROOT Release" value="6.26/02 [399874]"/>
+    <Info name="Creator" value="brownd"/>
+    <Info name="Date" value="Thu Oct 27 15:14:18 2022"/>
+    <Info name="Host" value="Darwin macphsft17.dyndns.cern.ch 21.4.0 Darwin Kernel Version 21.4.0: Fri Mar 18 00:45:05 PDT 2022; root:xnu-8020.101.4~15/RELEASE_X86_64 x86_64"/>
+    <Info name="Dir" value="/Users/brownd/MDC2020"/>
+    <Info name="Training events" value="40000"/>
+    <Info name="TrainingTime" value="1.40379913e+02"/>
+    <Info name="AnalysisType" value="Classification"/>
+  </GeneralInfo>
+  <Options>
+    <Option name="NCycles" modified="Yes">600</Option>
+    <Option name="HiddenLayers" modified="Yes">N+5</Option>
+    <Option name="NeuronType" modified="Yes">tanh</Option>
+    <Option name="RandomSeed" modified="No">1</Option>
+    <Option name="EstimatorType" modified="No">CE</Option>
+    <Option name="NeuronInputType" modified="No">sum</Option>
+    <Option name="V" modified="Yes">False</Option>
+    <Option name="VerbosityLevel" modified="No">Default</Option>
+    <Option name="VarTransform" modified="Yes">N</Option>
+    <Option name="H" modified="Yes">False</Option>
+    <Option name="CreateMVAPdfs" modified="No">False</Option>
+    <Option name="IgnoreNegWeightsInTraining" modified="No">False</Option>
+    <Option name="TrainingMethod" modified="No">BP</Option>
+    <Option name="LearningRate" modified="No">2.000000e-02</Option>
+    <Option name="DecayRate" modified="No">1.000000e-02</Option>
+    <Option name="TestRate" modified="Yes">5</Option>
+    <Option name="EpochMonitoring" modified="No">False</Option>
+    <Option name="Sampling" modified="No">1.000000e+00</Option>
+    <Option name="SamplingEpoch" modified="No">1.000000e+00</Option>
+    <Option name="SamplingImportance" modified="No">1.000000e+00</Option>
+    <Option name="SamplingTraining" modified="No">True</Option>
+    <Option name="SamplingTesting" modified="No">False</Option>
+    <Option name="ResetStep" modified="No">50</Option>
+    <Option name="Tau" modified="No">3.000000e+00</Option>
+    <Option name="BPMode" modified="No">sequential</Option>
+    <Option name="BatchSize" modified="No">-1</Option>
+    <Option name="ConvergenceImprove" modified="No">1.000000e-30</Option>
+    <Option name="ConvergenceTests" modified="No">-1</Option>
+    <Option name="UseRegulator" modified="Yes">False</Option>
+    <Option name="UpdateLimit" modified="No">10000</Option>
+    <Option name="CalculateErrors" modified="No">False</Option>
+    <Option name="WeightRange" modified="No">1.000000e+00</Option>
+  </Options>
+  <Variables NVar="7">
+    <Variable VarIndex="0" Expression="abs(detsh.udoca)" Label="udoca" Title="udoca" Unit="mm" Internal="udoca" Type="F" Min="1.78386072e-05" Max="2.15585136e+01"/>
+    <Variable VarIndex="1" Expression="detsh.rdrift" Label="rdrift" Title="rdrift" Unit="mm" Internal="rdrift" Type="F" Min="-2.75362819e-01" Max="2.78964353e+00"/>
+    <Variable VarIndex="2" Expression="(detsh.rdrift-fabs(detsh.udoca))/sqrt(detsh.rerr*detsh.rerr+detsh.udocavar)" Label="udpull" Title="udpull" Unit="F" Internal="udpull" Type="F" Min="-8.98637295e+00" Max="4.05151176e+00"/>
+    <Variable VarIndex="3" Expression="detsh.tottdrift" Label="tottdrift" Title="tottdrift" Unit="ns" Internal="tottdrift" Type="F" Min="8.79999995e-01" Max="3.60200005e+01"/>
+    <Variable VarIndex="4" Expression="1000*detsh.edep" Label="edep" Title="edep" Unit="KeV" Internal="edep" Type="F" Min="1.81988195e-01" Max="5.78904486e+00"/>
+    <Variable VarIndex="5" Expression="sqrt(detsh.udocavar)" Label="uderr" Title="uderr" Unit="mm" Internal="uderr" Type="F" Min="4.27435160e-01" Max="6.66008329e+00"/>
+    <Variable VarIndex="6" Expression="4.0*detsh.rdrift*fabs(detsh.udoca)/(detsh.rerr*detsh.rerr+detsh.udocavar)" Label="dchisq" Title="dchisq" Unit="F" Internal="dchisq" Type="F" Min="-2.34573531e+00" Max="1.47244278e+02"/>
+  </Variables>
+  <Spectators NSpec="0"/>
+  <Classes NClass="2">
+    <Class Name="Signal" Index="0"/>
+    <Class Name="Background" Index="1"/>
+  </Classes>
+  <Transformations NTransformations="1">
+    <Transform Name="Normalize">
+      <Selection>
+        <Input NInputs="7">
+          <Input Type="Variable" Label="udoca" Expression="abs(detsh.udoca)"/>
+          <Input Type="Variable" Label="rdrift" Expression="detsh.rdrift"/>
+          <Input Type="Variable" Label="udpull" Expression="(detsh.rdrift-fabs(detsh.udoca))/sqrt(detsh.rerr*detsh.rerr+detsh.udocavar)"/>
+          <Input Type="Variable" Label="tottdrift" Expression="detsh.tottdrift"/>
+          <Input Type="Variable" Label="edep" Expression="1000*detsh.edep"/>
+          <Input Type="Variable" Label="uderr" Expression="sqrt(detsh.udocavar)"/>
+          <Input Type="Variable" Label="dchisq" Expression="4.0*detsh.rdrift*fabs(detsh.udoca)/(detsh.rerr*detsh.rerr+detsh.udocavar)"/>
+        </Input>
+        <Output NOutputs="7">
+          <Output Type="Variable" Label="udoca" Expression="abs(detsh.udoca)"/>
+          <Output Type="Variable" Label="rdrift" Expression="detsh.rdrift"/>
+          <Output Type="Variable" Label="udpull" Expression="(detsh.rdrift-fabs(detsh.udoca))/sqrt(detsh.rerr*detsh.rerr+detsh.udocavar)"/>
+          <Output Type="Variable" Label="tottdrift" Expression="detsh.tottdrift"/>
+          <Output Type="Variable" Label="edep" Expression="1000*detsh.edep"/>
+          <Output Type="Variable" Label="uderr" Expression="sqrt(detsh.udocavar)"/>
+          <Output Type="Variable" Label="dchisq" Expression="4.0*detsh.rdrift*fabs(detsh.udoca)/(detsh.rerr*detsh.rerr+detsh.udocavar)"/>
+        </Output>
+      </Selection>
+      <Class ClassIndex="0">
+        <Ranges>
+          <Range Index="0" Min="1.3050218694843352e-04" Max="7.4602532386779785e+00"/>
+          <Range Index="1" Min="-2.4018673598766327e-01" Max="2.7896435260772705e+00"/>
+          <Range Index="2" Min="-5.2954211235046387e+00" Max="4.0515117645263672e+00"/>
+          <Range Index="3" Min="8.7999999523162842e-01" Max="3.6020000457763672e+01"/>
+          <Range Index="4" Min="1.8198819458484650e-01" Max="5.7872242927551270e+00"/>
+          <Range Index="5" Min="4.3773856759071350e-01" Max="5.3247666358947754e+00"/>
+          <Range Index="6" Min="-2.3457353115081787e+00" Max="1.4724427795410156e+02"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="1">
+        <Ranges>
+          <Range Index="0" Min="1.7838607163866982e-05" Max="2.1558513641357422e+01"/>
+          <Range Index="1" Min="-2.7536281943321228e-01" Max="2.6265559196472168e+00"/>
+          <Range Index="2" Min="-8.9863729476928711e+00" Max="3.8691959381103516e+00"/>
+          <Range Index="3" Min="8.7999999523162842e-01" Max="3.6020000457763672e+01"/>
+          <Range Index="4" Min="1.9836702942848206e-01" Max="5.7890448570251465e+00"/>
+          <Range Index="5" Min="4.2743515968322754e-01" Max="6.6600832939147949e+00"/>
+          <Range Index="6" Min="-1.9901106357574463e+00" Max="8.6610458374023438e+01"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="2">
+        <Ranges>
+          <Range Index="0" Min="1.7838607163866982e-05" Max="2.1558513641357422e+01"/>
+          <Range Index="1" Min="-2.7536281943321228e-01" Max="2.7896435260772705e+00"/>
+          <Range Index="2" Min="-8.9863729476928711e+00" Max="4.0515117645263672e+00"/>
+          <Range Index="3" Min="8.7999999523162842e-01" Max="3.6020000457763672e+01"/>
+          <Range Index="4" Min="1.8198819458484650e-01" Max="5.7890448570251465e+00"/>
+          <Range Index="5" Min="4.2743515968322754e-01" Max="6.6600832939147949e+00"/>
+          <Range Index="6" Min="-2.3457353115081787e+00" Max="1.4724427795410156e+02"/>
+        </Ranges>
+      </Class>
+    </Transform>
+  </Transformations>
+  <MVAPdfs/>
+  <Weights>
+    <Layout NLayers="3">
+      <Layer Index="0" NNeurons="8">
+        <Neuron NSynapses="12">
+          2.2277336642321228e+00 4.6480207304207353e+00 3.1567432145289631e-01 1.4929263068307199e+00 -2.6934344186280925e+00 3.5018492680348773e-01 -1.0653765653227376e+00 3.3433265116244058e+00 -4.1464885823869402e-01 1.4876606904420359e-01 -2.8557174996980845e+00 -2.0088622700597430e-01 
+        </Neuron>
+        <Neuron NSynapses="12">
+          2.3140340978567392e-01 -8.5497666156779083e-03 -1.3011755895781716e+00 7.4771423620313415e-01 -3.2722052502824535e+00 3.6891141952472978e-01 -2.1892617969090766e-01 2.5796590210540060e+00 -2.8307993103563094e+00 2.9628583119023635e-02 1.6897270097745685e+00 -2.9219522743614745e+00 
+        </Neuron>
+        <Neuron NSynapses="12">
+          -3.5899271535744210e+00 1.9879269980417260e+00 5.9075399534207245e+00 -6.4616922333112303e-01 5.4708668577218509e+00 2.5949291482250105e+00 -1.3771732958035229e-01 -3.2391753648928758e+00 3.1259850747032107e+00 -4.0975012983418573e+00 -1.0644154446573816e-01 1.5850324524364320e-01 
+        </Neuron>
+        <Neuron NSynapses="12">
+          8.6302698099107233e-02 5.1949767337403161e+00 1.1822469444253701e-01 1.1029407179358566e+00 -2.8998735285249466e-01 1.3653286485902330e-01 6.2630688139218760e-01 4.6807255267277983e-02 -1.2727205988702481e-01 -5.1976332572562056e-01 -6.0810291111452995e-02 -1.3742697651449898e+00 
+        </Neuron>
+        <Neuron NSynapses="12">
+          4.7758393286031370e-01 2.0844622807335842e+00 3.6226714926146379e+00 1.3479136398312446e+00 -4.3901917649887210e+00 -5.9290837725764352e+00 -8.6624971972440423e-01 -1.5702406352517193e-01 -1.9850141806505492e+00 -1.4171931125798289e+00 4.8810352628470914e+00 7.2126071444082185e-01 
+        </Neuron>
+        <Neuron NSynapses="12">
+          -1.1254799285186541e+00 1.0780506570853063e-01 1.0526661051196520e+00 8.1891634323018481e-01 3.8454107975743921e+00 -6.2014801892724687e-02 1.5179953119354128e-01 -7.8455483039656846e+00 3.8131936306094505e+00 -2.1070420509339729e+00 9.6764944471065484e-02 -2.5913762432840657e+00 
+        </Neuron>
+        <Neuron NSynapses="12">
+          -1.1819518753254616e+00 5.3603216354967764e-01 -2.9362280631543438e+00 5.6574312904388246e-02 -9.7962985234616617e-01 -3.4065424611316808e-01 1.6624253476009634e+00 5.5906722760324419e+00 3.4661878837940245e-02 2.4088747804899313e+00 8.3954149631477945e-02 -1.1716837226409695e+00 
+        </Neuron>
+        <Neuron NSynapses="12">
+          -4.1696083913481885e-01 -1.1925070152440831e-01 -2.7316717329842977e+00 -1.5906269260461423e+00 -4.8576037057433643e+00 -5.6480449190602044e+00 5.5964669245373810e-01 2.9474941667818895e+00 1.7883774587941386e+00 3.1419451469283355e+00 5.5740296873882944e-01 8.2383112764815181e-01 
+        </Neuron>
+      </Layer>
+      <Layer Index="1" NNeurons="13">
+        <Neuron NSynapses="1">
+          -1.8507459623521887e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -2.4978217104989642e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -6.4187929787453157e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          1.6080787972105548e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -3.7982925334739626e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -7.4462203722996678e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          5.9846206069076668e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          7.3199415030023351e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.2746160637395638e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          1.2615581544349546e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          5.0815095461708926e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.4433900255363934e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -2.1305074425518913e+00 
+        </Neuron>
+      </Layer>
+      <Layer Index="2" NNeurons="1">
+        <Neuron NSynapses="0"/>
+      </Layer>
+    </Layout>
+  </Weights>
+</MethodSetup>

--- a/Mu2eKinKal/inc/KKFit.hh
+++ b/Mu2eKinKal/inc/KKFit.hh
@@ -435,7 +435,10 @@ namespace mu2e {
 
   template <class KTRAJ> KalSeed KKFit<KTRAJ>::createSeed(KKTRK const& kktrk, TrkFitFlag const& seedflag, Calorimeter const& calo, std::set<double> const& savetimes) const {
     TrkFitFlag fflag(seedflag);  // initialize the flag with the seed fit flag
-    if(kktrk.fitStatus().usable())fflag.merge(TrkFitFlag::kalmanOK);
+    if(kktrk.fitStatus().usable()){
+      fflag.merge(TrkFitFlag::kalmanOK);
+      fflag.merge(TrkFitFlag::seedOK);
+    }
     if(kktrk.fitStatus().status_ == Status::converged) fflag.merge(TrkFitFlag::kalmanConverged);
     if(matcorr_)fflag.merge(TrkFitFlag::MatCorr);
     if(kktrk.config().bfcorr_ )fflag.merge(TrkFitFlag::BFCorr);

--- a/Mu2eKinKal/inc/KKFit.hh
+++ b/Mu2eKinKal/inc/KKFit.hh
@@ -446,12 +446,17 @@ namespace mu2e {
     double t0val = t0piece.paramVal(KTRAJ::t0_);
     double t0sig = sqrt(t0piece.params().covariance()(KTRAJ::t0_,KTRAJ::t0_));
     HitT0 t0(t0val,t0sig);
-    // create the shell for the output.  Note the (obsolete) flight length is given as t0
-    KalSeed fseed(tpart_,tdir_,fflag,t0.t0());
+    // create the shell for the output.
+    KalSeed fseed(tpart_,tdir_,fflag);
     auto const& fstatus = kktrk.fitStatus();
     fseed._chisq = fstatus.chisq_.chisq();
     fseed._fitcon = fstatus.chisq_.probability();
     fseed._nseg = fittraj.pieces().size();
+    size_t igap;
+    double maxgap,avggap;
+    fittraj.gaps(maxgap,igap,avggap);
+    fseed._maxgap = maxgap;
+    fseed._avggap = avggap;
     // loop over track components and store them
     fseed._hits.reserve(kktrk.strawHits().size());
     for(auto const& strawhit : kktrk.strawHits() ) {

--- a/Mu2eKinKal/test/TTCPR.fcl
+++ b/Mu2eKinKal/test/TTCPR.fcl
@@ -1,0 +1,261 @@
+# -*- mode:tcl -*-
+#------------------------------------------------------------------------------
+# performs the calorimeter and track reconstruciton
+#------------------------------------------------------------------------------
+#  > mu2e -c Offline/triggerAna_CE.fcl -s /pnfs/mu2e/tape/phy-sim/dig/mu2e/CeEndpointMix1BBSignal/MDC2020r_perfect_v1_0/art/4c/f6/dig.mu2e.CeEndpointMix1BBSignal.MDC2020r_perfect_v1_0.001210_00000990.art --nskip 9
+#include "Offline/fcl/minimalMessageService.fcl"
+#include "Offline/fcl/standardServices.fcl"
+#include "Offline/fcl/standardProducers.fcl"
+
+#include "Offline/Mu2eKinKal/fcl/prolog.fcl"
+
+## #include "CommonMC/fcl/prolog.fcl"
+## #include "TrackerMC/fcl/prolog.fcl"
+## #include "CaloMC/fcl/prolog.fcl"
+
+#include "Offline/Trigger/fcl/prolog_trigger.fcl"
+#include "TrkAna/fcl/prolog.fcl"
+
+BEGIN_PROLOG
+#Trigger.PrepareDigis : [ @sequence::CommonMC.DigiSim, @sequence::TrackerMC.DigiSim, @sequence::CaloMC.DigiSim ]
+END_PROLOG
+
+process_name : globalTrigger
+
+source :
+{
+  module_type : RootInput
+}
+# we don't need any simulation services for this job
+# services : @local::Services.Reco
+
+services : @local::Services.Reco
+
+# timing information
+services.TimeTracker : {
+  dbOutput : {
+    filename : ""
+    # filename : "runGlobalTrigger.db" #uncomment to create the .db output
+    overwrite : true
+  }
+}
+
+services.scheduler.wantSummary: true
+
+physics : {
+  producers : {
+    # @table::CommonMC.producers
+    # @table::TrackerMC.DigiProducers
+    @table::CaloReco.producers
+    @table::CaloCluster.producers
+    @table::CalPatRec.producers
+
+    @table::Trigger.producers
+
+    @table::Mu2eKinKal.producers
+    TTCalSeedFitDem : { @table::Mu2eKinKal.producers.KKDeMSeedFit
+      Mu2eSettings   : { @table::Mu2eKinKal.producers.KKDeMSeedFit.Mu2eSettings
+        AddMaterial    : false
+        MaterialCorrection : true
+        #MaterialCorrection : false
+        PrintLevel     : 0
+        UseCaloCluster : true
+        CaloTimeResolution : 1.5 # ns
+        MaxCaloClusterDt : 15 #ns
+        MaxCaloClusterDOCA : 500 #mm
+        AddHits : false
+      }
+      KinKalExtensionSettings: { @table::Mu2eKinKal.producers.KKDeMSeedFit.KinKalExtensionSettings
+        #MaxNIter : 3
+        BFieldCorrection         : true
+        BCorrTolerance           : 1e-2
+        PrintLevel               : 0
+        MetaIterationSettings    : [
+          [ 0.0, "CADSHU" ]
+          # [ 2.0, "CADSHU" ]
+        ]
+        CADSHUSettings           : [
+           [ 10.0, 20.0, 5.0, 5.0, "Null:Inactive", "", 0 ]
+          # [ 15.0, 15.0, 5.0, 4.0, "Null:Inactive", "", 0 ]
+        ]
+        StrawXingUpdaterSettings : [
+          [10.0, -1.0, -1.0, true, 0 ]
+          # [10.0, -1.0, -1.0, true, 0 ]
+        ]
+        BkgANNSHUSettings        : []
+        Chi2SHUSettings          : []
+      }
+      KinKalFitSettings : { @table::Mu2eKinKal.producers.KKDeMSeedFit.KinKalFitSettings
+        PrintLevel : 0
+        #BFieldCorrection         : true
+        BFieldCorrection         : false
+        BCorrTolerance           : 1e-2
+        DivergenceGap: 10
+        MaxNIter : 3
+      }
+      ModuleSettings : { @table::Mu2eKinKal.producers.KKDeMSeedFit.ModuleSettings
+        HelixSeedCollections   : [ "TTCalHelixMergerDeM" ]
+        ComboHitCollection     : "TTmakeSH"
+        CaloClusterCollection  : "CaloClusterFast"
+        StrawHitFlagCollection : "TTflagBkgHits:StrawHits"
+        PrintLevel             : 0
+        SaveAllFits            : false
+      }
+    }
+
+    TTCalSeedFitDep : { @table::Mu2eKinKal.producers.KKDePSeedFit
+      Mu2eSettings   : {@table::Mu2eKinKal.producers.KKDePSeedFit.Mu2eSettings
+        AddMaterial : false
+      }
+      KinKalExtensionSettings: {@table::Mu2eKinKal.producers.KKDePSeedFit.KinKalExtensionSettings
+        BFieldCorrection : false
+
+      }
+      ModuleSettings : {@table::Mu2eKinKal.producers.KKDePSeedFit.ModuleSettings
+        HelixSeedCollections   : [ "TTCalHelixMergerDeP" ]
+        ComboHitCollection     : "TTmakeSH"
+        CaloClusterCollection  : "CaloClusterFast"
+        StrawHitFlagCollection : "TTflagBkgHits:StrawHits"
+        PrintLevel             : 0
+        SaveAllFits            : false
+      }
+    }
+
+    TTKSFDeM : { @table::Mu2eKinKal.producers.KKDeMSeedFit
+      Mu2eSettings   : {@table::Mu2eKinKal.producers.KKDeMSeedFit.Mu2eSettings
+        AddMaterial : false
+        PrintLevel : 0
+        UseCaloCluster : false
+
+      }
+      KinKalExtensionSettings: {@table::Mu2eKinKal.producers.KKDeMSeedFit.KinKalExtensionSettings
+        BFieldCorrection : false
+
+      }
+      KinKalFitSettings : { @table::Mu2eKinKal.producers.KKDeMSeedFit.KinKalFitSettings
+        PrintLevel : 0
+      }
+      ModuleSettings : {@table::Mu2eKinKal.producers.KKDeMSeedFit.ModuleSettings
+        HelixSeedCollections   : [ "TTHelixMergerDeM" ]
+        ComboHitCollection     : "TTmakeSH"
+        CaloClusterCollection  : "CaloClusterFast"
+        StrawHitFlagCollection : "TTflagBkgHits:StrawHits"
+        SaveAllFits            : false
+        PrintLevel             : 0
+      }
+    }
+
+    TTKSFDeP : { @table::Mu2eKinKal.producers.KKDePSeedFit
+      Mu2eSettings   : {@table::Mu2eKinKal.producers.KKDePSeedFit.Mu2eSettings
+        AddMaterial : false
+      }
+      KinKalExtensionSettings: {@table::Mu2eKinKal.producers.KKDePSeedFit.KinKalExtensionSettings
+        BFieldCorrection : false
+      }
+      ModuleSettings : {@table::Mu2eKinKal.producers.KKDePSeedFit.ModuleSettings
+        HelixSeedCollections   : [ "TTHelixMergerDeP" ]
+        ComboHitCollection     : "TTmakeSH"
+        CaloClusterCollection  : "CaloClusterFast"
+        StrawHitFlagCollection : "TTflagBkgHits:StrawHits"
+        PrintLevel             : 0
+        SaveAllFits            : false
+      }
+    }
+
+  }
+
+  filters   : { @table::Trigger.filters
+    @table::CalPatRec.filters
+  }
+
+  analyzers : { @table::Trigger.analyzers
+
+    readTriggerInfo : { @table::Trigger.analyzers.ReadTriggerInfo
+      nPathIDs       : 250
+      nTrackTriggers : 25
+      processName    : globalTrigger
+    }
+    TAKK : @local::TrkAnaReco.analyzers.TrkAnaNeg
+
+  }
+
+  reco_offline : [ @sequence::CaloReco.Reco, @sequence::CaloCluster.Reco,
+    @sequence::TrkHitReco.PrepareHits,
+    CalTimePeakFinder  , DeltaFinder  , CalHelixFinderDe]
+
+  #out       : [ readTriggerInfo ]
+  out : [TAKK]
+  end_paths : [ out ]
+}
+
+outputs : {  @table::Trigger.outputs }
+
+
+services.TFileService.fileName : "debug_CE1BB_20221102.root"
+
+physics.analyzers.readTriggerInfo.SelectEvents : [ tprDeM_highP_stopTarg_trigger, tprDeP_highP_stopTarg_trigger, cprDeM_highP_stopTarg_trigger, cprDeP_highP_stopTarg_trigger, cprDeM_lowP_stopTarg_trigger, cprDeP_lowP_stopTarg_trigger, tprDeM_lowP_stopTarg_trigger, tprDeP_lowP_stopTarg_trigger, tprHelixDeM_ipa_trigger, tprHelixDeM_ipa_phiScaled_trigger ]
+
+physics.analyzers.readTriggerInfo.triggerPathsList : [ tprDeM_highP_stopTarg_trigger, tprDeP_highP_stopTarg_trigger, cprDeM_highP_stopTarg_trigger, cprDeP_highP_stopTarg_trigger, cprDeM_lowP_stopTarg_trigger, cprDeP_lowP_stopTarg_trigger, tprDeM_lowP_stopTarg_trigger, tprDeP_lowP_stopTarg_trigger, tprHelixDeM_ipa_trigger, tprHelixDeM_ipa_phiScaled_trigger ]
+
+#CommonMC.DigiSim : []
+#TrackerMC.DigiSim : []
+#CaloMC.DigiSim : []
+
+outputs.triggerOutput.SelectEvents : [   "*_trigger"]
+outputs.triggerOutput.fileName : "debug_20210619.art"
+
+#physics.filters.TTCalTimePeakFinder.dtOffset           : -61.
+
+#turn on the helix-finder diagnostics
+#physics.filters.TTCalTimePeakFinder.diagLevel               : 1
+# physics.filters.TTCalTimePeakFinder.DtMax                   :  20.
+# physics.filters.TTCalTimePeakFinder.DtMin                   : -20.
+
+# physics.trigger_paths[0] : reco_offline
+# physics.filters.CalTimePeakFinder.diagLevel               : 1
+# physics.filters.CalTimePeakFinder.DtMax                   :  100.
+# physics.filters.CalHelixFinderDe.diagLevel                  : 0
+# physics.filters.CalHelixFinderDe.HelixFinderAlg.diagLevel   : 0
+
+
+#physics.producers.TThelixFinder.DiagLevel                   : 1
+#physics.producers.TThelixFinder.HelixFitter.diagLevel       : 1
+
+#physics.producers.TTmakeSH.ProtonBunchTimeTag : "makeSD"
+## physics.producers.TTmakeSH.ProtonBunchTimeTag : "CaloDigiMaker"
+
+
+### #include "gen/fcl/Trigger/OnSpillTrigMenu/cprLowPSeedDeM.fcl"
+### physics.cprLowPSeedDeM_trigger : [ @sequence::Trigger.PrepareDigis, @sequence::Trigger.paths.cprLowPSeedDeM ]
+### physics.trigger_paths :  [cprLowPSeedDeM_trigger]
+services.DbService.purpose: MDC2020_perfect
+services.DbService.version: v1_0
+services.DbService.verbose : 2
+services.ProditionsService.strawResponse.useOldDrift: true
+
+###### #include "Offline/gen/fcl/Trigger/OnSpillTrigMenu/OnSpillTrigMenu.fcl"
+#include "Offline/gen/fcl/Trigger/OnSpillTrigMenu/cprDeM_highP_stopTarg.fcl"
+physics.cprDeM_highP_stopTarg_trigger : [ @sequence::Trigger.PrepareDigis, @sequence::Trigger.paths.cprDeM_highP_stopTarg ]
+physics.trigger_paths[150] : cprDeM_highP_stopTarg_trigger
+
+#####include "OnSpillMenuTest.fcl"
+
+#physics.producers.CaloClusterFast : { @table::CaloClusterTrigger.producers.CaloClusterOnline}
+
+#physics.filters.TTCalHelixFinderDe.StrawHitCollectionLabel : "TTflagBkgHits"
+
+
+physics.analyzers.TAKK.candidate.options : @local::AllOpt
+physics.analyzers.TAKK.candidate.options.fillBestCrv : false
+physics.analyzers.TAKK.diagLevel : 2
+physics.analyzers.TAKK.FillMCInfo : false
+physics.analyzers.TAKK.FillCRV : false
+physics.analyzers.TAKK.FillTrkQualInfo : false
+physics.analyzers.TAKK.FillTrkPIDInfo : false
+physics.analyzers.TAKK.FillHitInfo : true
+physics.analyzers.TAKK.FillTriggerInfo : false
+physics.analyzers.TAKK.candidate.input : "TT"
+physics.analyzers.TAKK.candidate.suffix : "CalSeedFitDem"
+physics.analyzers.TAKK.candidate.options.fillHits : true
+physics.analyzers.TAKK.supplements : []
+physics.analyzers.TAKK.SelectEvents : [ "cprDeM_highP_stopTarg_trigger" ]

--- a/RecoDataProducts/inc/KalSeed.hh
+++ b/RecoDataProducts/inc/KalSeed.hh
@@ -21,10 +21,9 @@
 namespace mu2e {
   class CaloCluster;
   struct KalSeed {
-    KalSeed() :  _chisq(-1.0), _fitcon(-1.0), _flt0(0)  {}
+    KalSeed() {}
     KalSeed(PDGCode::type tpart,TrkFitDirection fdir, TrkFitFlag const& status, double flt0=0.0 ) :
-      _tpart(tpart), _fdir(fdir), _status(status),
-      _chisq(-1.0), _fitcon(-1.0), _nseg(0), _flt0(static_cast<Float_t>(flt0)){}
+      _tpart(tpart), _fdir(fdir), _status(status), _flt0(static_cast<Float_t>(flt0)){}
 
     PDGCode::type particle() const { return _tpart; }
     TrkFitDirection const& fitDirection() const { return _fdir; }
@@ -42,12 +41,14 @@ namespace mu2e {
     std::vector<KalSegment>::const_iterator nearestSeg(double time)  const;
 
     // global information about the track
-    PDGCode::type       _tpart; // particle assumed for this fit
-    TrkFitDirection             _fdir; // direction in which this particle was fit
-    TrkFitFlag          _status; // status of this fit: includes alglorithm information
-    Float_t         _chisq; // fit chisquared value
-    Float_t         _fitcon; // fit consistency
-    UInt_t          _nseg; // # of fit trajectory segments
+    PDGCode::type     _tpart = PDGCode::unknown; // particle assumed for this fit
+    TrkFitDirection   _fdir = TrkFitDirection::downstream; // direction in which this particle was fit
+    TrkFitFlag        _status; // status of this fit: includes alglorithm information
+    Float_t           _chisq = -1; // fit chisquared value
+    Float_t           _fitcon = -1; // fit consistency
+    UInt_t            _nseg = 0; // # of fit trajectory segments
+    Float_t           _maxgap = 0;
+    Float_t           _avggap = 0; // information about trajectory gaps
     //
     // contained content substructure.
     //
@@ -62,7 +63,7 @@ namespace mu2e {
     std::vector<KalSegment>::const_iterator nearestSegmentFlt(float fltlen)  const;
     std::vector<KalSegment>::const_iterator nearestSegment(const XYZVectorF& pos)  const; // find nearest segment to a GLOBAL position
     Float_t flt0() const { return _flt0; }
-    Float_t         _flt0; // flight distance where the track crosses the tracker midplane (z=0).  Redundant with t0 in KinKal fits, and in the wrong unit
+    Float_t         _flt0 = 0.0; // flight distance where the track crosses the tracker midplane (z=0).  Redundant with t0 in KinKal fits, and in the wrong unit
   };
   typedef std::vector<mu2e::KalSeed> KalSeedCollection;
 }

--- a/RecoDataProducts/inc/KalSegment.hh
+++ b/RecoDataProducts/inc/KalSegment.hh
@@ -35,13 +35,14 @@ namespace mu2e {
     KinKal::VEC3 velocity() const { return _pstate.velocity(); }
     KinKal::VEC3 position3() const { return _pstate.position3(); }
     // convert content to a LoopHelix
-    KinKal::LoopHelix loopHelix() const { return KinKal::LoopHelix(_pstate, KKbnom(),KinKal::TimeRange(tmin(),tmax())); }
+    KinKal::LoopHelix loopHelix() const { return KinKal::LoopHelix(_pstate, KKbnom(),timeRange()); }
     // convert to a CentralHelix
-    KinKal::CentralHelix centralHelix() const { return KinKal::CentralHelix(_pstate, KKbnom(),KinKal::TimeRange(tmin(),tmax())); }
+    KinKal::CentralHelix centralHelix() const { return KinKal::CentralHelix(_pstate, KKbnom(),timeRange()); }
     // convert to a KinematicLine
-    KinKal::KinematicLine kinematicLine() const { return KinKal::KinematicLine(_pstate, KKbnom(),KinKal::TimeRange(tmin(),tmax())); }
+    KinKal::KinematicLine kinematicLine() const { return KinKal::KinematicLine(_pstate, KKbnom(),timeRange()); }
     Float_t tmin() const { return _tmin; }
     Float_t tmax() const { return _tmax; }
+    KinKal::TimeRange timeRange() const { return KinKal::TimeRange(_tmin,_tmax); }
     auto tref() const { return _pstate.time(); }
     // t0 = time (and error) for when particle goes through z=0;
     HitT0 t0() const;

--- a/RecoDataProducts/src/KalSeed.cc
+++ b/RecoDataProducts/src/KalSeed.cc
@@ -1,6 +1,50 @@
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 #include <limits>
 namespace mu2e {
+
+  KalSeed::LHPTPtr KalSeed::loopHelixFitTrajectory() const {
+    if(loopHelixFit() && segments().size() > 0){
+      // initialize the piecewise trajectory with the front segment
+      LHPTPtr ptraj(new KalSeed::LHPT(segments().front().loopHelix()));
+      auto iseg = segments().begin(); ++iseg;
+      while(iseg != segments().end()){
+        if(!iseg->timeRange().null())ptraj->append(iseg->loopHelix());
+        ++iseg;
+      }
+      return ptraj;
+    } else
+      return LHPTPtr();
+  }
+
+  KalSeed::CHPTPtr KalSeed::centralHelixFitTrajectory() const {
+    if(centralHelixFit() && segments().size() > 0){
+      // initialize the piecewise trajectory with the front segment
+      CHPTPtr ptraj(new KalSeed::CHPT(segments().front().centralHelix()));
+      auto iseg = segments().begin(); ++iseg;
+      while(iseg != segments().end()){
+        if(!iseg->timeRange().null())ptraj->append(iseg->centralHelix());
+        ++iseg;
+      }
+      return ptraj;
+    } else
+      return CHPTPtr();
+  }
+
+  KalSeed::KLPTPtr KalSeed::kinematicLineFitTrajectory() const {
+    if(kinematicLineFit() && segments().size() > 0){
+      // initialize the piecewise trajectory with the front segment
+      KLPTPtr ptraj(new KalSeed::KLPT(segments().front().kinematicLine()));
+      auto iseg = segments().begin(); ++iseg;
+      while(iseg != segments().end()){
+        if(!iseg->timeRange().null())ptraj->append(iseg->kinematicLine());
+        ++iseg;
+      }
+      return ptraj;
+    } else
+      return KLPTPtr();
+  }
+
+
   std::vector<KalSegment>::const_iterator KalSeed::nearestSeg(double time)  const {
     auto retval = segments().end();
     float dmin(std::numeric_limits<float>::max());


### PR DESCRIPTION
Add a time offset to the CaloClusters produced by CaloClusterFast, to make them consistent with the time of clusters reconstructed by CaloClusterMaker.  Disable the ad-hoc downstream corrections for cluster time offset (61ns!!!) in downstream trigger config.  With these changes the trigger configuration of the KinKal fit converges and produces good fits.  This addresses issue 884.  I'm sure the smart people working on the calorimeter code can do a better job of this eventually by getting the value from the conditions, this is just a patch to allow further progress with KinKal integration.