### PR TITLE
Move STM Sampling Frequency to Proditions

### DIFF
--- a/STMConditions/fcl/prolog.fcl
+++ b/STMConditions/fcl/prolog.fcl
@@ -4,6 +4,7 @@ STMEnergyCalib : {
    useDb : false
    verbose : 0
    pedestals : [ ["HPGe",0.0], ["LaBr",0.0] ]
+   samplingFrequencies : [ ["HPGe",1.0], ["LaBr",1.0] ]
 }
 
 END_PROLOG

--- a/STMConditions/inc/STMEnergyCalib.hh
+++ b/STMConditions/inc/STMEnergyCalib.hh
@@ -20,9 +20,10 @@ class STMEnergyCalib : virtual public ProditionsEntity {
 
   typedef std::map<STMChannel, STMEnergyCorr> CalibMap;
   typedef std::map<STMChannel, float> PedestalMap;
+  typedef std::map<STMChannel, float> SamplingFrequencyMap;
 
-  STMEnergyCalib(CalibMap const& cmap, PedestalMap const& pmap) :
-      ProditionsEntity(cxname), _cmap(cmap), _pmap(pmap) {}
+  STMEnergyCalib(CalibMap const& cmap, PedestalMap const& pmap, SamplingFrequencyMap const& sfmap) :
+    ProditionsEntity(cxname), _cmap(cmap), _pmap(pmap), _sfmap(sfmap) {}
 
   // the calibration struct for a given channel
   STMEnergyCorr const& calib(STMChannel const& channel) const {
@@ -30,10 +31,15 @@ class STMEnergyCalib : virtual public ProditionsEntity {
   }
 
   float pedestal(STMChannel const& channel) const { return _pmap.at(channel); }
+  float samplingFrequency(STMChannel const& channel) const { return _sfmap.at(channel); }
+
+  void setCalib(CalibMap cmap) { _cmap = cmap; }
+  void setPedestal(PedestalMap pmap) { _pmap = pmap; }
 
  private:
   CalibMap _cmap;
   PedestalMap _pmap;
+  SamplingFrequencyMap _sfmap;
 };
 
 }  // namespace mu2e

--- a/STMConfig/inc/STMEnergyCalibConfig.hh
+++ b/STMConfig/inc/STMEnergyCalibConfig.hh
@@ -19,6 +19,9 @@ struct STMEnergyCalibConfig {
   fhicl::Sequence<fhicl::Tuple<std::string, float>, 2> pedestals{
       Name("pedestals"),
       Comment("sequence of tuples of channel_name and value")};
+  fhicl::Sequence<fhicl::Tuple<std::string, float>, 2> samplingFrequencies{
+      Name("samplingFrequencies"),
+      Comment("sequence of tuples of channel_name and value")};
 };
 
 }  // namespace mu2e

--- a/STMReco/fcl/plotSTMWaveformDigis.fcl
+++ b/STMReco/fcl/plotSTMWaveformDigis.fcl
@@ -4,6 +4,7 @@
 
 #include "Offline/fcl/standardServices.fcl"
 #include "Offline/STMReco/fcl/prolog.fcl"
+#include "Offline/STMReco/fcl/prolog_testbeam.fcl"
 
 process_name: PlotSTMWaveformDigis
 
@@ -26,7 +27,6 @@ physics: {
       subtractPedestal : false
       verbosityLevel : 0
       xAxis : "event_time"
-      samplingFrequency : @local::STM.HPGe.samplingFrequency
     }
     plotLaBrWaveformDigis : {
       module_type : PlotSTMWaveformDigis
@@ -34,7 +34,6 @@ physics: {
       subtractPedestal : false
       verbosityLevel : 0
       xAxis : "event_time"
-      samplingFrequency : @local::STM.LaBr.samplingFrequency
     }
 
     plotHPGeWaveformDigisZP : {
@@ -43,7 +42,6 @@ physics: {
       subtractPedestal : false
       verbosityLevel : 0
       xAxis : "event_time"
-      samplingFrequency : @local::STM.HPGe.samplingFrequency
     }
     plotLaBrWaveformDigisZP : {
       module_type : PlotSTMWaveformDigis
@@ -51,7 +49,6 @@ physics: {
       subtractPedestal : false
       verbosityLevel : 0
       xAxis : "event_time"
-      samplingFrequency : @local::STM.LaBr.samplingFrequency
     }
   }
   # setup paths
@@ -63,3 +60,5 @@ physics: {
 
 # Can define pedestals in fcl like the commented line below
 # services.ProditionsService.stmEnergyCalib.pedestals : [ ["HPGe",100.0], ["LaBr",2000.0] ]
+
+services.ProditionsService.stmEnergyCalib.samplingFrequencies : @local::STMTestBeam.Conditions.samplingFrequencies

--- a/STMReco/fcl/prolog.fcl
+++ b/STMReco/fcl/prolog.fcl
@@ -1,15 +1,11 @@
 #
 # prolog.fcl for fcl paramaters that will be used in STM modules
 #
-# Some notes:
-# - The sampling frequency in different for the HPGe and LaBr in the test beam. In the real experiment this will not be the case.
-#
 BEGIN_PROLOG
 
 STM : {
 
   HPGe : {
-    samplingFrequency : 320.0520833313 # MHz - will probably end up in a DB somewhere
     # zero-suppression parameters
     tbefore : 2000 # ns
     tafter : 10000 # ns
@@ -18,7 +14,6 @@ STM : {
     naverage : 5
   }
   LaBr : {
-    samplingFrequency : 370.370370370 # MHz - will probably end up in a DB somewhere
     # zero-suppression parameters
     tbefore : 2000 # ns
     tafter : 10000 # ns

--- a/STMReco/fcl/prolog_testbeam.fcl
+++ b/STMReco/fcl/prolog_testbeam.fcl
@@ -1,0 +1,15 @@
+#
+# prolog for fcl parameters specific to the test beam
+#
+# Some notes:
+# - The sampling frequency in different for the HPGe and LaBr in the test beam. In the real experiment this will not be the case.
+#
+BEGIN_PROLOG
+
+STMTestBeam : {
+  Conditions : {
+    samplingFrequencies : [ ["HPGe",320.0520833313], ["LaBr",370.370370370] ]
+  }
+}
+
+END_PROLOG

--- a/STMReco/fcl/zeroSuppression.fcl
+++ b/STMReco/fcl/zeroSuppression.fcl
@@ -12,7 +12,7 @@ source : {
 }
 
 services : {
-  message : { @table::Services.Core.message }
+  @table::Services.Core
 }
 
 physics: {
@@ -20,7 +20,6 @@ physics: {
     zeroSuppressHPGe : {
       module_type : STMZeroSuppression
       stmWaveformDigisTag : "FromSTMTestBeamData:HPGe"
-      samplingFrequency : @local::STM.HPGe.samplingFrequency
       tbefore : @local::STM.HPGe.tbefore
       tafter : @local::STM.HPGe.tafter
       threshold : @local::STM.HPGe.threshold
@@ -32,7 +31,6 @@ physics: {
     zeroSuppressLaBr : {
       module_type : STMZeroSuppression
       stmWaveformDigisTag : "FromSTMTestBeamData:LaBr"
-      samplingFrequency : @local::STM.LaBr.samplingFrequency
       tbefore : @local::STM.LaBr.tbefore
       tafter : @local::STM.LaBr.tafter
       threshold : @local::STM.LaBr.threshold

--- a/STMReco/fcl/zeroSuppression_testbeam.fcl
+++ b/STMReco/fcl/zeroSuppression_testbeam.fcl
@@ -1,0 +1,4 @@
+#include "Offline/STMReco/fcl/prolog_testbeam.fcl"
+#include "Offline/STMReco/fcl/zeroSuppression.fcl"
+
+services.ProditionsService.stmEnergyCalib.samplingFrequencies : @local::STMTestBeam.Conditions.samplingFrequencies

--- a/STMReco/src/PlotSTMWaveformDigis_module.cc
+++ b/STMReco/src/PlotSTMWaveformDigis_module.cc
@@ -36,7 +36,6 @@ namespace mu2e {
         fhicl::Atom<bool> subtractPedestal{ Name("subtractPedestal"), Comment("True/False whether to subtract the pedestal before plotting")};
         fhicl::Atom<std::string> xAxis{ Name("xAxis"), Comment("Choice of x-axis unit: \"sample_number\", \"waveform_time\", or \"event_time\"") };
         fhicl::Atom<int> verbosityLevel{ Name("verbosityLevel"), Comment("Verbosity level")};
-        fhicl::Atom<double> samplingFrequency{ Name("samplingFrequency"), Comment("Sampling Frequency of ADC [MHz]")};
       };
       using Parameters = art::EDAnalyzer::Table<Config>;
       explicit PlotSTMWaveformDigis(const Parameters& conf);
@@ -58,8 +57,7 @@ namespace mu2e {
     _stmWaveformDigisTag(config().stmWaveformDigisTag()),
     _subtractPedestal(config().subtractPedestal()),
     _xAxis(config().xAxis()),
-    _verbosityLevel(config().verbosityLevel()),
-    _nsPerCt((1.0/config().samplingFrequency())*1e3) // convert to ns
+    _verbosityLevel(config().verbosityLevel())
   {
     consumes<STMWaveformDigiCollection>(_stmWaveformDigisTag);
     _channel = STMUtils::getChannel(_stmWaveformDigisTag);
@@ -77,6 +75,9 @@ namespace mu2e {
     if (_verbosityLevel > 0) {
       std::cout << _channel.name() << " Pedestal = " << pedestal << std::endl;
     }
+
+    const auto samplingFrequency = stmEnergyCalib.samplingFrequency(_channel);
+    _nsPerCt = (1.0/samplingFrequency)*1e3;
 
     for (const auto& waveform : *waveformsHandle) {
       histname.str("");

--- a/STMReco/src/STMZeroSuppression_module.cc
+++ b/STMReco/src/STMZeroSuppression_module.cc
@@ -218,33 +218,35 @@ namespace mu2e {
 
   void STMZeroSuppression::chooseStartsAndEnds() {
     // Now go through and account for overlapped data
-    unsigned int i_peak = 0;
-    size_t current_start = _starts.at(i_peak);
-    size_t current_end = _ends.at(i_peak);
+    if (_starts.size() != 0) { // need to be careful just in case there were no peaks found (i.e. just noise)
+      unsigned int i_peak = 0;
+      size_t current_start = _starts.at(i_peak);
+      size_t current_end = _ends.at(i_peak);
 
-    unsigned int peakcounter = _starts.size();
-    _finalstarts.clear();
-    _finalends.clear();
-    _finalstarts.reserve(peakcounter);
-    _finalends.reserve(peakcounter);
-    while (i_peak < peakcounter) {
-      if (i_peak == (peakcounter-1)) { // the final peak
-        _finalstarts.push_back(current_start);
-        _finalends.push_back(_ends.at(i_peak));
-        break;
-      }
-      else if (_starts.at(i_peak+1) <= _ends.at(i_peak)) { // peaks are overlapping
-        current_end = _ends.at(i_peak+1); // update so that we will go to the end of the second peak
-        ++i_peak;
-      }
-      else if (_starts.at(i_peak+1) > _ends.at(i_peak)) { // peaks don't overlap
-        _finalstarts.push_back(current_start);
-        _finalends.push_back(current_end);
+      unsigned int peakcounter = _starts.size();
+      _finalstarts.clear();
+      _finalends.clear();
+      _finalstarts.reserve(peakcounter);
+      _finalends.reserve(peakcounter);
+      while (i_peak < peakcounter) {
+        if (i_peak == (peakcounter-1)) { // the final peak
+          _finalstarts.push_back(current_start);
+          _finalends.push_back(_ends.at(i_peak));
+          break;
+        }
+        else if (_starts.at(i_peak+1) <= _ends.at(i_peak)) { // peaks are overlapping
+          current_end = _ends.at(i_peak+1); // update so that we will go to the end of the second peak
+          ++i_peak;
+        }
+        else if (_starts.at(i_peak+1) > _ends.at(i_peak)) { // peaks don't overlap
+          _finalstarts.push_back(current_start);
+          _finalends.push_back(current_end);
 
-        // go to next peak
-        current_start = _starts.at(i_peak+1);
-        current_end = _ends.at(i_peak+1);
-        ++i_peak;
+          // go to next peak
+          current_start = _starts.at(i_peak+1);
+          current_end = _ends.at(i_peak+1);
+          ++i_peak;
+        }
       }
     }
   }


### PR DESCRIPTION
After discussing with Ray, we decided that the sampling frequency parameter that is used in the STMZeroSuppression module should move to the ProditionsService for the time being. We also decided that this would just be defined in fcl and not yet put in a database table. At the moment, the STM test beam data has a different sampling frequency for different detectors; in the real experiment, these will be the same.