### PR TITLE
removed CrvStep collection name in epilog for extraced position

### DIFF
--- a/CRVResponse/fcl/epilog_extracted_v03.fcl
+++ b/CRVResponse/fcl/epilog_extracted_v03.fcl
@@ -1,5 +1,3 @@
-physics.producers.CrvPhotons.crvStepModuleLabels  : ["CrvSteps"]
-physics.producers.CrvPhotons.crvStepProcessNames  : ["CrvStepsConverter"]
 physics.producers.CrvPhotons.CRVSectors           : ["EX","T1","T2"]
 physics.producers.CrvPhotons.reflectors           : [  0,   1,   0 ]
 physics.producers.CrvPhotons.scintillationYields  : [39794,28573,28573]   //assuming modules from CRV-T(1.8mm),CRV-DS,CRV-L


### PR DESCRIPTION
The names of the CrvStep collections need to be set in Production: https://github.com/Mu2e/Production/blob/28f21e30d34ba55f3a712f49763840f9b9fc3269/JobConfig/digitize/epilog.fcl#L8-L9
See Production PR 304.