### PR TITLE
switch from cryptopp to std::hash

### DIFF
--- a/Mu2eG4/src/SConscript
+++ b/Mu2eG4/src/SConscript
@@ -24,9 +24,7 @@ helper=mu2e_helper(env)
 g4inc    = os.environ['G4INCLUDE'] + '/Geant4'
 g4inc2   = os.environ['G4INCLUDE']
 g4libdir = os.environ['G4LIB']
-cryptoppinc = os.environ['CRYPTOPP_INC']
-cryptopplibdir = os.environ['CRYPTOPP_LIB']
-g4LibInc = [ '-L'+g4libdir, '-I'+g4inc, '-I'+g4inc2, '-L'+cryptopplibdir, '-I'+cryptoppinc ]
+g4LibInc = [ '-L'+g4libdir, '-I'+g4inc, '-I'+g4inc2 ]
 g4_version = os.environ['GEANT4_VERSION']
 g4_version=g4_version.replace('_','')
 if g4_version[2] == '9':
@@ -262,8 +260,7 @@ mainlib = helper.make_mainlib ( [
         'Hist', 'Tree', 'Core',
         'boost_regex',
         'tbb',
-        'pthread',
-        'libcryptopp',
+        'pthread'
     ],
                                 [  G4CPPFLAGS, G4GS_CPPFLAGS, G4GV_CPPFLAGS ],
                                 [ g4LibInc, vgcLibInc ]
@@ -302,8 +299,7 @@ helper.make_plugins( [
     'Tree', 'Core',
     'boost_filesystem',
     'tbb',
-    'pthread',
-    'libcryptopp',
+    'pthread'
     ],
                      [],
                      [ G4CPPFLAGS, G4GS_CPPFLAGS, G4GV_CPPFLAGS ],


### PR DESCRIPTION
 In preparation for e28, we investigated whether cryptopp UPS product was necessary and it appears it can be replaced with std::hash.  By finding the source code and by simple tests, we confirmed that std::hash will produce the same random seed for the same event.  After install std::hash, we ran potSimMT twice and confirmed identical results.