### PR TITLE
removed the default configurations of the filters used in the trigger sequences from the TrkFilers/fcl/prolog_trigger file

### DIFF
--- a/DAQ/src/CaloHitsFromFragments_module.cc
+++ b/DAQ/src/CaloHitsFromFragments_module.cc
@@ -145,7 +145,7 @@ void art::CaloHitsFromFragments::addPulse(
       float eMean  = (eDep+pulse.energyDep())/2.0;
       float sigmaR = 0.707*sqrt(1.0/eMean/nPEperMeV_ + noise2_/eMean/eMean);
 
-      if (abs(ratio) > nSigmaNoise_*sigmaR) {
+      if (abs(ratio) <= nSigmaNoise_*sigmaR) {
         // combine the pulses
         pulse.setTime((pulse.time() + time) / 2.); // probably not necessary
         pulse.setEDep((pulse.energyDep() + eDep) / 2.);

--- a/DAQ/src/FragmentAna_module.cc
+++ b/DAQ/src/FragmentAna_module.cc
@@ -162,7 +162,7 @@ void FragmentAna::analyze(const art::Event& event) {
             analyze_calorimeter_(cc);
 
             totalSize += pair.second;
-            numTrkFrags++;
+            numCalFrags++;
           }
         }
       }

--- a/GeneralUtilities/inc/PhiPrescalingParams.hh
+++ b/GeneralUtilities/inc/PhiPrescalingParams.hh
@@ -1,7 +1,7 @@
 #ifndef GeneralUtilities_PhiPrescalingParams_hh
 #define GeneralUtilities_PhiPrescalingParams_hh
 
-#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/OptionalAtom.h"
 
 namespace mu2e {
   struct PhiPrescalingParams {
@@ -10,9 +10,9 @@ namespace mu2e {
     float    _phase;
 
     struct Config {
-      fhicl::Atom<float> amplitude{fhicl::Name("amplitude"), fhicl::Comment("amplitude"), 0.};
-      fhicl::Atom<float> frequency{fhicl::Name("frequency"), fhicl::Comment("frequency"), 0.};
-      fhicl::Atom<float> phase    {fhicl::Name("phase"),     fhicl::Comment("phase"), 0.};
+      fhicl::OptionalAtom<float> amplitude{fhicl::Name("amplitude"), fhicl::Comment("amplitude")};
+      fhicl::OptionalAtom<float> frequency{fhicl::Name("frequency"), fhicl::Comment("frequency")};
+      fhicl::OptionalAtom<float> phase    {fhicl::Name("phase"),     fhicl::Comment("phase")};
     };
 
     PhiPrescalingParams():
@@ -25,10 +25,12 @@ namespace mu2e {
       _frequency(Frequency),
       _phase    (Phase) {}
 
-    PhiPrescalingParams(const Config& conf):
-      _amplitude(conf.amplitude()),
-      _frequency(conf.frequency()),
-      _phase    (conf.phase()) {}
+    PhiPrescalingParams(const Config& conf){
+      float x;
+      if (conf.amplitude(x)) _amplitude = x;
+      if (conf.frequency(x)) _frequency = x;
+      if (conf.phase(x))     _phase     = x;
+    }
   };
 
 }

--- a/GeneralUtilities/inc/PhiPrescalingParams.hh
+++ b/GeneralUtilities/inc/PhiPrescalingParams.hh
@@ -10,9 +10,9 @@ namespace mu2e {
     float    _phase;
 
     struct Config {
-      fhicl::Atom<float> amplitude{fhicl::Name("amplitude"), fhicl::Comment("amplitude")};
-      fhicl::Atom<float> frequency{fhicl::Name("frequency"), fhicl::Comment("frequency")};
-      fhicl::Atom<float> phase    {fhicl::Name("phase"),     fhicl::Comment("phase")};
+      fhicl::Atom<float> amplitude{fhicl::Name("amplitude"), fhicl::Comment("amplitude"), 0.};
+      fhicl::Atom<float> frequency{fhicl::Name("frequency"), fhicl::Comment("frequency"), 0.};
+      fhicl::Atom<float> phase    {fhicl::Name("phase"),     fhicl::Comment("phase"), 0.};
     };
 
     PhiPrescalingParams():

--- a/Trigger/data/cprDeM_highP_stopTarg/main_cprDeM_highP_stopTarg_hsFilter.fcl
+++ b/Trigger/data/cprDeM_highP_stopTarg/main_cprDeM_highP_stopTarg_hsFilter.fcl
@@ -1,5 +1,6 @@
 physics.filters.cprDeMHighPStopTargHSFilter.requireCaloCluster   : false
 physics.filters.cprDeMHighPStopTargHSFilter.doHelicityCheck  : true
+physics.filters.cprDeMHighPStopTargHSFilter.helicity      : 1
 physics.filters.cprDeMHighPStopTargHSFilter.minNStrawHits : 15.0
 physics.filters.cprDeMHighPStopTargHSFilter.minHitRatio   : 0.4
 physics.filters.cprDeMHighPStopTargHSFilter.minMomentum   : 80.0

--- a/Trigger/data/tprHelixDeM_ipa_phiScaled/main_tprHelixDeM_ipa_phiScaled_hsFilter.fcl
+++ b/Trigger/data/tprHelixDeM_ipa_phiScaled/main_tprHelixDeM_ipa_phiScaled_hsFilter.fcl
@@ -1,5 +1,6 @@
 physics.filters.tprHelixDeMIpaPhiScaledHSFilter.requireCaloCluster   : false
 physics.filters.tprHelixDeMIpaPhiScaledHSFilter.doHelicityCheck      : true
+physics.filters.tprHelixDeMIpaPhiScaledHSFilter.helicity      : 1
 physics.filters.tprHelixDeMIpaPhiScaledHSFilter.minNStrawHits : 15
 physics.filters.tprHelixDeMIpaPhiScaledHSFilter.minHitRatio   : 0.5
 physics.filters.tprHelixDeMIpaPhiScaledHSFilter.minMomentum   : 30.

--- a/Trigger/fcl/prolog_trigger.fcl
+++ b/Trigger/fcl/prolog_trigger.fcl
@@ -183,11 +183,11 @@ Trigger : {
         triggerOutput : {
             module_type: RootOutput
             fileName: "filteredOutput.root"
-            SelectEvents : [ unbiasedTrigger,
-                             minBiasSDCountTrigger,
-                             largeSDCountTrigger,
-                             caloMVACETrigger,
-                             tprDeMHighPStopTargTrigger, tprDePHighPStopTargTrigger, cprDeMHighPStopTargTrigger, cprDePHighPStopTargTrigger ]
+            SelectEvents : [
+                            "tpr*",
+                            "cpr*",
+                            "calo*"
+                           ]
 #            Compressionlevel: 0
             # fileProperties : {
             #         maxEvents : 1000

--- a/TrkFilters/fcl/prolog_trigger.fcl
+++ b/TrkFilters/fcl/prolog_trigger.fcl
@@ -70,32 +70,26 @@ TrkFilters : {
     cprDeMTCFilter : {
       module_type : TimeClusterFilter
       timeClusterCollection : "TTCalTimePeakFinder"
-      minNStrawHits              : 1  #just check if there are TimeClusters
     }
     cprDePTCFilter : {
       module_type : TimeClusterFilter
       timeClusterCollection : "TTCalTimePeakFinder"
-      minNStrawHits              : 1  #just check if there are TimeClusters
     }
     cprHelixDeMTCFilter : {
       module_type : TimeClusterFilter
       timeClusterCollection : "TTCalTimePeakFinder"
-      minNStrawHits              : 1  #just check if there are TimeClusters
     }
     cprHelixDePTCFilter : {
       module_type : TimeClusterFilter
       timeClusterCollection : "TTCalTimePeakFinder"
-      minNStrawHits              : 1  #just check if there are TimeClusters
     }
     cprHelixUeMTCFilter : {
       module_type : TimeClusterFilter
       timeClusterCollection : "TTCalTimePeakFinderUe"
-      minNStrawHits              : 1  #just check if there are TimeClusters
     }
     cprHelixUePTCFilter : {
       module_type : TimeClusterFilter
       timeClusterCollection : "TTCalTimePeakFinderUe"
-      minNStrawHits              : 1  #just check if there are TimeClusters
     }
 
     #low p particles from the ST
@@ -110,12 +104,10 @@ TrkFilters : {
     cprDeMLowPStopTargTCFilter : {
       module_type : TimeClusterFilter
       timeClusterCollection : "TTCalTimePeakFinder"
-      minNStrawHits              : 1  #just check if there are TimeClusters
     }
     cprDePLowPStopTargTCFilter : {
       module_type : TimeClusterFilter
       timeClusterCollection : "TTCalTimePeakFinder"
-      minNStrawHits              : 1  #just check if there are TimeClusters
     }
 
     #fast sequcnes that process only the ComboHits in time with the calo-cluster with E>50MeV
@@ -130,12 +122,10 @@ TrkFilters : {
     cprSeedUCCDeMTCFilter : {
       module_type : TimeClusterFilter
       timeClusterCollection : "TTCalTimePeakFinderUCC"
-      minNStrawHits              : 1  #just check if there are TimeClusters
     }
     cprSeedUCCDePTCFilter : {
       module_type : TimeClusterFilter
       timeClusterCollection : "TTCalTimePeakFinderUCC"
-      minNStrawHits              : 1  #just check if there are TimeClusters
     }
 
     #e- from the IPA
@@ -157,281 +147,73 @@ TrkFilters : {
     tprDeMHighPStopTargHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 70.
-      maxMomentum         : 120.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 140.
-      maxAbsLambda        : 300.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     tprDePHighPStopTargHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerDeP"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 60.
-      maxMomentum         : 140.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 100.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
 
     cprDeMHighPStopTargHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 80.
-      maxMomentum         : 140.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 350.
-      minD0               : -350.
-      minAbsLambda        : 140.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     cprDePHighPStopTargHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixMergerDeP"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 60.
-      maxMomentum         : 140.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 100.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
 
     # cosmic tracks e-/e+ not from the ST
     tprDeMHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 50.
-      maxMomentum         : 70.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 140.
-      maxAbsLambda        : 300.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     tprDePHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerDeP"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 40.
-      maxMomentum         : 60.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 100.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
 
     cprDeMHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 60.
-      maxMomentum         : 80.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 350.
-      minD0               : -350.
-      minAbsLambda        : 140.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     cprDePHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixMergerDeP"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 50.
-      maxMomentum         : 60.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 100.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
 
     #cosmic helix: HS filters
     tprHelixDeMHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 50.
-      maxMomentum         : 70.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 140.
-      maxAbsLambda        : 300.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     tprHelixDePHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerDeP"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 40.
-      maxMomentum         : 60.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 100.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     tprHelixUeMHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerUeM"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 50.
-      maxMomentum         : 70.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 140.
-      maxAbsLambda        : 300.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     tprHelixUePHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerUeP"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 40.
-      maxMomentum         : 60.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 100.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
 
     cprHelixDeMHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 60.
-      maxMomentum         : 80.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 350.
-      minD0               : -350.
-      minAbsLambda        : 140.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     cprHelixDePHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixMergerDeP"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 50.
-      maxMomentum         : 60.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 100.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     cprHelixUeMHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixMergerUeM"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 40.
-      maxMomentum         : 500.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 800.
-      minD0               : -800.
-      minAbsLambda        : 50.
-      maxAbsLambda        : 1000.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     cprHelixUePHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixMergerUeP"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 40.
-      maxMomentum         : 500.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 800.
-      minD0               : -800.
-      minAbsLambda        : 50.
-      maxAbsLambda        : 1000.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
 
 
@@ -439,179 +221,49 @@ TrkFilters : {
     tprDeMLowPStopTargHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 50.
-      maxMomentum         : 70.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 140.
-      maxAbsLambda        : 300.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     tprDePLowPStopTargHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerDeP"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 40.
-      maxMomentum         : 60.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 100.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
 
     cprDeMLowPStopTargHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 60.
-      maxMomentum         : 80.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 350.
-      minD0               : -350.
-      minAbsLambda        : 140.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     cprDePLowPStopTargHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixMergerDeP"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 50.
-      maxMomentum         : 60.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 100.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
 
     # filters that uses the combohit collection filtered with the calorimeter info
     tprSeedUCCDeMHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixUCCMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 70.
-      maxMomentum         : 120.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 140.
-      maxAbsLambda        : 300.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     tprSeedUCCDePHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixUCCMergerDeP"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 60.
-      maxMomentum         : 140.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 100.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
 
     cprSeedUCCDeMHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixUCCMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 80.
-      maxMomentum         : 140.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 350.
-      minD0               : -350.
-      minAbsLambda        : 140.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
     cprSeedUCCDePHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTCalHelixUCCMergerDeP"
-      helicity            : -1
-      minNStrawHits       : 15
-      minMomentum         : 60.
-      maxMomentum         : 140.
-      minPt               : 0
-      maxChi2XY           : 5.
-      maxChi2PhiZ         : 5.
-      maxD0               : 300.
-      minD0               : -150.
-      minAbsLambda        : 100.
-      maxAbsLambda        : 330.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
 
 
     tprHelixDeMIpaHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 30.
-      maxMomentum         : 70.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 500.
-      minD0               : 200.
-      minAbsLambda        : 40.
-      maxAbsLambda        : 80.
-      prescaleUsingD0Phi  : false
-      prescalerPar        : { amplitude: 0 frequency : 0 phase : 0}
     }
 
     tprHelixDeMIpaPhiScaledHSFilter : {
       module_type : HelixFilter
       helixSeedCollection : "TTHelixMergerDeM"
-      helicity            : 1
-      minNStrawHits       : 15
-      minMomentum         : 30.
-      maxMomentum         : 70.
-      minPt               : 0
-      maxChi2XY           : 8.
-      maxChi2PhiZ         : 8.
-      maxD0               : 500.
-      minD0               : 200.
-      minAbsLambda        : 40.
-      maxAbsLambda        : 80.
-      prescaleUsingD0Phi  : true
-      prescalerPar        : { amplitude: 6.2 frequency : 0.9675 phase : 0.1396}
     }
 
 
@@ -619,87 +271,33 @@ TrkFilters : {
     tprDeMHighPStopTargTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTKSFDeM"
-      fitparticle       : @local::Particle.eminus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 80.
-      maxMomentum       : 200.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     cprDeMHighPStopTargTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTCalSeedFitDem"
-      fitparticle       : @local::Particle.eminus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 80.
-      maxMomentum       : 200.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     #cosmic tracks e-/e+
     tprDeMTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTKSFDeM"
-      fitparticle       : @local::Particle.eminus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 60.
-      maxMomentum       : 80.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     cprDeMTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTCalSeedFitDem"
-      fitparticle       : @local::Particle.eminus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 60.
-      maxMomentum       : 80.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     #low P e-/e+ from the ST
     tprDeMLowPStopTargTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTKSFDeM"
-      fitparticle       : @local::Particle.eminus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 60.
-      maxMomentum       : 80.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     cprDeMLowPStopTargTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTCalSeedFitDem"
-      fitparticle       : @local::Particle.eminus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 60.
-      maxMomentum       : 80.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
 
@@ -707,29 +305,11 @@ TrkFilters : {
     tprSeedUCCDeMTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTKSFUCCDeM"
-      fitparticle       : @local::Particle.eminus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 80.
-      maxMomentum       : 200.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     cprSeedUCCDeMTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTCalSeedFitUCCDem"
-      fitparticle       : @local::Particle.eminus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 80.
-      maxMomentum       : 200.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
     tprDeMHighPStopTargKFFilter : {
       module_type : SeedFilter
@@ -739,29 +319,11 @@ TrkFilters : {
     tprDePHighPStopTargTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTKSFDeP"
-      fitparticle       : @local::Particle.eplus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 70.
-      maxMomentum       : 110.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     cprDePHighPStopTargTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTCalSeedFitDep"
-      fitparticle       : @local::Particle.eplus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 70.
-      maxMomentum       : 110.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
 
@@ -769,58 +331,22 @@ TrkFilters : {
     tprDePTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTKSFDeP"
-      fitparticle       : @local::Particle.eplus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 50.
-      maxMomentum       : 70.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     cprDePTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTCalSeedFitDep"
-      fitparticle       : @local::Particle.eplus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 50.
-      maxMomentum       : 70.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     #low P e-/e+ from the ST
     tprDePLowPStopTargTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTKSFDeP"
-      fitparticle       : @local::Particle.eplus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 50.
-      maxMomentum       : 70.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     cprDePLowPStopTargTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTCalSeedFitDep"
-      fitparticle       : @local::Particle.eplus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 50.
-      maxMomentum       : 70.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
 
@@ -828,29 +354,11 @@ TrkFilters : {
     tprSeedUCCDePTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTKSFUCCDeP"
-      fitparticle       : @local::Particle.eplus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 70.
-      maxMomentum       : 110.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     cprSeedUCCDePTSFilter : {
       module_type : SeedFilter
       kalSeedCollection : "TTCalSeedFitUCCDep"
-      fitparticle       : @local::Particle.eplus
-      fitdirection      : @local::FitDir.downstream
-      minNStrawHits     : 15
-      minMomentum       : 70.
-      maxMomentum       : 110.     #don't apply cut
-      maxChi2DOF        : 20.      #don't apply cut
-      maxMomErr         : 10.      #don't apply cut
-      minD0             : -200.
-      maxD0             : 200.
     }
 
     tprDePHighPStopTargKFFilter : {
@@ -870,125 +378,55 @@ TrkFilters : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     tprTimeClusterDePSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
     tprHelixDeMSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     tprHelixDePSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     tprHelixDeMIpaSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
     tprHelixDeMIpaPhiScaledSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
     tprDeMHighPStopTargSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     tprDePHighPStopTargSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
     cprDeMHighPStopTargSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     cprDePHighPStopTargSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
     #SD counter filter for comisc track triggers
@@ -997,50 +435,22 @@ TrkFilters : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     tprDePSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
     cprDeMSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     cprDePSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
     #cosmic cpr helix
@@ -1048,74 +458,32 @@ TrkFilters : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     tprHelixDePSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     tprHelixUeMSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     tprHelixUePSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
     cprHelixDeMSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     cprHelixDePSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
 
@@ -1124,50 +492,22 @@ TrkFilters : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     tprDePLowPStopTargSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
     cprDeMLowPStopTargSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     cprDePLowPStopTargSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
 
@@ -1175,50 +515,22 @@ TrkFilters : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     tprSeedUCCDePSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
 
     cprSeedUCCDeMSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     cprSeedUCCDePSDCountFilter     : {
       module_type : DigiFilter
       strawDigiCollection : makeSD
       caloDigiCollection  : notUsed
-      useStrawDigi        : true
-      useCaloDigi         : false
-      minNStrawDigi       : 10
-      maxNStrawDigi       : 10000
-      minNCaloDigi        : -1
-      maxNCaloDigi        : -1
-      maxCaloEnergy       : -1
     }
     #  Prescaling filters
     #follow the prescaler filters for Tpr Track sequences
@@ -1226,94 +538,67 @@ TrkFilters : {
     #filters for the paths where decision is made using the TimeCluster
     tprTimeClusterDeMEventPrescale : {
       module_type : PrescaleEvent
-      nPrescale     : 1
     }
     tprTimeClusterDeMPrescale : {
       module_type : PrescaleEvent
-      nPrescale : 1000
-      useFilteredEvents : true
     }
     tprTimeClusterDePEventPrescale : {
       module_type : PrescaleEvent
-      nPrescale     : 1
     }
     tprTimeClusterDePPrescale : {
       module_type : PrescaleEvent
-      nPrescale : 1000
-      useFilteredEvents : true
     }
 
     #filters for the paths where decision is made using the HelixSeed
     tprHelixDeMEventPrescale : {
       module_type : PrescaleEvent
-      nPrescale     : 1
     }
     tprHelixDeMPrescale : {
       module_type : PrescaleEvent
-      useFilteredEvents : true
-      nPrescale         : 300
     }
     tprHelixDePEventPrescale : {
       module_type : PrescaleEvent
-      nPrescale     : 1
     }
     tprHelixDePPrescale : {
       module_type : PrescaleEvent
-      useFilteredEvents : true
-      nPrescale         : 300
     }
     tprHelixDeMIpaEventPrescale : {
       module_type : PrescaleEvent
-      nPrescale     : 1
     }
     tprHelixDeMIpaPrescale : {
       module_type : PrescaleEvent
-      useFilteredEvents : true
-      nPrescale         : 300
     }
 
     tprHelixDeMIpaPhiScaledEventPrescale : {
       module_type : PrescaleEvent
-      nPrescale     : 1
     }
     tprHelixDeMIpaPhiScaledPrescale : {
       module_type : PrescaleEvent
-      useFilteredEvents : true
-      nPrescale         : 300
     }
 
     #filters for the paths where decision is made using the TrackSeed
     tprDeMHighPStopTargEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     tprDeMHighPStopTargPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     tprDePHighPStopTargEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
     tprDePHighPStopTargPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
 
     tprDeMEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     tprDeMPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     tprDePEventPrescale: {
@@ -1322,191 +607,143 @@ TrkFilters : {
     }
     tprDePPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     #cosmic tpr helix
     tprHelixDeMEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     tprHelixDePEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     tprHelixUeMEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     tprHelixUePEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     # low p particles
     tprDeMLowPStopTargEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     tprDeMLowPStopTargPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     tprDePLowPStopTargEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
     tprDePLowPStopTargPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
 
     #follow the prescaler filters for Tpr Track sequences
     cprDeMHighPStopTargEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     cprDeMHighPStopTargPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     cprDePHighPStopTargEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     cprDePHighPStopTargPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     cprDePLowPStopTargPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     cprDePLowPStopTargEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     cprDeMLowPStopTargPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     cprDeMLowPStopTargEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     #cosmic tracks
     cprDeMPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     cprDeMEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     cprDePPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     cprDePEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     #cosmic helixes
     cprHelixDeMEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     cprHelixUeMEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     cprHelixDePPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     cprHelixDePEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     cprHelixUePEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     #prescaler for the sequences that use the combohit collection filtered with the calorimeter cluster
     tprSeedUCCDeMEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     tprSeedUCCDeMPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     tprSeedUCCDePEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
     tprSeedUCCDePPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     #follow the prescaler filters for Tpr Track sequences
     cprSeedUCCDeMEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
 
     cprSeedUCCDeMPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
     cprSeedUCCDePEventPrescale: {
       module_type : PrescaleEvent
-      nPrescale         : 1
     }
     cprSeedUCCDePPrescale : {
       module_type : PrescaleEvent
-      nPrescale         : 1
-      useFilteredEvents : true
     }
 
   }

--- a/TrkFilters/src/HelixFilter_module.cc
+++ b/TrkFilters/src/HelixFilter_module.cc
@@ -59,7 +59,7 @@ namespace mu2e
         fhicl::Atom<double>             minNLoops            {     Name("minNLoops"),               Comment("minNLoops      ") };
         fhicl::Sequence<std::string>    helixFitFlag         {     Name("helixFitFlag"),            Comment("helixFitFlag   "), std::vector<std::string>{"HelixOK"} };
         fhicl::Atom<int>                debugLevel           {     Name("debugLevel"),              Comment("debugLevel")     , 0 };
-        fhicl::Atom<bool>               prescaleUsingD0Phi   {     Name("prescaleUsingD0Phi"),      Comment("prescaleUsingD0Phi") };
+        fhicl::Atom<bool>               prescaleUsingD0Phi   {     Name("prescaleUsingD0Phi"),      Comment("prescaleUsingD0Phi"), false };
         fhicl::Table<PhiPrescalingParams::Config>             prescalerPar{     Name("prescalerPar"),      Comment("prescalerPar") };
       };
 

--- a/TrkFilters/src/HelixFilter_module.cc
+++ b/TrkFilters/src/HelixFilter_module.cc
@@ -4,6 +4,7 @@
 //
 // framework
 #include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/OptionalAtom.h"
 #include "fhiclcpp/types/Sequence.h"
 #include "art/Framework/Core/EDFilter.h"
 #include "art/Framework/Principal/Event.h"
@@ -59,7 +60,7 @@ namespace mu2e
         fhicl::Atom<double>             minNLoops            {     Name("minNLoops"),               Comment("minNLoops      ") };
         fhicl::Sequence<std::string>    helixFitFlag         {     Name("helixFitFlag"),            Comment("helixFitFlag   "), std::vector<std::string>{"HelixOK"} };
         fhicl::Atom<int>                debugLevel           {     Name("debugLevel"),              Comment("debugLevel")     , 0 };
-        fhicl::Atom<bool>               prescaleUsingD0Phi   {     Name("prescaleUsingD0Phi"),      Comment("prescaleUsingD0Phi"), false };
+        fhicl::OptionalAtom<bool>       prescaleUsingD0Phi   {     Name("prescaleUsingD0Phi"),      Comment("prescaleUsingD0Phi") };
         fhicl::Table<PhiPrescalingParams::Config>             prescalerPar{     Name("prescalerPar"),      Comment("prescalerPar") };
       };
 
@@ -120,13 +121,18 @@ namespace mu2e
     _minlambda         (config().minAbsLambda()),
     _maxnloops         (config().maxNLoops()),
     _minnloops         (config().minNLoops()),
-    _goodh             (config().helixFitFlag()),//,std::vector<std::string>{"HelixOK"})),
-    _prescaleUsingD0Phi(config().prescaleUsingD0Phi()),
+    _goodh             (config().helixFitFlag()),
     _debug             (config().debugLevel()),
     _nevt(0), _npass(0)
     {
-      if (_prescaleUsingD0Phi){
-        _prescalerPar    = PhiPrescalingParams(config().prescalerPar());
+      bool val;
+      if (config().prescaleUsingD0Phi(val)) {
+        _prescaleUsingD0Phi = val;
+        if (_prescaleUsingD0Phi){
+          _prescalerPar    = PhiPrescalingParams(config().prescalerPar());
+        }
+      }else {
+        _prescaleUsingD0Phi = false;
       }
       produces<TriggerInfo>();
     }


### PR DESCRIPTION
These filters must be configured by the script used to generate the Menu. Otherwise when we run the Online reconstruction in OTS mistakes could happen when configuring the trigger paths.