### PR TITLE
FilterStepPointPDG update

### DIFF
--- a/Filters/src/FilterStepPointPDG_module.cc
+++ b/Filters/src/FilterStepPointPDG_module.cc
@@ -37,14 +37,23 @@ namespace mu2e {
 
       fhicl::Sequence<int> pdgToDrop {
         Name("pdgToDrop"),
-        Comment("A list of particle types to drop while keeping everything else.  Mutually exclusive with pdgToKeep."),
+        Comment(
+                "A list of particle type names to drop while keeping everything else.\n"
+                "Accepted names, like e_minus, anti_proton, etc., can be found\n"
+                "in Offline/DataProducts/src/PDGCode.cc\n"
+                "Mutually exclusive with pdgToKeep."
+                ),
         std::vector<int>()
       };
 
-      fhicl::Sequence<int> pdgToKeep {
+      fhicl::Sequence<std::string> pdgToKeep {
         Name("pdgToKeep"),
-        Comment("A list of particle types to keep while dropping everything else.  Mutually exclusive with pdgToDrop."),
-        std::vector<int>()
+        Comment("A list of particle types to keep while dropping everything else.\n"
+                "Accepted names, like e_minus, anti_proton, etc., can be found\n"
+                "in Offline/DataProducts/src/PDGCode.cc\n"
+                "Mutually exclusive with pdgToDrop."
+                ),
+        std::vector<std::string>()
       };
     };
 
@@ -65,8 +74,8 @@ namespace mu2e {
 
     // Particle type lists are typically short, so a vector works
     // better than a set.
-    std::vector<PDGCode::type> pdgToDrop_;
-    std::vector<PDGCode::type> pdgToKeep_;
+    std::vector<PDGCode> pdgToDrop_;
+    std::vector<PDGCode> pdgToKeep_;
 
     // statistics
     unsigned numInputHits_;
@@ -96,12 +105,12 @@ namespace mu2e {
       produces<StepPointMCCollection>(i);
     }
 
-    for(const auto i: conf().pdgToDrop()) {
-      pdgToDrop_.emplace_back(PDGCode::type(i));
+    for(const auto& i: conf().pdgToDrop()) {
+      pdgToDrop_.emplace_back(PDGCode(i));
     }
 
-    for(const auto i: conf().pdgToKeep()) {
-      pdgToKeep_.emplace_back(PDGCode::type(i));
+    for(const auto& i: conf().pdgToKeep()) {
+      pdgToKeep_.emplace_back(PDGCode(i));
     }
 
     if(pdgToDrop_.empty() && pdgToKeep_.empty()) {

--- a/Filters/src/FilterStepPointPDG_module.cc
+++ b/Filters/src/FilterStepPointPDG_module.cc
@@ -86,6 +86,8 @@ namespace mu2e {
     , numPassedEvents_()
   {
     for(const auto& i: inputs_) {
+      consumes<StepPointMCCollection>(i);
+
       // Coalesce same instance names from multiple input modules/processes.
       outNames_.insert(i.instance());
     }


### PR DESCRIPTION
This PR touches a single module FilterStepPointPDG.  It

- implements FHICL configuration validation and description
- switches FHICL configuration from particle codes to particle names
- makes the module async multithreaded.  This is not performance-critical for the module itself but can serve as a simple example of making such a module.

I have checked that there are no FHICL files in Offline or Production that need to be modified for these changes.

Andrei
