### PR TITLE
Add module to merge KalSeed collections

### DIFF
--- a/RecoDataProducts/inc/KalSeed.hh
+++ b/RecoDataProducts/inc/KalSeed.hh
@@ -94,5 +94,7 @@ namespace mu2e {
     float         _flt0 = 0.0; // flight distance where the track crosses the tracker midplane (z=0).  Redundant with t0 in KinKal fits, and in the wrong unit
   };
   typedef std::vector<mu2e::KalSeed> KalSeedCollection;
+  typedef art::Ptr<mu2e::KalSeed> KalSeedPtr;
+  typedef std::vector<mu2e::KalSeedPtr> KalSeedPtrCollection;
 }
 #endif

--- a/RecoDataProducts/src/classes_def.xml
+++ b/RecoDataProducts/src/classes_def.xml
@@ -211,9 +211,10 @@
 
  <class name="mu2e::KalSeed"/>
  <class name="mu2e::KalSeedCollection"/>
- <class name="art::Ptr<mu2e::KalSeed>"/>
- <class name="std::vector<art::Ptr<mu2e::KalSeed> >"/>
+ <class name="mu2e::KalSeedPtr"/>
+ <class name="mu2e::KalSeedPtrCollection"/>
  <class name="art::Wrapper<mu2e::KalSeedCollection>"/>
+ <class name="art::Wrapper<mu2e::KalSeedPtrCollection>"/>
 
  <class name="mu2e::KalHelixAssns" />
  <class name="art::Wrapper<mu2e::KalHelixAssns>"/>

--- a/TrkReco/src/MergeKalSeeds_module.cc
+++ b/TrkReco/src/MergeKalSeeds_module.cc
@@ -3,8 +3,6 @@
 //  This module produces an indirect (Ptr) collection, not a deep copy, to keep from break provenance or MC truth associations
 //  Note that, when persisting merged collections created by this module, the KalSeed object collections merged here MUST ALSO BE PERSISTED in
 //  order for the references to not be broken.
-//  Note too that the MC truth association of these KalSeeds ARE NOT MERGED by this module.  This is to avoid making reco code depend on MC.
-//  There is a separate module which merges the Assns between the KalSeeds referenced by the output of this module and the associated KalSeedMCs.
 //  original author: D. Brown (LBNL) 2024
 //
 #include "fhiclcpp/types/Atom.h"

--- a/TrkReco/src/MergeKalSeeds_module.cc
+++ b/TrkReco/src/MergeKalSeeds_module.cc
@@ -1,0 +1,64 @@
+//
+//  Merge KalSeeds from different reconstruction paths.
+//  This module produces an indirect (Ptr) collection, not a deep copy, to keep from break provenance or MC truth associations
+//  Note that, when persisting merged collections created by this module, the KalSeed object collections merged here MUST ALSO BE PERSISTED in
+//  order for the references to not be broken.
+//  Note too that the MC truth association of these KalSeeds ARE NOT MERGED by this module.  This is to avoid making reco code depend on MC.
+//  There is a separate module which merges the Assns between the KalSeeds referenced by the output of this module and the associated KalSeedMCs.
+//  original author: D. Brown (LBNL)
+//
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "canvas/Utilities/InputTag.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+// mu2e data products
+#include "Offline/RecoDataProducts/inc/KalSeed.hh"
+#include "Offline/Mu2eUtilities/inc/LsqSums4.hh"
+// C++
+#include <vector>
+
+namespace mu2e {
+  class MergeKalSeeds : public art::EDProducer {
+    public:
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      struct Config {
+        fhicl::Atom<int> debug{ Name("debugLevel"), Comment("Debug Level"), 0};
+        fhicl::Sequence<art::InputTag> seedCollTags {Name("KalSeedCollections"), Comment("KalSeed collections tomerge") };
+      };
+      using Parameters = art::EDProducer::Table<Config>;
+      explicit MergeKalSeeds(const Parameters& conf);
+      void produce(art::Event& evt) override;
+    private:
+      int debug_;
+      std::vector<art::InputTag> seedcolltags_;
+  };
+
+  MergeKalSeeds::MergeKalSeeds(const Parameters& config) : art::EDProducer{config}, debug_(config().debug())
+    {
+      for(auto const& seedcolltag :config().seedCollTags()){
+        consumes<KalSeedCollection>    (seedcolltag);
+        seedcolltags_.push_back(seedcolltag);
+        if(debug_ > 0) std::cout << "Merging KalSeeds from " << seedcolltag << std::endl;
+      }
+      produces<KalSeedPtrCollection>    ();
+    }
+
+  void MergeKalSeeds::produce(art::Event& event) {
+    // create output
+    std::unique_ptr<KalSeedPtrCollection> mkseeds(new KalSeedPtrCollection);
+    // loop over input KalSeed collections
+    for(auto const& seedcolltag : seedcolltags_) {
+      auto const& ksch = event.getValidHandle<KalSeedCollection>(seedcolltag);
+      auto const& ksc = *ksch;
+      if(debug_ > 2) std::cout << seedcolltag << " Has " << ksc.size() << " KalSeeds" << std::endl;
+      for(size_t ikseed = 0; ikseed <ksc.size(); ++ikseed){ mkseeds->emplace_back(ksch,ikseed); }
+    }
+    if(debug_ > 1) std::cout << "Merged " << mkseeds->size() << " KalSeeds" << std::endl;
+    event.put(std::move(mkseeds));
+  }
+}
+DEFINE_ART_MODULE(mu2e::MergeKalSeeds)

--- a/TrkReco/src/MergeKalSeeds_module.cc
+++ b/TrkReco/src/MergeKalSeeds_module.cc
@@ -5,7 +5,7 @@
 //  order for the references to not be broken.
 //  Note too that the MC truth association of these KalSeeds ARE NOT MERGED by this module.  This is to avoid making reco code depend on MC.
 //  There is a separate module which merges the Assns between the KalSeeds referenced by the output of this module and the associated KalSeedMCs.
-//  original author: D. Brown (LBNL)
+//  original author: D. Brown (LBNL) 2024
 //
 #include "fhiclcpp/types/Atom.h"
 #include "fhiclcpp/types/Sequence.h"
@@ -16,7 +16,6 @@
 #include "art/Framework/Principal/Handle.h"
 // mu2e data products
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
-#include "Offline/Mu2eUtilities/inc/LsqSums4.hh"
 // C++
 #include <vector>
 

--- a/TrkReco/test/TestMergeKalSeeds.fcl
+++ b/TrkReco/test/TestMergeKalSeeds.fcl
@@ -1,0 +1,35 @@
+#
+#Simple test of MergeKalSeeds.  run as;
+# mu2e -c Offline/TrkReco/test/TestMergeKalSeeds.fcl --source "mcs.yourfile.art" --nevts 100
+#
+#include "Offline/fcl/minimalMessageService.fcl"
+#include "Offline/fcl/standardServices.fcl"
+#include "Production/JobConfig/reco/prolog.fcl"
+#include "Offline/Mu2eKinKal/fcl/prolog.fcl"
+#include "TrkAna/fcl/prolog.fcl"
+
+process_name: MKS
+source : { module_type : RootInput }
+services : @local::Services.Reco
+physics :
+{
+  producers : {
+    MergeKalSeeds : {
+      module_type : MergeKalSeeds
+      debugLevel : 2
+      KalSeedCollections : ["KKDeM", "KKDeP", "KKUeM", "KKUeP", "KKDmuM", "KKDmuP", "KKUmuM", "KKUmuP" ]
+    }
+  }
+  TPath : [ MergeKalSeeds ]
+  EPath : [ MergedOutput ]
+}
+outputs : {
+  MergedOutput : {
+    module_type : RootOutput
+    SelectEvents : [ "TPath" ]
+    outputCommands : [ "keep *_*_*_*" ]
+    fileName : "mcs.owner.MergedKalSeeds.version.sequencer.art"
+  }
+}
+physics.trigger_paths : [ TPath ]
+physics.end_paths : [ EPath ]


### PR DESCRIPTION
The primary use case for this module as to support all-in-one processing in TrkAna, but it could have other applications.  Note that the KalSeedMC collection and the Assns are already all-in-one, as those are created by createRecoMC.