### PR TITLE
remove SimParticleTimeOffset related to TrkAna

### DIFF
--- a/CRVAnalysis/inc/CRVAnalysis.hh
+++ b/CRVAnalysis/inc/CRVAnalysis.hh
@@ -7,7 +7,6 @@
 #include "Offline/CRVAnalysis/inc/CrvSummaryMC.hh"
 #include "Offline/CRVAnalysis/inc/CrvPlaneInfoMC.hh"
 #include "Offline/MCDataProducts/inc/SimParticle.hh"
-#include "Offline/Mu2eUtilities/inc/SimParticleTimeOffset.hh"
 #include "Offline/CRVAnalysis/inc/CrvPulseInfoReco.hh"
 #include "art/Framework/Principal/Event.h"
 
@@ -32,7 +31,6 @@ namespace mu2e
     static void FillCrvPulseInfoCollections(const std::string &crvRecoPulseCollection,
                                             const std::string &crvWaveformsModuleLabel,
                                             const std::string &crvDigiModuleLabel,
-                                            const SimParticleTimeOffset &timeOffsets,
                                             const art::Event& event, CrvPulseInfoRecoCollection &recoInfo, CrvHitInfoMCCollection &MCInfo, CrvWaveformInfoCollection &waveformInfo);
 
     private:

--- a/CRVAnalysis/src/CRVAnalysis.cc
+++ b/CRVAnalysis/src/CRVAnalysis.cc
@@ -182,7 +182,6 @@ namespace mu2e
    void CRVAnalysis::FillCrvPulseInfoCollections (const std::string &crvRecoPulseCollectionModuleLabel,
                                                   const std::string &crvWaveformsModuleLabel,
                                                   const std::string &crvDigiModuleLabel,
-                                                  const SimParticleTimeOffset &timeOffsets,
                                                   const art::Event& event, CrvPulseInfoRecoCollection &recoInfo, CrvHitInfoMCCollection &MCInfo, CrvWaveformInfoCollection &waveformInfo){
 
 
@@ -238,7 +237,7 @@ namespace mu2e
          CLHEP::Hep3Vector earliestHitPos;
          art::Ptr<SimParticle> mostLikelySimParticle;
          //for this reco pulse
-         CrvHelper::GetInfoFromCrvRecoPulse(crvRecoPulse, crvDigiMCCollection, timeOffsets, visibleEnergyDeposited,
+         CrvHelper::GetInfoFromCrvRecoPulse(crvRecoPulse, crvDigiMCCollection, visibleEnergyDeposited,
                                             earliestHitTime, earliestHitPos, mostLikelySimParticle);
 
          bool hasMCInfo = (mostLikelySimParticle.isNonnull()?true:false); //MC

--- a/CRVResponse/fcl/prolog_v11.fcl
+++ b/CRVResponse/fcl/prolog_v11.fcl
@@ -506,7 +506,6 @@ BEGIN_PROLOG
       module_type                            : CrvCoincidenceClusterMatchMC
       crvCoincidenceClusterFinderModuleLabel : "CrvCoincidenceClusterFinder"
       crvWaveformsModuleLabel                : "CrvWaveforms"
-      timeOffsets                            : { inputs : [ ] }
     }
     CrvPlot:
     {

--- a/CRVResponse/inc/CrvHelper.hh
+++ b/CRVResponse/inc/CrvHelper.hh
@@ -8,7 +8,6 @@
 
 #include "Offline/MCDataProducts/inc/CrvDigiMC.hh"
 #include "Offline/RecoDataProducts/inc/CrvRecoPulse.hh"
-#include "Offline/Mu2eUtilities/inc/SimParticleTimeOffset.hh"
 #include "art/Framework/Principal/Handle.h"
 
 #include "Offline/CosmicRayShieldGeom/inc/CosmicRayShield.hh"
@@ -25,13 +24,11 @@ namespace mu2e
                                               const art::Handle<CrvDigiMCCollection> &digis,
                                               std::set<art::Ptr<CrvStep> > &steps);
     static void GetInfoFromStepPoints(const std::set<art::Ptr<CrvStep> > &steps,
-                                      const SimParticleTimeOffset &timeOffsets,
                                       double &visibleEnergyDeposited,
                                       double &earliestHitTime, CLHEP::Hep3Vector &earliestHitPos,
                                       art::Ptr<SimParticle> &mostLikelySimParticle);
     static void GetInfoFromCrvRecoPulse(const art::Ptr<CrvRecoPulse> &crvRecoPulse,
                                         const art::Handle<CrvDigiMCCollection> &digis,
-                                        const SimParticleTimeOffset &timeOffsets,
                                         double &visibleEnergyDeposited,
                                         double &earliestHitTime, CLHEP::Hep3Vector &earliestHitPos,
                                         art::Ptr<SimParticle> &mostLikelySimParticle);

--- a/CRVResponse/src/CrvCoincidenceClusterMatchMC_module.cc
+++ b/CRVResponse/src/CrvCoincidenceClusterMatchMC_module.cc
@@ -18,7 +18,6 @@
 #include "Offline/MCDataProducts/inc/CrvCoincidenceClusterMC.hh"
 #include "Offline/RecoDataProducts/inc/CrvRecoPulse.hh"
 #include "Offline/RecoDataProducts/inc/CrvCoincidenceCluster.hh"
-#include "Offline/Mu2eUtilities/inc/SimParticleTimeOffset.hh"
 
 #include "canvas/Persistency/Common/Ptr.h"
 #include "art/Framework/Core/EDProducer.h"
@@ -49,14 +48,12 @@ namespace mu2e
                                                           //it is possible to have more than one instance of the CrvCoincidenceClusterFinder module
     std::string _crvWaveformsModuleLabel;  //module label of the CrvWaveform module.
                                            //this is optional. only needed, if MC information is required
-    SimParticleTimeOffset _timeOffsets;
   };
 
   CrvCoincidenceClusterMatchMC::CrvCoincidenceClusterMatchMC(fhicl::ParameterSet const& pset) :
    art::EDProducer{pset},
     _crvCoincidenceClusterFinderModuleLabel(pset.get<std::string>("crvCoincidenceClusterFinderModuleLabel")),
-    _crvWaveformsModuleLabel(pset.get<std::string>("crvWaveformsModuleLabel","")),
-    _timeOffsets(pset.get<fhicl::ParameterSet>("timeOffsets"))
+    _crvWaveformsModuleLabel(pset.get<std::string>("crvWaveformsModuleLabel",""))
   {
     produces<CrvCoincidenceClusterMCCollection>();
   }
@@ -75,7 +72,6 @@ namespace mu2e
 
   void CrvCoincidenceClusterMatchMC::produce(art::Event& event)
   {
-    _timeOffsets.updateMap(event);
 
     std::unique_ptr<CrvCoincidenceClusterMCCollection> crvCoincidenceClusterMCCollection(new CrvCoincidenceClusterMCCollection);
 
@@ -116,7 +112,7 @@ namespace mu2e
           CrvHelper::GetStepPointsFromCrvRecoPulse(crvRecoPulse, crvDigiMCCollection, steps);
 
           //get the sim particle and deposited energy of this reco pulse
-          CrvHelper::GetInfoFromCrvRecoPulse(crvRecoPulse, crvDigiMCCollection, _timeOffsets,
+          CrvHelper::GetInfoFromCrvRecoPulse(crvRecoPulse, crvDigiMCCollection,
                                              visibleEnergyDepositedThisPulse,
                                              earliestHitTimeThisPulse, earliestHitPosThisPulse, simParticleThisPulse);
         }
@@ -127,7 +123,7 @@ namespace mu2e
       }//loop over reco pulses
 
       //based on all step points, get the most likely sim particle, total energy, etc.
-      CrvHelper::GetInfoFromStepPoints(steps, _timeOffsets,
+      CrvHelper::GetInfoFromStepPoints(steps,
                                        visibleEnergyDeposited, earliestHitTime, earliestHitPos, simParticle);
 
       //insert the cluster information into the vector of the crv coincidence clusters (collection of pulses, most likely sim particle, etc.)

--- a/CRVResponse/src/CrvHelper.cc
+++ b/CRVResponse/src/CrvHelper.cc
@@ -22,7 +22,6 @@ namespace mu2e
   }
 
   void CrvHelper::GetInfoFromStepPoints(const std::set<art::Ptr<CrvStep> > &steps,
-                                        const SimParticleTimeOffset &timeOffsets,
                                         double &visibleEnergyDeposited,
                                         double &earliestHitTime, CLHEP::Hep3Vector &earliestHitPos,
                                         art::Ptr<SimParticle> &mostLikelySimParticle)
@@ -57,8 +56,7 @@ namespace mu2e
     for(stepPointIter=steps.begin(); stepPointIter!=steps.end(); stepPointIter++)
     {
       const CrvStep &step = **stepPointIter;
-      double timeOffset = timeOffsets.totalTimeOffset(step.simParticle());
-      double t = step.startTime()+timeOffset;
+      double t = step.startTime();
       if(firstLoop || earliestHitTime>t)
       {
         firstLoop=false;
@@ -70,7 +68,6 @@ namespace mu2e
 
   void CrvHelper::GetInfoFromCrvRecoPulse(const art::Ptr<CrvRecoPulse> &crvRecoPulse,
                                           const art::Handle<CrvDigiMCCollection> &digis,
-                                          const SimParticleTimeOffset &timeOffsets,
                                           double &visibleEnergyDeposited,
                                           double &earliestHitTime, CLHEP::Hep3Vector &earliestHitPos,
                                           art::Ptr<SimParticle> &mostLikelySimParticle)
@@ -78,7 +75,7 @@ namespace mu2e
     std::set<art::Ptr<CrvStep> > steps;
 
     CrvHelper::GetStepPointsFromCrvRecoPulse(crvRecoPulse, digis, steps);
-    CrvHelper::GetInfoFromStepPoints(steps, timeOffsets, visibleEnergyDeposited,
+    CrvHelper::GetInfoFromStepPoints(steps, visibleEnergyDeposited,
                                      earliestHitTime, earliestHitPos, mostLikelySimParticle);
   }
 


### PR DESCRIPTION
Remove SimParticleTimeOffset related to TrkAna, the only secondary repo use.  There will be a commit there too.