### PR TITLE
Reseeder prototype 

### DIFF
--- a/EventGenerator/src/StoppedParticleReactionGun_module.cc
+++ b/EventGenerator/src/StoppedParticleReactionGun_module.cc
@@ -37,6 +37,7 @@
 #include "Offline/Mu2eUtilities/inc/BinnedSpectrum.hh"
 #include "Offline/Mu2eUtilities/inc/Table.hh"
 #include "Offline/Mu2eUtilities/inc/RootTreeSampler.hh"
+#include "Offline/Mu2eUtilities/inc/ReSeedByEvent.hh"
 #include "Offline/GeneralUtilities/inc/RSNTIO.hh"
 
 #include "TH1.h"
@@ -57,6 +58,7 @@ namespace mu2e {
     GenId             genId_;
     int               verbosityLevel_;
 
+    SeedService::seed_t seed_;
     art::RandomNumberGenerator::base_engine_t& eng_;
     CLHEP::RandGeneral randSpectrum_;
     RandomUnitSphere   randomUnitSphere_;
@@ -71,6 +73,8 @@ namespace mu2e {
     TH1F*   _hGenId;
     TH1F*   _hTime;
     TH1F*   _hZ;
+
+    ReSeedByEvent reseeder_;
 
   private:
     static SpectrumVar    parseSpectrumVar(const std::string& name);
@@ -92,11 +96,13 @@ namespace mu2e {
     , spectrum_(BinnedSpectrum(psphys_))
     , genId_(GenId::findByName(psphys_.get<std::string>("genId")))
     , verbosityLevel_(pset.get<int>("verbosityLevel", 0))
-    , eng_(createEngine(art::ServiceHandle<SeedService>()->getSeed()))
+    , seed_(art::ServiceHandle<SeedService>()->getSeed())
+    , eng_(createEngine(seed_))
     , randSpectrum_(eng_, spectrum_.getPDF(), spectrum_.getNbins())
     , randomUnitSphere_(eng_)
     , stops_(eng_, pset.get<fhicl::ParameterSet>("muonStops"))
     , doHistograms_       (pset.get<bool>("doHistograms",false ) )
+    , reseeder_(eng_,seed_)
   {
     produces<mu2e::GenParticleCollection>();
 

--- a/EventGenerator/src/StoppedParticleReactionGun_module.cc
+++ b/EventGenerator/src/StoppedParticleReactionGun_module.cc
@@ -37,7 +37,7 @@
 #include "Offline/Mu2eUtilities/inc/BinnedSpectrum.hh"
 #include "Offline/Mu2eUtilities/inc/Table.hh"
 #include "Offline/Mu2eUtilities/inc/RootTreeSampler.hh"
-#include "Offline/Mu2eUtilities/inc/ReSeedByEvent.hh"
+#include "Offline/Mu2eUtilities/inc/ReSeedByEventID.hh"
 #include "Offline/GeneralUtilities/inc/RSNTIO.hh"
 
 #include "TH1.h"
@@ -74,7 +74,7 @@ namespace mu2e {
     TH1F*   _hTime;
     TH1F*   _hZ;
 
-    ReSeedByEvent reseeder_;
+    ReSeedByEventID reseeder_;
 
   private:
     static SpectrumVar    parseSpectrumVar(const std::string& name);
@@ -156,6 +156,8 @@ namespace mu2e {
 
   //================================================================
   void StoppedParticleReactionGun::produce(art::Event& event) {
+
+    reseeder_.reseed(event.id());
 
     std::unique_ptr<GenParticleCollection> output(new GenParticleCollection);
 

--- a/Mu2eUtilities/inc/ReSeedByEvent.hh
+++ b/Mu2eUtilities/inc/ReSeedByEvent.hh
@@ -1,0 +1,33 @@
+#ifndef Mu2eUtilities_ReSeedByEvent_hh
+#define Mu2eUtilities_ReSeedByEvent_hh
+//
+// Reseed a random engine using the event id.
+//
+//
+
+#include "Offline/SeedService/inc/SeedService.hh"
+
+#include "canvas/Persistency/Provenance/EventID.h"
+#include "art/Framework/Services/Optional/RandomNumberGenerator.h"
+#include "CLHEP/Random/MixMaxRng.h"
+
+namespace mu2e {
+
+  class ReSeedByEvent{
+
+  public:
+    ReSeedByEvent( CLHEP::HepRandomEngine& engine, SeedService::seed_t seed);
+
+    void reseed ( art::EventID const& id ) const;
+
+  private:
+
+    CLHEP::MixMaxRng *  _engine;
+    SeedService::seed_t _salt;
+
+  };
+
+} // namespace mu2e
+
+
+#endif

--- a/Mu2eUtilities/inc/ReSeedByEventID.hh
+++ b/Mu2eUtilities/inc/ReSeedByEventID.hh
@@ -1,0 +1,32 @@
+#ifndef Mu2eUtilities_ReSeedByEventID_hh
+#define Mu2eUtilities_ReSeedByEventID_hh
+//
+// Reseed a random engine using the event id and a user supplied salt.
+//
+
+#include "Offline/SeedService/inc/SeedService.hh"
+
+#include "canvas/Persistency/Provenance/EventID.h"
+#include "art/Framework/Services/Optional/RandomNumberGenerator.h"
+#include "CLHEP/Random/MixMaxRng.h"
+
+namespace mu2e {
+
+  class ReSeedByEventID{
+
+  public:
+    ReSeedByEventID( CLHEP::HepRandomEngine& engine, SeedService::seed_t salt);
+
+    void reseed ( art::EventID const& id ) const;
+
+  private:
+
+    CLHEP::MixMaxRng *  _engine; // the engine to be reseeded
+    SeedService::seed_t _salt;   // user supplied salt.
+
+  };
+
+} // namespace mu2e
+
+
+#endif

--- a/Mu2eUtilities/src/ReSeedByEvent.cc
+++ b/Mu2eUtilities/src/ReSeedByEvent.cc
@@ -1,0 +1,30 @@
+#include "Offline/Mu2eUtilities/inc/ReSeedByEvent.hh"
+//#include "art/Framework/EventProcessor/Scheduler.h"
+
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+
+#include <iostream>
+#include <string>
+
+namespace mu2e {
+  ReSeedByEvent::ReSeedByEvent( CLHEP::HepRandomEngine& engine, SeedService::seed_t salt):_salt(salt){
+    std::string engineType{art::ServiceHandle<art::RandomNumberGenerator>{}->defaultEngineKind()};
+    std::cout << "Kind:    " << engineType << std::endl;
+    if ( engineType != "MixMaxRng" ){
+      // throw
+    }
+    //std::cout << "Threads: " << art::ServiceHandle<art::Scheduler>{}->num_threads() << std::endl;
+    _engine = static_cast<CLHEP::MixMaxRng*>(&engine);
+  }
+
+  void  ReSeedByEvent::reseed ( art::EventID const& id ) const{
+    std::cout << "reseed: " << id  << std::endl;
+    std::array<long,4> seeds;
+    seeds[0] = id.run();
+    seeds[1] = id.subRun();
+    seeds[2] = id.event();
+    seeds[3] = _salt;
+    _engine->setSeeds( seeds.data(), seeds.size() );
+  }
+
+} // end namespace mu2e

--- a/Mu2eUtilities/src/ReSeedByEventID.cc
+++ b/Mu2eUtilities/src/ReSeedByEventID.cc
@@ -1,0 +1,35 @@
+#include "Offline/Mu2eUtilities/inc/ReSeedByEventID.hh"
+//#include "art/Framework/EventProcessor/Scheduler.h"
+
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+
+#include "fhiclcpp/exception.h"
+
+#include <iostream>
+#include <string>
+
+namespace mu2e {
+  ReSeedByEventID::ReSeedByEventID( CLHEP::HepRandomEngine& engine, SeedService::seed_t salt):_salt(salt){
+    std::string engineType{art::ServiceHandle<art::RandomNumberGenerator>{}->defaultEngineKind()};
+    std::cout << "Kind:    " << engineType << std::endl;
+    if ( engineType != "MixMaxRng" ){
+      throw cet::exception("BADCONFIG")
+        << "ReSeedByEventID requires that RandomNumberGenerator::defaultEngineKind be MixMaxRng.  It is: " << engineType << "\n";
+    }
+    // Ideally only do this when the number of schedules is >1.
+    // The next line is not working.
+    //std::cout << "Threads: " << art::ServiceHandle<art::Scheduler>{}->num_threads() << std::endl;
+    _engine = static_cast<CLHEP::MixMaxRng*>(&engine);
+  }
+
+  void  ReSeedByEventID::reseed ( art::EventID const& id ) const{
+    std::cout << "Reseed: " << id  << " " << _salt << std::endl;
+    std::array<long,4> seeds;
+    seeds[0] = id.run();
+    seeds[1] = id.subRun();
+    seeds[2] = id.event();
+    seeds[3] = _salt;
+    _engine->setSeeds( seeds.data(), seeds.size() );
+  }
+
+} // end namespace mu2e

--- a/SeedService/inc/SeedService.hh
+++ b/SeedService/inc/SeedService.hh
@@ -163,6 +163,7 @@ namespace mu2e {
     void preModuleConstruction (art::ModuleDescription const& md);
     void postModuleConstruction(art::ModuleDescription const& md);
     void preModuleBeginRun     (art::ModuleContext const& md);
+    void preModule             (art::ModuleContext const& md);
     void postModuleBeginRun    (art::ModuleContext const& md);
     void postEvent             (art::Event const& ev, art::ScheduleContext);
     void postEndJob();

--- a/SeedService/src/SeedService.cc
+++ b/SeedService/src/SeedService.cc
@@ -86,6 +86,7 @@ namespace mu2e {
     // Register callbacks.
     iRegistry.sPreModuleConstruction.watch  (this, &SeedService::preModuleConstruction  );
     iRegistry.sPostModuleConstruction.watch (this, &SeedService::postModuleConstruction );
+    iRegistry.sPreModule.watch              (this, &SeedService::preModule              );
     iRegistry.sPreModuleBeginRun.watch      (this, &SeedService::preModuleBeginRun      );
     iRegistry.sPostModuleBeginRun.watch     (this, &SeedService::postModuleBeginRun     );
     iRegistry.sPostEndJob.watch             (this, &SeedService::postEndJob             );
@@ -311,6 +312,10 @@ namespace mu2e {
 
   void SeedService::preModuleBeginRun ( art::ModuleContext const& mc){
     state_.set( SeedServiceHelper::ArtState::inBeginRun, mc.moduleLabel() );
+  }
+
+  void SeedService::preModule ( art::ModuleContext const& mc){
+    std::cerr << "Calling preModule: " << mc.moduleLabel() << std::endl;
   }
 
   void SeedService::postModuleBeginRun( art::ModuleContext const&){


### PR DESCRIPTION
Prototype of a class to reseed a random engine on each event,using the event id and a user supplied salt.

And an example of using it, using the SeedService seed for the module as the salt.

It still contains debugging printout and should be considered a draft for comment.  I would like to make the default that it only does this when the number of scheudles is > 1.  I would like to do it without having to put a nscheudles argument into each module fcl config.
