### PR TITLE
move OnSpillBins to GlobalConstants

### DIFF
--- a/CommonMC/src/EventWindowMarkerProducer_module.cc
+++ b/CommonMC/src/EventWindowMarkerProducer_module.cc
@@ -55,8 +55,9 @@ namespace mu2e {
       bool _recoFromMCTruth;
       float _recoFromMCTruthErr;
       bool _fixInitialPhase;
-      float _period;
+      double _period;
       int _onSpillMaxLength;
+      int _onSpillBins;
       float _initialPhaseShift;
       art::RandomNumberGenerator::base_engine_t& _engine;
       CLHEP::RandGaussQ _randgauss;
@@ -74,6 +75,7 @@ namespace mu2e {
     _fixInitialPhase( false),
     _period(GlobalConstantsHandle<PhysicsParams>()->getNominalDAQClockTick()),
     _onSpillMaxLength(GlobalConstantsHandle<PhysicsParams>()->getNominalDAQTicks()),
+    _onSpillBins(GlobalConstantsHandle<PhysicsParams>()->getNominalDAQOnSpillBins()),
     _initialPhaseShift( 0),
     _engine(createEngine( art::ServiceHandle<SeedService>()->getSeed())),
     _randgauss( _engine ),
@@ -110,10 +112,10 @@ namespace mu2e {
       marker->_eventLength = eventTiming.offSpillLength()*_period;
     }else{
       // calculate which bin we are in from event number
-      int bin = event.id().event() % eventTiming.onSpillBins();
+      int bin = event.id().event() % _onSpillBins;
       // determine phase for this event
       // each microbunch the proton bunch gets shifted back 5 ns from the event window
-      double shiftPer = -1*_period/eventTiming.onSpillBins();
+      double shiftPer = -1*_period/_onSpillBins;
       double phaseShift = (_initialPhaseShift*_period + bin*shiftPer);
       if (phaseShift < -1*_period)
         phaseShift += _period;

--- a/DAQConditions/fcl/prolog.fcl
+++ b/DAQConditions/fcl/prolog.fcl
@@ -8,7 +8,6 @@ EventTiming : {
    TimeFromProtonsToDRMarker : 200.0
    # clock counts
    OffSpillEventLength : 4000
-   OnSpillBins : 5
 }
 
 END_PROLOG

--- a/DAQConditions/inc/EventTiming.hh
+++ b/DAQConditions/inc/EventTiming.hh
@@ -31,18 +31,15 @@ namespace mu2e {
 
     // construct with constants, then some values are computed and filled below
     EventTiming( double timeFromProtonsToDRMarker,
-                 unsigned offSpillLength,
-                 int onSpillBins) :
+                 unsigned offSpillLength) :
       ProditionsEntity(cxname),
       _timeFromProtonsToDRMarker(timeFromProtonsToDRMarker),
-      _offSpillLength(offSpillLength),
-      _onSpillBins(onSpillBins) {}
+      _offSpillLength(offSpillLength) {}
 
     virtual ~EventTiming() = default;
 
     double timeFromProtonsToDRMarker() const { return _timeFromProtonsToDRMarker; }
     unsigned offSpillLength() const { return _offSpillLength; }
-    int onSpillBins() const { return _onSpillBins; }
 
     void print(std::ostream& os) const;
 
@@ -50,7 +47,6 @@ namespace mu2e {
 
     double _timeFromProtonsToDRMarker;
     unsigned _offSpillLength;
-    int _onSpillBins;
 
   };
 

--- a/DAQConditions/src/EventTimingMaker.cc
+++ b/DAQConditions/src/EventTimingMaker.cc
@@ -16,8 +16,7 @@ namespace mu2e {
     // partially constructed, to complete the construction
     auto ptr = std::make_shared<EventTiming>(
         _config.timeFromProtonsToDRMarker(),
-        _config.offSpillLength(),
-        _config.onSpillBins());
+        _config.offSpillLength());
 
     return ptr;
 

--- a/DAQConfig/inc/EventTimingConfig.hh
+++ b/DAQConfig/inc/EventTimingConfig.hh
@@ -22,8 +22,6 @@ namespace mu2e {
       Name("TimeFromProtonsToDRMarker"), Comment("Time shift in ns of DR marker wrt to proton peak. Positive means marker arrives after protons")};
     fhicl::Atom<unsigned> offSpillLength{
       Name("OffSpillEventLength"), Comment("Length of off spill events in clock counts" )};
-    fhicl::Atom<int> onSpillBins{
-      Name("OnSpillBins"), Comment("Number of microbunches before proton bunch phase repeats")};
 
   };
 

--- a/GlobalConstantsService/data/globalConstants_01.txt
+++ b/GlobalConstantsService/data/globalConstants_01.txt
@@ -17,6 +17,7 @@ double physicsParams.protonKE = 8000.; // - in MeV
 // if significant variations appear, this can be moved to conditions database
 double physicsParams.nominalDRPeriod = 1695.; // ns
 int    physicsParams.nominalDAQTicks = 68; // ticks of DAQ clock in DRPeriod
+int    physicsParams.nominalDAQOnSpillBins = 5; // how often to 68->67
 double physicsParams.nominalDAQFrequency = 40.; // MHz
 
 // charged pion and kaon

--- a/GlobalConstantsService/inc/PhysicsParams.hh
+++ b/GlobalConstantsService/inc/PhysicsParams.hh
@@ -45,6 +45,7 @@ namespace mu2e
 
     double   getNominalDRPeriod() const { return _nominalDRPeriod; } // ns
     int      getNominalDAQTicks() const { return _nominalDAQTicks; } // counts, DAQ ticks per DRperiod
+    int      getNominalDAQOnSpillBins() const { return _nominalDAQOnSpillBins; } // how often to 68->67
     double   getNominalDAQFrequency() const { return _nominalDAQFrequency; } // MHz
     double   getNominalDAQClockTick() const { return 1000.0/_nominalDAQFrequency; } // ns
 
@@ -170,6 +171,7 @@ namespace mu2e
 
     double _nominalDRPeriod;
     int    _nominalDAQTicks;
+    int    _nominalDAQOnSpillBins;
     double _nominalDAQFrequency;
 
     typedef std::map<PDGCode::type, double> FreeLifeMap;

--- a/GlobalConstantsService/src/PhysicsParams.cc
+++ b/GlobalConstantsService/src/PhysicsParams.cc
@@ -39,6 +39,7 @@ namespace mu2e {
 
     _nominalDRPeriod = config.getDouble("physicsParams.nominalDRPeriod");
     _nominalDAQTicks  = config.getInt("physicsParams.nominalDAQTicks");
+    _nominalDAQOnSpillBins  = config.getInt("physicsParams.nominalDAQOnSpillBins");
     _nominalDAQFrequency = config.getDouble("physicsParams.nominalDAQFrequency");
 
     std::vector<int> tmpPDGId;


### PR DESCRIPTION
This is the last item to move to GlobalConstants because it is true constant.  This will help with other conditions cleanups.  I also change _period in CommonMC/src/EventWindowMarkerProducer_module.cc from float back to double.  This inadvertent change may have triggered and "unstable' in the nightly validation.  Checked with small sample of ceSimReco.