### PR TITLE
art v3_14_03 s128

### DIFF
--- a/.muse
+++ b/.muse
@@ -1,5 +1,5 @@
 # prefer to build with this environment
-ENVSET p051
+ENVSET p055
 # add these to python path
 PYTHONPATH Trigger/python
 # add Offline/bin to path


### PR DESCRIPTION
This is the second attempt to move to art v3_14.  The first was art v3_14_01 in p052 and p054 with root v6_28_04c, but this showed a serious memory leak.  This has been fixed and is released here as p055 with art v3_14_03 and root v6_28_10a. A short test with reco shows the memory usage has now decreased notably.

I tested this envset with short tests with ceSimReco, cosmicSimReco, potSim and reco.  All showed some differences except reco which was an exact match.  I think this is consistent with what we saw before in #1148, expected due to clhep changing, which affects geant.