### PR TITLE
Add ignore rule for Spack build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ EMFCAnalysis
 tags
 .clangd/*
 compile_commands.json
+spack-*


### PR DESCRIPTION
```
[eflumerf@ironvirt9 Offline]$ git status
On branch main
Your branch is up to date with 'origin/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        spack-build-01-cmake-out.txt
        spack-build-02-build-out.txt
        spack-build-03-install-out.txt
        spack-build-env-mods.txt
        spack-build-env.txt
        spack-build-out.txt
        spack-build-pxkqzo6/
        spack-build-rsgwvmh/
        spack-configure-args.txt
```