### PR TITLE
enabling newer versions of geant4 (v11.1.p03 and v11.2)

### DIFF
--- a/MCDataProducts/inc/ProcessCode.hh
+++ b/MCDataProducts/inc/ProcessCode.hh
@@ -88,7 +88,7 @@ namespace mu2e {
       mu2eCePlusLeadingLog, mu2ePionCaptureAtRest, mu2eExternalRPC, mu2eInternalRPC,
       mu2eCaloCalib, mu2eunused6, mu2eunused7, mu2eunused8,
       uninitialized, NoProcess, GammaGeneralProc,
-      mu2eGammaConversion,
+      mu2eGammaConversion, Radioactivation,
       lastEnum,
       // An alias for backward compatibility
       mu2eHallAir = mu2eKillerVolume
@@ -145,7 +145,7 @@ namespace mu2e {
   "mu2eCePlusLeadingLog", "mu2ePionCaptureAtRest", "mu2eExternalRPC", "mu2eInternalRPC", \
     "mu2eCaloCalib", "mu2eunused6", "mu2eunused7", "mu2eunused8", \
       "uninitialized", "NoProcess", "GammaGeneralProc", \
-   "mu2eGammaConversion"
+      "mu2eGammaConversion","Radioactivation"
 #endif
 
   public:

--- a/Mu2eG4/src/SConscript
+++ b/Mu2eG4/src/SConscript
@@ -191,6 +191,12 @@ if g4vg != 'off':
 if g4_version > '4106':
     G4GLOBALIBS.append('libG4ptl')
 
+if g4_version > '4111':
+    G4GLOBALIBS.remove('libG4persistency')
+    G4GLOBALIBS.append('libG4gdml')
+    G4GLOBALIBS.append('libG4geomtext')
+    G4GLOBALIBS.append('libG4mctruth')
+
 if g4_version < '4095':
     G4LIBS = G4GRANULARLIBS
 else:


### PR DESCRIPTION
Adding a new process name introduced in geant4 11.1.p03 to enable a bug fix related to biasing (which should not affect not biased processes) and modifying the global library list for versions above 11.1