### PR TITLE
do not use gslcblas

### DIFF
--- a/Mu2eUtilities/src/SConscript
+++ b/Mu2eUtilities/src/SConscript
@@ -47,8 +47,7 @@ mainlib = helper.make_mainlib ( [ 'mu2e_ConditionsService',
                                   'cetlib_except',
                                   'hep_concurrency',
                                   rootlibs,
-                                  babarlibs,
-                                  'gslcblas'
+                                  babarlibs
                                   ] )
 
 # This tells emacs to view this file in python mode.


### PR DESCRIPTION
gslcblas has some of the same symbols as openblas.  Since we need opendblas for SOFIE, use openblas everywhere blas is needed