### PR TITLE
remove deprecated std::binary_function from code using BTrk

### DIFF
--- a/BTrkData/inc/TrkStrawHit.hh
+++ b/BTrkData/inc/TrkStrawHit.hh
@@ -107,7 +107,7 @@ namespace mu2e
   };
 
 // binary functor to sort TrkStrawHits by StrawHit index
-  struct indexcomp : public std::binary_function<TrkStrawHit,TrkStrawHit, bool> {
+  struct indexcomp {
     bool operator()(const TrkStrawHit* x,const TrkStrawHit* y) { return x->index() < y->index(); }
   };
 

--- a/CalPatRec/src/CalHelixFinderAlg.cc
+++ b/CalPatRec/src/CalHelixFinderAlg.cc
@@ -65,12 +65,12 @@ namespace mu2e {
 //   };
 
   // comparison functor for sorting by z
-  struct zcomp : public std::binary_function<mu2e::ComboHit,mu2e::ComboHit,bool> {
+  struct zcomp {
     bool operator()(mu2e::ComboHit const& p1, mu2e::ComboHit const& p2) { return p1._pos.z() < p2._pos.z(); }
   };
 
   // comparison functor for sorting byuniquePanel ID
-  struct panelcomp : public std::binary_function<mu2e::ComboHit,mu2e::ComboHit,bool> {
+  struct panelcomp {
     bool operator()(mu2e::ComboHit const& p1, mu2e::ComboHit const& p2) { return p1.strawId().uniquePanel() < p2.strawId().uniquePanel(); }
   };
 

--- a/CosmicReco/src/CosmicTrackFinder_module.cc
+++ b/CosmicReco/src/CosmicTrackFinder_module.cc
@@ -65,7 +65,7 @@ using CLHEP::Hep3Vector;
 using CLHEP::HepVector;
 
 namespace{
-  struct ycomp_iter : public std::binary_function<std::vector<ComboHit>::const_iterator, std::vector<ComboHit>::const_iterator, bool> {
+  struct ycomp_iter {
     bool operator()(std::vector<ComboHit>::const_iterator p1, std::vector<ComboHit>::const_iterator p2) { return p1->_pos.y() > p2->_pos.y(); }
   };
 }

--- a/CosmicReco/src/CosmicTrackFit.cc
+++ b/CosmicReco/src/CosmicTrackFit.cc
@@ -58,7 +58,7 @@ using namespace ROOT::Math;
 
 std::vector<double> TrackerConstraints(1500, 1500);
 
-struct ycomp : public std::binary_function<XYZVectorF,XYZVectorF,bool> {
+struct ycomp {
     bool operator()(XYZVectorF const& p1, XYZVectorF p2) { return p1.y() > p2.y(); }
   };
 

--- a/CosmicReco/src/SimpleTimeCluster_module.cc
+++ b/CosmicReco/src/SimpleTimeCluster_module.cc
@@ -27,7 +27,7 @@
 
 namespace {
 // comparison functor for sorting by t
-struct tcomp : public std::binary_function<mu2e::ComboHit, mu2e::ComboHit, bool> {
+struct tcomp {
   bool operator()(mu2e::ComboHit const& p1, mu2e::ComboHit const& p2) {
     return p1.correctedTime() < p2.correctedTime();
   }

--- a/Mu2eUtilities/inc/MedianCalculator.hh
+++ b/Mu2eUtilities/inc/MedianCalculator.hh
@@ -20,7 +20,7 @@ class MedianCalculator {
     float val;
     float wg;
   };
-  struct lessByValue : public std::binary_function<MedianData, MedianData, bool> {
+  struct lessByValue {
     bool operator()(MedianData const& p1, MedianData const& p2) { return p1.val < p2.val; }
   };
 

--- a/RecoDataProducts/inc/TrkStrawHitSeed.hh
+++ b/RecoDataProducts/inc/TrkStrawHitSeed.hh
@@ -155,7 +155,7 @@ namespace mu2e {
     float     _stime =0;   // signal propagation time for this hit, to the nearest end
   };
   // binary functor to sort TrkStrawHits by StrawHit index
-  struct indexcompseed : public std::binary_function<TrkStrawHitSeed,TrkStrawHitSeed, bool> {
+  struct indexcompseed {
     bool operator()(const TrkStrawHitSeed& x,const TrkStrawHitSeed& y) { return x.index() < y.index(); }
   };
 }

--- a/TrkDiag/inc/SPCount.hh
+++ b/TrkDiag/inc/SPCount.hh
@@ -12,7 +12,7 @@ namespace mu2e {
     art::Ptr<SimParticle> _spp;
     unsigned _count;
   };
-  struct SPCountComp : public binary_function<SPCount, SPCount , bool> {
+  struct SPCountComp {
     bool operator() (SPCount a, SPCount b) { return a._count > b._count; }
   };
 }

--- a/TrkDiag/inc/TimeClusterInfo.hh
+++ b/TrkDiag/inc/TimeClusterInfo.hh
@@ -77,7 +77,7 @@ namespace mu2e {
     }
   };
   // predicate to sort by decreasing # of CE hits
-  struct NCEComp : public std::binary_function<TimeClusterInfo,TimeClusterInfo, bool> {
+  struct NCEComp {
     bool operator()(TimeClusterInfo const& x,TimeClusterInfo const& y) { return x._ncehits > y._ncehits; }
   };
 

--- a/TrkDiag/inc/TrkMCTools.hh
+++ b/TrkDiag/inc/TrkMCTools.hh
@@ -44,12 +44,12 @@ namespace mu2e {
       unsigned _acount; // counts active
     };
     // sort by active hits
-    struct spcountcomp : public std::binary_function <spcount, spcount, bool> {
+    struct spcountcomp {
       bool operator() (spcount a, spcount b) { return a._acount > b._acount; }
     };
 
     typedef StepPointMCCollection::const_iterator MCStepItr;
-    struct timecomp : public std::binary_function<MCStepItr,MCStepItr, bool> {
+    struct timecomp {
       bool operator()(MCStepItr x,MCStepItr y) { return x->time() < y->time(); }
     };
 

--- a/TrkDiag/src/TimeClusterDiag_module.cc
+++ b/TrkDiag/src/TimeClusterDiag_module.cc
@@ -74,7 +74,7 @@ namespace mu2e {
       art::Ptr<SimParticle> _spp;
       unsigned _count;
     };
-    struct spcountcomp : public binary_function<spcount, spcount , bool> {
+    struct spcountcomp {
       bool operator() (spcount a, spcount b) { return a._count > b._count; }
     };
 

--- a/TrkPatRec/src/RobustHelixFinder_module.cc
+++ b/TrkPatRec/src/RobustHelixFinder_module.cc
@@ -71,12 +71,12 @@ using namespace ROOT::Math::VectorUtil;
 
 namespace {
   // comparison functor for sorting by z
-  struct zcomp : public std::binary_function<mu2e::ComboHit,mu2e::ComboHit,bool> {
+  struct zcomp {
     bool operator()(mu2e::ComboHit const& p1, mu2e::ComboHit const& p2) { return p1._pos.z() < p2._pos.z(); }
   };
 
   // comparison functor for sorting byuniquePanel ID
-  struct panelcomp : public std::binary_function<mu2e::ComboHit,mu2e::ComboHit,bool> {
+  struct panelcomp {
     bool operator()(mu2e::ComboHit const& p1, mu2e::ComboHit const& p2) { return p1.strawId().uniquePanel() < p2.strawId().uniquePanel(); }
   };
   struct HelixHitMVA
@@ -1007,7 +1007,7 @@ unsigned  RobustHelixFinder::filterCircleHits(RobustHelixFinderData& helixData)
 
       if(oldoutBest) ++changed;
 
-      if (chCounter < RobustHelixFinderData::kMaxResidIndex) {
+      if (chCounter < float(RobustHelixFinderData::kMaxResidIndex)) {
         drBestVec   [int(chCounter)] = drBest;
         rwdotBestVec[int(chCounter)] = rwdotBest;
       }

--- a/TrkReco/src/KalFit.cc
+++ b/TrkReco/src/KalFit.cc
@@ -63,7 +63,7 @@ using CLHEP::HepSymMatrix;
 namespace mu2e
 {
   // comparison functor for ordering hits.  This should operate on TrkHit, FIXME!
-  struct fcomp : public binary_function<TrkHit*, TrkHit*, bool> {
+  struct fcomp {
     bool operator()(TrkHit* x, TrkHit* y) {
       return x->fltLen() < y->fltLen();
     }
@@ -79,7 +79,7 @@ namespace mu2e
 
   // comparison operators understand that the same straw could be hit twice, so the flight lengths need
   // to be similar befoew we consider these 'the same'
-  struct StrawFlightComp : public binary_function<StrawFlight, StrawFlight, bool> {
+  struct StrawFlightComp {
     double _maxdiff; // maximum flight difference; below this, consider 2 intersections 'the same'
     StrawFlightComp(double maxdiff) : _maxdiff(maxdiff) {}
     bool operator () (StrawFlight const& a, StrawFlight const& b) const { return a._id < b._id ||

--- a/TrkReco/src/PanelAmbigResolver.cc
+++ b/TrkReco/src/PanelAmbigResolver.cc
@@ -26,12 +26,12 @@ using CLHEP::HepVector;
 namespace mu2e {
   namespace PanelAmbig {
     // functor for sorting by panel.  Note that PanelId uniquely defines a panel
-    struct panelcomp : public std::binary_function<TrkStrawHit*, TrkStrawHit*, bool> {
+    struct panelcomp {
       bool operator()(TrkStrawHit* x, TrkStrawHit* y) { return x->straw().id().getPanelId() < y->straw().id().getPanelId(); }
     };
 
     // functor to sort panel results by chisquared
-    struct resultcomp : public std::binary_function<PanelResult const&, PanelResult const&,bool> {
+    struct resultcomp {
       bool operator()(PanelResult const& a, PanelResult const& b) { return a._chisq < b._chisq; }
     };
 


### PR DESCRIPTION
Last PR for e28 compatibility before changing to new envset. Clean validation with 2000 ceSimReco events.