### PR TITLE
Add a c'tor from a string.  

### DIFF
--- a/DataProducts/inc/VirtualDetectorId.hh
+++ b/DataProducts/inc/VirtualDetectorId.hh
@@ -142,6 +142,14 @@ namespace mu2e {
       _id(id)
     {}
 
+    // Constructor from a string;
+    //  - if throwIfUnknown is true, the c'tor will throw an exception if the string is "unknown".
+    //  - if throwIfUndefined is true, the c'tor will throw an exception if the string is not
+    //    found among the known strings.
+    explicit VirtualDetectorId( std::string const& idName,
+                                bool throwIfUnknown=true,
+                                bool throwIfUndefined=true);
+
     enum_type id() const { return _id;}
 
     // Member function version of the name function.
@@ -281,7 +289,7 @@ namespace mu2e {
   private:
 
     // The one and only per-instance member datum.
-    enum_type _id;
+    enum_type _id = unknown;
 
   };
 

--- a/DataProducts/src/VirtualDetectorId.cc
+++ b/DataProducts/src/VirtualDetectorId.cc
@@ -5,22 +5,50 @@
 
 #include "Offline/DataProducts/inc/VirtualDetectorId.hh"
 
+#include "cetlib_except/exception.h"
+
 #include <boost/static_assert.hpp>
 
-#include <iostream>
+#include <algorithm>
 #include <iomanip>
-#include <sstream>
-#include <stdexcept>
+#include <iostream>
 
 using namespace std;
 
 namespace mu2e {
 
+  VirtualDetectorId::VirtualDetectorId( std::string const& name,
+                                        bool throwIfUnknown,
+                                        bool throwIfUndefined)
+    :_id(unknown)
+  {
+
+    auto b = names().begin();
+    auto e = names().end();
+    auto i = find( b, e , name );
+
+    // Found it.
+    if ( i != e ){
+      _id = static_cast<enum_type>( i - b );
+      if ( _id == unknown && throwIfUnknown ) {
+        throw cet::exception("BADCONFIG") << "VirtualDetectorId::unknown is not allowed at this time";
+      }
+      return;
+    }
+
+    // Did not find it.
+    if ( throwIfUndefined ) {
+      throw cet::exception("BADCONFIG") << "VirtualDetectorID: invalid enum name : " << name;
+    }
+
+  }
+
+
   void VirtualDetectorId::printAll( std::ostream& ost){
     ost << "List of Virtual Detector Id codes: " << endl;
     for ( int i=0; i<lastEnum; ++i){
       VirtualDetectorId id(i);
-      ost << setw(2) << i << " " << name(id.id()) << std::endl;
+      ost << setw(3) << i << " " << name(id.id()) << std::endl;
     }
   }
 
@@ -43,10 +71,7 @@ namespace mu2e {
 
   bool VirtualDetectorId::isValidorThrow( enum_type id){
     if ( !isValid(id) ){
-      ostringstream os;
-      os << "Invalid VirtualDetectorId::enum_type : "
-         << id;
-      throw std::out_of_range( os.str() );
+      throw cet::exception("OutOfRange") << "Invalid VirtualDetectorID::enum_type : " << id;
     }
     return true;
   }


### PR DESCRIPTION
This is the PR that Andy requested so that he could use names of VirtualDetectorIds in fcl configuration.

I added a few cleanups.