### PR TITLE
Enabling the use of Geant4 11.1 etc.

### DIFF
--- a/MCDataProducts/inc/ProcessCode.hh
+++ b/MCDataProducts/inc/ProcessCode.hh
@@ -87,7 +87,7 @@ namespace mu2e {
       mu2eExternalRMC,         mu2eFlateMinus,      mu2eFlatePlus, mu2eFlatPhoton, // 175
       mu2eCePlusLeadingLog, mu2ePionCaptureAtRest, mu2eExternalRPC, mu2eInternalRPC,
       mu2eCaloCalib, mu2eunused6, mu2eunused7, mu2eunused8,
-      uninitialized, NoProcess,
+      uninitialized, NoProcess, GammaGeneralProc,
       lastEnum,
       // An alias for backward compatibility
       mu2eHallAir = mu2eKillerVolume
@@ -143,7 +143,7 @@ namespace mu2e {
     "mu2eExternalRMC",  "mu2eFlateMinus",      "mu2eFlatePlus", "mu2eFlatPhoton", \
   "mu2eCePlusLeadingLog", "mu2ePionCaptureAtRest", "mu2eExternalRPC", "mu2eInternalRPC", \
     "mu2eCaloCalib", "mu2eunused6", "mu2eunused7", "mu2eunused8", \
-    "uninitialized", "NoProcess"
+      "uninitialized", "NoProcess", "GammaGeneralProc"
 #endif
 
   public:

--- a/Mu2eG4/fcl/prolog.fcl
+++ b/Mu2eG4/fcl/prolog.fcl
@@ -26,6 +26,12 @@ mu2eg4DefaultPhysics: {
     setMuHadLateralDisplacement: true // improves accuracy of boundary
                                       // crossing for muons and common charged hadrons
 
+    // disableEnergyLossFluctuations: false // only disable it for testing pourposes
+    // the following parameter works with Geant4 11.1 and above
+    // setEnergyLossFluctuationModel: 2 // the deafult changes with Geant4 version; it is 2 for 11.1
+    // enum G4EmFluctuationType { fDummyFluctuation = 0, fUniversalFluctuation, fUrbanFluctuation };
+
+
     useDensityEffectInIonizationLossCalc: false // improves accuracy of energy loss calculations;
                                                 // done for the materials listed below, for now
                                                 // to be used with Geant4 10.7.p03 and above

--- a/Mu2eG4/inc/Mu2eG4Config.hh
+++ b/Mu2eG4/inc/Mu2eG4Config.hh
@@ -141,6 +141,10 @@ namespace mu2e {
                   "or one of \"PDG\", \"All\", \"None\" pre-defined settings.")
           };
 
+      fhicl::OptionalAtom<bool> disableEnergyLossFluctuations {Name("disableEnergyLossFluctuations")};
+#if G4VERSION>4110
+      fhicl::OptionalAtom<unsigned int> setEnergyLossFluctuationModel {Name("energyLossFluctuationModel")};
+#endif
       fhicl::OptionalAtom<double> mscModelTransitionEnergy {Name("mscModelTransitionEnergy")};
       fhicl::OptionalAtom<double> muonPreAssignedDecayProperTime {Name("muonPreAssignedDecayProperTime")};
       fhicl::OptionalAtom<double> muonMaxPreAssignedDecayProperTime {Name("muonMaxPreAssignedDecayProperTime")};

--- a/Mu2eG4/src/Mu2eG4CustomizationPhysicsConstructor.cc
+++ b/Mu2eG4/src/Mu2eG4CustomizationPhysicsConstructor.cc
@@ -79,6 +79,46 @@ namespace mu2e {
       params->SetMuHadLateralDisplacement(true);
     }
 
+    { bool disableEnergyLossFluctuations = false; // they are enabled by deafult
+      if (phys_->disableEnergyLossFluctuations(disableEnergyLossFluctuations)) {
+        if (disableEnergyLossFluctuations) {
+          if (debug_->diagLevel()>0) {
+            G4cout << __func__
+                   << " Turning off energy loss fluctuations "
+                   << G4endl;
+          }
+          G4EmParameters* params = G4EmParameters::Instance();
+          params->SetLossFluctuations(!disableEnergyLossFluctuations);
+        }
+      }
+    }
+
+#if G4VERSION>4110
+    { unsigned int energyLossFluctuationModel = 2; // 2 is geant4 11.1 default
+      if (phys_->setEnergyLossFluctuationModel(energyLossFluctuationModel)) {
+        if (debug_->diagLevel()>0) {
+          G4cout << __func__
+                 << " Setting energy loss fluctuations model to: "
+                 << energyLossFluctuationModel
+                 << G4endl;
+        }
+        G4EmParameters* params = G4EmParameters::Instance();
+        // a potential maintance point, 3 options as of Geant4 11.1
+        G4EmFluctuationType fluctType = fDummyFluctuation; // actually a model
+        if (energyLossFluctuationModel == 0) { fluctType = fDummyFluctuation; }
+        else if (energyLossFluctuationModel == 1) { fluctType = fUniversalFluctuation; }
+        else if (energyLossFluctuationModel == 2) { fluctType = fUrbanFluctuation; }
+        else {
+          throw cet::exception("BADINPUT")
+            << "Mu2eG4CustomizationPhysicsConstructor::ConstructProcess() Error: unknown energyLossFluctuationModel: "
+            << energyLossFluctuationModel
+            << "\n";
+        }
+        params->SetFluctuationType(fluctType);
+      }
+    }
+#endif
+
   }
 
 }

--- a/Mu2eG4/src/Mu2eG4TrackingAction.cc
+++ b/Mu2eG4/src/Mu2eG4TrackingAction.cc
@@ -60,6 +60,7 @@
 #include "Geant4/G4MaterialCutsCouple.hh"
 #include "Geant4/G4ParticleChange.hh"
 #include "Geant4/G4DynamicParticle.hh"
+#include "Geant4/G4Exp.hh"
 #include "Geant4/G4Log.hh"
 #include "Geant4/Randomize.hh"
 

--- a/Mu2eG4/src/PhysicsProcessInfo.cc
+++ b/Mu2eG4/src/PhysicsProcessInfo.cc
@@ -46,6 +46,9 @@ namespace mu2e{
     // Number of processes that are not known to the ProcessCode enum.
     int nUnknownProcesses(0);
 
+    // a special process
+    G4String gammaGP = G4String("GammaGeneralProc");
+
     // Get an iterator over existing particles. See note 1.
     G4ParticleTable* ptable = G4ParticleTable::GetParticleTable();
     G4ParticleTable::G4PTblDicIterator* iter = ptable->GetIterator();
@@ -73,7 +76,22 @@ namespace mu2e{
       for( G4int j=0; j<pmanager->GetProcessListLength(); ++j ) {
 
         G4VProcess const* proc = (*pVector)[j];
-        nUnknownProcesses+=insertIfNotFound(proc->GetProcessName(),particleName);
+        G4String const& processName = proc->GetProcessName();
+        nUnknownProcesses+=insertIfNotFound(processName,particleName);
+
+        if ( processName == gammaGP ){
+          // special case for G4GammaGeneralProcess as of Geant4 11
+          // if the process name is GammaGeneralProc then one has to
+          // insert all its component processes:
+          // phot, Rayl, compt, conv, GammaToMuPair, photonNuclear
+          nUnknownProcesses+=insertIfNotFound(G4String("phot"),particleName);
+          nUnknownProcesses+=insertIfNotFound(G4String("Rayl"),particleName);
+          nUnknownProcesses+=insertIfNotFound(G4String("compt"),particleName);
+          nUnknownProcesses+=insertIfNotFound(G4String("conv"),particleName);
+          nUnknownProcesses+=insertIfNotFound(G4String("GammaToMuPair"),particleName);
+          nUnknownProcesses+=insertIfNotFound(G4String("photonNuclear"),particleName);
+        }
+
         // we will artificially attach "mu2eFieldPropagator" to all charged particles
         if( (particle->GetPDGCharge())!=0.0 ) {
           nUnknownProcesses+=insertIfNotFound(G4String("mu2eFieldPropagator"),particleName);


### PR DESCRIPTION
This pull request enables the use of Geant4 11.1
It introduces two optional parameters which affect EM energy fluctuations
(their functionality, by definition of them being optional, is disabled by default)