### PR TITLE
added a sort function to a set used in CrvCoincidenceFinder

### DIFF
--- a/CRVResponse/src/CrvCoincidenceFinder_module.cc
+++ b/CRVResponse/src/CrvCoincidenceFinder_module.cc
@@ -570,7 +570,8 @@ namespace mu2e
     //we want to collect all hits belonging to coincidence groups,
     //but avoid collecting hits multiple times, if they belong to different coincidence groups.
     //can be done by placing the hit interator into a set.
-    std::set<std::vector<CrvHit>::const_iterator> coincidenceHitSet;
+    auto setComp = [](const std::vector<CrvHit>::const_iterator &a, const std::vector<CrvHit>::const_iterator &b) {return a->_crvRecoPulse < b->_crvRecoPulse;};
+    std::set<std::vector<CrvHit>::const_iterator,decltype(setComp)> coincidenceHitSet(setComp);
 
     int minCoincidenceLayers = std::min_element(hits.begin(),hits.end(),
                                [](const CrvHit &a, const CrvHit &b){return a._coincidenceLayers < b._coincidenceLayers;})->_coincidenceLayers;


### PR DESCRIPTION
This change prevents the CrvRecoPulses belonging to a CRV coincidence cluster to be stored in a random order. It fixes Issue #936 (CrvRecoPulses random order). I verified that it solves the problem by running Validation/cosmicSimReco.fcl multiple times before and after this change.