### PR TITLE
also make extracted gdml

### DIFF
--- a/scripts/build/bin/procs.sh
+++ b/scripts/build/bin/procs.sh
@@ -78,11 +78,23 @@ elif [ "$COMMAND" == "GDML"  ]; then
         echo "save existing mu2e.gdml: mv mu2e.gdml mu2e.gdml.$STR"
         /bin/mv mu2e.gdml mu2e.gdml.$STR
     fi
+
     # make the standard gdml file
     mu2e -c Offline/Mu2eG4/fcl/gdmldump.fcl;
     [ $? -ne 0 ] && RC=1
     /bin/mv mu2e.gdml ${MUSE_BUILD_BASE}/Offline/gen/gdml/mu2e.gdml
     [ $? -ne 0 ] && RC=1
+
+    # make the extracted gdml file
+    TMPF=$(mktemp)
+    cp Offline/Mu2eG4/fcl/gdmldump.fcl $TMPF
+    echo "services.GeometryService.inputFile : \"Offline/Mu2eG4/geom/geom_common_extracted.txt\"" >> $TMPF
+    mu2e -c $TMPF
+    [ $? -ne 0 ] && RC=1
+    /bin/mv mu2e.gdml ${MUSE_BUILD_BASE}/Offline/gen/gdml/mu2e_extracted.gdml
+    [ $? -ne 0 ] && RC=1
+    rm -f $TMPF
+
 elif [ "$COMMAND" == "TEST03"  ]; then
     # see if this fcl runs
     mu2e -c Offline/Mu2eG4/fcl/g4test_03.fcl -o /dev/null -T /dev/null


### PR DESCRIPTION
`muse build GDML`
will make a gdml file of the common geometry and put it in $MUSE_BUILD_DIR/Offline/gen/gdml/mu2e.gdml
This commit causes this target to also create and store mu2e_extracted.gdml
