### PR TITLE
Hit fix for PR #1036. 

### DIFF
--- a/Mu2eG4/geom/STM_v08.txt
+++ b/Mu2eG4/geom/STM_v08.txt
@@ -19,7 +19,7 @@ bool   stm.det2.build                 = false;
 bool   stm.SScollimator.build         = false;
 bool   stm.SScollimator.liner.build   = false;
 bool   stm.detector.stand.build       = false;
-bool   stm.shield.build               = false;
+bool   stm.shield.build               = true;
 
 
 //"spot-size" collimator, just upstream of the detector(s)


### PR DESCRIPTION
Restore the STM_CRVShieldPipe and STM_CRVShieldMatingBlock volumes. See issue #1128 .

This is a one line change to restore two volumes that were removed in PR1036 but should not have been.  To verify that the problem is fixed I compared Production/Validation/nightly/pileup_00.fcl and 2K events from Production/Validation/nightly/ceSimReco_00.fcl  .  Both comparisons look like small statistic changes due to random number decoherence trigged by the geometry change.

I also did the G4 surface check and the root overlap check.  Both passed.


