### PR TITLE
Remove unneeded lib

### DIFF
--- a/Mu2eG4/src/SConscript
+++ b/Mu2eG4/src/SConscript
@@ -176,8 +176,7 @@ G4GLOBALIBS = [
               'libG4track',
               'libG4tracking',
               'libG4visHepRep',
-              'libG4vis_management',
-              'libG4zlib'
+              'libG4vis_management'
               ]
 
 if g4vis != 'none':


### PR DESCRIPTION

  Found this lib was not in our spack builds, then found we could link without it.  Let me know if there are link options or cases I'm not aware of.