### PR TITLE
method cleanup

### DIFF
--- a/BTrkData/inc/Doublet.hh
+++ b/BTrkData/inc/Doublet.hh
@@ -51,16 +51,12 @@ namespace mu2e {
 // constructors and such
 //-----------------------------------------------------------------------------
     Doublet();
-    Doublet(const Doublet& R);                 // unfortunately, need a copy constructor...
-
     Doublet(int index,
             int station, int panel,
             CLHEP::Hep3Vector shdir,
             CLHEP::Hep3Vector trkdir,
             CLHEP::Hep3Vector trkpos,
             TrkStrawHit*      hit);
-
-    ~Doublet();
 
     double chi2Best     () const { return fChi2     [fIBest]; }
     double chi2SlopeBest() const { return fChi2Slope[fIBest]; }

--- a/BTrkData/src/Doublet.cc
+++ b/BTrkData/src/Doublet.cc
@@ -35,37 +35,6 @@ namespace mu2e {
     fOs    = -999;
   }
 
-//-----------------------------------------------------------------------------
-//
-  Doublet::Doublet(const Doublet& R) {
-    fIndex      = R.fIndex;
-    fStationId  = R.fStationId;
-    fPanelId    = R.fPanelId;
-    fShDir      = R.fShDir;
-    fNStrawHits = R.fNStrawHits;
-
-    for (int i=0; i<kMaxNHits; i++) {
-      fStrawAmbig[i] = R.fStrawAmbig[i];
-      fHit       [i] = R.fHit[i];
-      fMcDoca    [i] = R.fMcDoca[i];
-      fTrkDir    [i] = R.fTrkDir[i];
-      fTrkPos    [i] = R.fTrkPos[i];
-    }
-
-    fHitIndex[0] = R.fHitIndex[0];
-    fHitIndex[1] = R.fHitIndex[1];
-    fTrkDxDz     = R.fTrkDxDz;
-
-    for (int i=0; i<kMaxNComb; i++) {
-      fDxDz[i] = R.fDxDz[i];
-      fChi2[i] = R.fChi2[i];
-    }
-
-    fIBest = R.fIBest;
-    fINext = R.fINext;
-    fOs    = R.fOs;
-  }
-
 
 //-----------------------------------------------------------------------------
   Doublet::Doublet(int               Index,
@@ -100,9 +69,6 @@ namespace mu2e {
     fINext       = -1;
     fOs          = -1;
   }
-
-//-----------------------------------------------------------------------------
-  Doublet::~Doublet(){}
 
 //-----------------------------------------------------------------------------
   void Doublet::addStrawHit(CLHEP::Hep3Vector trkdir,

--- a/MCDataProducts/inc/GenId.hh
+++ b/MCDataProducts/inc/GenId.hh
@@ -89,8 +89,6 @@ namespace mu2e {
       _id(unknown){
     }
 
-    virtual ~GenId(){}
-
     bool operator==(const GenId g) const{
       return ( _id == g._id );
     }


### PR DESCRIPTION
remove a few explicit defined methods where the default generated method could be used.  These examples came up during investigations of gcc switches, there are more.