### PR TITLE
STM Hits

### DIFF
--- a/RecoDataProducts/inc/STMHit.hh
+++ b/RecoDataProducts/inc/STMHit.hh
@@ -1,0 +1,29 @@
+#ifndef RecoDataProducts_STMHit_hh
+#define RecoDataProducts_STMHit_hh
+//
+// Data product represnting a time and energy of a hit in the STM
+//
+
+// C++ includes
+#include <iostream>
+#include <vector>
+#include <array>
+#include <Rtypes.h>
+
+namespace mu2e {
+
+  class STMHit {
+  public:
+    STMHit() {};
+    STMHit(float time, float energy) : _time(time), _energy(energy) {};
+
+    float time() const { return _time; }
+    float energy() const { return _energy; }
+
+  private:
+    float _time;
+    float _energy;
+  };
+  typedef std::vector<mu2e::STMHit> STMHitCollection;
+}
+#endif

--- a/RecoDataProducts/src/classes.h
+++ b/RecoDataProducts/src/classes.h
@@ -99,5 +99,6 @@
 // STM
 #include "Offline/RecoDataProducts/inc/STMWaveformDigi.hh"
 #include "Offline/RecoDataProducts/inc/STMMWDDigi.hh"
+#include "Offline/RecoDataProducts/inc/STMHit.hh"
 
 #undef ENABLE_MU2E_GENREFLEX_HACKS

--- a/RecoDataProducts/src/classes_def.xml
+++ b/RecoDataProducts/src/classes_def.xml
@@ -382,5 +382,8 @@
  <class name="mu2e::STMMWDDigi"/>
  <class name="mu2e::STMMWDDigiCollection"/>
  <class name="art::Wrapper<mu2e::STMMWDDigiCollection>"/>
+ <class name="mu2e::STMHit"/>
+ <class name="mu2e::STMHitCollection"/>
+ <class name="art::Wrapper<mu2e::STMHitCollection>"/>
 
 </lcgdict>

--- a/STMReco/fcl/makeSTMHits.fcl
+++ b/STMReco/fcl/makeSTMHits.fcl
@@ -1,0 +1,43 @@
+#
+# Create STMHits from STMMWDDigis
+#
+
+#include "Offline/fcl/standardServices.fcl"
+
+process_name: MakeSTMHits
+
+source : {
+  module_type : RootInput
+}
+
+services : @local::Services.Reco
+physics: {
+  producers : {
+    stmHitsHPGe : { module_type : MakeSTMHits
+                    stmMWDDigisTag : "mwdHPGe"
+    }
+    stmHitsLaBr : { module_type : MakeSTMHits
+                    stmMWDDigisTag : "mwdLaBr"
+    }
+  }
+  filters : {
+  }
+  analyzers : {
+  }
+  # setup paths
+  HPGePath : [ stmHitsHPGe ]
+  LaBrPath : [ stmHitsLaBr ]
+  trigger_paths: [ HPGePath, LaBrPath ]
+  outPath : [ STMOutput ]
+  end_paths: [outPath]
+}
+
+outputs: {
+
+  STMOutput : {
+    module_type: RootOutput
+    outputCommands:   [ "keep *_*_*_*" ]
+    SelectEvents: [ ]
+    fileName : "mcs.owner.STM.version.sequencer.art"
+  }
+}

--- a/STMReco/fcl/makeSTMHits_testbeam.fcl
+++ b/STMReco/fcl/makeSTMHits_testbeam.fcl
@@ -1,0 +1,12 @@
+#include "Offline/STMReco/fcl/prolog_testbeam.fcl"
+#include "Offline/STMReco/fcl/makeSTMHits.fcl"
+
+# Can define pedestals in fcl like the line below
+services.ProditionsService.stmEnergyCalib.pedestals : @local::STMTestBeam.Conditions.pedestals
+services.ProditionsService.stmEnergyCalib.samplingFrequencies : @local::STMTestBeam.Conditions.samplingFrequencies
+
+services.DbService.verbose : 0
+services.DbService.textFile : [ "STMAnalysis/stmPedestals.txt", "STMAnalysis/stmTest.txt" ]
+services.ProditionsService.verbose : 0
+services.ProditionsService.stmEnergyCalib.verbose : 0
+services.ProditionsService.stmEnergyCalib.useDb : true

--- a/STMReco/fcl/plotSTMEnergySpectrum.fcl
+++ b/STMReco/fcl/plotSTMEnergySpectrum.fcl
@@ -1,0 +1,35 @@
+#
+# Plot STMWaveformDigis
+#
+
+#include "Offline/fcl/standardServices.fcl"
+
+process_name: PlotSTMEnergySpectrum
+
+source : {
+  module_type : RootInput
+}
+
+services : @local::Services.Reco
+physics: {
+  producers : {
+  }
+  filters : {
+  }
+  analyzers : {
+    plotHPGeEnergySpectrum : {
+      module_type : PlotSTMEnergySpectrum
+      stmHitsTag : "stmHitsHPGe"
+    }
+    plotLaBrEnergySpectrum : {
+      module_type : PlotSTMEnergySpectrum
+      stmHitsTag : "stmHitsLaBr"
+    }
+  }
+  # setup paths
+  trigger_paths: [  ]
+  anaPath : [ plotHPGeEnergySpectrum, plotLaBrEnergySpectrum ]
+  end_paths: [anaPath]
+}
+
+services.TFileService.fileName : "stmEnergySpectrum.root"

--- a/STMReco/src/MakeSTMHits_module.cc
+++ b/STMReco/src/MakeSTMHits_module.cc
@@ -1,0 +1,87 @@
+//
+// Create STMHits from STMMWDDigis
+//
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "cetlib_except/exception.h"
+#include "fhiclcpp/types/Atom.h"
+#include "canvas/Utilities/InputTag.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include "art_root_io/TFileService.h"
+#include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+#include "Offline/Mu2eUtilities/inc/STMUtils.hh"
+#include "Offline/ProditionsService/inc/ProditionsHandle.hh"
+#include "Offline/STMConditions/inc/STMEnergyCalib.hh"
+
+#include <utility>
+// root
+#include "TH1F.h"
+#include "TTree.h"
+
+#include "Offline/RecoDataProducts/inc/STMMWDDigi.hh"
+#include "Offline/RecoDataProducts/inc/STMHit.hh"
+
+// C++
+#include <vector>
+
+using namespace std;
+using CLHEP::Hep3Vector;
+namespace mu2e {
+
+  class MakeSTMHits : public art::EDProducer {
+  public:
+    using Name=fhicl::Name;
+    using Comment=fhicl::Comment;
+    struct Config {
+      fhicl::Atom<art::InputTag> stmMWDDigisTag{ Name("stmMWDDigisTag"), Comment("InputTag for STMMWDDigiCollection")};
+    };
+    using Parameters = art::EDProducer::Table<Config>;
+    explicit MakeSTMHits(const Parameters& conf);
+
+  private:
+    void produce(art::Event& e) override;
+
+    art::ProductToken<STMMWDDigiCollection> _stmMWDDigisToken;
+    STMChannel _channel;
+    ProditionsHandle<STMEnergyCalib> _stmEnergyCalib_h;
+  };
+
+  MakeSTMHits::MakeSTMHits(const Parameters& config )  :
+    art::EDProducer{config}
+    ,_stmMWDDigisToken(consumes<STMMWDDigiCollection>(config().stmMWDDigisTag()))
+    ,_channel(STMUtils::getChannel(config().stmMWDDigisTag()))
+    ,_stmEnergyCalib_h()
+    {
+      produces<STMHitCollection>();
+    }
+
+    void MakeSTMHits::produce(art::Event& event) {
+    // create output
+    unique_ptr<STMHitCollection> outputSTMHits(new STMHitCollection);
+    auto mwdDigisHandle = event.getValidHandle(_stmMWDDigisToken);
+
+    STMEnergyCalib const& stmEnergyCalib = _stmEnergyCalib_h.get(event.id()); // get calibration
+
+    const auto nsPerCt = stmEnergyCalib.nsPerCt(_channel);
+    const auto& pars = stmEnergyCalib.calib(_channel);
+    std::cout << _channel.name() << ": p0 = " << pars.p0 << ", p1 = " << pars.p1 << ", p2 = " << pars.p2 << std::endl;
+
+    for (const auto& mwd_digi : *mwdDigisHandle) {
+      auto uncalib_time = mwd_digi.time();
+      auto uncalib_energy = mwd_digi.energy();
+      float time = uncalib_time*nsPerCt;
+      float energy = pars.p0 + pars.p1*uncalib_energy + pars.p2*uncalib_energy*uncalib_energy;
+      std::cout << "Calibrated energy: " << energy << ", uncalibrated: " << uncalib_energy << std::endl;
+      STMHit stm_hit(time,energy);
+      outputSTMHits->push_back(stm_hit);
+    }
+
+    event.put(std::move(outputSTMHits));
+  }
+}
+
+DEFINE_ART_MODULE(mu2e::MakeSTMHits)

--- a/STMReco/src/MakeSTMHits_module.cc
+++ b/STMReco/src/MakeSTMHits_module.cc
@@ -68,14 +68,13 @@ namespace mu2e {
 
     const auto nsPerCt = stmEnergyCalib.nsPerCt(_channel);
     const auto& pars = stmEnergyCalib.calib(_channel);
-    std::cout << _channel.name() << ": p0 = " << pars.p0 << ", p1 = " << pars.p1 << ", p2 = " << pars.p2 << std::endl;
 
     for (const auto& mwd_digi : *mwdDigisHandle) {
       auto uncalib_time = mwd_digi.time();
       auto uncalib_energy = mwd_digi.energy();
       float time = uncalib_time*nsPerCt;
       float energy = pars.p0 + pars.p1*uncalib_energy + pars.p2*uncalib_energy*uncalib_energy;
-      std::cout << "Calibrated energy: " << energy << ", uncalibrated: " << uncalib_energy << std::endl;
+
       STMHit stm_hit(time,energy);
       outputSTMHits->push_back(stm_hit);
     }

--- a/STMReco/src/PlotSTMEnergySpectrum_module.cc
+++ b/STMReco/src/PlotSTMEnergySpectrum_module.cc
@@ -1,0 +1,76 @@
+//
+// Analyzer module to create a histogram of the STMMWDDigi uncalibrated energies
+//
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "cetlib_except/exception.h"
+#include "fhiclcpp/types/Atom.h"
+#include "canvas/Utilities/InputTag.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include "art_root_io/TFileService.h"
+#include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+
+#include "Offline/MCDataProducts/inc/StepPointMC.hh"
+#include <utility>
+// root
+#include "TH1F.h"
+#include "TF1.h"
+#include "TTree.h"
+#include "TSpectrum.h"
+#include "TGraph.h"
+
+#include "Offline/RecoDataProducts/inc/STMHit.hh"
+
+using namespace std;
+using CLHEP::Hep3Vector;
+namespace mu2e {
+
+  class PlotSTMEnergySpectrum : public art::EDAnalyzer {
+    public:
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      struct Config {
+        fhicl::Atom<art::InputTag> stmHitsTag{ Name("stmHitsTag"), Comment("InputTag for STMHitCollection")};
+      };
+      using Parameters = art::EDAnalyzer::Table<Config>;
+      explicit PlotSTMEnergySpectrum(const Parameters& conf);
+
+    private:
+    void beginJob() override;
+    void analyze(const art::Event& e) override;
+
+    TH1D* _energySpectrum;
+    art::ProductToken<STMHitCollection> _stmHitsToken;
+  };
+
+  PlotSTMEnergySpectrum::PlotSTMEnergySpectrum(const Parameters& config )  :
+    art::EDAnalyzer{config},
+    _stmHitsToken(consumes<STMHitCollection>(config().stmHitsTag()))
+  { }
+
+  void PlotSTMEnergySpectrum::beginJob() {
+    art::ServiceHandle<art::TFileService> tfs;
+    // create histograms
+    double min_energy = 0;
+    double max_energy = 10;
+    double energy_bin_width = 0.001;
+    int n_bins = (max_energy - min_energy) / energy_bin_width;
+    _energySpectrum=tfs->make<TH1D>("energySpectrum", "Energy Spectrum", n_bins, min_energy, max_energy);
+  }
+
+  void PlotSTMEnergySpectrum::analyze(const art::Event& event) {
+
+    auto stmHitsHandle = event.getValidHandle(_stmHitsToken);
+
+    for (const auto& stmHit : *stmHitsHandle) {
+      auto energy = stmHit.energy();
+      _energySpectrum->Fill(energy);
+    }
+  }
+}
+
+DEFINE_ART_MODULE(mu2e::PlotSTMEnergySpectrum)


### PR DESCRIPTION
Hi Everyone,

This should be the last big commit for the STM Offline infrastructure. It adds the ```STMHit``` data product which respresents a calibrated energy and time of a hit in the STM. It also adds a ```MakeSTMHits``` module to turn ```STMMWDDigis``` into ```STMHits``` using energy calibration constants through the proditions service, and a ```PlotSTMEnergySpectrum``` module as an example of how to analyze these hits.

Thanks,
Andy