### PR TITLE
Have TrackQuality follow MU2E_SEARCH_PATH for dat files

### DIFF
--- a/TrkDiag/inc/TrkQual_ANN1.hxx
+++ b/TrkDiag/inc/TrkQual_ANN1.hxx
@@ -65,7 +65,7 @@ Session(std::string filename ="") {
    std::ifstream f;
    f.open(filename);
    if (!f.is_open()){
-      throw std::runtime_error("tmva-sofie failed to open file for input weights");
+      throw std::runtime_error("tmva-sofie failed to open file \"" + filename +"\" for input weights");
    }
    std::string tensor_name;
    int length;

--- a/TrkDiag/src/TrackQuality_module.cc
+++ b/TrkDiag/src/TrackQuality_module.cc
@@ -17,6 +17,7 @@
 #include "Offline/Mu2eUtilities/inc/MVATools.hh"
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+#include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
 // data
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 #include "Offline/RecoDataProducts/inc/MVAResult.hh"
@@ -70,7 +71,9 @@ namespace mu2e
     _printMVA(conf().printMVA())
     {
       produces<MVAResultCollection>();
-      mva_ = std::make_shared<TMVA_SOFIE_TrkQual_ANN1::Session>(conf().datFilename());
+
+      ConfigFileLookupPolicy configFile;
+      mva_ = std::make_shared<TMVA_SOFIE_TrkQual_ANN1::Session>(configFile(conf().datFilename()));
     }
 
   void TrackQuality::produce(art::Event& event ) {


### PR DESCRIPTION
This solves a bug where the user has to be in the directory above Offline for TMVA::SOFIE to find the .dat file. This uses ConfigFileLookupPolicy so that it follows MU2E_SEARCH_PATH. I've done a test and it works.