### PR TITLE
enforce deterministic ordering

### DIFF
--- a/CRVResponse/src/CrvCoincidenceFinder_module.cc
+++ b/CRVResponse/src/CrvCoincidenceFinder_module.cc
@@ -63,6 +63,15 @@ namespace mu2e
       fhicl::Atom<int> bigClusterThreshold{Name("bigClusterThreshold"), Comment("no coincidence check for clusters with a number of hits above this threshold")};
     };
 
+    // a vector that checks for duplicates
+    template <typename T> class uniqueVector : public std::vector<T> {
+    public:
+      void insert(const T& x) {
+        using Base = std::vector<T>;
+        if( std::find(Base::begin(),Base::end(),x) == Base::end() ) Base::push_back(x);
+      }
+    };
+
     typedef art::EDProducer::Table<Config> Parameters;
 
     explicit CrvCoincidenceFinder(const Parameters& config);
@@ -570,7 +579,7 @@ namespace mu2e
     //we want to collect all hits belonging to coincidence groups,
     //but avoid collecting hits multiple times, if they belong to different coincidence groups.
     //can be done by placing the hit interator into a set.
-    std::set<std::vector<CrvHit>::const_iterator> coincidenceHitSet;
+    uniqueVector<std::vector<CrvHit>::const_iterator> coincidenceHitSet;
 
     int minCoincidenceLayers = std::min_element(hits.begin(),hits.end(),
                                [](const CrvHit &a, const CrvHit &b){return a._coincidenceLayers < b._coincidenceLayers;})->_coincidenceLayers;


### PR DESCRIPTION
The CrvRecoPulse collection was printing in a random order which was caused by it being a random order, which was SelectRecoMC seeing a random order of pulse lists inside coincidences.  This was caused by using a std::set containing vector iterators, which seems to have caused a sort on memory addresses (did not track that down fully).  This PR has a solution which is minimally disrupting, but the internet seems to prefer a free-standing function, which would require more edits.