### PR TITLE
avoid very strict compiler check on amibuous terminated string

### DIFF
--- a/GeneralUtilities/inc/csv.hh
+++ b/GeneralUtilities/inc/csv.hh
@@ -75,8 +75,12 @@ namespace io {
             with_file_name() { std::memset(file_name, 0, max_file_name_length + 1); }
 
             void set_file_name(const char* file_name) {
-                std::strncpy(this->file_name, file_name, max_file_name_length+1);
-                this->file_name[max_file_name_length] = '\0';
+                size_t i = 0;
+                while( file_name[i] != '\0' && i < max_file_name_length) {
+                  this->file_name[i] = file_name[i];
+                  i++;
+                };
+                this->file_name[i] = '\0';
             }
 
             char file_name[max_file_name_length + 1];


### PR DESCRIPTION
The e28 compiler warnings included a strict check on strncpy.  If the source and destination strings are the same size, there is no way that it can be guaranteed that you do not truncate the source string.  If you make the destination string longer, and add an insurance \0, then the compiler accepts it.  I didn't want to make the destination string longer since that might be copied somewhere else in the code, the easiest thing to do is to copy the string and enforce a termination, which is the obvious intended behavior by the author.

In general though, I do not like this code, and this is good example why.  It is c-ish, threaded and locked, which I don't think we want in the middle of code base.  It is also complete overkill - 1100 lines where 30 lines will do.  If Rob and Dave give me the go-ahead I'll just replace it with a short, readable utility routine.