### PR TITLE
avoid overflow

### DIFF
--- a/CalPatRec/src/MergeHelixFinder_module.cc
+++ b/CalPatRec/src/MergeHelixFinder_module.cc
@@ -182,7 +182,7 @@ namespace mu2e {
                                   int Index, AlgorithmIDCollection* AidColl) {
 
     AlgorithmID                              aid;
-    short                                    best(0),  mask(0xffff);
+    short                                    best(0),  mask(-1);
     art::Handle<mu2e::AlgorithmIDCollection> algH;
 
     HelixColl->push_back(*Helix);


### PR DESCRIPTION
Initializing a short to 0xFFFF causes a pedantic warning