### PR TITLE
remove duplicate binary write

### DIFF
--- a/GeometryService/src/BFieldManagerMaker.cc
+++ b/GeometryService/src/BFieldManagerMaker.cc
@@ -404,9 +404,6 @@ namespace mu2e {
 
         mapContainer.emplace_back(dsmap);
 
-        if (config.writeBinaries()) {
-          writeG4BLBinary(*dsmap, key + ".bin");
-        }
     }
 
 


### PR DESCRIPTION
At some point, probably when I was re-organizing this code, we were left with writing binary files in two places in the code.  I noticed it the last time I converted Bfields.  This PR just removes one of the two writes.  Checked that the conversion works properly.  Checked that ceSimReco is not affected.