### PR TITLE
STM Zero Suppression

### DIFF
--- a/Mu2eUtilities/inc/STMUtils.hh
+++ b/Mu2eUtilities/inc/STMUtils.hh
@@ -3,8 +3,10 @@
 //
 // Helper class to do work on STM objects.
 //
-
+#include "Offline/GeneralUtilities/inc/Binning.hh"
 #include "Offline/DataProducts/inc/STMChannel.hh"
+#include "Offline/RecoDataProducts/inc/STMWaveformDigi.hh"
+
 #include "canvas/Utilities/InputTag.h"
 
 namespace mu2e {
@@ -12,6 +14,9 @@ namespace mu2e {
   namespace STMUtils {
     // Want to take an input tag and return an STMChannel
     STMChannel getChannel(art::InputTag const& tag);
+
+    // To get the binning for a specific STMWaveformDigi
+Binning getBinning(const STMWaveformDigi& waveform, const std::string& xAxis, const double nsPerCt);
   }
 }
 

--- a/Mu2eUtilities/src/STMUtils.cc
+++ b/Mu2eUtilities/src/STMUtils.cc
@@ -2,6 +2,8 @@
 
 #include "Offline/Mu2eUtilities/inc/STMUtils.hh"
 
+#include "cetlib_except/exception.h"
+
 namespace mu2e {
 
   namespace STMUtils {
@@ -16,6 +18,29 @@ namespace mu2e {
         std::string label = tag.label();
         // Look at last four characeters of module label to decide channel
         return STMChannel(STMChannel::findByName(label.substr(label.length()-4,4)));
+      }
+    }
+
+    // A function to get the histogram binning for a certain STMWaveformDigi
+    Binning getBinning(const STMWaveformDigi& waveform, const std::string& xAxis, const double nsPerCt) {
+
+      int n_bins = waveform.adcs().size();
+      double x_min = 0;
+      double x_max = n_bins;
+      double t_min = waveform.trigTimeOffset()*nsPerCt;
+      double t_max = n_bins*nsPerCt;
+
+      if (xAxis == "sample_number") {
+        return Binning(n_bins, x_min, x_max);
+      }
+      else if (xAxis == "waveform_time") {
+        return Binning(n_bins, x_min, t_max);
+      }
+      else if (xAxis == "event_time") {
+        return Binning(n_bins, t_min, t_min+t_max);
+      }
+      else {
+        throw cet::exception("STMUtils::getBinning") << "Invalid xAxis option: \"" << xAxis << "\"" << std::endl;
       }
     }
   }

--- a/Mu2eUtilities/src/STMUtils.cc
+++ b/Mu2eUtilities/src/STMUtils.cc
@@ -25,19 +25,21 @@ namespace mu2e {
     Binning getBinning(const STMWaveformDigi& waveform, const std::string& xAxis, const double nsPerCt) {
 
       int n_bins = waveform.adcs().size();
-      double x_min = 0;
-      double x_max = n_bins;
-      double t_min = waveform.trigTimeOffset()*nsPerCt;
-      double t_max = n_bins*nsPerCt;
+      double samp_min = 0;
+      double samp_max = n_bins;
+      double wvf_t_min = 0;
+      double wvf_t_max = n_bins*nsPerCt;
+      double evt_t_min = waveform.trigTimeOffset()*nsPerCt;
+      double evt_t_max = evt_t_min + wvf_t_max;
 
       if (xAxis == "sample_number") {
-        return Binning(n_bins, x_min, x_max);
+        return Binning(n_bins, samp_min, samp_max);
       }
       else if (xAxis == "waveform_time") {
-        return Binning(n_bins, x_min, t_max);
+        return Binning(n_bins, wvf_t_min, wvf_t_max);
       }
       else if (xAxis == "event_time") {
-        return Binning(n_bins, t_min, t_min+t_max);
+        return Binning(n_bins, evt_t_min, evt_t_max);
       }
       else {
         throw cet::exception("STMUtils::getBinning") << "Invalid xAxis option: \"" << xAxis << "\"" << std::endl;

--- a/STMReco/fcl/plotSTMWaveformDigis.fcl
+++ b/STMReco/fcl/plotSTMWaveformDigis.fcl
@@ -3,6 +3,7 @@
 #
 
 #include "Offline/fcl/standardServices.fcl"
+#include "Offline/STMReco/fcl/prolog.fcl"
 
 process_name: PlotSTMWaveformDigis
 
@@ -24,17 +25,39 @@ physics: {
       stmWaveformDigisTag : "FromSTMTestBeamData:HPGe"
       subtractPedestal : false
       verbosityLevel : 0
+      xAxis : "event_time"
+      samplingFrequency : @local::STM.HPGe.samplingFrequency
     }
     plotLaBrWaveformDigis : {
       module_type : PlotSTMWaveformDigis
       stmWaveformDigisTag : "FromSTMTestBeamData:LaBr"
       subtractPedestal : false
       verbosityLevel : 0
+      xAxis : "event_time"
+      samplingFrequency : @local::STM.LaBr.samplingFrequency
+    }
+
+    plotHPGeWaveformDigisZP : {
+      module_type : PlotSTMWaveformDigis
+      stmWaveformDigisTag : "zeroSuppressHPGe"
+      subtractPedestal : false
+      verbosityLevel : 0
+      xAxis : "event_time"
+      samplingFrequency : @local::STM.HPGe.samplingFrequency
+    }
+    plotLaBrWaveformDigisZP : {
+      module_type : PlotSTMWaveformDigis
+      stmWaveformDigisTag : "zeroSuppressLaBr"
+      subtractPedestal : false
+      verbosityLevel : 0
+      xAxis : "event_time"
+      samplingFrequency : @local::STM.LaBr.samplingFrequency
     }
   }
   # setup paths
   trigger_paths: [  ]
-  anaPath : [ plotHPGeWaveformDigis, plotLaBrWaveformDigis ]
+  anaPath : [ plotHPGeWaveformDigis, plotLaBrWaveformDigis,
+    plotHPGeWaveformDigisZP, plotLaBrWaveformDigisZP ]
   end_paths: [anaPath]
 }
 

--- a/STMReco/fcl/prolog.fcl
+++ b/STMReco/fcl/prolog.fcl
@@ -1,5 +1,8 @@
 #
-# prolog.fcl for fcl paramaters that might be used in multiple modules
+# prolog.fcl for fcl paramaters that will be used in STM modules
+#
+# Some notes:
+# - The sampling frequency in different for the HPGe and LaBr in the test beam. In the real experiment this will not be the case.
 #
 BEGIN_PROLOG
 

--- a/STMReco/fcl/prolog.fcl
+++ b/STMReco/fcl/prolog.fcl
@@ -1,0 +1,28 @@
+#
+# prolog.fcl for fcl paramaters that might be used in multiple modules
+#
+BEGIN_PROLOG
+
+STM : {
+
+  HPGe : {
+    samplingFrequency : 320.0520833313 # MHz - will probably end up in a DB somewhere
+    # zero-suppression parameters
+    tbefore : 2000 # ns
+    tafter : 10000 # ns
+    threshold : -100
+    window : 100
+    naverage : 5
+  }
+  LaBr : {
+    samplingFrequency : 370.370370370 # MHz - will probably end up in a DB somewhere
+    # zero-suppression parameters
+    tbefore : 2000 # ns
+    tafter : 10000 # ns
+    threshold : -100
+    window : 100
+    naverage : 5
+  }
+}
+
+END_PROLOG

--- a/STMReco/fcl/zeroSuppression.fcl
+++ b/STMReco/fcl/zeroSuppression.fcl
@@ -1,0 +1,63 @@
+#
+# Apply zero-suppression to unsuppressed STMWaveformDigis
+#
+
+#include "Offline/fcl/standardServices.fcl"
+#include "Offline/STMReco/fcl/prolog.fcl"
+
+process_name: STMZeroSuppression
+
+source : {
+  module_type : RootInput
+}
+
+services : {
+  message : { @table::Services.Core.message }
+}
+
+physics: {
+  producers : {
+    zeroSuppressHPGe : {
+      module_type : STMZeroSuppression
+      stmWaveformDigisTag : "FromSTMTestBeamData:HPGe"
+      samplingFrequency : @local::STM.HPGe.samplingFrequency
+      tbefore : @local::STM.HPGe.tbefore
+      tafter : @local::STM.HPGe.tafter
+      threshold : @local::STM.HPGe.threshold
+      window : @local::STM.HPGe.window
+      naverage : @local::STM.HPGe.naverage
+      verbosityLevel : 1
+    }
+
+    zeroSuppressLaBr : {
+      module_type : STMZeroSuppression
+      stmWaveformDigisTag : "FromSTMTestBeamData:LaBr"
+      samplingFrequency : @local::STM.LaBr.samplingFrequency
+      tbefore : @local::STM.LaBr.tbefore
+      tafter : @local::STM.LaBr.tafter
+      threshold : @local::STM.LaBr.threshold
+      window : @local::STM.LaBr.window
+      naverage : @local::STM.LaBr.naverage
+      verbosityLevel : 1
+    }
+  }
+  filters : {  }
+  analyzers : {  }
+
+  # setup paths
+  HPGePath : [ zeroSuppressHPGe ]
+  LaBrPath : [ zeroSuppressLaBr ]
+  trigger_paths: [ HPGePath, LaBrPath ]
+  outPath : [ STMOutput ]
+  end_paths: [outPath]
+}
+
+outputs: {
+
+  STMOutput : {
+    module_type: RootOutput
+    outputCommands:   [ "keep *_*_*_*" ]
+    SelectEvents: [ HPGePath, LaBrPath ]
+    fileName : "dig.owner.ZPWaveformDigis.version.sequencer.art"
+  }
+}

--- a/STMReco/src/PlotSTMWaveformDigis_module.cc
+++ b/STMReco/src/PlotSTMWaveformDigis_module.cc
@@ -50,7 +50,7 @@ namespace mu2e {
     int _verbosityLevel;
     ProditionsHandle<STMEnergyCalib> _stmEnergyCalib_h;
     STMChannel _channel;
-    double _ctPerNs;
+    double _nsPerCt;
   };
 
   PlotSTMWaveformDigis::PlotSTMWaveformDigis(const Parameters& config )  :
@@ -59,7 +59,7 @@ namespace mu2e {
     _subtractPedestal(config().subtractPedestal()),
     _xAxis(config().xAxis()),
     _verbosityLevel(config().verbosityLevel()),
-    _ctPerNs((1.0/config().samplingFrequency())*1e3) // convert to ns
+    _nsPerCt((1.0/config().samplingFrequency())*1e3) // convert to ns
   {
     consumes<STMWaveformDigiCollection>(_stmWaveformDigisTag);
     _channel = STMUtils::getChannel(_stmWaveformDigisTag);
@@ -94,11 +94,11 @@ namespace mu2e {
       }
       else if (_xAxis == "waveform_time") {
         x_min = 0;
-        x_max = n_bins*_ctPerNs;
+        x_max = n_bins*_nsPerCt;
       }
       else if (_xAxis == "event_time") {
-        x_min = waveform.trigTimeOffset()*_ctPerNs;
-        x_max = x_min+n_bins*_ctPerNs;
+        x_min = waveform.trigTimeOffset()*_nsPerCt;
+        x_max = x_min+n_bins*_nsPerCt;
       }
       else {
         throw cet::exception("PlotSTMWaveformDigis") << "Invalid xAxis option: \"" << _xAxis << "\"" << std::endl;

--- a/STMReco/src/STMZeroSuppression_module.cc
+++ b/STMReco/src/STMZeroSuppression_module.cc
@@ -60,7 +60,7 @@ namespace mu2e {
     double _tbefore; // time before the peak [ns]
     double _tafter; // time after the peak [ns]
     double _threshold; // threshold
-    double _ctPerNs; // clock ticks per ns
+    double _nsPerCt; // nanosecond per clock tick
     unsigned int _nadcBefore; // number of samples before peak
     unsigned int _nadcAfter; // number of samples after peak
 
@@ -84,9 +84,9 @@ namespace mu2e {
     ,_tbefore(config().tbefore())
     ,_tafter(config().tafter())
     ,_threshold(config().threshold())
-    ,_ctPerNs((1.0/config().samplingFrequency())*1e3) // convert to ns
-    ,_nadcBefore(_tbefore/_ctPerNs)
-    ,_nadcAfter(_tafter/_ctPerNs)
+    ,_nsPerCt((1.0/config().samplingFrequency())*1e3) // convert to ns
+    ,_nadcBefore(_tbefore/_nsPerCt)
+    ,_nadcAfter(_tafter/_nsPerCt)
     ,_window(config().window())
     ,_naverage(config().naverage())
   {

--- a/STMReco/src/STMZeroSuppression_module.cc
+++ b/STMReco/src/STMZeroSuppression_module.cc
@@ -1,0 +1,253 @@
+//
+// Create zero-suppressed STMWaveformDigis from unsuppressed STMWaveformDigis
+// Original authors: Claudia Alvarez-Garcia, Alex Keshavarzi, and Mark Lancaster (see DocDB-43057 for details)
+// Adapted for Offline: Andy Edmonds
+//
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "cetlib_except/exception.h"
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "canvas/Utilities/InputTag.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include "art_root_io/TFileService.h"
+
+#include <utility>
+#include <algorithm>
+
+// root
+#include "TH1F.h"
+#include "TF1.h"
+
+#include "Offline/RecoDataProducts/inc/STMWaveformDigi.hh"
+#include "Offline/Mu2eUtilities/inc/STMUtils.hh"
+
+namespace mu2e {
+
+  class STMZeroSuppression : public art::EDProducer {
+    public:
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      struct Config {
+        fhicl::Atom<art::InputTag> stmWaveformDigisTag{ Name("stmWaveformDigisTag"), Comment("InputTag for STMWaveformDigiCollection")};
+        fhicl::Atom<double> samplingFrequency{ Name("samplingFrequency"), Comment("Sampling Frequency of ADC [MHz]")};
+        fhicl::Atom<double> tbefore{ Name("tbefore"), Comment("Store this time before the peak [ns]")};
+        fhicl::Atom<double> tafter{ Name("tafter"), Comment("Store this time after the peak [ns]")};
+        fhicl::Atom<double> threshold{ Name("threshold"), Comment("Threshold to define the peak [ADC/ct]")};
+        fhicl::Atom<double> window{ Name("window"), Comment("Calculate the gradient between ADC values this number of elements away from each other")};
+        fhicl::Atom<double> naverage{ Name("naverage"), Comment("Number of ADC values to average the gradient over")};
+        fhicl::Atom<int> verbosityLevel{Name("verbosityLevel"), Comment("Verbosity level")};
+      };
+      using Parameters = art::EDProducer::Table<Config>;
+      explicit STMZeroSuppression(const Parameters& conf);
+
+    private:
+    void beginJob() override;
+    void produce(art::Event& e) override;
+
+    void calculateGradient(const std::vector<int16_t>& adcs);
+    void averageGradient();
+    void findPeaks();
+    void chooseStartsAndEnds(); // taking into account any overlapping data
+
+    int _verbosityLevel;
+    art::InputTag _stmWaveformDigisTag;
+    STMChannel _channel;
+
+    double _tbefore; // time before the peak [ns]
+    double _tafter; // time after the peak [ns]
+    double _threshold; // threshold
+    double _ctPerNs; // clock ticks per ns
+    unsigned int _nadcBefore; // number of samples before peak
+    unsigned int _nadcAfter; // number of samples after peak
+
+    unsigned long int _nadc; // number of ADC values in unsuppressed waveform
+    unsigned long int _window; // distance between two ADC values to calculate the gradient for
+    int _naverage; // number of ADC values to average the gradient over
+    std::vector<int16_t> _gradient; // vector to store gradient (difference between consecutive ADC values)
+    std::vector<double> _avgradient; // vector to store averaged gradient
+    std::vector<double> _avtime; // vector to store times at averaged gradient points
+    std::vector<unsigned long int> _peaks; // vector with each peak time in clock ticks
+    std::vector<size_t> _starts; // start positions of each zero-suppressed waveform
+    std::vector<size_t> _ends; // end positions of each zero-suppressed waveform
+    std::vector<size_t> _finalstarts; // start positions of each zero-suppressed waveform after taking into account overlapping data
+    std::vector<size_t> _finalends; // end positions of each zero-suppressed waveform after taking into account overlapping data
+  };
+
+  STMZeroSuppression::STMZeroSuppression(const Parameters& config )  :
+    art::EDProducer{config}
+    ,_verbosityLevel(config().verbosityLevel())
+    ,_stmWaveformDigisTag(config().stmWaveformDigisTag())
+    ,_tbefore(config().tbefore())
+    ,_tafter(config().tafter())
+    ,_threshold(config().threshold())
+    ,_ctPerNs((1.0/config().samplingFrequency())*1e3) // convert to ns
+    ,_nadcBefore(_tbefore/_ctPerNs)
+    ,_nadcAfter(_tafter/_ctPerNs)
+    ,_window(config().window())
+    ,_naverage(config().naverage())
+  {
+    consumes<STMWaveformDigiCollection>(_stmWaveformDigisTag);
+    produces<STMWaveformDigiCollection>();
+
+    _channel = STMUtils::getChannel(_stmWaveformDigisTag);
+  }
+
+  void STMZeroSuppression::beginJob() {
+  }
+
+  void STMZeroSuppression::produce(art::Event& event) {
+    // create output
+    auto waveformsHandle = event.getValidHandle<STMWaveformDigiCollection>(_stmWaveformDigisTag);
+    std::unique_ptr<STMWaveformDigiCollection> outputSTMWaveformDigis(new STMWaveformDigiCollection());
+
+    if (_verbosityLevel > 0) {
+      std::cout << "STM Zero-Suppression Algorithm Parameters:" << std::endl;
+      std::cout << "\ttbefore = " << _tbefore << " ns" << std::endl;
+      std::cout << "\ttafter = " << _tafter << " ns" << std::endl;
+      std::cout << "\tthreshold = " << _threshold << std::endl;
+    }
+
+    for (const auto& waveform : *waveformsHandle) {
+      const auto& adcs = waveform.adcs();
+      _nadc = adcs.size();
+      _gradient.clear();
+      _avgradient.clear();
+      _avtime.clear();
+      _peaks.clear();
+
+      _gradient.reserve(_nadc-_window);
+      _avgradient.reserve(_nadc-_window);
+      _avtime.reserve(_nadc-_window);
+      _peaks.reserve(_nadc-_window);
+
+      calculateGradient(adcs);
+      averageGradient();
+      findPeaks();
+      chooseStartsAndEnds();
+
+      const auto& n_zp_waveforms = _finalstarts.size();
+      for (size_t i_zp_waveform = 0; i_zp_waveform < n_zp_waveforms; ++i_zp_waveform) {
+        const auto& i_start = _finalstarts.at(i_zp_waveform);
+        const auto& i_end = _finalends.at(i_zp_waveform);
+        std::vector<int16_t> zp_adcs(waveform.adcs().begin()+i_start, waveform.adcs().begin()+i_end);
+        STMWaveformDigi stm_waveform(waveform.trigTimeOffset()+i_start, zp_adcs);
+        outputSTMWaveformDigis->push_back(stm_waveform);
+      }
+    }
+
+    if (_verbosityLevel > 0) {
+      std::cout << _channel.name() << ": " << outputSTMWaveformDigis->size() << " waveforms found" << std::endl;
+    }
+    event.put(std::move(outputSTMWaveformDigis));
+  }
+
+  void STMZeroSuppression::calculateGradient(const std::vector<int16_t>& adcs) {
+    //Calculate the time and gradient vectors
+    for(unsigned long int i=0;i<_nadc-_window;i++){
+      _gradient.push_back(adcs[i+_window]-adcs[i]);
+    }
+  }
+
+  void STMZeroSuppression::averageGradient() {
+    //Calculate the average of the gradient each _naverage ADC values to avoid fluctuations
+    unsigned long int j=0;
+    double av_gradient=0;
+    unsigned long int h=0; // will be the number of elements in the averaged gradient vector
+
+    unsigned long int n_gradient_points = _gradient.size(); // = _nadc - _window
+    while(j<n_gradient_points){
+      //Each point of the gradient and ADCtime averaged with the (_naverage-1) following points, each point is the mean of _naverage points of the gradient
+      if((j+_naverage)>(n_gradient_points)){_naverage= (n_gradient_points)-j;}
+      av_gradient=0;
+      for(int k=0;k<_naverage;k++){
+        av_gradient= av_gradient+_gradient[j+k];
+      }
+      _avgradient.push_back(av_gradient/_naverage);
+      _avtime.push_back(j);
+
+      j=j+_naverage;
+      h++;
+    }
+  }
+
+  void STMZeroSuppression::findPeaks() {
+    //Initial values
+    bool found_peak=false;
+    unsigned int peak=0;
+    unsigned int peakcounter=0;
+    unsigned long int n_avgradient_points = _avgradient.size();
+    _starts.clear();
+    _ends.clear();
+    //Store positions in clock ticks for the peaks found, fill _peaks[]
+    for(unsigned long int i=0;i<n_avgradient_points;i++){
+
+      if(_avgradient[i]>_threshold){
+        found_peak=false;
+        continue;
+      }
+      //skip the rest indexes of the peak after the peak that has already been stored
+      if((_avgradient[i]<_threshold)&&(found_peak==true)){
+        continue;
+      }
+
+      if((_avgradient[i]<_threshold)&&(found_peak==false)){
+        found_peak=true;
+        peak=_avtime[i];
+        _peaks[peakcounter]=peak;
+        if (peak<_nadcBefore) {
+          _starts.push_back(0); // too close to the start of the waveform so can't go tbefore back
+        }
+        else {
+          _starts.push_back(peak - _nadcBefore);
+        }
+        if (peak>_nadc-_nadcAfter) {
+          _ends.push_back(_nadc); // too close to the end of the waveform so can't go tafter forwaed
+        }
+        else {
+          _ends.push_back(peak + _nadcAfter);
+        }
+
+        peakcounter++;
+      }
+    }
+  }
+
+  void STMZeroSuppression::chooseStartsAndEnds() {
+    // Now go through and account for overlapped data
+    unsigned int i_peak = 0;
+    size_t current_start = _starts.at(i_peak);
+    size_t current_end = _ends.at(i_peak);
+
+    unsigned int peakcounter = _starts.size();
+    _finalstarts.clear();
+    _finalends.clear();
+    _finalstarts.reserve(peakcounter);
+    _finalends.reserve(peakcounter);
+    while (i_peak < peakcounter) {
+      if (i_peak == (peakcounter-1)) { // the final peak
+        _finalstarts.push_back(current_start);
+        _finalends.push_back(_ends.at(i_peak));
+        break;
+      }
+      else if (_starts.at(i_peak+1) <= _ends.at(i_peak)) { // peaks are overlapping
+        current_end = _ends.at(i_peak+1); // update so that we will go to the end of the second peak
+        ++i_peak;
+      }
+      else if (_starts.at(i_peak+1) > _ends.at(i_peak)) { // peaks don't overlap
+        _finalstarts.push_back(current_start);
+        _finalends.push_back(current_end);
+
+        // go to next peak
+        current_start = _starts.at(i_peak+1);
+        current_end = _ends.at(i_peak+1);
+        ++i_peak;
+      }
+    }
+  }
+}
+
+DEFINE_ART_MODULE(mu2e::STMZeroSuppression)

--- a/STMReco/test/plotZeroSuppression.C
+++ b/STMReco/test/plotZeroSuppression.C
@@ -1,0 +1,17 @@
+//
+// This example ROOT macro plots an unsuppressed STMWaveformDigi (blue) and a handful of zero-suppressed digis on top (red).
+// This ROOT macro runs on the output of Offline/STMReco/fcl/plotSTMWaveformDigis.fcl
+//
+void plotZeroSuppression(std::string filename = "stmWaveformDigis.root", int n_zp_digis_to_draw = 5) {
+
+  TFile* file = new TFile(filename.c_str(), "READ");
+
+  TH1F* hRawWaveform = (TH1F*) file->Get("plotHPGeWaveformDigis/evt1_waveform0");
+  hRawWaveform->Draw("HIST");
+
+  for (int i_zp_digi = 0; i_zp_digi < n_zp_digis_to_draw; ++i_zp_digi) {
+    TH1F* hZPWaveform = (TH1F*) file->Get(Form("plotHPGeWaveformDigisZP/evt1_waveform%d", i_zp_digi));
+    hZPWaveform->SetLineColor(kRed);
+    hZPWaveform->Draw("HIST SAME");
+  }
+}


### PR DESCRIPTION
Hi Everyone,

In this PR I:
 - add a new STM module (```STMReco/src/STMZeroSuppression_module.cc```) to perform the zero-suppression algorithm on the unsuppressed ```STMWaveformDigis```
    - note that the output data product type is the same as the input data product type
 - add a fcl file to run the zero suppression
    - note that I am defining the ```samplingFrequency``` parameter in fcl. This is used to convert from clock ticks to nanoseconds and, in the test beam data, the HPGe and LaBr data have different sampling frequencies. In the real experiment, they will have the same sampling frequency and I guess will be defined in a database somewhere
 - update ```PlotSTMWaveformDigis``` module and its fcl file to take advantage of the clock tick to nanosecond conversion so that we can plot zero-suppressed waveforms on top of the unsuppressed waveform
     - I also added an example macro that can be used to make such a plot

Once this is merged in, I will work on the Moving Window Deconvolution (MWD) algorithm, which will require a new data product.

Let me know if you have any questions or comments

Thanks,
Andy