### PR TITLE
db columns names

### DIFF
--- a/DbTables/inc/CalCosmicEnergyCalib.hh
+++ b/DbTables/inc/CalCosmicEnergyCalib.hh
@@ -35,7 +35,7 @@ namespace mu2e {
 
     constexpr static const char* cxname = "CalCosmicEnergyCalib";
 
-    CalCosmicEnergyCalib():DbTable(cxname,"cal.cosmicenergycalib","roid,EPeak,ErrEPeak,Width,ErrWidth,chisq"){}
+    CalCosmicEnergyCalib():DbTable(cxname,"cal.cosmicenergycalib","roid,epeak,errepeak,width,errwidth,chisq"){}
 
     const Row& row(CaloSiPMId  roid) const {
                 return _rows.at(roid.id()); }

--- a/DbTables/inc/CalCosmicT0Align.hh
+++ b/DbTables/inc/CalCosmicT0Align.hh
@@ -31,10 +31,10 @@ namespace mu2e {
 
     constexpr static const char* cxname = "CalCosmicT0Align";
 
-    CalCosmicT0Align():DbTable(cxname,"cal.cosmicT0align","roid,tcorr,terr,chisq"){}
+    CalCosmicT0Align():DbTable(cxname,"cal.cosmict0align","roid,tcorr,terr,chisq"){}
 
-    const Row& row(CaloSiPMId  _roid) const {
-                return _rows.at(_roid.id()); }
+    const Row& row(CaloSiPMId  roid) const {
+                return _rows.at(roid.id()); }
     std::vector<Row> const& rows() const {return _rows;}
     std::size_t nrow() const override { return _rows.size(); };
     size_t size() const override { return baseSize() + nrow()*sizeof(Row); };

--- a/DbTables/inc/CalCosmicTimeCalib.hh
+++ b/DbTables/inc/CalCosmicTimeCalib.hh
@@ -30,7 +30,7 @@ namespace mu2e {
 
     constexpr static const char* cxname = "CalCosmicTimeCalib";
 
-    CalCosmicTimeCalib():DbTable(cxname,"cal.cosmictimecalib","roid,T0,ErrT0,chisq"){}
+    CalCosmicTimeCalib():DbTable(cxname,"cal.cosmictimecalib","roid,t0,errt0,chisq"){}
 
     const Row& row(CaloSiPMId  roid) const {
                 return _rows.at(roid.id()); }

--- a/DbTables/inc/CalEnergyCalib.hh
+++ b/DbTables/inc/CalEnergyCalib.hh
@@ -40,7 +40,7 @@ namespace mu2e {
 
     constexpr static const char* cxname = "CalEnergyCalib";
 
-    CalEnergyCalib():DbTable(cxname,"cal.energycalib","roid,ADC2MeV,ErrADC2MeV,algID"){}
+    CalEnergyCalib():DbTable(cxname,"cal.energycalib","roid,adc2mev,erradc2mev,algid"){}
 
     const Row& row(CaloSiPMId id) const {
                 return _rows[id.id()];

--- a/DbTables/inc/CalLaserEnergyCalib.hh
+++ b/DbTables/inc/CalLaserEnergyCalib.hh
@@ -31,7 +31,7 @@ namespace mu2e {
 
     constexpr static const char* cxname = "CalLaserEnergyCalib";
 
-    CalLaserEnergyCalib():DbTable(cxname,"cal.laserenergycalib","roid,LAS,ErrLAS,chisq"){}
+    CalLaserEnergyCalib():DbTable(cxname,"cal.laserenergycalib","roid,las,errlas,chisq"){}
 
     const Row& row(CaloSiPMId  roid) const {
                 return _rows.at(roid.id()); }

--- a/DbTables/inc/CalLaserTimeCalib.hh
+++ b/DbTables/inc/CalLaserTimeCalib.hh
@@ -33,7 +33,7 @@ namespace mu2e {
     constexpr static const char* cxname = "CalLaserTimeCalib";
 
     CalLaserTimeCalib():DbTable(cxname,"calolasertimecalib",
-    "roid,T0,ErrT0,chisq") {}
+    "roid,t0,errt0,chisq") {}
 
     const Row& row(CaloSiPMId  roid) const {
                 return _rows.at(roid.id()); }

--- a/DbTables/inc/CalSourceEnergyCalib.hh
+++ b/DbTables/inc/CalSourceEnergyCalib.hh
@@ -62,7 +62,7 @@ namespace mu2e {
 
     constexpr static const char* cxname = "CalSourceEnergyCalib";
 
-    CalSourceEnergyCalib():DbTable(cxname,"cal.sourceenergycalib","roid,fullEPeak,fullErrEPeak,fullWidth,fullErrWidth,firstescEPeak,firstescErrEPeak,firstescWidth,firstescErrWidth,secescEPeak,secescErrEPeak,secescWidth,secescErrWidth, frFull,frFirst,frSecond,chisq"){}
+    CalSourceEnergyCalib():DbTable(cxname,"cal.sourceenergycalib","roid,fullepeak,fullerrepeak,fullwidth,fullerrwidth,firstescepeak,firstescerrepeak,firstescwidth,firstescerrwidth,secescepeak,secescerrepeak,secescwidth,secescerrwidth, frfull,frfirst,frsecond,chisq"){}
 
     const Row& row(CaloSiPMId  roid) const {
                 return _rows.at(roid.id()); }


### PR DESCRIPTION
postgres is case insensitive, so use non-caps for column names.  No change to any functionality or validation.