### PR TITLE
Use types defined within KalSeed.hh instead of redefinining them from scratch

### DIFF
--- a/EventDisplay/src/DataInterface.cc
+++ b/EventDisplay/src/DataInterface.cc
@@ -799,9 +799,10 @@ void DataInterface::findBoundaryP(spaceminmax &m, double x, double y, double z)
   if(std::isnan(m.maxz) || z>m.maxz) m.maxz=z;
 }
 
-using LHPT = KinKal::ParticleTrajectory<KinKal::LoopHelix>;
-using CHPT = KinKal::ParticleTrajectory<KinKal::CentralHelix>;
-using KLPT = KinKal::ParticleTrajectory<KinKal::KinematicLine>;
+using LHPT = mu2e::KalSeed::LHPT;
+using CHPT = mu2e::KalSeed::CHPT;
+using KLPT = mu2e::KalSeed::KLPT;
+
 template<class KTRAJ> void DataInterface::fillKalSeedTrajectory(std::unique_ptr<KTRAJ> &trajectory,
                                                                 int particleid, int trackclass, int trackclassindex, double p1,
                                                                 boost::shared_ptr<ComponentInfo> info)

--- a/TEveEventDisplay/src/TEveMu2eDataInterface.cc
+++ b/TEveEventDisplay/src/TEveMu2eDataInterface.cc
@@ -290,9 +290,9 @@ namespace mu2e{
   }
 
 
-using LHPT = KinKal::ParticleTrajectory<KinKal::LoopHelix>;
-using CHPT = KinKal::ParticleTrajectory<KinKal::CentralHelix>;
-using KLPT = KinKal::ParticleTrajectory<KinKal::KinematicLine>;
+using LHPT = KalSeed::LHPT;
+using CHPT = KalSeed::CHPT;
+using KLPT = KalSeed::KLPT;
 template<class KTRAJ> void TEveMu2eDataInterface::AddKinKalTrajectory( std::unique_ptr<KTRAJ> const& trajectory, TEveMu2eCustomHelix *line, TEveMu2eCustomHelix *line_twoDXY, TEveMu2eCustomHelix *line_twoDXZ){
   double t1=trajectory->range().begin();
   double t2=trajectory->range().end();


### PR DESCRIPTION
With this change, this code will automatically follow redefinitions of LHPT, CHPT and KLPT within KallSeed.hh

