### PR TITLE
Cleaned up prototype of a re-seeder helper class.

### DIFF
--- a/EventGenerator/src/StoppedParticleReactionGun_module.cc
+++ b/EventGenerator/src/StoppedParticleReactionGun_module.cc
@@ -102,7 +102,7 @@ namespace mu2e {
     , randomUnitSphere_(eng_)
     , stops_(eng_, pset.get<fhicl::ParameterSet>("muonStops"))
     , doHistograms_       (pset.get<bool>("doHistograms",false ) )
-    , reseeder_(eng_,seed_)
+    , reseeder_(eng_,seed_,verbosityLevel_)
   {
     produces<mu2e::GenParticleCollection>();
 

--- a/EventGenerator/src/StoppedParticleReactionGun_module.cc
+++ b/EventGenerator/src/StoppedParticleReactionGun_module.cc
@@ -37,6 +37,7 @@
 #include "Offline/Mu2eUtilities/inc/BinnedSpectrum.hh"
 #include "Offline/Mu2eUtilities/inc/Table.hh"
 #include "Offline/Mu2eUtilities/inc/RootTreeSampler.hh"
+#include "Offline/Mu2eUtilities/inc/ReSeedByEventID.hh"
 #include "Offline/GeneralUtilities/inc/RSNTIO.hh"
 
 #include "TH1.h"
@@ -57,6 +58,7 @@ namespace mu2e {
     GenId             genId_;
     int               verbosityLevel_;
 
+    SeedService::seed_t seed_;
     art::RandomNumberGenerator::base_engine_t& eng_;
     CLHEP::RandGeneral randSpectrum_;
     RandomUnitSphere   randomUnitSphere_;
@@ -71,6 +73,8 @@ namespace mu2e {
     TH1F*   _hGenId;
     TH1F*   _hTime;
     TH1F*   _hZ;
+
+    ReSeedByEventID reseeder_;
 
   private:
     static SpectrumVar    parseSpectrumVar(const std::string& name);
@@ -92,11 +96,13 @@ namespace mu2e {
     , spectrum_(BinnedSpectrum(psphys_))
     , genId_(GenId::findByName(psphys_.get<std::string>("genId")))
     , verbosityLevel_(pset.get<int>("verbosityLevel", 0))
-    , eng_(createEngine(art::ServiceHandle<SeedService>()->getSeed()))
+    , seed_(art::ServiceHandle<SeedService>()->getSeed())
+    , eng_(createEngine(seed_))
     , randSpectrum_(eng_, spectrum_.getPDF(), spectrum_.getNbins())
     , randomUnitSphere_(eng_)
     , stops_(eng_, pset.get<fhicl::ParameterSet>("muonStops"))
     , doHistograms_       (pset.get<bool>("doHistograms",false ) )
+    , reseeder_(eng_,seed_)
   {
     produces<mu2e::GenParticleCollection>();
 
@@ -150,6 +156,8 @@ namespace mu2e {
 
   //================================================================
   void StoppedParticleReactionGun::produce(art::Event& event) {
+
+    reseeder_.reseed(event.id());
 
     std::unique_ptr<GenParticleCollection> output(new GenParticleCollection);
 

--- a/Mu2eUtilities/inc/ReSeedByEventID.hh
+++ b/Mu2eUtilities/inc/ReSeedByEventID.hh
@@ -3,30 +3,33 @@
 //
 // Reseed a random engine using the event id and a user supplied salt.
 //
+// Does not work with all CLHEP::RandomEngine concrete types.
+//   - see description in .cc file
+//
 
 #include "Offline/SeedService/inc/SeedService.hh"
 
 #include "canvas/Persistency/Provenance/EventID.h"
 #include "art/Framework/Services/Optional/RandomNumberGenerator.h"
-#include "CLHEP/Random/MixMaxRng.h"
+#include "CLHEP/Random/RandomEngine.h"
 
 namespace mu2e {
 
   class ReSeedByEventID{
 
   public:
-    ReSeedByEventID( CLHEP::HepRandomEngine& engine, SeedService::seed_t salt);
+    ReSeedByEventID( CLHEP::HepRandomEngine& engine, SeedService::seed_t salt, int verbosity=0 );
 
     void reseed ( art::EventID const& id ) const;
 
   private:
 
-    CLHEP::MixMaxRng *  _engine; // the engine to be reseeded
-    SeedService::seed_t _salt;   // user supplied salt.
+    CLHEP::HepRandomEngine& engine_;     // The engine to be reseeded
+    SeedService::seed_t     salt_;       // User supplied salt.
+    int                     verbosity_;  // Control amount of printout; 0=none.
 
   };
 
 } // namespace mu2e
-
 
 #endif

--- a/Mu2eUtilities/inc/ReSeedByEventID.hh
+++ b/Mu2eUtilities/inc/ReSeedByEventID.hh
@@ -1,0 +1,32 @@
+#ifndef Mu2eUtilities_ReSeedByEventID_hh
+#define Mu2eUtilities_ReSeedByEventID_hh
+//
+// Reseed a random engine using the event id and a user supplied salt.
+//
+
+#include "Offline/SeedService/inc/SeedService.hh"
+
+#include "canvas/Persistency/Provenance/EventID.h"
+#include "art/Framework/Services/Optional/RandomNumberGenerator.h"
+#include "CLHEP/Random/MixMaxRng.h"
+
+namespace mu2e {
+
+  class ReSeedByEventID{
+
+  public:
+    ReSeedByEventID( CLHEP::HepRandomEngine& engine, SeedService::seed_t salt);
+
+    void reseed ( art::EventID const& id ) const;
+
+  private:
+
+    CLHEP::MixMaxRng *  _engine; // the engine to be reseeded
+    SeedService::seed_t _salt;   // user supplied salt.
+
+  };
+
+} // namespace mu2e
+
+
+#endif

--- a/Mu2eUtilities/src/ReSeedByEventID.cc
+++ b/Mu2eUtilities/src/ReSeedByEventID.cc
@@ -1,0 +1,35 @@
+#include "Offline/Mu2eUtilities/inc/ReSeedByEventID.hh"
+//#include "art/Framework/EventProcessor/Scheduler.h"
+
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+
+#include "fhiclcpp/exception.h"
+
+#include <iostream>
+#include <string>
+
+namespace mu2e {
+  ReSeedByEventID::ReSeedByEventID( CLHEP::HepRandomEngine& engine, SeedService::seed_t salt):_salt(salt){
+    std::string engineType{art::ServiceHandle<art::RandomNumberGenerator>{}->defaultEngineKind()};
+    std::cout << "Kind:    " << engineType << std::endl;
+    if ( engineType != "MixMaxRng" ){
+      throw cet::exception("BADCONFIG")
+        << "ReSeedByEventID requires that RandomNumberGenerator::defaultEngineKind be MixMaxRng.  It is: " << engineType << "\n";
+    }
+    // Ideally only do this when the number of schedules is >1.
+    // The next line is not working.
+    //std::cout << "Threads: " << art::ServiceHandle<art::Scheduler>{}->num_threads() << std::endl;
+    _engine = static_cast<CLHEP::MixMaxRng*>(&engine);
+  }
+
+  void  ReSeedByEventID::reseed ( art::EventID const& id ) const{
+    std::cout << "Reseed: " << id  << " " << _salt << std::endl;
+    std::array<long,4> seeds;
+    seeds[0] = id.run();
+    seeds[1] = id.subRun();
+    seeds[2] = id.event();
+    seeds[3] = _salt;
+    _engine->setSeeds( seeds.data(), seeds.size() );
+  }
+
+} // end namespace mu2e

--- a/Mu2eUtilities/src/ReSeedByEventID.cc
+++ b/Mu2eUtilities/src/ReSeedByEventID.cc
@@ -1,35 +1,60 @@
+//
+// Reseed a random engine using the art::EventID and a user supplied salt.
+//
+// Notes:
+// 1) The current algorithm requires an engine that can accept 4 seeds.
+//    We could adapt the algorithm to fewer seeds but have chosen not to
+//    unless and until it is needed.  We know that the MixMaxRng engine
+//    does support up to 4 seeds and, for the foreseeable future, it is
+//    the only engine we plan to use.
+//
+// 2) We have not checked all CLHEP engines but we know that the following
+//    do NOT support 4 seeds:
+//       - HepJamesRandom
+//       - Ranlux64Engine
+//       - MTwistEngine
+//
+// 3) Because of 1 and 2 the c'tor whitelists only MixMaxRng.
+//
+// Fixme: The code may require maintenance if we change to a different engine type.
+//
+
 #include "Offline/Mu2eUtilities/inc/ReSeedByEventID.hh"
-//#include "art/Framework/EventProcessor/Scheduler.h"
-
-#include "art/Framework/Services/Registry/ServiceHandle.h"
-
 #include "fhiclcpp/exception.h"
 
 #include <iostream>
 #include <string>
 
 namespace mu2e {
-  ReSeedByEventID::ReSeedByEventID( CLHEP::HepRandomEngine& engine, SeedService::seed_t salt):_salt(salt){
-    std::string engineType{art::ServiceHandle<art::RandomNumberGenerator>{}->defaultEngineKind()};
-    std::cout << "Kind:    " << engineType << std::endl;
+  ReSeedByEventID::ReSeedByEventID( CLHEP::HepRandomEngine& engine, SeedService::seed_t salt, int verbosity)
+    :engine_(engine)
+    ,salt_{salt}
+    ,verbosity_{verbosity}
+  {
+    const std::string engineType{engine.name()};
+
+    if ( verbosity_ > 0 ){
+      std::cout << "ReSeedbyEventID.  Engine name:             " << engineType  << std::endl;
+      std::cout << "                  salt:                    " << salt_       << std::endl;
+    }
+
+    // Only accept whitelisted engines.  See notes above.
     if ( engineType != "MixMaxRng" ){
       throw cet::exception("BADCONFIG")
-        << "ReSeedByEventID requires that RandomNumberGenerator::defaultEngineKind be MixMaxRng.  It is: " << engineType << "\n";
+        << "ReSeedByEventID requires that engine::name() be MixMaxRng.  It is: " << engineType << "\n";
     }
-    // Ideally only do this when the number of schedules is >1.
-    // The next line is not working.
-    //std::cout << "Threads: " << art::ServiceHandle<art::Scheduler>{}->num_threads() << std::endl;
-    _engine = static_cast<CLHEP::MixMaxRng*>(&engine);
+
   }
 
   void  ReSeedByEventID::reseed ( art::EventID const& id ) const{
-    std::cout << "Reseed: " << id  << " " << _salt << std::endl;
-    std::array<long,4> seeds;
-    seeds[0] = id.run();
-    seeds[1] = id.subRun();
-    seeds[2] = id.event();
-    seeds[3] = _salt;
-    _engine->setSeeds( seeds.data(), seeds.size() );
+
+    if ( verbosity_ > 1 ){
+      std::cout << "ReseedByEventID: " << id  << std::endl;
+    }
+
+    const std::array<long,4> seeds{ id.run(), id.subRun(), id.event(), salt_};
+    engine_.setSeeds( seeds.data(), seeds.size() );
+
   }
 
 } // end namespace mu2e


### PR DESCRIPTION
Prototype of a class to reseed a random engine on each event,using the event id and a user supplied salt.

And an example of using it, using the SeedService seed for the module as the salt.

It still contains debugging printout and should be considered a draft for comment. I would like to make the default that it only does this when the number of scheudles is > 1. I would like to do it without having to put a nscheudles argument into each module fcl config.