### PR TITLE
Updated TEve Event Display to plot the new KKTraj options

### DIFF
--- a/TEveEventDisplay/CallerFclExamples/helix_example.fcl
+++ b/TEveEventDisplay/CallerFclExamples/helix_example.fcl
@@ -18,14 +18,14 @@ physics :
 }
 
 # edit the below options for different products:
-physics.analyzers.TEveEventDisplayHelix.filler.addHits : true
+physics.analyzers.TEveEventDisplayHelix.filler.addHits : false
 physics.analyzers.TEveEventDisplayHelix.filler.addTrkHits : false
 physics.analyzers.TEveEventDisplayHelix.filler.addTimeClusters : false
 physics.analyzers.TEveEventDisplayHelix.filler.addTracks : true
 physics.analyzers.TEveEventDisplayHelix.filler.addCrvHits : false
 physics.analyzers.TEveEventDisplayHelix.filler.addCosmicSeedFit : false
-physics.analyzers.TEveEventDisplayHelix.filler.addClusters : true
-physics.analyzers.TEveEventDisplayHelix.filler.addMCTraj : true
+physics.analyzers.TEveEventDisplayHelix.filler.addClusters : false
+physics.analyzers.TEveEventDisplayHelix.filler.addMCTraj : false
 physics.analyzers.TEveEventDisplayHelix.show.showCRV : false
 physics.EndPath  : [ @sequence::TEveDis.seqHelix]
 

--- a/TEveEventDisplay/CallerFclExamples/helix_example.fcl
+++ b/TEveEventDisplay/CallerFclExamples/helix_example.fcl
@@ -18,15 +18,14 @@ physics :
 }
 
 # edit the below options for different products:
-physics.analyzers.TEveEventDisplayHelix.filler.addHits : false
+physics.analyzers.TEveEventDisplayHelix.filler.addHits : true
 physics.analyzers.TEveEventDisplayHelix.filler.addTrkHits : false
 physics.analyzers.TEveEventDisplayHelix.filler.addTimeClusters : false
 physics.analyzers.TEveEventDisplayHelix.filler.addTracks : true
 physics.analyzers.TEveEventDisplayHelix.filler.addCrvHits : false
 physics.analyzers.TEveEventDisplayHelix.filler.addCosmicSeedFit : false
-physics.analyzers.TEveEventDisplayHelix.filler.addClusters : false
-physics.analyzers.TEveEventDisplayHelix.filler.addMCTraj : false
-physics.analyzers.TEveEventDisplayHelix.filler.addKKTracks : true
+physics.analyzers.TEveEventDisplayHelix.filler.addClusters : true
+physics.analyzers.TEveEventDisplayHelix.filler.addMCTraj : true
 physics.analyzers.TEveEventDisplayHelix.show.showCRV : false
 physics.EndPath  : [ @sequence::TEveDis.seqHelix]
 

--- a/TEveEventDisplay/CallerFclExamples/helix_example.fcl
+++ b/TEveEventDisplay/CallerFclExamples/helix_example.fcl
@@ -26,6 +26,7 @@ physics.analyzers.TEveEventDisplayHelix.filler.addCrvHits : false
 physics.analyzers.TEveEventDisplayHelix.filler.addCosmicSeedFit : false
 physics.analyzers.TEveEventDisplayHelix.filler.addClusters : false
 physics.analyzers.TEveEventDisplayHelix.filler.addMCTraj : false
+physics.analyzers.TEveEventDisplayHelix.filler.addKKTracks : true
 physics.analyzers.TEveEventDisplayHelix.show.showCRV : false
 physics.EndPath  : [ @sequence::TEveDis.seqHelix]
 

--- a/TEveEventDisplay/fcl/prolog.fcl
+++ b/TEveEventDisplay/fcl/prolog.fcl
@@ -21,7 +21,7 @@ TEveEventDisplayBase : {
       CaloClusterCollection     :  "CaloClusterMaker"
       CaloHitCollection  :  NULL
       HelixSeedCollection       :  "HelixFinderDe:Negative"
-      KalSeedCollection         :  ["KKDeM"]
+      KalSeedCollection         :  ["KFFDeM"]
       TrkExtTrajCollection      :  NULL
       MCTrajectoryCollection    :  "compressRecoMCs"
       addHits                   : true

--- a/TEveEventDisplay/fcl/prolog.fcl
+++ b/TEveEventDisplay/fcl/prolog.fcl
@@ -21,7 +21,7 @@ TEveEventDisplayBase : {
       CaloClusterCollection     :  "CaloClusterMaker"
       CaloHitCollection  :  NULL
       HelixSeedCollection       :  "HelixFinderDe:Negative"
-      KalSeedCollection         :  ["KFFDeM"]
+      KalSeedCollection         :  ["KKDeM"]
       TrkExtTrajCollection      :  NULL
       MCTrajectoryCollection    :  "compressRecoMCs"
       addHits                   : true

--- a/TEveEventDisplay/fcl/prolog.fcl
+++ b/TEveEventDisplay/fcl/prolog.fcl
@@ -33,6 +33,7 @@ TEveEventDisplayBase : {
       addClusters                  : true
       addTrkExtTrajs                  : false
       addMCTraj                  : true
+      addKKTracks                : false
     }
     gdmlname :    "Offline/TEveEventDisplay/src/mu2e.gdml"
     particles :   [11,13,2212,2112,211,22,212]

--- a/TEveEventDisplay/src/Collection_Filler.cc
+++ b/TEveEventDisplay/src/Collection_Filler.cc
@@ -24,6 +24,7 @@ namespace mu2e{
     RecoOnly_(conf.RecoOnly()),
     FillAll_(conf.FillAll()),
     addMCTraj_(conf.addMCTraj()),
+    addKKTracks_(conf.addKKTracks()),
     MCOnly_(conf.MCOnly())
   {}
 #endif

--- a/TEveEventDisplay/src/TEveEventDisplay_module.cc
+++ b/TEveEventDisplay/src/TEveEventDisplay_module.cc
@@ -97,7 +97,7 @@ namespace mu2e
       application_ = new TApplication( "noapplication", &tmp_argc, tmp_argv );
     }
     //construct GUI:
-    const DrawOptions DrawOpts(_filler.addCrvHits_, _filler.addCosmicSeedFit_, _filler.addTracks_, _filler.addClusters_, _filler.addHits_, _filler.addTrkHits_, _filler.addTimeClusters_, false, _filler.addMCTraj_);
+    const DrawOptions DrawOpts(_filler.addCrvHits_, _filler.addCosmicSeedFit_, _filler.addTracks_, _filler.addClusters_, _filler.addHits_, _filler.addTrkHits_, _filler.addTimeClusters_, false, _filler.addMCTraj_, _filler.addKKTracks_);
 
     _frame = new TEveMu2eMainWindow(gClient->GetRoot(), 1000,600, _pset, DrawOpts, _show);
 

--- a/TEveEventDisplay/src/TEveMu2eDataInterface.cc
+++ b/TEveEventDisplay/src/TEveMu2eDataInterface.cc
@@ -293,7 +293,7 @@ namespace mu2e{
 using LHPT = KinKal::PiecewiseTrajectory<KinKal::LoopHelix>;
 using CHPT = KinKal::PiecewiseTrajectory<KinKal::CentralHelix>;
 using KLPT = KinKal::PiecewiseTrajectory<KinKal::KinematicLine>;
-template<class KTRAJ> void TEveMu2eDataInterface::AddKinKalTrajectory( std::unique_ptr<KTRAJ> &trajectory, TEveMu2eCustomHelix *line, TEveMu2eCustomHelix *line_twoDXY, TEveMu2eCustomHelix *line_twoDXZ){
+template<class KTRAJ> void TEveMu2eDataInterface::AddKinKalTrajectory( std::unique_ptr<KTRAJ> const& trajectory, TEveMu2eCustomHelix *line, TEveMu2eCustomHelix *line_twoDXY, TEveMu2eCustomHelix *line_twoDXZ){
   double t1=trajectory->range().begin();
   double t2=trajectory->range().end();
 
@@ -307,7 +307,7 @@ template<class KTRAJ> void TEveMu2eDataInterface::AddKinKalTrajectory( std::uniq
   line->SetPoint(0,pointmmTocm(InMu2e.x()), pointmmTocm(InMu2e.y()) , pointmmTocm(InMu2e.z()));
   line_twoDXY->SetPoint(0,pointmmTocm(x1), pointmmTocm(y1) , pointmmTocm(z1));
   line_twoDXZ->SetPoint(0,pointmmTocm(x1), pointmmTocm(y1) , pointmmTocm(z1));
-  for(double t=t1; t<=t2; t+=0.1)
+  for(double t=t1; t<=t2; t+=0.01)
   {
     const auto &p = trajectory->position3(t);
     double xt=p.x();
@@ -332,7 +332,7 @@ void TEveMu2eDataInterface::FillKinKalTrajectory(bool firstloop, std::tuple<std:
     const KalSeedCollection* seedcol = track_list[j];
     colour.push_back(j+3);
     if(seedcol!=0){  
-     for(unsigned int k = 0; k < seedcol->size(); k = k + 20){
+     for(unsigned int k = 0; k < seedcol->size(); k++){
         mu2e::KalSeed kseed = (*seedcol)[k];
         TEveMu2eCustomHelix *line = new TEveMu2eCustomHelix();
         TEveMu2eCustomHelix *line_twoDXY = new TEveMu2eCustomHelix();

--- a/TEveEventDisplay/src/TEveMu2eDataInterface.cc
+++ b/TEveEventDisplay/src/TEveMu2eDataInterface.cc
@@ -300,8 +300,11 @@ template<class KTRAJ> void TEveMu2eDataInterface::AddKinKalTrajectory( std::uniq
   double x1=trajectory->position3(t1).x();
   double y1=trajectory->position3(t1).y();
   double z1=trajectory->position3(t1).z();
-  
-  line->SetPoint(0,pointmmTocm(x1), pointmmTocm(y1) , pointmmTocm(z1));
+  GeomHandle<DetectorSystem> det;
+  XYZVectorF pos(x1,y1,z1);
+  CLHEP::Hep3Vector p = GenVector::Hep3Vec(pos);
+  CLHEP::Hep3Vector InMu2e = det->toMu2e(p);
+  line->SetPoint(0,pointmmTocm(InMu2e.x()), pointmmTocm(InMu2e.y()) , pointmmTocm(InMu2e.z()));
   line_twoDXY->SetPoint(0,pointmmTocm(x1), pointmmTocm(y1) , pointmmTocm(z1));
   line_twoDXZ->SetPoint(0,pointmmTocm(x1), pointmmTocm(y1) , pointmmTocm(z1));
   for(double t=t1; t<=t2; t+=0.1)
@@ -310,7 +313,10 @@ template<class KTRAJ> void TEveMu2eDataInterface::AddKinKalTrajectory( std::uniq
     double xt=p.x();
     double yt=p.y();
     double zt=p.z();
-    line->SetNextPoint(pointmmTocm(xt), pointmmTocm(yt) , pointmmTocm(zt));
+    XYZVectorF pos(x1,y1,z1);
+    CLHEP::Hep3Vector pmu2e = GenVector::Hep3Vec(pos);
+    CLHEP::Hep3Vector InMu2e = det->toMu2e(pmu2e);
+    line->SetNextPoint(pointmmTocm(InMu2e.x()), pointmmTocm(InMu2e.y()) , pointmmTocm(InMu2e.z()));
     line_twoDXY->SetNextPoint(pointmmTocm(xt), pointmmTocm(yt), pointmmTocm(zt));
     line_twoDXZ->SetNextPoint(pointmmTocm(xt), pointmmTocm(yt), pointmmTocm(zt));
    // CLHEP::Hep3Vector p = GenVector::Hep3Vec(pos);
@@ -332,7 +338,7 @@ void TEveMu2eDataInterface::FillKinKalTrajectory(bool firstloop, std::tuple<std:
     if(seedcol!=0){  
      for(unsigned int k = 0; k < seedcol->size(); k = k + 20){ 
         mu2e::KalSeed kseed = (*seedcol)[k];
-        std::cout<<" is loop "<<kseed.loopHelixFit()<<std::endl;
+        
         TEveMu2eCustomHelix *line = new TEveMu2eCustomHelix();
         TEveMu2eCustomHelix *line_twoDXY = new TEveMu2eCustomHelix();
         TEveMu2eCustomHelix *line_twoDXZ = new TEveMu2eCustomHelix();

--- a/TEveEventDisplay/src/TEveMu2eDataInterface.cc
+++ b/TEveEventDisplay/src/TEveMu2eDataInterface.cc
@@ -319,10 +319,6 @@ template<class KTRAJ> void TEveMu2eDataInterface::AddKinKalTrajectory( std::uniq
     line->SetNextPoint(pointmmTocm(InMu2e.x()), pointmmTocm(InMu2e.y()) , pointmmTocm(InMu2e.z()));
     line_twoDXY->SetNextPoint(pointmmTocm(xt), pointmmTocm(yt), pointmmTocm(zt));
     line_twoDXZ->SetNextPoint(pointmmTocm(xt), pointmmTocm(yt), pointmmTocm(zt));
-   // CLHEP::Hep3Vector p = GenVector::Hep3Vec(pos);
-    //          CLHEP::Hep3Vector InMu2e = det->toMu2e(p);
-         
-    
   }
 }
 
@@ -331,24 +327,23 @@ void TEveMu2eDataInterface::FillKinKalTrajectory(bool firstloop, std::tuple<std:
   std::vector<const KalSeedCollection*> track_list = std::get<1>(track_tuple);
   std::vector<std::string> names = std::get<0>(track_tuple);
   std::vector<int> colour;
-  
+
   for(unsigned int j=0; j< track_list.size(); j++){
     const KalSeedCollection* seedcol = track_list[j];
     colour.push_back(j+3);
     if(seedcol!=0){  
-     for(unsigned int k = 0; k < seedcol->size(); k = k + 20){ 
+     for(unsigned int k = 0; k < seedcol->size(); k = k + 20){
         mu2e::KalSeed kseed = (*seedcol)[k];
-        
         TEveMu2eCustomHelix *line = new TEveMu2eCustomHelix();
         TEveMu2eCustomHelix *line_twoDXY = new TEveMu2eCustomHelix();
         TEveMu2eCustomHelix *line_twoDXZ = new TEveMu2eCustomHelix();
         line->fKalSeed_ = kseed;
         line->SetSeedInfo(kseed);
-             
+     
         if(kseed.loopHelixFit())
         {
           auto trajectory=kseed.loopHelixFitTrajectory();
-          AddKinKalTrajectory<LHPT>(trajectory,line, line_twoDXY,line_twoDXZ);
+          AddKinKalTrajectory<LHPT>(trajectory, line, line_twoDXY,line_twoDXZ);
         }
         else if(kseed.centralHelixFit())
         {
@@ -360,8 +355,7 @@ void TEveMu2eDataInterface::FillKinKalTrajectory(bool firstloop, std::tuple<std:
           auto trajectory=kseed.kinematicLineFitTrajectory();
           AddKinKalTrajectory<KLPT>(trajectory,line,line_twoDXY,line_twoDXZ);
         }
-      
-      
+
       line_twoDXY->SetLineColor(kOrange);
       line_twoDXY->SetLineWidth(3);
       fTrackList2DXY->AddElement(line_twoDXY);
@@ -375,23 +369,18 @@ void TEveMu2eDataInterface::FillKinKalTrajectory(bool firstloop, std::tuple<std:
       line->SetLineWidth(3);
       fTrackList3D->AddElement(line);
       }
-
-      /*TXYMgr->ImportElements(fTrackList2D, scene1);
-      TRZMgr->ImportElements(fTrackList2D, scene2);*/
       tracker2Dproj->fXYMgr->ImportElements(fTrackList2DXY, tracker2Dproj->fEvtXYScene);
       tracker2Dproj->fRZMgr->ImportElements(fTrackList2DXZ, tracker2Dproj->fEvtRZScene);
       gEve->AddElement(fTrackList3D);
       gEve->Redraw3D(kTRUE);
       }
-      }
-
     }
+  }
 
 
 
   /*------------Function to color code the Tracker hits in 3D and 2D displays:-------------*/
-  void TEveMu2eDataInterface::AddTrkHits(bool firstloop, const ComboHitCollection *chcol,std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, TEveMu2e2DProjection *tracker2Dproj,
-                                         bool Redraw, double  min_energy, double max_energy, double min_time, double max_time, bool accumulate, TEveProjectionManager *TXYMgr, TEveProjectionManager *TRZMgr, TEveScene *scene1, TEveScene *scene2){
+  void TEveMu2eDataInterface::AddTrkHits(bool firstloop, const ComboHitCollection *chcol,std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, TEveMu2e2DProjection *tracker2Dproj,bool Redraw, double  min_energy, double max_energy, double min_time, double max_time, bool accumulate, TEveProjectionManager *TXYMgr, TEveProjectionManager *TRZMgr, TEveScene *scene1, TEveScene *scene2){
     std::vector<const KalSeedCollection*> track_list = std::get<1>(track_tuple);
     std::vector<std::string> names = std::get<0>(track_tuple);
     GeomHandle<DetectorSystem> det;
@@ -585,7 +574,6 @@ void TEveMu2eDataInterface::FillKinKalTrajectory(bool firstloop, std::tuple<std:
             calo2Dproj->fRZMgr->ImportElements(fClusterList2D_disk1, calo2Dproj->fDetRZScene);
             //CfRZMgr->ImportElements(fClusterList2D_disk1, scene2); For MultiView
           }
-
         }
       }
       gEve->AddElement(fClusterList3D);
@@ -757,50 +745,13 @@ void TEveMu2eDataInterface::FillKinKalTrajectory(bool firstloop, std::tuple<std:
       line->SetLineColor(kGreen);
       line->SetLineWidth(3);
       fTrackList3D->AddElement(line);
-
     }
-
     tracker2Dproj->fXYMgr->ImportElements(fTrackList2DXY, tracker2Dproj->fEvtXYScene);
     tracker2Dproj->fRZMgr->ImportElements(fTrackList2DXZ, tracker2Dproj->fEvtRZScene);
-
     /*TXYMgr->ImportElements(fTrackList2D, scene1);
     TRZMgr->ImportElements(fTrackList2D, scene2);*/
     gEve->AddElement(fTrackList3D);
     gEve->Redraw3D(kTRUE);
     }
   }
-
-  /*TODO - Note this function is untested and awaits compatibility in current Offline. We made it for future upgrades.
-  void TEveMu2eDataInterface::AddTrackExitTrajectories(bool firstloop, const TrkExtTrajCollection *trkextcol, double min_time, double max_time, bool Redraw, bool accumulate) {
-  DataLists<const TrkExtTrajCollection*, TEveMu2e2DProjection*>(trkextcol, Redraw, accumulate, "TrackExitTraj", &fExtTrackList3D);
-    if(trkextcol!=0){
-       for(unsigned int i = 0; i < trkextcol->size(); i++){
-        TrkExtTraj trkext = (*trkextcol)[i];
-        TEveMu2eCustomHelix *line = new TEveMu2eCustomHelix();
-        line->fTrkExtTraj_ = trkext;
-
-        line->SetMomentumExt();
-        line->SetParticleExt();
-
-        line->SetPoint(0,trkext.front().x(),trkext.front().y(),trkext.front().z());
-        for(unsigned int k = 0 ; k< trkext.size(); k+=10){
-          const mu2e::TrkExtTrajPoint &trkextpoint = trkext[k];
-          line->SetNextPoint(trkextpoint.x(), trkextpoint.y(), trkextpoint.z());  //TODO accurate translation
-        }
-        //     fExtTrackList2D->AddElement(line);
-        //     tracker2Dproj->fXYMgr->ImportElements(fExtTrackList2D, tracker2Dproj->fDetXYScene);
-        //     tracker2Dproj->fRZMgr->ImportElements(fExtTrackList2D, tracker2Dproj->fDetRZScene);
-        line->SetPickable(kTRUE);
-        const std::string title = "Helix #" + to_string(i + 1) + ", Momentum = " + to_string(line->Momentum_);
-        line->SetTitle(Form(title.c_str()));
-        line->SetLineColor(kRed);
-        line->SetLineWidth(3);
-        fExtTrackList3D->AddElement(line);
-
-      }
-        gEve->AddElement(fExtTrackList3D);
-        gEve->Redraw3D(kTRUE);
-    }
-
-  }*/
 }

--- a/TEveEventDisplay/src/TEveMu2eMainWindow.cc
+++ b/TEveEventDisplay/src/TEveMu2eMainWindow.cc
@@ -902,10 +902,9 @@ namespace mu2e{
 
       if (DrawOpts.addCryHits) pass_data->AddCrystalHits(firstLoop, data.cryHitcol, calo2Dproj, ftimemin, ftimemax, false, _accumulate, CfXYMgr, CfRZMgr, proj0, proj1);
 
-      if (DrawOpts.addTracks){
-        pass_data->AddHelixPieceWise3D(firstLoop, data.track_tuple, tracker2Dproj,  ftimemin, ftimemax, false, _accumulate, TfXYMgr, TfRZMgr, proj2, proj3);
-        pass_data->FillKinKalTrajectory(firstLoop, data.track_tuple, tracker2Dproj,  TfXYMgr, TfRZMgr, proj2, proj3);
-      }
+      if (DrawOpts.addTracks) pass_data->AddHelixPieceWise3D(firstLoop, data.track_tuple, tracker2Dproj,  ftimemin, ftimemax, false, _accumulate, TfXYMgr, TfRZMgr, proj2, proj3);
+      if (DrawOpts.addTracks) pass_data->FillKinKalTrajectory(firstLoop, data.track_tuple, tracker2Dproj,  TfXYMgr, TfRZMgr, proj2, proj3);
+      
 
       if(DrawOpts.addCosmicTracks) pass_data->AddCosmicTrack(firstLoop, data.cosmiccol, tracker2Dproj, ftimemin, ftimemax, false, _accumulate, TfXYMgr, TfRZMgr, proj2, proj3);
 

--- a/TEveEventDisplay/src/TEveMu2eMainWindow.cc
+++ b/TEveEventDisplay/src/TEveMu2eMainWindow.cc
@@ -902,7 +902,10 @@ namespace mu2e{
 
       if (DrawOpts.addCryHits) pass_data->AddCrystalHits(firstLoop, data.cryHitcol, calo2Dproj, ftimemin, ftimemax, false, _accumulate, CfXYMgr, CfRZMgr, proj0, proj1);
 
-      if (DrawOpts.addTracks) pass_data->AddHelixPieceWise3D(firstLoop, data.track_tuple, tracker2Dproj,  ftimemin, ftimemax, false, _accumulate, TfXYMgr, TfRZMgr, proj2, proj3);
+      if (DrawOpts.addTracks){
+        pass_data->AddHelixPieceWise3D(firstLoop, data.track_tuple, tracker2Dproj,  ftimemin, ftimemax, false, _accumulate, TfXYMgr, TfRZMgr, proj2, proj3);
+        pass_data->FillKinKalTrajectory(firstLoop, data.track_tuple, tracker2Dproj,  TfXYMgr, TfRZMgr, proj2, proj3);
+      }
 
       if(DrawOpts.addCosmicTracks) pass_data->AddCosmicTrack(firstLoop, data.cosmiccol, tracker2Dproj, ftimemin, ftimemax, false, _accumulate, TfXYMgr, TfRZMgr, proj2, proj3);
 

--- a/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eDataInterface.h
+++ b/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eDataInterface.h
@@ -73,7 +73,7 @@ namespace mu2e{
 
       void AddTrkHits(bool firstloop, const ComboHitCollection *chcol, std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, TEveMu2e2DProjection *tracker2Dproj, bool Redraw, double min_energy, double max_energy, double min_time, double max_time, bool accumulate, TEveProjectionManager *TXYMgr, TEveProjectionManager *TRZMgr, TEveScene *scene1, TEveScene *scene2);
       void AddTimeClusters(bool firstloop, const TimeClusterCollection *tccol, TEveMu2e2DProjection *tracker2Dproj, bool Redraw, bool accumulate, TEveProjectionManager *TXYMgr, TEveProjectionManager *TRZMgr, TEveScene *scene1, TEveScene *scene2);
-      template<class KTRAJ> void AddKinKalTrajectory( std::unique_ptr<KTRAJ> &trajectory, TEveMu2eCustomHelix *line, TEveMu2eCustomHelix *line_twoDXY, TEveMu2eCustomHelix *line_twoDXZ);
+      template<class KTRAJ> void AddKinKalTrajectory( std::unique_ptr<KTRAJ> const& trajectory, TEveMu2eCustomHelix *line, TEveMu2eCustomHelix *line_twoDXY, TEveMu2eCustomHelix *line_twoDXZ);
       void FillKinKalTrajectory(bool firstloop, std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, TEveMu2e2DProjection *tracker2Dproj, TEveProjectionManager *TXYMgr, TEveProjectionManager *TRZMgr, TEveScene *scene1, TEveScene *scene2);
 
       std::vector<double> AddCaloClusters(bool firstloop, const CaloClusterCollection *clustercol,TEveMu2e2DProjection *calo2Dproj,  bool Redraw, double min_energy, double max_energy, double min_time, double max_time, bool accumulate, TEveProjectionManager *CfXYMgr, TEveProjectionManager *CfRZMgr, TEveScene *scene1, TEveScene *scene2);

--- a/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eDataInterface.h
+++ b/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eDataInterface.h
@@ -73,6 +73,8 @@ namespace mu2e{
 
       void AddTrkHits(bool firstloop, const ComboHitCollection *chcol, std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, TEveMu2e2DProjection *tracker2Dproj, bool Redraw, double min_energy, double max_energy, double min_time, double max_time, bool accumulate, TEveProjectionManager *TXYMgr, TEveProjectionManager *TRZMgr, TEveScene *scene1, TEveScene *scene2);
       void AddTimeClusters(bool firstloop, const TimeClusterCollection *tccol, TEveMu2e2DProjection *tracker2Dproj, bool Redraw, bool accumulate, TEveProjectionManager *TXYMgr, TEveProjectionManager *TRZMgr, TEveScene *scene1, TEveScene *scene2);
+      template<class KTRAJ> void AddKinKalTrajectory( std::unique_ptr<KTRAJ> &trajectory, TEveMu2eCustomHelix *line, TEveMu2eCustomHelix *line_twoDXY, TEveMu2eCustomHelix *line_twoDXZ);
+      void FillKinKalTrajectory(bool firstloop, std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, TEveMu2e2DProjection *tracker2Dproj, TEveProjectionManager *TXYMgr, TEveProjectionManager *TRZMgr, TEveScene *scene1, TEveScene *scene2);
 
       std::vector<double> AddCaloClusters(bool firstloop, const CaloClusterCollection *clustercol,TEveMu2e2DProjection *calo2Dproj,  bool Redraw, double min_energy, double max_energy, double min_time, double max_time, bool accumulate, TEveProjectionManager *CfXYMgr, TEveProjectionManager *CfRZMgr, TEveScene *scene1, TEveScene *scene2);
 

--- a/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eMainWindow.h
+++ b/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eMainWindow.h
@@ -84,9 +84,10 @@ namespace mu2e{
     bool addTimeClusters = false;
     bool addCryHits = false;
     bool addMCTraj = false;
+    bool addKKTracks = false;
     DrawOptions(){};
-    DrawOptions(bool crv, bool cosmictracks, bool tracks, bool clusters, bool combohits, bool trkhits, bool timeclusters, bool cryhits, bool mctraj)
-    : addCRVInfo(crv), addCosmicTracks(cosmictracks), addTracks(tracks), addClusters(clusters), addComboHits(combohits), addTrkHits(trkhits), addTimeClusters(timeclusters), addCryHits(cryhits), addMCTraj(mctraj) {};
+    DrawOptions(bool crv, bool cosmictracks, bool tracks, bool clusters, bool combohits, bool trkhits, bool timeclusters, bool cryhits, bool mctraj, bool kktracks)
+    : addCRVInfo(crv), addCosmicTracks(cosmictracks), addTracks(tracks), addClusters(clusters), addComboHits(combohits), addTrkHits(trkhits), addTimeClusters(timeclusters), addCryHits(cryhits), addMCTraj(mctraj), addKKTracks(kktracks) {};
    };
 
 

--- a/TEveEventDisplay/src/dict_classes/Collection_Filler.h
+++ b/TEveEventDisplay/src/dict_classes/Collection_Filler.h
@@ -80,6 +80,7 @@ namespace mu2e{
       fhicl::Atom<bool> RecoOnly{Name("RecoOnly"), Comment("set to see only Reco Data Products"), false};
       fhicl::Atom<bool> FillAll{Name("FillAll"), Comment("to see all available products"), false};
       fhicl::Atom<bool> addMCTraj{Name("addMCTraj"), Comment("set to add MC trajectories"), false};
+      fhicl::Atom<bool> addKKTracks{Name("addKKTracks"), Comment("set to add KinKal traj"), false};
       fhicl::Atom<bool> MCOnly{Name("MCOnly"), Comment("set to see only MC Data Products"), false};
     };
 
@@ -104,7 +105,7 @@ namespace mu2e{
 
     art::Event *_event;
     art::Run *_run;
-    bool addHits_, addTimeClusters_, addTrkHits_, addTracks_, addClusters_, addCrvHits_, addCosmicSeedFit_, isCosmic_, addTrkExtTrajs_, RecoOnly_,  FillAll_, addMCCaloDigis_, addMCTraj_, MCOnly_;
+    bool addHits_, addTimeClusters_, addTrkHits_, addTracks_, addClusters_, addCrvHits_, addCosmicSeedFit_, isCosmic_, addTrkExtTrajs_, RecoOnly_,  FillAll_, addMCCaloDigis_, addMCTraj_, addKKTracks_, MCOnly_;
     void FillRecoCollections(const art::Event& evt, Data_Collections &data, RecoDataProductName code);
     void FillMCCollections(const art::Event& evt, Data_Collections &data, MCDataProductName code);
     virtual ~Collection_Filler(){};


### PR DESCRIPTION
This code allows plotting of the KinKal trajectories as requested by @brownd1978 

Note - the REve code is the newest version of the Eve Event Display so any comments on general coding should be provided on that version not this. TEve is maintained as REve currently does not support all the features we developed there. 