### PR TITLE
dev moved

### DIFF
--- a/DbService/data/connections.txt
+++ b/DbService/data/connections.txt
@@ -19,7 +19,7 @@ database mu2e_conditions_prd
     nocache    https://dbdata0vm.fnal.gov:9443/QE/mu2e/prod/app/SQ/query?
 
 database mu2e_conditions_dev
-    host ifdb07
+    host ifdb10
     port 5444
     cache      https://dbdata0vm.fnal.gov:8444/QE/mu2e/dev/app/SQ/query?
     nocache    https://dbdata0vm.fnal.gov:9443/QE/mu2e/dev/app/SQ/query?


### PR DESCRIPTION
mu2e_conditions_dev moved to a new al9 host.  This commit is for archive only, and does not change any behavior.  The active file is on cvmfs.