### PR TITLE
improve string cleanup

### DIFF
--- a/GeneralUtilities/inc/BitMap.hh
+++ b/GeneralUtilities/inc/BitMap.hh
@@ -289,7 +289,7 @@ namespace mu2e {
       if(invalid){
       // try to interpret as a (text) hex string; make sure to edit out spaces first!
         std::string cname(name);
-        cname.erase(cname.begin(), std::find_if(cname.begin(), cname.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+        cname.erase(std::remove_if(cname.begin(), cname.end(), ::isspace), cname.end());
         if(cname.compare(0,2,"0x") == 0 || cname.compare(0,2,"0X") == 0){
           mask = std::stoul(name,0,16);
           if((isValid(mask)) && mask != 0){


### PR DESCRIPTION
Test code:
```
  std::string test("\t1 2\t3\f\n4 \n");
  string test2 = test;
  cout << "X" << test << "X "<< test.size()<<endl;
  test.erase(test.begin(), std::find_if(test.begin(), test.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
  cout << "X" << test << "X "<< test.size()<<endl;
  test2.erase(std::remove_if(test2.begin(), test2.end(), ::isspace), test2.end());
  cout << "X" << test2 << "X "<< test2.size()<<endl;

```

output:
```
X       1 2     3

4 
X 11
X1 2    3

4 
X 10
X1234X 4
```
showing the new code is probably doing what was originally intended

