### PR TITLE
deprecated arithmetic fixes for e28

### DIFF
--- a/CaloFilters/src/EcalTriggerPreselect_module.cc
+++ b/CaloFilters/src/EcalTriggerPreselect_module.cc
@@ -110,7 +110,7 @@ namespace mu2e {
     float _TANDIPMIN;
     float _TANDIPMAX;
     float _MVAMIN;
-    float _VDPID;
+    int _VDPID;
     float _PMIN;
     float _PMATCHMIN;
     float _ECLUMIN;

--- a/TrkPatRec/src/RobustHelixFinder_module.cc
+++ b/TrkPatRec/src/RobustHelixFinder_module.cc
@@ -1007,7 +1007,7 @@ unsigned  RobustHelixFinder::filterCircleHits(RobustHelixFinderData& helixData)
 
       if(oldoutBest) ++changed;
 
-      if (chCounter < RobustHelixFinderData::kMaxResidIndex) {
+      if (chCounter < float(RobustHelixFinderData::kMaxResidIndex)) {
         drBestVec   [int(chCounter)] = drBest;
         rwdotBestVec[int(chCounter)] = rwdotBest;
       }

--- a/TrkReco/src/RobustHelixFit.cc
+++ b/TrkReco/src/RobustHelixFit.cc
@@ -599,7 +599,7 @@ bool RobustHelixFit::initFZ_2(RobustHelixFinderData& HelixData) {
   // Part 2: perform a more accurate estimate - straight line fit
   //-----------------------------------------------------------------------------
   if (nstations_with_hits < 2) return false;//hdfdz = _mpDfDz;
-  else                         hdfdz = xmp*rhel.helicity()._value;
+  else                         hdfdz = xmp*double(rhel.helicity()._value);
   //-----------------------------------------------------------------------------
   // last step - determine phi0 = phi(z=0)
   //-----------------------------------------------------------------------------

--- a/TrkReco/src/RobustHelixFit.cc
+++ b/TrkReco/src/RobustHelixFit.cc
@@ -599,7 +599,7 @@ bool RobustHelixFit::initFZ_2(RobustHelixFinderData& HelixData) {
   // Part 2: perform a more accurate estimate - straight line fit
   //-----------------------------------------------------------------------------
   if (nstations_with_hits < 2) return false;//hdfdz = _mpDfDz;
-  else                         hdfdz = xmp*double(rhel.helicity()._value);
+  else                         hdfdz = xmp*float(rhel.helicity()._value);
   //-----------------------------------------------------------------------------
   // last step - determine phi0 = phi(z=0)
   //-----------------------------------------------------------------------------


### PR DESCRIPTION
Another PR for e28 compiler compatibility, enum types have been deprecated in some arithmetic statements.