### PR TITLE
fixes

### DIFF
--- a/CalPatRec/src/CalHelixFinderAlg.cc
+++ b/CalPatRec/src/CalHelixFinderAlg.cc
@@ -1757,7 +1757,7 @@ namespace mu2e {
           if (Helix._hitsUsed[index] >= 1)                    continue;
           hit       = &Helix._chHitsToProcess[index];
           shPos     = hit->_pos;
-          strawDir  = hit->_sdir;
+          strawDir  = hit->vDir();
 
           dx        = hePos.x() - shPos.x();
           dy        = hePos.y() - shPos.y();
@@ -2195,7 +2195,7 @@ namespace mu2e {
     float y   = Hit.pos().y();
     float dx  = x-HelCenter.x();
     float dy  = y-HelCenter.y();
-    float dxn = dx*Hit._sdir.x()+dy*Hit._sdir.y();
+    float dxn = dx*Hit.vDir().x()+dy*Hit.vDir().y();
 
     float costh2 = dxn*dxn/(dx*dx+dy*dy);
     float sinth2 = 1-costh2;
@@ -2229,7 +2229,7 @@ namespace mu2e {
 //-----------------------------------------------------------------------------
 // if dr(dx,dy) is orthogonal to the wire, costh = 1
 //-----------------------------------------------------------------------------
-    float dxn    = dx*Hit._sdir.x()+dy*Hit._sdir.y();
+    float dxn    = dx*Hit.vDir().x()+dy*Hit.vDir().y();
     float costh2 = dxn*dxn/(dx*dx+dy*dy);
     float sinth2 = 1-costh2;
 
@@ -2328,7 +2328,7 @@ namespace mu2e {
 
           if (_debug > 10) {
             printf("[CalHelixFinderAlg::doWeightedCircleFit:LOOP] %4i %10.3f %10.3f %10.3f %10.3e %10.4f %10.4f\n",
-                   (int)hit->index(), hit->_pos.x(), hit->_pos.y(), hit->_pos.z(), wt, hit->_sdir.x(), hit->_sdir.y());
+                   (int)hit->index(), hit->_pos.x(), hit->_pos.y(), hit->_pos.z(), wt, hit->vDir().x(), hit->vDir().y());
           }
         }
       }//end panels loop
@@ -2758,7 +2758,7 @@ namespace mu2e {
           if (Helix._hitsUsed[index] >= 1)                    continue;
 
           hitPos    = hit->_pos;
-          strawDir  = hit->_sdir;
+          strawDir  = hit->vDir();
 
           dr = calculateRadialDist(hitPos,helCenter,r);
           wt = calculateWeight    (*hit,helCenter,r);

--- a/CosmicReco/fcl/prolog.fcl
+++ b/CosmicReco/fcl/prolog.fcl
@@ -129,7 +129,6 @@ CosmicTrackDetails : {
     #TimeClusterCollection : TimeClusterFinderCosmics
     CosmicTrackSeedCollection : CosmicTrackFinder
     StrawDigiMCCollection : "compressDigiMCs"
-    TimeOffsets : {inputs : [ @sequence::DigiCompression.TimeMaps ]}
 }
 
 CosmicMCRecoDiff  : {
@@ -139,7 +138,6 @@ CosmicMCRecoDiff  : {
     #TimeClusterCollection : TimeClusterFinderCosmics
     CosmicTrackSeedCollection : "CosmicTrackFinderTimeFit"
     StrawDigiMCCollection : "compressDigiMCs"
-    TimeOffsets : {inputs : [ @sequence::DigiCompression.TimeMaps ]}
 }
 
 
@@ -150,7 +148,6 @@ CosmicAnalysis : {
     #TimeClusterCollection : TimeClusterFinderCosmics
     CosmicTrackSeedCollection : CosmicTrackFinder
     StrawDigiMCCollection : "compressDigiMCs"
-    TimeOffsets : {inputs : [ @sequence::DigiCompression.TimeMaps ]}
 }
 
 CosmicFitDisplay : {

--- a/Mu2eKinKal/fcl/prolog_trigger.fcl
+++ b/Mu2eKinKal/fcl/prolog_trigger.fcl
@@ -16,12 +16,16 @@ Mu2eKinKalTrigger : {
 
   KKSEEDFIT: {
     @table::Mu2eKinKal.KKSEEDFIT
-    MaxNIter : 2
-    CADSHUSettings : [
-      [ 40.0, 80.0, 5.0, 5.0, "TOT", "Null:Inactive", "", 0 ]
-    ]
+    MaxNIter : 3
+    #    DivergenceDeltaChisq : 1e6
+    # DivergenceDeltaParams : 1e6
+    # DivergenceGap : 100 # mm
     MetaIterationSettings : [
-      [ 5.0, "CADSHU" ]
+      [ 4.0, "CADSHU" ]
+    ]
+    CADSHUSettings : [
+      # maxdoca, maxderr, minrdrift, maxrdrift, flag, , allowed, freeze, diag
+      [ 60.0, 1e6, 5.0, 5.0, "TOT", "Null:Inactive", "", 0 ]
     ]
     StrawXingUpdaterSettings : [
       [10.0, -1.0, -1.0, true, 0 ]
@@ -30,15 +34,16 @@ Mu2eKinKalTrigger : {
 
   KKSEEDEXT: {
     @table::Mu2eKinKal.KKSEEDEXT
-    MaxNIter : 2
+    MaxNIter : 3
     CADSHUSettings : [
-      [ 8.0,  16.0, 5.0, 3.0, "TOT:NullDriftVar", "Null:Inactive", "", 0 ]
+      #      [ 40.0, 20.0, 5.0, 5.0, "TOT", "Null:Inactive", "", 0 ]
     ]
     MetaIterationSettings : [
-      [ 0.0, "CADSHU" ]
+      # annealing temp, strawhit updater algorithm
+      # [ 3.0, "CADSHU" ]
     ]
     StrawXingUpdaterSettings : [
-      [3.0, 3.0, -1.0, true, 0 ]
+      # [10.0, -1.0, -1.0, true, 0 ]
     ]
     BkgANNSHUSettings : [
     ]

--- a/Mu2eKinKal/fcl/prolog_trigger.fcl
+++ b/Mu2eKinKal/fcl/prolog_trigger.fcl
@@ -12,20 +12,20 @@ Mu2eKinKalTrigger : {
     @table::Mu2eKinKal.KKMU2E
     AddHits : false
     AddMaterial : false
+    MaterialCorrection : false
   }
 
   KKSEEDFIT: {
     @table::Mu2eKinKal.KKSEEDFIT
-    MaxNIter : 3
-    #    DivergenceDeltaChisq : 1e6
-    # DivergenceDeltaParams : 1e6
-    # DivergenceGap : 100 # mm
+    MaxNIter : 2
     MetaIterationSettings : [
       [ 4.0, "CADSHU" ]
+      #      [ 2.0, "CADSHU" ]
     ]
     CADSHUSettings : [
       # maxdoca, maxderr, minrdrift, maxrdrift, flag, , allowed, freeze, diag
       [ 60.0, 1e6, 5.0, 5.0, "TOT", "Null:Inactive", "", 0 ]
+      #      [ 40.0, 1e6, 5.0, 5.0, "TOT", "Null:Inactive", "", 0 ]
     ]
     StrawXingUpdaterSettings : [
       [10.0, -1.0, -1.0, true, 0 ]
@@ -34,7 +34,9 @@ Mu2eKinKalTrigger : {
 
   KKSEEDEXT: {
     @table::Mu2eKinKal.KKSEEDEXT
-    MaxNIter : 3
+    MaxNIter : 2
+    BFieldCorrection : false
+
     CADSHUSettings : [
       #      [ 40.0, 20.0, 5.0, 5.0, "TOT", "Null:Inactive", "", 0 ]
     ]
@@ -51,6 +53,15 @@ Mu2eKinKalTrigger : {
 
   KKLOOPHELIX : {
     @table::Mu2eKinKal.KKLOOPHELIX
+    SeedErrors: [
+      5,
+      5,
+      5,
+      5,
+      2e-2,
+      5
+    ]
+    ZSavePositions: [ 0 ]
     SaveFullFit : false
   }
 

--- a/Mu2eKinKal/test/TTBTrk.fcl
+++ b/Mu2eKinKal/test/TTBTrk.fcl
@@ -1,0 +1,115 @@
+# Minimal KinKal job that fits digis to a downstream electron as a trigger seed fit , and analyzes the output with TrkAna
+# To create a functional job you must add database purpose and version; ie create a fcl stub that #includes this file and
+# adds (for instance):
+# services.DbService.purpose: MDC2020_perfect
+# services.DbService.version: v1_0
+#
+#include "Offline/fcl/minimalMessageService.fcl"
+#include "Offline/fcl/standardServices.fcl"
+#include "Production/JobConfig/reco/prolog.fcl"
+#include "Offline/Mu2eKinKal/fcl/prolog_trigger.fcl"
+#include "Offline/TrkHitReco/fcl/prolog_trigger.fcl"
+#include "Offline/TrkReco/fcl/prolog_trigger.fcl"
+#include "Offline/TrkPatRec/fcl/prolog_trigger.fcl"
+#include "Offline/TrkFilters/fcl/prolog_trigger.fcl"
+#include "Offline/CalPatRec/fcl/prolog.fcl"
+#include "Offline/CalPatRec/fcl/prolog_trigger.fcl"
+#include "Offline/Trigger/fcl/prolog_trigger.fcl"
+#include "TrkAna/fcl/prolog.fcl"
+#include "Offline/CommonMC/fcl/prolog.fcl"
+
+process_name: TTKKSeed
+source : { module_type : RootInput }
+services : @local::Services.Reco
+physics :
+{
+  producers : {
+    @table::CaloHitRecoTrigger.producers
+    @table::CaloClusterTrigger.producers
+    @table::TrkHitRecoTrigger.producers
+    @table::TrkRecoTrigger.producers
+    @table::TrkHitRecoTrigger.producers
+    @table::TprTrigger.producers
+    @table::CprTrigger.producers
+    @table::TTMu2eKinKal.producers
+  }
+  filters : {
+    @table::CprTrigger.filters
+    @table::CaloFilters.filters
+    @table::TrkFilters.filters
+    @table::CstTrigger.filters
+    @table::Trigger.filters
+  }
+
+  analyzers : {
+    TAtpr : @local::TrkAnaReco.analyzers.TrkAnaNeg
+    evtprint : {
+      module_type : RunEventSubRun
+      printSam    : false
+      printRun    : false
+      printSubrun : false
+      printEvent  : true
+    }
+    TAcpr : @local::TrkAnaReco.analyzers.TrkAnaNeg
+    evtprint : {
+      module_type : RunEventSubRun
+      printSam    : false
+      printRun    : false
+      printSubrun : false
+      printEvent  : true
+    }
+  }
+  EndPath : [TAtpr, TAcpr]
+
+  tprDeM_highP_stopTarg           : [ @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
+    @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
+    TTtimeClusterFinder, tprDeMHighPStopTargTCFilter, TThelixFinder,
+    TTHelixMergerDeM, tprDeMHighPStopTargHSFilter,
+    TTKSFDeM, tprDeMHighPStopTargTSFilter ]
+  cprDeM_highP_stopTarg           : [ @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
+    @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
+    TTCalTimePeakFinder, cprDeMHighPStopTargTCFilter, TTCalHelixFinderDe,
+    TTCalHelixMergerDeM, cprDeMHighPStopTargHSFilter,
+    TTCalSeedFitDem, cprDeMHighPStopTargTSFilter]
+
+}
+#include "Offline/gen/fcl/Trigger/OnSpillTrigMenu/OnSpillTrigMenu.fcl"
+physics.trigger_paths : [tprDeM_highP_stopTarg, cprDeM_highP_stopTarg ]
+physics.end_paths : [ EndPath ]
+
+physics.analyzers.TAtpr.SelectEvents : [  tprDeM_highP_stopTarg  ]
+physics.analyzers.TAtpr.candidate.options : @local::AllOpt
+physics.analyzers.TAtpr.candidate.options.fillBestCrv : false
+physics.analyzers.TAtpr.diagLevel : 2
+physics.analyzers.TAtpr.FillCRV : false
+physics.analyzers.TAtpr.FillMCInfo : false
+physics.analyzers.TAtpr.RecoCountTag : ""
+physics.analyzers.TAtpr.FillTriggerInfo : true
+physics.analyzers.TAtpr.FillTrkQualInfo : false
+physics.analyzers.TAtpr.FillTrkPIDInfo : false
+physics.analyzers.TAtpr.FillHitInfo : true
+physics.analyzers.TAtpr.FillTriggerInfo : false
+physics.analyzers.TAtpr.candidate.input : "TTKSF"
+physics.analyzers.TAtpr.candidate.suffix : "DeM"
+physics.analyzers.TAtpr.candidate.options.fillHits : true
+physics.analyzers.TAtpr.supplements : []
+
+physics.analyzers.TAcpr.SelectEvents : [  cprDeM_highP_stopTarg  ]
+physics.analyzers.TAcpr.candidate.options : @local::AllOpt
+physics.analyzers.TAcpr.candidate.options.fillBestCrv : false
+physics.analyzers.TAcpr.diagLevel : 2
+physics.analyzers.TAcpr.FillCRV : false
+physics.analyzers.TAcpr.FillMCInfo : false
+physics.analyzers.TAcpr.RecoCountTag : ""
+physics.analyzers.TAcpr.FillTriggerInfo : true
+physics.analyzers.TAcpr.FillTrkQualInfo : false
+physics.analyzers.TAcpr.FillTrkPIDInfo : false
+physics.analyzers.TAcpr.FillHitInfo : true
+physics.analyzers.TAcpr.FillTriggerInfo : false
+physics.analyzers.TAcpr.candidate.input : "TTCalSeedFit"
+physics.analyzers.TAcpr.candidate.suffix : "Dem"
+physics.analyzers.TAcpr.candidate.options.fillHits : true
+physics.analyzers.TAcpr.supplements : []
+
+services.TimeTracker.printSummary: true
+services.TFileService.fileName: "nts.owner.TTBTrk.version.sequence.root"

--- a/Mu2eKinKal/test/TTBTrk.fcl
+++ b/Mu2eKinKal/test/TTBTrk.fcl
@@ -18,7 +18,7 @@
 #include "TrkAna/fcl/prolog.fcl"
 #include "Offline/CommonMC/fcl/prolog.fcl"
 
-process_name: TTKKSeed
+process_name: TTBTrk
 source : { module_type : RootInput }
 services : @local::Services.Reco
 physics :

--- a/Mu2eKinKal/test/TTKK.fcl
+++ b/Mu2eKinKal/test/TTKK.fcl
@@ -67,7 +67,15 @@ physics :
   }
 
   analyzers : {
-    TAKK : @local::TrkAnaReco.analyzers.TrkAnaNeg
+    TAtpr : @local::TrkAnaReco.analyzers.TrkAnaNeg
+    evtprint : {
+      module_type : RunEventSubRun
+      printSam    : false
+      printRun    : false
+      printSubrun : false
+      printEvent  : true
+    }
+    TAcpr : @local::TrkAnaReco.analyzers.TrkAnaNeg
     evtprint : {
       module_type : RunEventSubRun
       printSam    : false
@@ -76,38 +84,57 @@ physics :
       printEvent  : true
     }
   }
-  EndPath : [TAKK]
+  EndPath : [TAtpr, TAcpr]
 
   tprDeM_highP_stopTarg           : [ @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
     @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
-    TTtimeClusterFinder, tprDeMHighPStopTargTCFilter, TThelixFinder, TTHelixMergerDeM, tprDeMHighPStopTargHSFilter, TTKSFDeM, tprDeMHighPStopTargTSFilter ]
-
+    TTtimeClusterFinder, tprDeMHighPStopTargTCFilter, TThelixFinder,
+    TTHelixMergerDeM, tprDeMHighPStopTargHSFilter,
+    TTKSFDeM, tprDeMHighPStopTargTSFilter ]
   cprDeM_highP_stopTarg           : [ @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
     @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
-    TTCalTimePeakFinder, cprDeMHighPStopTargTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprDeMHighPStopTargHSFilter,
-    TTCalSeedFitDem, cprDeMHighPStopTargTSFilter ]
+    TTCalTimePeakFinder, cprDeMHighPStopTargTCFilter, TTCalHelixFinderDe,
+    TTCalHelixMergerDeM, cprDeMHighPStopTargHSFilter,
+    TTCalSeedFitDem, cprDeMHighPStopTargTSFilter]
 
 }
 #include "Offline/gen/fcl/Trigger/OnSpillTrigMenu/OnSpillTrigMenu.fcl"
-physics.trigger_paths : [tprDeM_highP_stopTarg, cprDeM_highP_stopTarg]
+physics.trigger_paths : [tprDeM_highP_stopTarg, cprDeM_highP_stopTarg ]
+physics.end_paths : [ EndPath ]
 
-physics.analyzers.TAKK.SelectEvents : [  tprDeM_highP_stopTarg  ]
-physics.analyzers.TAKK.candidate.options : @local::AllOpt
-physics.analyzers.TAKK.candidate.options.fillBestCrv : false
-physics.analyzers.TAKK.diagLevel : 2
-physics.analyzers.TAKK.FillCRV : false
-physics.analyzers.TAKK.FillMCInfo : false
-physics.analyzers.TAKK.RecoCountTag : ""
-physics.analyzers.TAKK.FillTriggerInfo : true
-physics.analyzers.TAKK.FillTrkQualInfo : false
-physics.analyzers.TAKK.FillTrkPIDInfo : false
-physics.analyzers.TAKK.FillHitInfo : true
-physics.analyzers.TAKK.FillTriggerInfo : false
-physics.analyzers.TAKK.candidate.input : "TTKSF"
-physics.analyzers.TAKK.candidate.suffix : "DeM"
-physics.analyzers.TAKK.candidate.options.fillHits : true
-physics.analyzers.TAKK.supplements : []
+physics.analyzers.TAtpr.SelectEvents : [  tprDeM_highP_stopTarg  ]
+physics.analyzers.TAtpr.candidate.options : @local::AllOpt
+physics.analyzers.TAtpr.candidate.options.fillBestCrv : false
+physics.analyzers.TAtpr.diagLevel : 2
+physics.analyzers.TAtpr.FillCRV : false
+physics.analyzers.TAtpr.FillMCInfo : false
+physics.analyzers.TAtpr.RecoCountTag : ""
+physics.analyzers.TAtpr.FillTriggerInfo : true
+physics.analyzers.TAtpr.FillTrkQualInfo : false
+physics.analyzers.TAtpr.FillTrkPIDInfo : false
+physics.analyzers.TAtpr.FillHitInfo : true
+physics.analyzers.TAtpr.FillTriggerInfo : false
+physics.analyzers.TAtpr.candidate.input : "TTKSF"
+physics.analyzers.TAtpr.candidate.suffix : "DeM"
+physics.analyzers.TAtpr.candidate.options.fillHits : true
+physics.analyzers.TAtpr.supplements : []
 
-physics.end_paths : [ EndPath ] # needed for generate_fcl
+physics.analyzers.TAcpr.SelectEvents : [  cprDeM_highP_stopTarg  ]
+physics.analyzers.TAcpr.candidate.options : @local::AllOpt
+physics.analyzers.TAcpr.candidate.options.fillBestCrv : false
+physics.analyzers.TAcpr.diagLevel : 2
+physics.analyzers.TAcpr.FillCRV : false
+physics.analyzers.TAcpr.FillMCInfo : false
+physics.analyzers.TAcpr.RecoCountTag : ""
+physics.analyzers.TAcpr.FillTriggerInfo : true
+physics.analyzers.TAcpr.FillTrkQualInfo : false
+physics.analyzers.TAcpr.FillTrkPIDInfo : false
+physics.analyzers.TAcpr.FillHitInfo : true
+physics.analyzers.TAcpr.FillTriggerInfo : false
+physics.analyzers.TAcpr.candidate.input : "TTCalSeedFit"
+physics.analyzers.TAcpr.candidate.suffix : "Dem"
+physics.analyzers.TAcpr.candidate.options.fillHits : true
+physics.analyzers.TAcpr.supplements : []
+
 services.TimeTracker.printSummary: true
 services.TFileService.fileName: "nts.owner.TTKKSeed.version.sequence.root"

--- a/Mu2eKinKal/test/TTKKSeed.fcl
+++ b/Mu2eKinKal/test/TTKKSeed.fcl
@@ -45,6 +45,18 @@ physics :
         PrintLevel             : 0
       }
     }
+    TTCalSeedFitDem : {
+      @table::TTMu2eKinKal.producers.TTKKDeMSeedFit
+      ModuleSettings : {
+        @table::TTMu2eKinKal.producers.TTKKDeMSeedFit.ModuleSettings
+        HelixSeedCollections   : [ "TTCalHelixMergerDeM" ]
+        ComboHitCollection     : "TTmakeSH"
+        CaloClusterCollection  : "CaloClusterFast"
+        StrawHitFlagCollection : "TTflagBkgHits:StrawHits"
+        SaveAllFits            : false
+        PrintLevel             : 0
+      }
+    }
   }
   filters : {
     @table::CprTrigger.filters
@@ -77,8 +89,7 @@ physics :
 
 }
 #include "Offline/gen/fcl/Trigger/OnSpillTrigMenu/OnSpillTrigMenu.fcl"
-outputs : {}
-physics.trigger_paths : [tprDeM_highP_stopTarg ]
+physics.trigger_paths : [tprDeM_highP_stopTarg, cprDeM_highP_stopTarg]
 
 physics.analyzers.TAKK.SelectEvents : [  tprDeM_highP_stopTarg  ]
 physics.analyzers.TAKK.candidate.options : @local::AllOpt

--- a/Mu2eKinKal/test/TTKKSeed.fcl
+++ b/Mu2eKinKal/test/TTKKSeed.fcl
@@ -4,14 +4,19 @@
 # services.DbService.purpose: MDC2020_perfect
 # services.DbService.version: v1_0
 #
-# To convert the fit to use CentralHelix instead of LoopHelix, add the following line to the stub:
-# physics.producers.KKDeMDriftFit.module_type : CentralHelixFit
-
 #include "Offline/fcl/minimalMessageService.fcl"
 #include "Offline/fcl/standardServices.fcl"
 #include "Production/JobConfig/reco/prolog.fcl"
 #include "Offline/Mu2eKinKal/fcl/prolog_trigger.fcl"
+#include "Offline/TrkHitReco/fcl/prolog_trigger.fcl"
+#include "Offline/TrkReco/fcl/prolog_trigger.fcl"
+#include "Offline/TrkPatRec/fcl/prolog_trigger.fcl"
+#include "Offline/TrkFilters/fcl/prolog_trigger.fcl"
+#include "Offline/CalPatRec/fcl/prolog.fcl"
+#include "Offline/CalPatRec/fcl/prolog_trigger.fcl"
+#include "Offline/Trigger/fcl/prolog_trigger.fcl"
 #include "TrkAna/fcl/prolog.fcl"
+#include "Offline/CommonMC/fcl/prolog.fcl"
 
 process_name: TTKKSeed
 source : { module_type : RootInput }
@@ -19,30 +24,36 @@ services : @local::Services.Reco
 physics :
 {
   producers : {
-    @table::TrkHitReco.producers
-    @table::Tracking.producers
-    @table::CalPatRec.producers
-    @table::CaloReco.producers
-    @table::CaloCluster.producers
-    @table::CaloMC.TruthProducers
-    @table::CrvResponsePackage.producers
-    @table::Reconstruction.producers
-    @table::TrkAnaReco.producers
+    @table::CaloHitRecoTrigger.producers
+    @table::CaloClusterTrigger.producers
+    @table::TrkHitRecoTrigger.producers
+    @table::TrkRecoTrigger.producers
+    @table::TrkHitRecoTrigger.producers
+    @table::TprTrigger.producers
+    @table::CprTrigger.producers
     @table::TTMu2eKinKal.producers
+
+    TTKSFDeM : {
+      @table::TTMu2eKinKal.producers.TTKKDeMSeedFit
+      ModuleSettings : {
+        @table::TTMu2eKinKal.producers.TTKKDeMSeedFit.ModuleSettings
+        HelixSeedCollections   : [ "TTHelixMergerDeM" ]
+        ComboHitCollection     : "TTmakeSH"
+        CaloClusterCollection  : "CaloClusterFast"
+        StrawHitFlagCollection : "TTflagBkgHits:StrawHits"
+        SaveAllFits            : false
+        PrintLevel             : 0
+      }
+    }
   }
   filters : {
-    @table::CalPatRec.filters
+    @table::CprTrigger.filters
+    @table::CaloFilters.filters
+    @table::TrkFilters.filters
+    @table::CstTrigger.filters
+    @table::Trigger.filters
   }
-  RecoPath : [
-    @sequence::Reconstruction.CaloReco,
-    @sequence::Reconstruction.TrkReco,
-    @sequence::Reconstruction.CrvReco,
-    TimeClusterFinderDe, HelixFinderDe,
-    CalTimePeakFinder, CalHelixFinderDe,
-    MHDeM,
-    TTKKDeMSeedFit,
-    @sequence::Reconstruction.MCReco
-  ]
+
   analyzers : {
     TAKK : @local::TrkAnaReco.analyzers.TrkAnaNeg
     evtprint : {
@@ -54,44 +65,38 @@ physics :
     }
   }
   EndPath : [TAKK]
+
+  tprDeM_highP_stopTarg           : [ @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
+    @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
+    TTtimeClusterFinder, tprDeMHighPStopTargTCFilter, TThelixFinder, TTHelixMergerDeM, tprDeMHighPStopTargHSFilter, TTKSFDeM, tprDeMHighPStopTargTSFilter ]
+
+  cprDeM_highP_stopTarg           : [ @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
+    @sequence::TrkHitRecoTrigger.sequences.TTprepareHits,
+    TTCalTimePeakFinder, cprDeMHighPStopTargTCFilter, TTCalHelixFinderDe, TTCalHelixMergerDeM, cprDeMHighPStopTargHSFilter,
+    TTCalSeedFitDem, cprDeMHighPStopTargTSFilter ]
+
 }
-outputs : {
-  Output : {
-    @table::Reconstruction.Output
-    SelectEvents : [ "RecoPath" ]
-  }
-}
+#include "Offline/gen/fcl/Trigger/OnSpillTrigMenu/OnSpillTrigMenu.fcl"
+outputs : {}
+physics.trigger_paths : [tprDeM_highP_stopTarg ]
 
-#include "Production/JobConfig/reco/epilog.fcl"
-physics.producers.CaloHitTruthMatch.primaryParticle : "compressDigiMCs"
-physics.producers.CaloHitTruthMatch.caloShowerSimCollection : "compressDigiMCs"
-physics.filters.CalHelixFinderDe.StrawHitFlagCollectionLabel                 : "FlagBkgHits:ComboHits"
-physics.producers.SelectRecoMC.KalSeedCollections  : ["TTKKDeMSeedFit"]
-physics.producers.SelectRecoMC.HelixSeedCollections  : ["MHDeM"]
-physics.producers.SelectRecoMC.debugLevel : 0
-
-physics.producers.TTKKDeMSeedFit.ModuleSettings.HelixSeedCollections : [ "MHDeM" ]
-physics.producers.TTKKDeMSeedFit.ModuleSettings.ComboHitCollection : "makeSH"
-physics.producers.TTKKDeMSeedFit.ModuleSettings.CaloClusterCollection : "CaloClusterMaker"
-physics.producers.TTKKDeMSeedFit.ModuleSettings.StrawHitFlagCollection : "FlagBkgHits:StrawHits"
-physics.producers.TTKKDeMSeedFit.ModuleSettings.PrintLevel : 0
-physics.producers.TTKKDeMSeedFit.ModuleSettings.SaveAllFits : true
-
+physics.analyzers.TAKK.SelectEvents : [  tprDeM_highP_stopTarg  ]
 physics.analyzers.TAKK.candidate.options : @local::AllOpt
 physics.analyzers.TAKK.candidate.options.fillBestCrv : false
 physics.analyzers.TAKK.diagLevel : 2
 physics.analyzers.TAKK.FillCRV : false
-physics.analyzers.TAKK.FillMCInfo : true
+physics.analyzers.TAKK.FillMCInfo : false
+physics.analyzers.TAKK.RecoCountTag : ""
 physics.analyzers.TAKK.FillTriggerInfo : true
 physics.analyzers.TAKK.FillTrkQualInfo : false
 physics.analyzers.TAKK.FillTrkPIDInfo : false
 physics.analyzers.TAKK.FillHitInfo : true
 physics.analyzers.TAKK.FillTriggerInfo : false
-physics.analyzers.TAKK.candidate.input : "TTKK"
-physics.analyzers.TAKK.candidate.suffix : "DeMSeedFit"
+physics.analyzers.TAKK.candidate.input : "TTKSF"
+physics.analyzers.TAKK.candidate.suffix : "DeM"
 physics.analyzers.TAKK.candidate.options.fillHits : true
 physics.analyzers.TAKK.supplements : []
 
 physics.end_paths : [ EndPath ] # needed for generate_fcl
 services.TimeTracker.printSummary: true
-services.TFileService.fileName: "nts.owner.KKSeed.version.sequence.root"
+services.TFileService.fileName: "nts.owner.TTKKSeed.version.sequence.root"

--- a/RecoDataProducts/src/ComboHit.cc
+++ b/RecoDataProducts/src/ComboHit.cc
@@ -16,10 +16,13 @@ namespace mu2e {
   Float_t ComboHit::posRes(edir dir) const {
     switch ( dir ) {
       case ComboHit::wire : {
-        return _wres;
+        return _ures;
       }
       case ComboHit::trans : {
-        return _tres;
+        return _vres;
+      }
+      case ComboHit::z : {
+        return _wres;
       }
       default : {
         return -1.0;

--- a/TrkDiag/inc/ComboHitInfo.hh
+++ b/TrkDiag/inc/ComboHitInfo.hh
@@ -7,22 +7,18 @@ namespace mu2e {
   struct ComboHitInfo {
 
     XYZVectorF _pos; // position of this hit
-    XYZVectorF _wdir; // direction of this hit
-    Float_t _wdist; // distance from wire center along this direction
-    Float_t _wres; // estimated error along this direction
-    Float_t _tres; // estimated error perpendicular to this direction
-    Float_t _tdrift; // drift time estimate
+    XYZVectorF _udir; // U direction of this hit
+    Float_t _du; // distance from this hit to the parent ComboHit in U
+    Float_t _dv; // distance from this hit to the parent ComboHit in V
+    Float_t _dw; // distance from this hit to the parent ComboHit in W
+    Float_t _ures; // estimated error along the U direction
+    Float_t _vres; // estimated error along the V direction
+    Float_t _wres; // estimated error along the W direction
+    Float_t _tres; // estimated time error
     Float_t _thit; // hit time
     Int_t _strawid; // strawid info
     Int_t _panelid; // panelid info
-    Float_t _dperp, _dwire; // distance from average to this hit
-    Float_t _dterr; // estimated error on distance to center
-    Float_t _dwerr; // estimated error along wire direction
-    Float_t _dtime; // time diference to average
-    Float_t _dedep; // energy dep difference
-    Int_t _ds; // straw difference
-    Int_t _dp; // panel difference
-    Int_t _nch;
+    Int_t _nch; // hit counts
     Int_t _nsh;
   };
   struct ComboHitInfoMC {

--- a/TrkDiag/src/HelixDiag_module.cc
+++ b/TrkDiag/src/HelixDiag_module.cc
@@ -348,8 +348,8 @@ namespace mu2e {
 
             hhinfo._dwire = dwire;
             hhinfo._dtrans = dtrans;
-            hhinfo._wres = sqrt(wres2);
-            hhinfo._wtres = sqrt(wtres2);
+            hhinfo._werr = sqrt(wres2);
+            hhinfo._terr = sqrt(wtres2);
             hhinfo._chisq = dwire*dwire/wres2 + dtrans*dtrans/wtres2;
             hhinfo._hqual = hhit.qual();
 
@@ -460,7 +460,7 @@ namespace mu2e {
       double proj = that.Dot(hhit.wdir());
       double fcent = rhel.circleAzimuth(hhit.pos().z());
       TEllipse* te = new TEllipse(hhit.pos().z(),hhit.helixPhi()-fcent,
-          hhit._tres, hhit._wres*proj/rhel.radius());
+          hhit.vRes(), hhit.uRes()*proj/rhel.radius());
 
       // mc truth
       if(_mcdiag){
@@ -500,7 +500,7 @@ namespace mu2e {
         XYZVectorF that = XYZVectorF(-rpos.y(),rpos.x(),0.0).unit(); // local phi direction at this hit
         double proj = that.Dot(ch.wdir());
         TEllipse* te = new TEllipse(ch.pos().z(),dphi,
-            ch._tres, ch._wres*proj/rhel.radius());
+            ch.vRes(), ch.uRes()*proj/rhel.radius());
         te->SetLineColor(kGreen);
         te->SetFillColor(kGreen);
         tc_list->Add(te);
@@ -516,13 +516,13 @@ namespace mu2e {
       XYZVectorF that = XYZVectorF(-rpos.y(),rpos.x(),0.0).unit(); // local phi direction at this hit
       double proj = that.Dot(ch.wdir());
       TEllipse* te = new TEllipse(ch.pos().z(),dphi,
-          ch._tres, ch._wres*proj/rhel.radius());
+          ch.vRes(), ch.uRes()*proj/rhel.radius());
       te->SetLineColor(kYellow);
       te->SetFillColor(kYellow);
       notselected_list->Add(te);
       if(selectedHit(ich)){
         TEllipse* tes = new TEllipse(ch.pos().z(),dphi,
-            ch._tres, ch._wres*proj/rhel.radius());
+            ch.vRes(), ch.uRes()*proj/rhel.radius());
         tes->SetLineColor(kOrange);
         tes->SetFillColor(kOrange);
         selected_list->Add(tes);
@@ -653,7 +653,7 @@ namespace mu2e {
       ComboHit const& hhit = hhits[ihit];
       // create an elipse for this hit
       TEllipse* te = new TEllipse(hhit.pos().x()-pcent.x(),hhit.pos().y()-pcent.y(),
-          hhit._wres, hhit._tres,0.0,360.0, hhit.wdir().phi()*180.0/TMath::Pi());
+          hhit.uRes(), hhit.vRes(),0.0,360.0, hhit.wdir().phi()*180.0/TMath::Pi());
       // mc truth
       if(_mcdiag){
         std::vector<StrawDigiIndex> sdis;
@@ -684,7 +684,7 @@ namespace mu2e {
       for(auto ih : timec->hits()){
         auto const& ch = _chcol->at(ih);
         TEllipse* te = new TEllipse(ch._pos.x()-pcent.x(),ch._pos.y()-pcent.y(),
-            ch._wres, ch._tres,0.0,360.0, ch._wdir.phi()*180.0/TMath::Pi());
+            ch.uRes(), ch.vRes(),0.0,360.0, ch.uDir().phi()*180.0/TMath::Pi());
         te->SetLineColor(kGreen);
         te->SetFillColor(kGreen);
         tc_list->Add(te);
@@ -695,7 +695,7 @@ namespace mu2e {
       auto const& ch = _chcol->at(ich);
       // create an elipse for this hit
       TEllipse* te = new TEllipse(ch._pos.x()-pcent.x(),ch._pos.y()-pcent.y(),
-          ch._wres, ch._tres,0.0,360.0, ch._wdir.phi()*180.0/TMath::Pi());
+          ch.uRes(), ch.vRes(),0.0,360.0, ch.uDir().phi()*180.0/TMath::Pi());
       // draw all hits
       te->SetLineColor(kYellow);
       te->SetFillColor(kYellow);
@@ -703,7 +703,7 @@ namespace mu2e {
       // selected hits; this overlaps with those below
       if(selectedHit(ich)){
         TEllipse* tes = new TEllipse(ch._pos.x()-pcent.x(),ch._pos.y()-pcent.y(),
-            ch._wres, ch._tres,0.0,360.0, ch._wdir.phi()*180.0/TMath::Pi());
+            ch.uRes(), ch.vRes(),0.0,360.0, ch.uDir().phi()*180.0/TMath::Pi());
         tes->SetLineColor(kOrange);
         tes->SetFillColor(kOrange);
         selected_list->Add(tes);

--- a/TrkHitReco/fcl/prolog.fcl
+++ b/TrkHitReco/fcl/prolog.fcl
@@ -41,9 +41,8 @@ makePH : {
   MaxDt                 : 40 # ns
   UseTOT                : true
   MaxWireDistDiffPull   : 4.0
-  TransError            : 8.0 #mm
   MaxDS                 : 3
-  WireError             : 10.0 # mm
+  UError                : 10.0 # mm
   MinimumTime           : 420.0 # ns
   MaximumTime           : 1690.0 # ns
   MinimumEnergy         : 0.0 # MeV
@@ -70,7 +69,7 @@ makeSTH : {
   MaxWdot               : 0.9
   MaxChisquared         : 5.0
   MinMVA                : 0.6
-  WErrorFactor          : 0.3 # mm
+  UVRes                 : 10.0 # mm
   ZErrorFactor          : 1.0 # mm
   MinRho                : 330 # mm
   MaxRho                : 700 # mm

--- a/TrkHitReco/src/CombineStrawHits_module.cc
+++ b/TrkHitReco/src/CombineStrawHits_module.cc
@@ -268,8 +268,8 @@ namespace mu2e {
     combohit._wres       = sqrt(1.0/weights + _werr2);
     combohit._tres       = _terr/sqrt(combohit._nsh); // error proportional to # of straws (roughly)
     float wdist2 = wacc2/weights;
-    float sigw(combohit._wres);
-    if (combohit.nCombo() > 1) sigw = sqrt((wdist2-combohit._wdist*combohit._wdist)/(combohit.nCombo()-1));
+    float nc2 = pow(combohit.nCombo()-1,2);
+    float sigw = sqrt(std::max(_werr2,(wdist2-combohit._wdist*combohit._wdist)/nc2));
     combohit._qual       = sigw/combohit._wres; // set to ratio of original to reduced chi
 
 //-----------------------------------------------------------------------------

--- a/TrkHitReco/src/StrawHitRecoUtils.cc
+++ b/TrkHitReco/src/StrawHitRecoUtils.cc
@@ -168,10 +168,14 @@ namespace mu2e {
     ComboHit ch;
     ch._nsh = 1; // 'combo' of 1 digi
     ch._pos = pos;
-    ch._wdir = straw.getDirection();
-    ch._sdir = _zdir.Cross(ch._wdir);
+    ch._udir = straw.getDirection();
+    ch._vdir = _zdir.Cross(ch._udir);
     ch._wdist = dw;
-    ch._wres = dwerr;
+    ch._ures = dwerr;
+    // initial estimate of the transverse error is the straw diameter/sqrt(12)
+    static const float invsqrt3 = 1.0/sqrt(3.0);
+    ch._vres = tt.strawOuterRadius()*invsqrt3;
+    ch._wres = ch._vres;
     ch._time = time;
     ch._timeres = tres;
     ch._edep = energy;
@@ -181,9 +185,6 @@ namespace mu2e {
     ch._etime = times;
     ch._ptime = ptime;
     ch.addIndex(isd);
-    // initial estimate of the transverse error is the straw diameter/sqrt(12)
-    static const float invsqrt3 = 1.0/sqrt(3.0);
-    ch._tres = tt.strawOuterRadius()*invsqrt3;
     // set flags
     ch._mask = _mask;
     ch._flag = flag;

--- a/TrkReco/src/MergeHelices_module.cc
+++ b/TrkReco/src/MergeHelices_module.cc
@@ -195,12 +195,12 @@ namespace mu2e {
         // Calculate the transverse and z-phi weights of the hits
         float dx = hh.pos().x() - h1.helix().center().x();
         float dy = hh.pos().y() - h1.helix().center().y();
-        float dxn = dx*hh._sdir.x()+dy*hh._sdir.y();
+        float dxn = dx*hh.vDir().x()+dy*hh.vDir().y();
         float costh2 = dxn*dxn/(dx*dx+dy*dy);
         float sinth2 = 1-costh2;
-        float e2xy = hh.wireVar()*sinth2+hh.transVar()*costh2;
+        float e2xy = hh.uVar()*sinth2+hh.vVar()*costh2;
         float wtxy = 1./e2xy;
-        float e2zphi = hh.wireVar()*costh2+hh.transVar()*sinth2;
+        float e2zphi = hh.uVar()*costh2+hh.vVar()*sinth2;
         float wtzphi = h1.helix().radius()*h1.helix().radius()/e2zphi;
         wtxy *= _scaleXY;
         wtzphi *= _scaleZPhi;

--- a/TrkReco/src/RobustHelixFit.cc
+++ b/TrkReco/src/RobustHelixFit.cc
@@ -1412,20 +1412,6 @@ bool RobustHelixFit::goodLambda(Helicity const& h, float lambda) const {
 }
 
 float RobustHelixFit::evalWeightXY(const ComboHit& Hit, XYVec& Center){
-  // XYVec rvec = (XYVec(Hit.pos().x(),Hit.pos().y())-Center);
-  // XYVec rdir = rvec.unit();
-  // float wdot = rdir.Dot(XYVec(Hit.wdir().x(),Hit.wdir().y()));
-  // float wdot2 = wdot*wdot;
-  // float tdot2 = 1.0 - wdot2;
-  // float err2 = wdot2*Hit.wireVar() + tdot2*Hit.transVar();
-  // float wt = 1/err2;// or 1.0/sqrtf(err2); // or 1/err2?
-
-//  float    transErr = 5./sqrt(12.);
-//  //scale the error based on the number of the strawHits that are within teh ComboHit
-//  if (Hit.nStrawHits() > 1) transErr *= 1.5;
-//  float    transVar = transErr*transErr;
-
-
   float x   = Hit.pos().x();
   float y   = Hit.pos().y();
   float dx  = x-Center.x();
@@ -1435,7 +1421,6 @@ float RobustHelixFit::evalWeightXY(const ComboHit& Hit, XYVec& Center){
   float costh2 = dxn*dxn/(dx*dx+dy*dy);
   float sinth2 = 1-costh2;
 
-  // float e2     = _ew*_ew*sinth2+rs*rs*costh2;
   float e2     = Hit.uVar()*sinth2+Hit.vVar()*costh2;
   float wt     = 1./e2;
 
@@ -1443,11 +1428,6 @@ float RobustHelixFit::evalWeightXY(const ComboHit& Hit, XYVec& Center){
 }
 
 float RobustHelixFit::evalWeightZPhi(const ComboHit& Hit, XYVec& Center, float Radius){
-//  float    transErr = 5./sqrt(12.);
-//  //scale the error based on the number of the strawHits that are within teh ComboHit
-//  if (Hit.nStrawHits() > 1) transErr *= 1.5;
-//  float    transVar = transErr*transErr;
-
   float x  = Hit.pos().x();
   float y  = Hit.pos().y();
   float dx = x-Center.x();
@@ -1458,10 +1438,8 @@ float RobustHelixFit::evalWeightZPhi(const ComboHit& Hit, XYVec& Center, float R
   float costh2 = dxn*dxn/(dx*dx+dy*dy);
   float sinth2 = 1-costh2;
 
-  // float e2     = _ew*_ew*costh2+rs*rs*sinth2;
   float e2     = Hit.uVar()*costh2+Hit.vVar()*sinth2;
   float wt     = Radius*Radius/e2;
-  //    wt           *= 0.025;//_weightZPhi;
 
   return wt;
 }

--- a/TrkReco/src/RobustHelixFit.cc
+++ b/TrkReco/src/RobustHelixFit.cc
@@ -1420,51 +1420,46 @@ float RobustHelixFit::evalWeightXY(const ComboHit& Hit, XYVec& Center){
   // float err2 = wdot2*Hit.wireVar() + tdot2*Hit.transVar();
   // float wt = 1/err2;// or 1.0/sqrtf(err2); // or 1/err2?
 
-  float    transErr = 5./sqrt(12.);
-  //scale the error based on the number of the strawHits that are within teh ComboHit
-  if (Hit.nStrawHits() > 1) transErr *= 1.5;
-  float    transVar = transErr*transErr;
+//  float    transErr = 5./sqrt(12.);
+//  //scale the error based on the number of the strawHits that are within teh ComboHit
+//  if (Hit.nStrawHits() > 1) transErr *= 1.5;
+//  float    transVar = transErr*transErr;
 
-  static const XYZVectorF _zdir(0.0,0.0,1.0);
-  XYZVectorF _sdir  = _zdir.Cross(Hit._wdir);
 
   float x   = Hit.pos().x();
   float y   = Hit.pos().y();
   float dx  = x-Center.x();
   float dy  = y-Center.y();
-  float dxn = dx*_sdir.x()+dy*_sdir.y();
+  float dxn = dx*Hit.vDir().x()+dy*Hit.vDir().y();
 
   float costh2 = dxn*dxn/(dx*dx+dy*dy);
   float sinth2 = 1-costh2;
 
   // float e2     = _ew*_ew*sinth2+rs*rs*costh2;
-  float e2     = Hit.wireVar()*sinth2+transVar*costh2;
+  float e2     = Hit.uVar()*sinth2+Hit.vVar()*costh2;
   float wt     = 1./e2;
 
   return wt;
 }
 
 float RobustHelixFit::evalWeightZPhi(const ComboHit& Hit, XYVec& Center, float Radius){
-  float    transErr = 5./sqrt(12.);
-  //scale the error based on the number of the strawHits that are within teh ComboHit
-  if (Hit.nStrawHits() > 1) transErr *= 1.5;
-  float    transVar = transErr*transErr;
+//  float    transErr = 5./sqrt(12.);
+//  //scale the error based on the number of the strawHits that are within teh ComboHit
+//  if (Hit.nStrawHits() > 1) transErr *= 1.5;
+//  float    transVar = transErr*transErr;
 
   float x  = Hit.pos().x();
   float y  = Hit.pos().y();
   float dx = x-Center.x();
   float dy = y-Center.y();
 
-  static const XYZVectorF _zdir(0.0,0.0,1.0);
-  XYZVectorF _sdir  = _zdir.Cross(Hit._wdir);
-
-  float dxn    = dx*_sdir.x()+dy*_sdir.y();
+  float dxn    = dx*Hit.vDir().x()+dy*Hit.vDir().y();
 
   float costh2 = dxn*dxn/(dx*dx+dy*dy);
   float sinth2 = 1-costh2;
 
   // float e2     = _ew*_ew*costh2+rs*rs*sinth2;
-  float e2     = Hit.wireVar()*costh2+transVar*sinth2;
+  float e2     = Hit.uVar()*costh2+Hit.vVar()*sinth2;
   float wt     = Radius*Radius/e2;
   //    wt           *= 0.025;//_weightZPhi;
 


### PR DESCRIPTION
Add protection against FP errors in KalSeed from BTrk.  Use UVW coordinates consistently in ComboHit and clients.  Fix stereo hit 'wire' direction.  Improve KinKal prolog_trigger: the trigger fit is now more efficient than BTrk and 10X faster.