### PR TITLE
Fix for extracted position reconstruction

### DIFF
--- a/Mu2eKinKal/fcl/prolog.fcl
+++ b/Mu2eKinKal/fcl/prolog.fcl
@@ -356,6 +356,7 @@ Mu2eKinKal : {
     ExtensionSettings : {
       @table::Mu2eKinKal.DRIFTEXT
       BFieldCorrection : false
+      ProcessEnds : false
       MetaIterationSettings : [
         # annealing temp, strawhit updater algorithms
         [ 2.0, "CADSHU" ],


### PR DESCRIPTION
This is a placeholder fix. It will be unnecessary once we have fully configured extrapolation in different fit modes.