### PR TITLE
expand clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-misleading-indentation,readability-non-const-parameter,-bugprone-narrowing-conversions,-bugprone-easily-swappable-parameters'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-misleading-indentation,readability-non-const-parameter,cppcoreguidelines-*,-bugprone-narrowing-conversions,-bugprone-easily-swappable-parameters'
 WarningsAsErrors: ''
-HeaderFilterRegex: ''
+HeaderFilterRegex: 'Offline/.*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 User:            roneil


### PR DESCRIPTION
run on header files and add some checks, most notably, uninitialized class members. 
