### PR TITLE
DAQ CRV update

### DIFF
--- a/DAQ/fcl/prolog_trigger.fcl
+++ b/DAQ/fcl/prolog_trigger.fcl
@@ -80,9 +80,9 @@ DAQ : {
 
       CrvDigi:
       {
-         module_type: CrvDigisFromFragments
-         diagLevel: 0
-         fragmentsTag   : "daq:crv"
+         module_type : CrvDigisFromFragments
+         diagLevel   : 0
+         crvTag      : "genFrags"
       }
 
       makeSH:

--- a/DAQ/src/ArtFragmentsFromDTCEvents_module.cc
+++ b/DAQ/src/ArtFragmentsFromDTCEvents_module.cc
@@ -184,7 +184,7 @@ void art::ArtFragmentsFromDTCEvents::produce(Event& event) {
           auto block = cf.dataAtBlockIndex(0);
           if(block == nullptr) continue;
           auto header = block->GetHeader();
-          if(header->GetSubsystemID() != 2) continue;
+          if(header->GetSubsystemID() != DTCLib::DTC_Subsystem::DTC_Subsystem_CRV) continue;
 
           crvFragColl->emplace_back(cf);
           ++nFrags;

--- a/DAQ/src/ArtFragmentsFromDTCEvents_module.cc
+++ b/DAQ/src/ArtFragmentsFromDTCEvents_module.cc
@@ -164,7 +164,8 @@ void art::ArtFragmentsFromDTCEvents::produce(Event& event) {
     }
 
     if (makeCRVFrag_ > 0) { // CRV
-      auto crvSEvents = bb.getSubsystemData(DTCLib::DTC_Subsystem::DTC_Subsystem_CRV);
+//      auto crvSEvents = bb.getSubsystemData(DTCLib::DTC_Subsystem::DTC_Subsystem_CRV);
+      auto crvSEvents = bb.getSubsystemData(DTCLib::DTC_Subsystem::DTC_Subsystem_Tracker); //FIXME
       for (auto& subevent : crvSEvents) {
         mu2e::CRVFragment cf(subevent);
         crvFragColl->emplace_back(cf);

--- a/DAQ/src/CrvDigisFromFragments_module.cc
+++ b/DAQ/src/CrvDigisFromFragments_module.cc
@@ -17,25 +17,23 @@
 #include <artdaq-core/Data/Fragment.hh>
 
 #include <iostream>
-
 #include <string>
-
 #include <memory>
 
-#define LONG_FROM_CRV 0 // Whether to print long-form data or single-line summary
-
-namespace art {
-class CrvDigisFromFragments;
+namespace art
+{
+  class CrvDigisFromFragments;
 }
 
 using art::CrvDigisFromFragments;
 
 // ======================================================================
 
-class art::CrvDigisFromFragments : public EDProducer {
-
-public:
-  struct Config {
+class art::CrvDigisFromFragments : public EDProducer
+{
+  public:
+  struct Config
+  {
     fhicl::Atom<int> diagLevel{fhicl::Name("diagLevel"), fhicl::Comment("diagnostic Level")};
     fhicl::Atom<art::InputTag> crvFragmentsTag{fhicl::Name("crvTag"),
                                                fhicl::Comment("crv Fragments Tag")};
@@ -48,13 +46,12 @@ public:
   // --- Production:
   virtual void produce(Event&);
 
-private:
+  private:
   //  int decompressCrvDigi(uint8_t adc);
   int16_t decompressCrvDigi(int16_t adc);
 
-  int diagLevel_;
-
-  art::InputTag crvFragmentsTag_;
+  int                                      _diagLevel;
+  art::InputTag                            _crvFragmentsTag;
   mu2e::ProditionsHandle<mu2e::CRVOrdinal> _channelMap_h;
 
 }; // CrvDigisFromFragments
@@ -62,37 +59,40 @@ private:
 // ======================================================================
 
 CrvDigisFromFragments::CrvDigisFromFragments(const art::EDProducer::Table<Config>& config) :
-    art::EDProducer{config}, diagLevel_(config().diagLevel()),
-    crvFragmentsTag_(config().crvFragmentsTag()) {
+    art::EDProducer{config}, _diagLevel(config().diagLevel()), _crvFragmentsTag(config().crvFragmentsTag())
+{
   produces<mu2e::CrvDigiCollection>();
 }
 
 // ----------------------------------------------------------------------
 
-int16_t CrvDigisFromFragments::decompressCrvDigi(int16_t adc) {
+int16_t CrvDigisFromFragments::decompressCrvDigi(int16_t adc)
+{
   // TODO: This is a temporary implementation.
   return adc;
 }
 
-void CrvDigisFromFragments::produce(Event& event) {
-
+void CrvDigisFromFragments::produce(Event& event)
+{
   art::EventNumber_t eventNumber = event.event();
 
-  auto crvFragments = event.getValidHandle<std::vector<mu2e::CRVFragment> >(crvFragmentsTag_);
+  auto crvFragments = event.getValidHandle<std::vector<mu2e::CRVFragment> >(_crvFragmentsTag);
   size_t numCrvFrags = crvFragments->size();
 
-  if (diagLevel_ > 1) {
+  if(_diagLevel>1)
+  {
     std::cout << std::dec << "Producer: Run " << event.run() << ", subrun " << event.subRun()
               << ", event " << eventNumber << " has " << std::endl;
     std::cout << crvFragments->size() << " CRV fragments." << std::endl;
 
     size_t totalSize = 0;
-    for (auto frag : *crvFragments) {
-      for (size_t i = 0; i < frag.block_count(); ++i) {
-        auto size = frag.blockSizeBytes(i); //((*crvFragments)[idx]) * sizeof(artdaq::RawDataType);
+    for(auto frag : *crvFragments)
+    {
+      for(size_t i = 0; i < frag.block_count(); ++i)
+      {
+        auto size = frag.blockSizeBytes(i);
         totalSize += size;
       }
-      //      std::cout << "\tCRV Fragment " << idx << " has size " << size << std::endl;
     }
 
     std::cout << "\tTotal Size: " << (int)totalSize << " bytes." << std::endl;
@@ -103,38 +103,41 @@ void CrvDigisFromFragments::produce(Event& event) {
   auto const& channelMap = _channelMap_h.get(event.id());
 
   // Loop over the CRV fragments
-  for (size_t idx = 0; idx < numCrvFrags; ++idx) {
+  for(size_t idx = 0; idx < numCrvFrags; ++idx)
+  {
+    const mu2e::CRVFragment& crvFragment((*crvFragments)[idx]);
+    crvFragment.setup_event();
 
-    const auto& fragment((*crvFragments)[idx]);
-
-    mu2e::CRVFragment crvFragment(fragment);
-
-    for (size_t iDataBlock = 0; iDataBlock < crvFragment.block_count(); ++iDataBlock) {
+    for(size_t iDataBlock = 0; iDataBlock < crvFragment.block_count(); ++iDataBlock)
+    {
       auto block = crvFragment.dataAtBlockIndex(iDataBlock);
-      if (block == nullptr) {
+      if(block == nullptr)
+      {
         std::cerr << "Unable to retrieve block " << iDataBlock << "!" << std::endl;
         continue;
       }
       auto header = block->GetHeader();
-      if (header->GetSubsystemID() != 2) {
+      if(header->GetSubsystemID() != 2)
+      {
         throw cet::exception("DATA") << " CRV packet does not have system ID 2";
       }
 
-      if (header->GetPacketCount() > 0) {
+      if(header->GetPacketCount() > 0)
+      {
         auto crvRocHeader = crvFragment.GetCRVROCStatusPacket(iDataBlock);
-        if (crvRocHeader == nullptr) {
-          std::cerr << "Error retrieving CRV ROC Status Packet from DataBlock " << iDataBlock
-                    << std::endl;
+        if(crvRocHeader == nullptr)
+        {
+          std::cerr << "Error retrieving CRV ROC Status Packet from DataBlock " << iDataBlock << std::endl;
           continue;
         }
 
         auto crvHits = crvFragment.GetCRVHits(iDataBlock);
-        for (auto const& crvHit : crvHits) {
+        for(auto const& crvHit : crvHits)
+        {
           const auto& crvHitInfo = crvHit.first;
           const auto& waveform = crvHit.second;
 
-          uint16_t rocID = crvHitInfo.controllerNumber +
-                           1; // FIXME ROC IDs between 1 and 17   //also: header->GetLinkID()+1;
+          uint16_t rocID = crvHitInfo.controllerNumber + 1; // FIXME ROC IDs between 1 and 17   //also: header->GetLinkID()+1;
           uint16_t rocPort = crvHitInfo.portNumber;
           uint16_t febChannel = crvHitInfo.febChannel;
           mu2e::CRVROC onlineChannel(rocID, rocPort, febChannel);
@@ -143,23 +146,26 @@ void CrvDigisFromFragments::produce(Event& event) {
           int crvBarIndex = offlineChannel / 4;
           int SiPMNumber = offlineChannel % 4;
 
-          for (int i = 0; i < crvHitInfo.NumSamples; i += 8) {
+          for(int i = 0; i < crvHitInfo.NumSamples; i += 8)
+          {
             std::array<int16_t, 8> adc = {0};
-            for (int j = i; j < i + 8 && j < crvHitInfo.NumSamples; ++j)
+            for(int j = i; j < i + 8 && j < crvHitInfo.NumSamples; ++j)
               adc[j] = decompressCrvDigi(waveform.at(j).ADC);
 
             // CrvDigis use a constant array size of 8 samples
             // waveforms with more than 8 samples need to be written to multiple CrvDigis
             // the TDC increases by 8 for every subsequent CrvDigi
-            crv_digis->emplace_back(adc, crvHitInfo.HitTime + i,
-                                   mu2e::CRSScintillatorBarIndex(crvBarIndex), SiPMNumber);
+            crv_digis->emplace_back(adc, crvHitInfo.HitTime + i, mu2e::CRSScintillatorBarIndex(crvBarIndex), SiPMNumber);
           }
         } // loop over all crvHits
 
-        if (diagLevel_ > 0) {
-          for (auto const& crvHit : crvHits) {
+        if(_diagLevel>0)
+        {
+          for(auto const& crvHit : crvHits)
+          {
             std::cout << "iSubEvent/iDataBlock: " << idx << "/" << iDataBlock << std::endl;
-            if (diagLevel_ > 1) {
+            if(_diagLevel>1)
+            {
               std::cout << "EventWindowTag (TDC header): "
                         << header->GetEventWindowTag().GetEventWindowTag(true) << std::endl;
               std::cout << "SubsystemID: " << (uint16_t)header->GetSubsystemID() << std::endl;
@@ -169,17 +175,14 @@ void CrvDigisFromFragments::produce(Event& event) {
               std::cout << "EVB mode: " << header->GetEVBMode() << std::endl;
               std::cout << "TriggerCount: " << crvRocHeader->TriggerCount << std::endl;
               std::cout << "ActiveFEBFlags: " << crvRocHeader->GetActiveFEBFlags() << std::endl;
-              std::cout << "ROCID (ROC header): " << (uint16_t)crvRocHeader->ControllerID
-                        << std::endl;
-              std::cout << "EventWindowTag (ROC header): " << crvRocHeader->GetEventWindowTag()
-                        << std::endl;
+              std::cout << "ROCID (ROC header): " << (uint16_t)crvRocHeader->ControllerID  << std::endl;
+              std::cout << "EventWindowTag (ROC header): " << crvRocHeader->GetEventWindowTag() << std::endl;
             }
 
             const auto& crvHitInfo = crvHit.first;
             const auto& waveform = crvHit.second;
 
-            uint16_t rocID =
-                crvHitInfo.controllerNumber + 1; // FIXME  //ROC IDs are between 1 and 17
+            uint16_t rocID = crvHitInfo.controllerNumber + 1; // FIXME  //ROC IDs are between 1 and 17
             uint16_t rocPort = crvHitInfo.portNumber;
             uint16_t febChannel = crvHitInfo.febChannel;
             mu2e::CRVROC onlineChannel(rocID, rocPort, febChannel);
@@ -195,11 +198,11 @@ void CrvDigisFromFragments::produce(Event& event) {
             std::cout << "TDC: " << crvHitInfo.HitTime << std::endl;
             std::cout << "nSamples " << crvHitInfo.NumSamples << "  ";
             std::cout << "Waveform: {";
-            for (size_t i = 0; i < crvHitInfo.NumSamples; i++)
+            for(size_t i = 0; i < crvHitInfo.NumSamples; i++)
               std::cout << "  " << waveform.at(i).ADC;
             std::cout << "}" << std::endl;
             std::cout << "Waveform decompressed: {";
-            for (size_t i = 0; i < crvHitInfo.NumSamples; i++)
+            for(size_t i = 0; i < crvHitInfo.NumSamples; i++)
               std::cout << "  " << decompressCrvDigi(waveform.at(i).ADC);
             std::cout << "}" << std::endl;
             std::cout << std::endl;

--- a/DAQ/src/CrvDigisFromFragments_module.cc
+++ b/DAQ/src/CrvDigisFromFragments_module.cc
@@ -117,7 +117,7 @@ void CrvDigisFromFragments::produce(Event& event)
         continue;
       }
       auto header = block->GetHeader();
-      if(header->GetSubsystemID() != 2)
+      if(header->GetSubsystemID() != DTCLib::DTC_Subsystem::DTC_Subsystem_CRV)
       {
         throw cet::exception("DATA") << " CRV packet does not have system ID 2";
       }

--- a/DAQ/test/generateCrvDigiFromFragment.fcl
+++ b/DAQ/test/generateCrvDigiFromFragment.fcl
@@ -26,15 +26,24 @@ physics :
 {
   producers :
   {
-    CrvDigi:
+    genFrags :
+    {
+       module_type  : ArtFragmentsFromDTCEvents
+       diagLevel    : 10
+       makeCaloFrag : 0
+       makeTrkFrag  : 0
+       makeCRVFrag  : 1
+       makeSTMFrag  : 0
+
+    }
+    CrvDigi :
     {
       @table::DAQ.producers.CrvDigi
-      diagLevel: 2
-      fragmentsTag: "daq:DTCEVT"
+      diagLevel : 2
     }
   }
 
-  t1 : [ CrvDigi ]
+  t1 : [ genFrags, CrvDigi]
   e1 : [ outfile ]
 
   trigger_paths  : [t1]


### PR DESCRIPTION
It has a temporary solution in ArtFragmentsFromDTCEvents_module that deals with the problem, that the DTC_SubEventHeader uses `DTCLib::DTC_Subsystem::DTC_Subsystem_Tracker` instead of `DTCLib::DTC_Subsystem::DTC_Subsystem_CRV` for the Subsystem ID of CRV data.