### PR TITLE
Trigger MC truth fcl

### DIFF
--- a/CommonMC/fcl/prolog_trigger.fcl
+++ b/CommonMC/fcl/prolog_trigger.fcl
@@ -1,0 +1,28 @@
+#
+# Trigger specific: used for trigger MC-truth based diagnostics
+#
+#include "Offline/CommonMC/fcl/prolog.fcl"
+BEGIN_PROLOG
+CommonMCTrigger : {
+  TTSelectRecoMC : {
+    @table::CommonMC.SelectRecoMC
+    TrkOnly : true
+    CaloClusterMinE : 10.0
+    SaveEnergySteps : false
+    SaveUnusedDigiMCs : false
+    SaveAllUnusedDigiMCs : false
+    UseStrawHitFlagCollection: false
+    PrimaryParticle : "compressDigiMCs"
+    StrawDigiCollection : "makeSD"
+    StrawHitFlagCollection : "TTflagBkgHits:StrawHits"
+    ComboHitCollection : "TTmakeSH"
+    CaloDigiCollection : "CaloDigiMaker"
+    CaloClusterCollection : "CaloClusterFast"
+    StrawDigiMCCollection : "compressDigiMCs"
+    CrvDigiCollection : "CrvDigi"
+    CrvDigiMCCollection : "compressDigiMCs"
+    CrvCoincidenceClusterCollection : "CrvCoincidenceClusterFinder"
+    VDSPCollection : "compressDigiMCs:virtualdetector"
+  }
+}
+END_PROLOG

--- a/Mu2eKinKal/test/TTTA.fcl
+++ b/Mu2eKinKal/test/TTTA.fcl
@@ -10,7 +10,7 @@
 #include "Offline/Mu2eKinKal/fcl/prolog_trigger.fcl"
 #include "Offline/Trigger/fcl/prolog_trigger.fcl"
 #include "TrkAna/fcl/prolog.fcl"
-#include "Offline/CommonMC/fcl/prolog.fcl"
+#include "Offline/CommonMC/fcl/prolog_trigger.fcl"
 
 process_name: TTKKSeed
 source : {module_type : RootInput
@@ -35,48 +35,14 @@ physics :
     @table::CprTrigger.producers
     @table::TTMu2eKinKal.producers
     SelectRecoMCcpr : {
-      @table::CommonMC.SelectRecoMC
-      TrkOnly : true
-      CaloClusterMinE : 10.0
-      SaveEnergySteps : false
-      SaveUnusedDigiMCs : false
-      SaveAllUnusedDigiMCs : false
-      UseStrawHitFlagCollection: false
-      PrimaryParticle : "compressDigiMCs"
-      StrawDigiCollection : "makeSD"
-      StrawHitFlagCollection : "TTflagBkgHits:StrawHits"
-      ComboHitCollection : "TTmakeSH"
-      CaloDigiCollection : "CaloDigiMaker"
-      CaloClusterCollection : "CaloClusterFast"
-      StrawDigiMCCollection : "compressDigiMCs"
-      CrvDigiCollection : "CrvDigi"
-      CrvDigiMCCollection : "compressDigiMCs"
-      CrvCoincidenceClusterCollection : "CrvCoincidenceClusterFinder"
+      @table::CommonMCTrigger.TTSelectRecoMC
       KalSeedCollections  : [ "TTCalSeedFitDem" ]
       HelixSeedCollections  : ["TTCalHelixMergerDeM" ]
-      VDSPCollection : "compressDigiMCs:virtualdetector"
     }
-
     SelectRecoMCtpr : {
-      @table::CommonMC.SelectRecoMC
-      TrkOnly : true
-      CaloClusterMinE : 10.0
-      SaveEnergySteps : false
-      SaveUnusedDigiMCs : false
-      SaveAllUnusedDigiMCs : false
-      PrimaryParticle : "compressDigiMCs"
-      StrawDigiCollection : "makeSD"
-      StrawHitFlagCollection : "TTflagBkgHits:StrawHits"
-      ComboHitCollection : "TTmakeSH"
-      CaloDigiCollection : "CaloDigiMaker"
-      CaloClusterCollection : "CaloClusterFast"
-      StrawDigiMCCollection : "compressDigiMCs"
-      CrvDigiCollection : "CrvDigi"
-      CrvDigiMCCollection : "compressDigiMCs"
-      CrvCoincidenceClusterCollection : "CrvCoincidenceClusterFinder"
+      @table::CommonMCTrigger.TTSelectRecoMC
       KalSeedCollections  : [ "TTKSFDeM" ]
       HelixSeedCollections  : ["TTHelixMergerDeM" ]
-      VDSPCollection : "compressDigiMCs:virtualdetector"
     }
 
     TTKSFDeM : {

--- a/Mu2eKinKal/test/TTTA.fcl
+++ b/Mu2eKinKal/test/TTTA.fcl
@@ -10,6 +10,7 @@
 #include "Offline/Mu2eKinKal/fcl/prolog_trigger.fcl"
 #include "Offline/Trigger/fcl/prolog_trigger.fcl"
 #include "TrkAna/fcl/prolog.fcl"
+#include "Offline/TrkDiag/fcl/prolog.fcl"
 #include "Offline/CommonMC/fcl/prolog_trigger.fcl"
 
 process_name: TTKKSeed
@@ -95,6 +96,20 @@ physics :
       printSubrun : false
       printEvent  : true
     }
+    CHDS : {
+      @table::CHD
+      diagLevel : 2
+      digiDiag : true
+      ComboHitCollection : "TTmakeSH"
+      useFlagCollection : false
+    }
+    CHDP : {
+      @table::CHD
+      diagLevel : 2
+      digiDiag : true
+      ComboHitCollection : "TTmakePH"
+      useFlagCollection : false
+    }
   }
 
   tprDeM_highP_stopTarg           : [ @sequence::CaloHitRecoTrigger.prepareHits, @sequence::CaloClusterTrigger.Reco,
@@ -107,8 +122,8 @@ physics :
     TTCalTimePeakFinder, cprDeMHighPStopTargTCFilter, TTCalHelixFinderDe,
     TTCalHelixMergerDeM, cprDeMHighPStopTargHSFilter,
     TTCalSeedFitDem, cprDeMHighPStopTargTSFilter, SelectRecoMCcpr]
+  #  EndPath : [TAtpr, TAcpr, CHDS, CHDP]
   EndPath : [TAtpr, TAcpr]
-  #  EndPath : [Output]
 }
 outputs : {
   Output : {
@@ -125,6 +140,10 @@ physics.end_paths : [ EndPath ]
 # this next is currently needed to get correct hit-level MC truth matching.  It needs to be fixed at the
 # ComboHitCollection.  This setting works, but will slow down the trigger: don't use this script for timing studies
 physics.producers.TTmakeSH.FilterHits : false
+physics.producers.TTmakePH.TestFlag : true
+#physics.producers.TTmakePH.FilterHits : true
+physics.producers.TTmakePH.StrawHitSelectionBits : ["EnergySelection","TimeSelection","RadiusSelection"]
+physics.producers.TTmakePH.StrawHitMask          : ["Noisy"]
 
 physics.producers.TTKSFDeM.FitSettings.BkgANNSHUSettings : [
   [ "Offline/Mu2eKinKal/data/TrainBkgTTtpr.dat",0.01,"Inactive", 1]

--- a/TrkHitReco/fcl/prolog.fcl
+++ b/TrkHitReco/fcl/prolog.fcl
@@ -13,8 +13,8 @@ makeSH : {
   MaximumTime             : 1690.0 # ns
   MinimumEnergy           : 0.0001 # MeV
   MaximumEnergy           : 0.0035 # MeV
-  MinimumRadius           : 0.0 # mm
-  MaximumRadius           : 800.0 # mm
+  MinimumRadius           : 395.0 # mm
+  MaximumRadius           : 650.0 # mm
   FitType                 : 1
   FilterHits              : false
   WriteStrawHitCollection : true

--- a/TrkHitReco/fcl/prolog_trigger.fcl
+++ b/TrkHitReco/fcl/prolog_trigger.fcl
@@ -19,6 +19,8 @@ TTmakeSH : {
 # combine hits in a panel
 TTmakePH : {
   @table::makePH
+  TestFlag   : false # not needed, since TTmakeSH is filtering
+  FilterHits : false
   ComboHitCollection    : "TTmakeSH"
   StrawHitSelectionBits : []
   StrawHitMask          : []
@@ -36,7 +38,6 @@ TTmakePHUCC : {
 # stereo version: defer the radius test
 TTSmakePH : {
   @table::TTmakePH
-  TestRadius : false
 }
 # combine panel hits in a station
 TTmakeSTH : {


### PR DESCRIPTION
Add fcl to configure KalSeedMC construction in the trigger reco sequences.  This also fixes a configuration bug which allowed background hits into the pattern recognition.