### PR TITLE
Production target geometry fixes

### DIFF
--- a/Mu2eG4/geom/ProductionTarget_Hayman_v2_0.txt
+++ b/Mu2eG4/geom/ProductionTarget_Hayman_v2_0.txt
@@ -33,7 +33,7 @@ vector<double> targetPS_heightOfRectangularGapPerSection = {12.135,12.135,12.640
 vector<double> targetPS_thicknessOfGapPerSection                 = {2.0,2.0,1.0}; //mm
 
 int targetPS_nHaymanFins                        = 4;
-vector<double> targetPS_finAngles                        = {30.,120.,210.,300.}; //degrees
+vector<double> targetPS_finAngles                        = {-30.,-120.,-210.,-300.}; //degrees
 double targetPS_finOuterRadius             = 16.15;
 double targetPS_finThickness               = 1.0; //                                                                                                                                                              full thickness
 double targetPS_supportRingLength          = 8.0; // full length in mm

--- a/Mu2eG4/geom/ProductionTarget_Hayman_v2_1.txt
+++ b/Mu2eG4/geom/ProductionTarget_Hayman_v2_1.txt
@@ -21,11 +21,15 @@ string targetPS.supports.wheel.material   =  "G4_Al";
 
 int  targetPS.supports.nSpokes = 3;
 //features on the wheel
-vector<double> targetPS.supports.features.angles = {-30.,  90., 210.}; //degrees
+//vector<double> targetPS.supports.features.angles = {-30.,  90., 210.}; //degrees
+vector<double> targetPS.supports.features.angles = {-46.62.,  79.38., 194.38.}; //degrees
+//vector<double> targetPS.supports.features.angles = {-30.,  90., 197.12.}; //degrees
 vector<double> targetPS.supports.features.arcs   = { 28.,  28.,  28.}; //degrees
 vector<double> targetPS.supports.features.rIns   = {158.75, 158.75, 158.75}; //mm
 //support rods in the wheel that the wires connect to
-vector<double> targetPS.supports.rods.angles       = {-37, 83, 203}; //degrees
+//vector<double> targetPS.supports.rods.angles       = {-37, 83, 203}; //degrees
+//vector<double> targetPS.supports.rods.angles       = {-52.5., 71.5, 186.0}; //degrees
+vector<double> targetPS.supports.rods.angles       = {-54., 71.5, 186.0}; //degrees
 vector<double> targetPS.supports.rods.halfLength   = {70., 70., 70.}; //mm
 vector<double> targetPS.supports.rods.offset       = {-40., -10., 40.}; //mm
 vector<double> targetPS.supports.rods.radius       = {9., 9., 9.}; //mm
@@ -33,8 +37,10 @@ vector<double> targetPS.supports.rods.radialOffset = {177.8, 177.8, 177.8}; //mm
 vector<double> targetPS.supports.rods.wireOffset.downstream = {10., 10., 10.}; //mm
 vector<double> targetPS.supports.rods.wireOffset.upstream   = {10., 10., 10.}; //mm
 //spokes connecting the target to the wheel rods
-vector<double> targetPS.supports.spokes.targetAngles.downstream = {-37, 83, 203}; //degrees
-vector<double> targetPS.supports.spokes.targetAngles.upstream   = {-37, 83, 203}; //degrees
+//vector<double> targetPS.supports.spokes.targetAngles.downstream = {-37, 83, 203}; //degrees
+//vector<double> targetPS.supports.spokes.targetAngles.upstream   = {-37, 83, 203}; //degrees
+vector<double> targetPS.supports.spokes.targetAngles.downstream = {-54., 71.5, 186.0}; //degrees
+vector<double> targetPS.supports.spokes.targetAngles.upstream   = {-54., 71.5, 186.0}; //degrees
 double targetPS.supports.spokes.diameter = 2.;
 string targetPS.supports.spokes.material = "ProductionTargetTungstenLa2_O3";
 

--- a/Mu2eG4/geom/ProductionTarget_Hayman_v2_1.txt
+++ b/Mu2eG4/geom/ProductionTarget_Hayman_v2_1.txt
@@ -21,14 +21,10 @@ string targetPS.supports.wheel.material   =  "G4_Al";
 
 int  targetPS.supports.nSpokes = 3;
 //features on the wheel
-//vector<double> targetPS.supports.features.angles = {-30.,  90., 210.}; //degrees
 vector<double> targetPS.supports.features.angles = {-46.62.,  79.38., 194.38.}; //degrees
-//vector<double> targetPS.supports.features.angles = {-30.,  90., 197.12.}; //degrees
 vector<double> targetPS.supports.features.arcs   = { 28.,  28.,  28.}; //degrees
 vector<double> targetPS.supports.features.rIns   = {158.75, 158.75, 158.75}; //mm
 //support rods in the wheel that the wires connect to
-//vector<double> targetPS.supports.rods.angles       = {-37, 83, 203}; //degrees
-//vector<double> targetPS.supports.rods.angles       = {-52.5., 71.5, 186.0}; //degrees
 vector<double> targetPS.supports.rods.angles       = {-54., 71.5, 186.0}; //degrees
 vector<double> targetPS.supports.rods.halfLength   = {70., 70., 70.}; //mm
 vector<double> targetPS.supports.rods.offset       = {-40., -10., 40.}; //mm
@@ -37,8 +33,6 @@ vector<double> targetPS.supports.rods.radialOffset = {177.8, 177.8, 177.8}; //mm
 vector<double> targetPS.supports.rods.wireOffset.downstream = {10., 10., 10.}; //mm
 vector<double> targetPS.supports.rods.wireOffset.upstream   = {10., 10., 10.}; //mm
 //spokes connecting the target to the wheel rods
-//vector<double> targetPS.supports.spokes.targetAngles.downstream = {-37, 83, 203}; //degrees
-//vector<double> targetPS.supports.spokes.targetAngles.upstream   = {-37, 83, 203}; //degrees
 vector<double> targetPS.supports.spokes.targetAngles.downstream = {-54., 71.5, 186.0}; //degrees
 vector<double> targetPS.supports.spokes.targetAngles.upstream   = {-54., 71.5, 186.0}; //degrees
 double targetPS.supports.spokes.diameter = 2.;

--- a/Mu2eG4/geom/ProductionTarget_Hayman_v2_1.txt
+++ b/Mu2eG4/geom/ProductionTarget_Hayman_v2_1.txt
@@ -25,16 +25,16 @@ vector<double> targetPS.supports.features.angles = {-30.,  90., 210.}; //degrees
 vector<double> targetPS.supports.features.arcs   = { 28.,  28.,  28.}; //degrees
 vector<double> targetPS.supports.features.rIns   = {158.75, 158.75, 158.75}; //mm
 //support rods in the wheel that the wires connect to
-vector<double> targetPS.supports.rods.angles       = {-23, 97, 217}; //degrees
+vector<double> targetPS.supports.rods.angles       = {-37, 83, 203}; //degrees
 vector<double> targetPS.supports.rods.halfLength   = {70., 70., 70.}; //mm
-vector<double> targetPS.supports.rods.offset       = {-40., 10., 40.}; //mm
+vector<double> targetPS.supports.rods.offset       = {-40., -10., 40.}; //mm
 vector<double> targetPS.supports.rods.radius       = {9., 9., 9.}; //mm
 vector<double> targetPS.supports.rods.radialOffset = {177.8, 177.8, 177.8}; //mm
 vector<double> targetPS.supports.rods.wireOffset.downstream = {10., 10., 10.}; //mm
 vector<double> targetPS.supports.rods.wireOffset.upstream   = {10., 10., 10.}; //mm
 //spokes connecting the target to the wheel rods
-vector<double> targetPS.supports.spokes.targetAngles.downstream = {-23, 97, 217}; //degrees
-vector<double> targetPS.supports.spokes.targetAngles.upstream   = {-23, 97, 217}; //degrees
+vector<double> targetPS.supports.spokes.targetAngles.downstream = {-37, 83, 203}; //degrees
+vector<double> targetPS.supports.spokes.targetAngles.upstream   = {-37, 83, 203}; //degrees
 double targetPS.supports.spokes.diameter = 2.;
 string targetPS.supports.spokes.material = "ProductionTargetTungstenLa2_O3";
 


### PR DESCRIPTION
This PR addresses 2 concerns regarding the geometry of the production target: the orientation of the production target and the locations of the support tabs and rods.

- The production target was previously put in "backwards", meaning it was rotated 180 degress about y-axis from the nominal orientation. This is the most important and significant issue addressed in this PR.

- The tabs, support rods, and wires that hold the production target were not in the correct positions. These have been moved much closer to the as-built locations, but I suspect are not perfect (especially the support rods). I do not expect these changes to impact much of anything.

In a future PR, I intend to consolidate the production target to a single geometry file, but I feel there is no need to wait to do that before inserting these fixes. Ideally, one should not have to update any FCL to use the fixes in this PR, whereas consolidating geom files would require FCL changes.