### PR TITLE
Throw an exception rather than do nothing on a configuration mistake.

### DIFF
--- a/Mu2eG4/src/Mu2eStudyWorld.cc
+++ b/Mu2eG4/src/Mu2eStudyWorld.cc
@@ -144,17 +144,16 @@ namespace mu2e {
                                           placePV,
                                           doSurfaceCheck));
 
-    std::string simulatedDetector = _geom.simulatedDetector().get<std::string>("tool_type");
+    constructEnv_ = art::make_tool<InitEnvToolBase>(_geom.simulatedDetector());
 
-    if (simulatedDetector != "Mu2e") {
-
-      constructEnv_ = art::make_tool<InitEnvToolBase>(_geom.simulatedDetector());
-
-      if (constructEnv_) constructEnv_->construct(boxInTheWorldVInfo,_config);
-      else {
-        throw cet::exception("CONFIG") << __func__ << ": unknown study environment: " << simulatedDetector << "\n";
-      }
+    if (constructEnv_) {
+      constructEnv_->construct(boxInTheWorldVInfo,_config);
     }
+    else {
+      std::string simulatedDetector = _geom.simulatedDetector().get<std::string>("tool_type");
+      throw cet::exception("CONFIG") << __func__ << ": unknown study environment: " << simulatedDetector << "\n";
+    }
+
     if ( _verbosityLevel > 0) {
       cout << __func__ << " world half dimensions     : "
            << worldBoundaries[0] << ", "


### PR DESCRIPTION
The existing code in Mu2eStudyWorld throws an exception for unrecognized values of services.GeometryService.tool_type, but does nothing if the string is set to "Mu2e".   As long as "Mu2e" is not a valid name for a g4study setup, this is still a configuration mistake and the code should throw instead of trying to run with a bad configuration.
This PR removes the "do nothing" special case.  Please comment.

