### PR TITLE
add libraries for e28 compatibility: cstdint for uint8,16,32_t types,…

### DIFF
--- a/DataProducts/inc/CaloConst.hh
+++ b/DataProducts/inc/CaloConst.hh
@@ -5,6 +5,7 @@
 // used in geometry, channel number ID classes, and database access
 //
 #include <array>
+#include <cstdint>
 
 namespace mu2e {
 

--- a/DataProducts/inc/TrkTypes.hh
+++ b/DataProducts/inc/TrkTypes.hh
@@ -6,6 +6,7 @@
 #define TrackerConditions_Types_hh
 #include <array>
 #include <vector>
+#include <cstdint>
 
 namespace mu2e {
   namespace TrkTypes {

--- a/DbService/src/DbEngine.cc
+++ b/DbService/src/DbEngine.cc
@@ -4,6 +4,7 @@
 #include "cetlib_except/exception.h"
 #include <chrono>
 #include <iostream>
+#include <mutex>
 
 using namespace std;
 

--- a/RecoDataProducts/inc/CrvDigi.hh
+++ b/RecoDataProducts/inc/CrvDigi.hh
@@ -8,6 +8,7 @@
 #include "Offline/DataProducts/inc/CRSScintillatorBarIndex.hh"
 #include <array>
 #include <vector>
+#include <cstdint>
 
 namespace mu2e
 {

--- a/Sources/inc/STMTestBeamHeaders.hh
+++ b/Sources/inc/STMTestBeamHeaders.hh
@@ -10,6 +10,7 @@
 #include <array>
 #include <ctime>
 #include <iomanip>
+#include <cstdint>
 
 namespace mu2e {
 


### PR DESCRIPTION
… mutex for DbEngine function unique_lock

Second iteration of fixes for e28 compiler compatibility. Comparison with reference of 2000 ceSimReco events showed exact matches.