### PR TITLE
Streamline handling of mf::LogInfo messages from GenEventCountReader.

### DIFF
--- a/CommonMC/src/GenEventCountReader_module.cc
+++ b/CommonMC/src/GenEventCountReader_module.cc
@@ -77,7 +77,7 @@ namespace mu2e {
         <<"GenEventCountReader: no GenEventCount record in "<<sr.id()<<"\n";
     }
 
-    mf::LogInfo("INFO")<<"GenEventCount: "
+    mf::LogInfo("GenEventCount")<<"GenEventCount: "
       <<hh.front()->count()<<" events in "<<sr.id()
       <<"\n";
 
@@ -87,7 +87,7 @@ namespace mu2e {
 
   //================================================================
   void GenEventCountReader::endJob() {
-    mf::LogInfo("Summary")<<"GenEventCount total: "
+    mf::LogInfo("GenEventCountSummary")<<"GenEventCount total: "
       <<numEvents_<<" events in "
       <<numSubRuns_<<" SubRuns"
       <<"\n";

--- a/fcl/standardMessageDestinations.fcl
+++ b/fcl/standardMessageDestinations.fcl
@@ -140,6 +140,8 @@ mf_coutInfo:
    COSMIC_STEPPOINTS : { limit : 0 }
    Summary : { limit : 0 }
    INFO : { limit : 0 }
+   GenEventCount        : { limit : 1   reportEvery : 1 }
+   GenEventCountSummary : { limit : 1   reportEvery : 1 }
  } # end categories
 } # end mf_coutInfo
 

--- a/fcl/standardMessageDestinations.fcl
+++ b/fcl/standardMessageDestinations.fcl
@@ -140,8 +140,8 @@ mf_coutInfo:
    COSMIC_STEPPOINTS : { limit : 0 }
    Summary : { limit : 0 }
    INFO : { limit : 0 }
-   GenEventCount        : { limit : 1   reportEvery : 1 }
-   GenEventCountSummary : { limit : 1   reportEvery : 1 }
+   GenEventCount        : { limit : -1 }
+   GenEventCountSummary : { limit : -1 }
  } # end categories
 } # end mf_coutInfo
 


### PR DESCRIPTION
This is a candidate to replace the fcl/messageService.fcl part of  PR #1134