### PR TITLE
Segregate drift functions for BTrk

### DIFF
--- a/BTrkData/src/TrkStrawHit.cc
+++ b/BTrkData/src/TrkStrawHit.cc
@@ -104,15 +104,15 @@ namespace mu2e
       else
         doca = _rdrift + _iamb*resid;
     // restrict the range, symmetrically to avoid bias
-      double mint0doca = _strawResponse->Mint0doca();
+      double mint0doca = _strawResponse->BTrk_Mint0doca();
       if(doca > mint0doca && doca < _rstraw-mint0doca){
         // compute phi WRT BField for lorentz drift.
         CLHEP::Hep3Vector trjDir(parentRep()->traj().direction(fltLen()));
         Hep3Vector tperp = trjDir - trjDir.dot(straw().getDirection())*straw().getDirection();
         double phi = tperp.theta();   // This assumes B along z, FIXME!
         // translate the DOCA into a time
-        double tdrift = _strawResponse->driftDistanceToTime(_combohit.strawId(), doca, phi,true);
-        double vdrift = _strawResponse->driftInstantSpeed(_combohit.strawId(),doca, phi,true);
+        double tdrift = _strawResponse->BTrk_driftDistanceToTime(_combohit.strawId(), doca, phi);
+        double vdrift = _strawResponse->BTrk_driftInstantSpeed(_combohit.strawId(),doca, phi);
         t0._t0 = tdrift + _stime;
         t0._t0err = residerr/vdrift;// instantaneous velocity to translate the error on the residual
       } else {
@@ -137,10 +137,10 @@ namespace mu2e
 
    Hep3Vector tperp = tdir - tdir.dot(straw().getDirection())*straw().getDirection();
    _phi = tperp.theta();
-   _rdrift = _strawResponse->driftTimeToDistance(_combohit.strawId(),tdrift,_phi);
-   _vdriftinst = _strawResponse->driftInstantSpeed(_combohit.strawId(),fabs(poca().doca()),_phi,true);
+   _rdrift = _strawResponse->BTrk_driftTimeToDistance(_combohit.strawId(),tdrift,_phi);
+   _vdriftinst = _strawResponse->BTrk_driftInstantSpeed(_combohit.strawId(),fabs(poca().doca()),_phi);
    double vdriftconst = _strawResponse->driftConstantSpeed();
-   _rdrifterr = _strawResponse->signedDriftError(_combohit.strawId(),fabs(poca().doca()),_phi);
+   _rdrifterr = _strawResponse->BTrk_driftDistanceError(_combohit.strawId(),fabs(poca().doca()),_phi);
 
 // Propogate error in t0, using local drift velocity
     double rt0err = hitT0()._t0err*_vdriftinst;

--- a/TrackerConditions/fcl/prolog.fcl
+++ b/TrackerConditions/fcl/prolog.fcl
@@ -239,8 +239,6 @@ StrawResponse : {
   errorFactor : 1.0
   useNonLinearDrift : true
   linearDriftVelocity : 0.0625
-  minT0DOCA : -0.2
-
 
   # Jan 23, 2020 - R. Bonventre, docdb-31095
   defaultPeakMinusPedestalEnergyScale : 0.002

--- a/TrackerConditions/inc/StrawResponse.hh
+++ b/TrackerConditions/inc/StrawResponse.hh
@@ -47,7 +47,7 @@ namespace mu2e {
           std::vector<double> unsignedDriftRMS, double dRdTScale,
           bool driftResIsTime,
           double wbuf, double slfac, double errfac, bool usenonlindrift,
-          double lindriftvel, double mint0doca,
+          double lindriftvel,
           std::array<double, StrawId::_nustraws> pmpEnergyScale,
           double electronicsTimeDelay, double gasGain,
           std::array<double,StrawElectronics::npaths> analognoise,
@@ -77,7 +77,6 @@ namespace mu2e {
         _driftResIsTime(driftResIsTime),
         _wbuf(wbuf), _slfac(slfac), _errfac(errfac),
         _usenonlindrift(usenonlindrift), _lindriftvel(lindriftvel),
-        _mint0doca(mint0doca),
         _pmpEnergyScale(pmpEnergyScale),
         _electronicsTimeDelay(electronicsTimeDelay),
         _gasGain(gasGain), _analognoise(analognoise),
@@ -90,18 +89,14 @@ namespace mu2e {
 
       virtual ~StrawResponse() {}
 
-      double driftDistanceToTime(StrawId strawId, double ddist, double phi,
-          bool forceOld=false) const;
-      double driftInstantSpeed(StrawId strawId, double ddist, double phi,
-          bool forceOld=false) const;
-      double driftTimeError(StrawId strawId, double ddist, double phi,
-          bool forceOld=false) const;
+      double driftDistanceToTime(StrawId strawId, double ddist, double phi) const;
+      double driftInstantSpeed(StrawId strawId, double ddist, double phi) const;
+      double driftTimeError(StrawId strawId, double ddist, double phi) const;
 
       bool wireDistance(Straw const& straw, double edep, double dt,
           double& wdist, double& wderr, double& halfpv) const;
       bool useParameterizedDriftError() const { return _usepderr; }
       bool useNonLinearDrift() const { return _usenonlindrift; }
-      double Mint0doca() const { return _mint0doca;}
       double strawGain() const { return _strawPhysics->strawGain();}
 
       double halfPropV(StrawId strawId, double kedep) const;
@@ -122,9 +117,9 @@ namespace mu2e {
 
       DriftInfo driftInfo(StrawId strawId, double dtime, double phi) const;
 
-      double driftTimeToDistance(StrawId strawId, double dtime, double phi, bool forceOld=false) const;
+      double driftTimeToDistance(StrawId strawId, double dtime, double phi) const;
       double driftConstantSpeed() const {return _lindriftvel;} // constant value used for annealing errors, should be close to average velocity
-      double signedDriftError(StrawId strawId, double ddist, double phi, bool forceOld=false) const;
+      double signedDriftError(StrawId strawId, double ddist, double phi) const;
       double driftDistanceOffset(double DOCA) const;
       double driftTimeOffset(StrawId strawId, double ddist, double phi, double DOCA) const;
 
@@ -166,6 +161,15 @@ namespace mu2e {
 
       // access raw drift information
       auto const& strawDrift() const { return *_strawDrift; }
+      // BTrk legacy functions.  These will be retired with BTrk
+      // DO NOT write any new code referencing these functions, or modify them (except to fix bugs)
+      // values are intentionally hard-coded: no modification is allowed
+      double BTrk_Mint0doca() const { return -0.2; }
+      double BTrk_driftDistanceToTime(StrawId strawId, double ddist, double phi) const;
+      double BTrk_driftInstantSpeed(StrawId strawId, double ddist, double phi) const;
+      double BTrk_driftDistanceError(StrawId strawId, double ddist, double phi) const;
+      double BTrk_driftTimeToDistance(StrawId strawId, double dtime, double phi) const;
+
     private:
 
       // helper functions

--- a/TrackerConditions/src/StrawResponse.cc
+++ b/TrackerConditions/src/StrawResponse.cc
@@ -128,9 +128,8 @@ namespace mu2e {
     return dinfo;
   }
 
-  double StrawResponse::driftDistanceToTime(StrawId strawId,
-      double ddist, double phi, bool forceOld) const {
-    if (!_useOldDrift && !forceOld){
+  double StrawResponse::driftDistanceToTime(StrawId strawId, double ddist, double phi) const {
+    if (!_useOldDrift ){
       if (_driftIgnorePhi)
         phi = 0;
       double calibrated_ddist = calibrateDriftDistanceToT2D(ddist);
@@ -147,15 +146,14 @@ namespace mu2e {
     }
   }
 
-  double StrawResponse::driftTimeError(StrawId strawId,
-      double ddist, double phi, bool forceOld) const {
-    if (!_useOldDrift && !forceOld){
+  double StrawResponse::driftTimeError(StrawId strawId, double ddist, double phi) const {
+    if (!_useOldDrift ){
       if (_driftResIsTime){
         ddist = std::max(0.0,std::min(rstraw_,ddist));
         return PieceLineDrift(_driftRMSBins, _signedDriftRMS, ddist);
       }else{
-        double distance_error = signedDriftError(strawId,ddist,phi,forceOld);
-        double speed_at_ddist = driftInstantSpeed(strawId,ddist,phi,forceOld);
+        double distance_error = signedDriftError(strawId,ddist,phi);
+        double speed_at_ddist = driftInstantSpeed(strawId,ddist,phi);
         return distance_error/speed_at_ddist;
       }
     }else{
@@ -164,14 +162,13 @@ namespace mu2e {
         ddist = std::max(0.0,std::min(rstraw_,ddist));
         return PieceLineDrift(_driftRMSBins, _signedDriftRMS, ddist);
       }else{
-        return signedDriftError(strawId, ddist, phi, forceOld) / _lindriftvel;
+        return signedDriftError(strawId, ddist, phi) / _lindriftvel;
       }
     }
   }
 
-  double StrawResponse::driftInstantSpeed(StrawId strawId,
-      double ddist, double phi, bool forceOld) const {
-    if (!_useOldDrift && !forceOld){
+  double StrawResponse::driftInstantSpeed(StrawId strawId, double ddist, double phi) const {
+    if (!_useOldDrift ){
       if (_driftIgnorePhi)
         phi = 0;
 //      double calibrated_ddist = calibrateDriftDistanceToT2D(ddist);
@@ -186,9 +183,8 @@ namespace mu2e {
     }
   }
 
-  double StrawResponse::driftTimeToDistance(StrawId strawId,
-      double dtime, double phi, bool forceOld) const {
-    if (!_useOldDrift && !forceOld){
+  double StrawResponse::driftTimeToDistance(StrawId strawId, double dtime, double phi) const {
+    if (!_useOldDrift ){
       if (_driftIgnorePhi)
         phi = 0;
       double ddist = _strawDrift->T2D(dtime,phi,false);
@@ -206,14 +202,13 @@ namespace mu2e {
     }
   }
 
-  double StrawResponse::signedDriftError(StrawId strawId,
-      double ddist, double phi, bool forceOld) const {
-    if (!_useOldDrift && !forceOld){
+  double StrawResponse::signedDriftError(StrawId strawId, double ddist, double phi) const {
+    if (!_useOldDrift ){
       if (_driftIgnorePhi)
         phi = 0;
       if (_driftResIsTime){
-        double time_error = driftTimeError(strawId,ddist,phi,forceOld);
-        double speed_at_ddist = driftInstantSpeed(strawId,ddist,phi,forceOld);
+        double time_error = driftTimeError(strawId,ddist,phi);
+        double speed_at_ddist = driftInstantSpeed(strawId,ddist,phi);
         return time_error*speed_at_ddist;
       }else{
       //  ddist = std::max(0.0,std::min(rstraw_,ddist));
@@ -391,5 +386,32 @@ namespace mu2e {
       }
 
     }
+
+   double StrawResponse::BTrk_driftDistanceToTime(StrawId strawId, double ddist, double phi) const {
+     return _strawDrift->D2T(ddist,phi);
+  }
+
+   double StrawResponse::BTrk_driftInstantSpeed(StrawId strawId, double ddist, double phi) const {
+     return _strawDrift->GetInstantSpeedFromD(ddist);
+   }
+
+   double StrawResponse::BTrk_driftDistanceError(StrawId strawId, double ddist, double phi) const {
+     static const std::vector<double> derr = {0.363559, 0.362685, 0.359959, 0.349385,
+       0.336731, 0.321784, 0.302363, 0.282691, 0.268223, 0.252673, 0.238557,
+       0.229172, 0.2224, 0.219224, 0.217334, 0.212797, 0.210303, 0.209876,
+       0.208739, 0.207411, 0.208738, 0.209646, 0.210073, 0.207101, 0.20431,
+       0.203994, 0.202931, 0.19953, 0.196999, 0.194559, 0.191766, 0.187725,
+       0.185959, 0.181423, 0.17848, 0.171357, 0.171519, 0.168422, 0.161338,
+       0.156641, 0.151196, 0.146546, 0.144069, 0.139858, 0.135838, 0.13319,
+       0.132159, 0.130062, 0.123545, 0.120212 };
+     static double rstraw(2.5);
+     double doca = std::min(fabs(ddist),rstraw);
+     size_t idoca = std::min(derr.size()-1,size_t(floor(derr.size()*(doca/rstraw))));
+     return derr[idoca];
+   }
+
+   double StrawResponse::BTrk_driftTimeToDistance(StrawId strawId, double dtime, double phi) const {
+     return _strawDrift->T2D(dtime,phi);
+   }
 
 }

--- a/TrackerConditions/src/StrawResponseMaker.cc
+++ b/TrackerConditions/src/StrawResponseMaker.cc
@@ -119,7 +119,6 @@ namespace mu2e {
         _config.wireLengthBuffer(), _config.strawLengthFactor(),
         _config.errorFactor(), _config.useNonLinearDrift(),
         _config.linearDriftVelocity(),
-        _config.minT0DOCA(),
         pmpEnergyScale,
         electronicsTimeDelay,
         gasGain, analognoise, dVdI, vsat, ADCped,

--- a/TrackerConfig/inc/StrawResponseConfig.hh
+++ b/TrackerConfig/inc/StrawResponseConfig.hh
@@ -91,8 +91,6 @@ namespace mu2e {
       Name("useNonLinearDrift"), Comment(" useNonLinearDrift ")};
     fhicl::Atom<double> linearDriftVelocity {
       Name("linearDriftVelocity"), Comment(" mm/ns, only used if nonlindrift= ")};
-    fhicl::Atom<double> minT0DOCA {
-      Name("minT0DOCA"), Comment("FIXME should be moved to a reconstruction configuration ")};
     fhicl::Atom<double> defaultPeakMinusPedestalEnergyScale {
       Name("defaultPeakMinusPedestalEnergyScale"), Comment("default constant value for pmp energy method calibration")};
     fhicl::Sequence<double> peakMinusPedestalEnergyScale {


### PR DESCRIPTION
This addresses the FPE observed in the Monday testing.  It also starts the process of segregating BTrk from the rest of the code base, leading up to its removal.