### PR TITLE
cleanup two warnings

### DIFF
--- a/.muse
+++ b/.muse
@@ -5,4 +5,4 @@ PYTHONPATH Trigger/python
 # add Offline/bin to path
 PATH bin
 # recent commits can take enforce these flags
-CPPFLAGS -Wtype-limits
+CPPFLAGS -Wtype-limits -Wimplicit-fallthrough -Wunused-but-set-parameter

--- a/EventDisplay/src/EventDisplayFrame.cc
+++ b/EventDisplay/src/EventDisplayFrame.cc
@@ -839,6 +839,7 @@ Bool_t EventDisplayFrame::ProcessMessage(Long_t msg, Long_t param1, Long_t param
         default:
           break;
       }
+      break;
 
     case kC_COMMAND:
       switch (GET_SUBMSG(msg))

--- a/EventGenerator/src/AntiProtonGun_module.cc
+++ b/EventGenerator/src/AntiProtonGun_module.cc
@@ -140,9 +140,8 @@ namespace mu2e {
   }
 
   //================================================================
-  double AntiProtonGun::zLambda(double *val, double *par) {
+  double AntiProtonGun::zLambda(double *val, double *) {
 
-    par = 0;
     double kLambda = 99.4;
     double kTgtHL = 80.0;
     double value=1/kLambda*exp(-(kTgtHL-val[0])/kLambda);
@@ -179,9 +178,8 @@ namespace mu2e {
   } // plmax
 
   //================================================================
-  double AntiProtonGun::dsigma(double *val, double *parm) {
+  double AntiProtonGun::dsigma(double *val, double *) {
 
-    parm=0;
     double x=1.9;
     double total=0;
     double theta=val[0];

--- a/TEveEventDisplay/src/TEveMu2eMainWindow.cc
+++ b/TEveEventDisplay/src/TEveMu2eMainWindow.cc
@@ -784,6 +784,7 @@ namespace mu2e{
             }
       break;
     }
+    break;
     case kC_COMMAND:
       switch (GET_SUBMSG(msg))
       {

--- a/TrackerConditions/src/StrawResponse.cc
+++ b/TrackerConditions/src/StrawResponse.cc
@@ -104,9 +104,7 @@ namespace mu2e {
     return PieceLineDrift(_llDriftTimeRMSBins, _llDriftTimeRMS, ddist);
   }
 
-  double StrawResponse::driftInstantSpeed(StrawId strawId, double ddist, double phi) const {
-    if (_driftIgnorePhi)
-      phi = 0;
+  double StrawResponse::driftInstantSpeed(StrawId strawId, double ddist, double) const {
     if(_usenonlindrift){
       return _strawDrift->GetInstantSpeedFromD(ddist);
     }else{


### PR DESCRIPTION
Fixed a couple of warnings, unused-but-set parameters and implicit-fallthrough.  If the fallthrough was intended, the warning can be avoid as [here](https://gcc.gnu.org/onlinedocs/gcc-13.1.0/gcc/Warning-Options.html#index-Wimplicit-fallthrough) 