### PR TITLE
compressPDGCodeHisto() tweak

### DIFF
--- a/Mu2eUtilities/inc/compressPdgId.hh
+++ b/Mu2eUtilities/inc/compressPdgId.hh
@@ -15,7 +15,7 @@ namespace mu2e {
   CompressedPDGCode::enum_type compressPDGCode(PDGCode::enum_type pdgId);
 
   // a histogram with text labels, ready for use with CompressedPDGCode
-  TH1D* compressPDGCodeHisto(art::ServiceHandle<art::TFileService>& tfs,
+  TH1D* compressPDGCodeHisto(art::ServiceHandle<art::TFileService> tfs,
                              std::string name="compPdgId",
                              std::string title="Compressed PDG ID");
 

--- a/Mu2eUtilities/src/compressPdgId.cc
+++ b/Mu2eUtilities/src/compressPdgId.cc
@@ -74,7 +74,7 @@ namespace mu2e {
     return code;
   }
 
-  TH1D* compressPDGCodeHisto(art::ServiceHandle<art::TFileService>& tfs,
+  TH1D* compressPDGCodeHisto(art::ServiceHandle<art::TFileService> tfs,
                              std::string name, std::string title) {
 
     float low = float(CompressedPDGCode::minBin) - 0.5;


### PR DESCRIPTION
Passing a *handle* by address instead of by value probably does not affect code performance in a measurable way, but loses functionality: member initialization like the following example does not work with the extraneous '&'

```
MyAnalyzer::MyAnalyzer(const Parameters& conf, const art::ProcessingFrame&)
    : SharedAnalyzer{conf}
    , myhisto_{compressPDGCodeHisto(art::ServiceHandle<art::TFileService>())}
    , ....
{ ... }
```