### PR TITLE
create sim version of tracker alignment prodition and db tables

### DIFF
--- a/DbTables/inc/TrkAlignElement.hh
+++ b/DbTables/inc/TrkAlignElement.hh
@@ -80,6 +80,8 @@ class TrkAlignPanel : public TrkAlignElement {
   constexpr static const char* cxname = "TrkAlignPanel";
   TrkAlignPanel() :
       TrkAlignElement(cxname, "trk.alignpanel", StrawId::_nupanels) {}
+  TrkAlignPanel(const char* name, const char* dbname) :
+    TrkAlignElement(name, dbname,  StrawId::_nupanels) {}
 };
 
 class TrkAlignPlane : public TrkAlignElement {
@@ -87,12 +89,15 @@ class TrkAlignPlane : public TrkAlignElement {
   constexpr static const char* cxname = "TrkAlignPlane";
   TrkAlignPlane() :
       TrkAlignElement(cxname, "trk.alignplane", StrawId::_nplanes) {}
+  TrkAlignPlane(const char* name, const char* dbname) :
+      TrkAlignElement(name, dbname, StrawId::_nplanes) {}
 };
 
 class TrkAlignTracker : public TrkAlignElement {
  public:
   constexpr static const char* cxname = "TrkAlignTracker";
-  TrkAlignTracker() : TrkAlignElement(cxname, "trk.aligntracker", size_t(1)) {}
+  TrkAlignTracker() : TrkAlignElement(cxname, "trk.aligntracker", size_t(1)) {}   TrkAlignTracker(const char* name, const char* dbname) :
+      TrkAlignElement(name, dbname, size_t(1)) {}
 };
 
 }  // namespace mu2e

--- a/DbTables/inc/TrkAlignElementSim.hh
+++ b/DbTables/inc/TrkAlignElementSim.hh
@@ -1,0 +1,36 @@
+//
+// Alignment tables for tracker elements for simulation
+// derived from the reco version of the tables, and have the same structure
+//
+
+#ifndef DbTables_TrkAlignElementSim_hh
+#define DbTables_TrkAlignElementSim_hh
+
+#include "Offline/DbTables/inc/TrkAlignElement.hh"
+
+namespace mu2e {
+
+
+// unique classes for Db usage: not sure why this is needed
+class TrkAlignPanelSim : public TrkAlignPanel {
+ public:
+  constexpr static const char* cxname = "TrkAlignPanelSim";
+  TrkAlignPanelSim() :
+      TrkAlignPanel(cxname, "trk.alignpanelsim") {}
+};
+
+class TrkAlignPlaneSim : public TrkAlignPlane {
+ public:
+  constexpr static const char* cxname = "TrkAlignPlaneSim";
+  TrkAlignPlaneSim() :
+      TrkAlignPlane(cxname, "trk.alignplanesim") {}
+};
+
+class TrkAlignTrackerSim : public TrkAlignTracker {
+ public:
+  constexpr static const char* cxname = "TrkAlignTrackerSim";
+  TrkAlignTrackerSim() : TrkAlignTracker(cxname, "trk.aligntrackersim") {}
+};
+
+}  // namespace mu2e
+#endif

--- a/DbTables/inc/TrkAlignStraw.hh
+++ b/DbTables/inc/TrkAlignStraw.hh
@@ -19,8 +19,9 @@ class TrkAlignStraw : public DbTable {
   typedef std::shared_ptr<const TrkAlignStraw> cptr_t;
   constexpr static const char* cxname = "TrkAlignStraw";
 
-  TrkAlignStraw() :
-      DbTable(cxname, "trk.alignstraw",
+  TrkAlignStraw() : TrkAlignStraw(cxname, "trk.alignstraw") {}
+  TrkAlignStraw(const char* name, const char* dbname) :
+      DbTable(name, dbname,
               "index,StrawId,wire_cal_dV,wire_cal_dW,wire_hv_dV,wire_hv_dW,"
               "straw_cal_dV,straw_cal_dW,straw_hv_dV,straw_hv_dW") {
   }  // this last should come from the Row class FIXME!

--- a/DbTables/inc/TrkAlignStrawSim.hh
+++ b/DbTables/inc/TrkAlignStrawSim.hh
@@ -1,0 +1,21 @@
+#ifndef DbTables_TrkAlignStrawSim_hh
+#define DbTables_TrkAlignStrawSim_hh
+
+#include "Offline/DbTables/inc/DbTable.hh"
+#include "Offline/DbTables/inc/TrkStrawEndAlign.hh"
+#include "CLHEP/Vector/ThreeVector.h"
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <string>
+
+namespace mu2e {
+
+class TrkAlignStrawSim : public TrkAlignStraw {
+ public:
+  constexpr static const char* cxname = "TrkAlignStrawSim";
+  TrkAlignStrawSim() : TrkAlignStraw(cxname,"trk.alignstrawsim") {}
+};
+
+}  // namespace mu2e
+#endif

--- a/DbTables/src/DbTableFactory.cc
+++ b/DbTables/src/DbTableFactory.cc
@@ -18,7 +18,9 @@
 #include "Offline/DbTables/inc/CalCosmicT0Align.hh"
 
 #include "Offline/DbTables/inc/TrkAlignElement.hh"
+#include "Offline/DbTables/inc/TrkAlignElementSim.hh"
 #include "Offline/DbTables/inc/TrkAlignStraw.hh"
+#include "Offline/DbTables/inc/TrkAlignStrawSim.hh"
 #include "Offline/DbTables/inc/TrkDelayPanel.hh"
 #include "Offline/DbTables/inc/TrkDelayRStraw.hh"
 #include "Offline/DbTables/inc/TrkElementStatus.hh"
@@ -50,6 +52,14 @@ mu2e::DbTable::ptr_t mu2e::DbTableFactory::newTable(std::string const& name) {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkAlignPanel());
   } else if (name == "TrkAlignStraw") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkAlignStraw());
+  } else if (name == "TrkAlignTrackerSim") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkAlignTrackerSim());
+  } else if (name == "TrkAlignPlaneSim") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkAlignPlaneSim());
+  } else if (name == "TrkAlignPanelSim") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkAlignPanelSim());
+  } else if (name == "TrkAlignStrawSim") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkAlignStrawSim());
   } else if (name == "TrkPlaneStatus") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkPlaneStatus());
   } else if (name == "TrkPanelStatus") {

--- a/ProditionsService/fcl/prolog.fcl
+++ b/ProditionsService/fcl/prolog.fcl
@@ -18,6 +18,7 @@ Proditions : {
    strawElectronics : @local::StrawElectronics
    strawResponse : @local::StrawResponse
    alignedTracker : @local::AlignedTracker
+   alignedTrackerSim : @local::AlignedTrackerSim
    mu2eMaterial : @local::Mu2eMaterial
    mu2eDetector : @local::Mu2eDetector
    caloDAQConditions : @local::CaloDAQConditions

--- a/ProditionsService/inc/ProditionsHandle.hh
+++ b/ProditionsService/inc/ProditionsHandle.hh
@@ -17,9 +17,9 @@ class ProditionsHandle {
   typedef std::shared_ptr<ENTITY> ptr_t;
   typedef std::shared_ptr<const ENTITY> cptr_t;
 
-  ProditionsHandle() : ptr(nullptr) {
+  ProditionsHandle(const std::string& tag = std::string()) : ptr(nullptr) {
     // find the name of the ENTITY
-    _name = std::string(ENTITY::cxname);
+    _name = std::string(ENTITY::cxname) + tag;
     // connect to the service cache of this type
     art::ServiceHandle<ProditionsService> sg;
     _cptr = sg->getCache(_name);

--- a/ProditionsService/inc/ProditionsService.hh
+++ b/ProditionsService/inc/ProditionsService.hh
@@ -78,6 +78,8 @@ class ProditionsService {
         Name("strawResponse"), Comment("Straw response model")};
     fhicl::Table<AlignedTrackerConfig> alignedTracker{
         Name("alignedTracker"), Comment("Tracker alignment in reco code")};
+    fhicl::Table<AlignedTrackerConfig> alignedTrackerSim{
+        Name("alignedTrackerSim"), Comment("Tracker alignment in sim code")};
     fhicl::Table<Mu2eMaterialConfig> mu2eMaterial{
         Name("mu2eMaterial"), Comment("Mu2e material for BTrk")};
     fhicl::Table<Mu2eDetectorConfig> mu2eDetector{

--- a/ProditionsService/src/ProditionsService.cc
+++ b/ProditionsService/src/ProditionsService.cc
@@ -75,9 +75,13 @@ ProditionsService::ProditionsService(Parameters const& sTable,
   auto src =
       std::make_shared<mu2e::StrawResponseCache>(_config.strawResponse());
   _caches[src->name()] = src;
+  // tracker alignment has two templated variants, for reco and simulation
   auto atc =
-      std::make_shared<mu2e::AlignedTrackerCache>(_config.alignedTracker());
+      std::make_shared<mu2e::AlignedTrackerCacheReco>(_config.alignedTracker());
   _caches[atc->name()] = atc;
+  auto atcs =
+    std::make_shared<mu2e::AlignedTrackerCacheSim>(_config.alignedTrackerSim());
+  _caches[atcs->name()+"Sim"] = atcs;
   auto mmc = std::make_shared<mu2e::Mu2eMaterialCache>(_config.mu2eMaterial());
   _caches[mmc->name()] = mmc;
   auto mdc = std::make_shared<mu2e::Mu2eDetectorCache>(_config.mu2eDetector());

--- a/TrackerConditions/fcl/prolog.fcl
+++ b/TrackerConditions/fcl/prolog.fcl
@@ -24,6 +24,11 @@ AlignedTracker : {
   useDb : false
 }
 
+AlignedTrackerSim : {
+  verbose : 0
+  useDb : false
+}
+
 FullReadoutStraw : {
   verbose : 0
   useDb : false

--- a/TrackerConditions/inc/AlignedTrackerCache.hh
+++ b/TrackerConditions/inc/AlignedTrackerCache.hh
@@ -4,28 +4,33 @@
 //
 // hold a set of run-dependent conditions objects
 // and update them when needed
+// this cache is templated so it can be instianted for reco or sim,
+// which are a different set of tables
 //
 
 #include "Offline/Mu2eInterfaces/inc/ProditionsCache.hh"
 #include "Offline/DbService/inc/DbHandle.hh"
 #include "Offline/DbTables/inc/TrkAlignElement.hh"
+#include "Offline/DbTables/inc/TrkAlignElementSim.hh"
 #include "Offline/DbTables/inc/TrkAlignStraw.hh"
+#include "Offline/DbTables/inc/TrkAlignStrawSim.hh"
 #include "Offline/TrackerConditions/inc/AlignedTrackerMaker.hh"
 
 
 namespace mu2e {
+  template <typename TTr,typename TPl,typename TPa,typename TSt>
   class AlignedTrackerCache : public ProditionsCache {
     public:
-      AlignedTrackerCache(AlignedTrackerConfig const& config):
+    AlignedTrackerCache(AlignedTrackerConfig const& config):
         ProditionsCache(Tracker::cxname,config.verbose()),
         _useDb(config.useDb()),_maker(config) {}
 
       void initialize() {
         if(_useDb) {
-          _tatr_p = std::make_unique<DbHandle<TrkAlignTracker>>();
-          _tapl_p = std::make_unique<DbHandle<TrkAlignPlane>>();
-          _tapa_p = std::make_unique<DbHandle<TrkAlignPanel>>();
-          _tast_p = std::make_unique<DbHandle<TrkAlignStraw>>();
+          _tatr_p = std::make_unique<DbHandle<TTr>>();
+          _tapl_p = std::make_unique<DbHandle<TPl>>();
+          _tapa_p = std::make_unique<DbHandle<TPa>>();
+          _tast_p = std::make_unique<DbHandle<TSt>>();
         }
       }
 
@@ -72,12 +77,16 @@ namespace mu2e {
       bool _useDb;
       AlignedTrackerMaker _maker;
 
-      std::unique_ptr<DbHandle<TrkAlignTracker>> _tatr_p;
-      std::unique_ptr<DbHandle<TrkAlignPlane>>   _tapl_p;
-      std::unique_ptr<DbHandle<TrkAlignPanel>>   _tapa_p;
-      std::unique_ptr<DbHandle<TrkAlignStraw>>   _tast_p;
+    std::unique_ptr<DbHandle<TTr>> _tatr_p;
+    std::unique_ptr<DbHandle<TPl>> _tapl_p;
+    std::unique_ptr<DbHandle<TPa>> _tapa_p;
+    std::unique_ptr<DbHandle<TSt>> _tast_p;
 
   };
+
+  typedef AlignedTrackerCache<TrkAlignTracker,TrkAlignPlane,TrkAlignPanel,TrkAlignStraw> AlignedTrackerCacheReco;
+  typedef AlignedTrackerCache<TrkAlignTrackerSim,TrkAlignPlaneSim,TrkAlignPanelSim,TrkAlignStrawSim> AlignedTrackerCacheSim;
+
 }
 
 #endif


### PR DESCRIPTION
In discussions it was decided to create a permanent alignment system for simulation purposes, in parallel to the reco system.  This PR implements that plan.   The new prodition adds minimal code since it can be templated or derived from the reco code.
It is off by default.

I tested that there is no change in default ceSimReco, and that one can load different alignments in the different proditions.  I'd advise an expert to further test it at the full detector physics level.

The alignment tables X are duplicated as tables XSim.  These can be loaded from text now for testing, and then we can decide when to create the tables in the db and add to conditions sets.

At the module level, one can access both proditions by instantiating :
  ProditionsHandle<Tracker> _trkr_h;
  ProditionsHandle<Tracker> _trks_h{"Sim"};
and in fcl
services.ProditionsService.alignedTracker.useDb: true
services.ProditionsService.alignedTrackerSim.useDb: true

This sets a pattern for variants of proditions, which will probably come up again.
