### PR TITLE
Added support to save unfiltered helices in TimeAndPhiClusterFinder

### DIFF
--- a/TrkPatRec/fcl/prolog.fcl
+++ b/TrkPatRec/fcl/prolog.fcl
@@ -78,6 +78,7 @@ TimeAndPhiClusterFinder : {
   MinTimeYbin            : 6
   MaxTimeDT              : 35.0
   FilterMVA              : true
+  MinHitSelect           : 50
   MinCutMVA              : 0.1
   SplitPhi               : true
   MaxDeltaPhi            : 0.3


### PR DESCRIPTION
For cases leaving a large number of hits in the tracker (e.g. track bouncing back and forth). 