### PR TITLE
changed CRV digi period and oincidence criteria

### DIFF
--- a/CRVConditions/inc/CRVDigitizationPeriod.hh
+++ b/CRVConditions/inc/CRVDigitizationPeriod.hh
@@ -3,7 +3,7 @@
 
 namespace mu2e {
 
-  constexpr double CRVDigitizationPeriod = 12.55; // ns
+  constexpr double CRVDigitizationPeriod = 12.5; // ns
 
 }  // namespace mu2e
 

--- a/CRVResponse/fcl/epilog_extracted_v03.fcl
+++ b/CRVResponse/fcl/epilog_extracted_v03.fcl
@@ -13,7 +13,7 @@ physics.producers.CrvCoincidenceClusterFinder.sectorConfig :
       [
         {
           CRVSector : "EX"
-          PEthreshold : 20  //PEs
+          PEthreshold : 10  //PEs
           maxTimeDifferenceAdjacentPulses : 10  //ns
           maxTimeDifference : 20  //ns
           minOverlapTimeAdjacentPulses : 30  //ns
@@ -21,12 +21,12 @@ physics.producers.CrvCoincidenceClusterFinder.sectorConfig :
           minSlope :-11
           maxSlope : 11  //width direction over thickness direction
           maxSlopeDifference : 4
-          coincidenceLayers : 3
+          coincidenceLayers : 2
           minClusterPEs : 0
         },
         {
           CRVSector : "T1"
-          PEthreshold : 20
+          PEthreshold : 10
           maxTimeDifferenceAdjacentPulses : 10
           maxTimeDifference : 20
           minOverlapTimeAdjacentPulses : 30
@@ -34,12 +34,12 @@ physics.producers.CrvCoincidenceClusterFinder.sectorConfig :
           minSlope :-11
           maxSlope : 11
           maxSlopeDifference : 4
-          coincidenceLayers : 4
+          coincidenceLayers : 2
           minClusterPEs : 0
         },
         {
           CRVSector : "T2"
-          PEthreshold : 20
+          PEthreshold : 10
           maxTimeDifferenceAdjacentPulses : 10
           maxTimeDifference : 20
           minOverlapTimeAdjacentPulses : 30
@@ -47,7 +47,7 @@ physics.producers.CrvCoincidenceClusterFinder.sectorConfig :
           minSlope :-11
           maxSlope : 11
           maxSlopeDifference : 4
-          coincidenceLayers : 4
+          coincidenceLayers : 2
           minClusterPEs : 0
         }
       ]


### PR DESCRIPTION
Changed CRV digi period to 12.5ns and changed CRV coincidence criteria for extracted position to 10 PE threshold and 2 out of 4 layers.