### PR TITLE
remove three clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-braces-around-statements,readability-misleading-indentation,readability-non-const-parameter'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-misleading-indentation,readability-non-const-parameter,-bugprone-narrowing-conversions,-bugprone-easily-swappable-parameters'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
These are ubiquitous and will likely never be fixed, so turn them off for now to reduce the noise and the remainder can actually be examined.

readability-braces-around-statements
`if(condition) expression;  // no braces`
bugprone-narrowing-conversions
`int = size_t  or float = double // coordinate or make conversion explicit`
bugprone-easily-swappable-parameters
`function(float x, float y) // suggestion is to pass a struct`
