### PR TITLE
Remove dead straws even in offspill

### DIFF
--- a/TrkDiag/src/ComboHitDiag_module.cc
+++ b/TrkDiag/src/ComboHitDiag_module.cc
@@ -96,7 +96,7 @@ namespace mu2e
       int _nsh, _nch; // number of associated straw hits
       int _strawid, _straw, _panel, _plane, _level; // strawid info
       int _eend;
-      int _esel,_rsel, _tsel, _nsel,  _bkgclust, _bkg, _sth, _ph, _tdiv, _isolated, _strawxtalk, _elecxtalk, _calosel, _sline;
+      int _esel,_rsel, _tsel, _nsel,  _bkgclust, _bkg, _sth, _dead, _ph, _tdiv, _isolated, _strawxtalk, _elecxtalk, _calosel, _sline;
       // mc diag
       XYZVectorF _mcpos, _mcmom;
       float _mctime, _mcwdist;
@@ -167,6 +167,7 @@ namespace mu2e
     _chdiag->Branch("bkgclust",&_bkgclust,"bkgclust/I");
     _chdiag->Branch("bkg",&_bkg,"bkg/I");
     _chdiag->Branch("sth",&_sth,"sth/I");
+    _chdiag->Branch("dead",&_dead,"dead/I");
     _chdiag->Branch("ph",&_ph,"ph/I");
     _chdiag->Branch("tdiv",&_tdiv,"tdiv/I");
     _chdiag->Branch("strawxtalk",&_strawxtalk,"strawxtalk/I");
@@ -246,6 +247,7 @@ namespace mu2e
       _qual = ch.qual();
       auto const& flag = ch.flag();
       _sth = flag.hasAllProperties(StrawHitFlag::stereo);
+      _dead = flag.hasAllProperties(StrawHitFlag::dead);
       _ph = flag.hasAllProperties(StrawHitFlag::panelcombo);
       _tdiv = flag.hasAllProperties(StrawHitFlag::tdiv);
       _esel = flag.hasAllProperties(StrawHitFlag::energysel);

--- a/TrkDiag/src/StrawHitDiag_module.cc
+++ b/TrkDiag/src/StrawHitDiag_module.cc
@@ -88,7 +88,7 @@ namespace mu2e
       Float_t _mcwt[2];
       Double_t _mcsptime;
       Double_t _mcptime;
-      Int_t _esel,_rsel, _tsel,  _bkgclust, _bkg, _stereo, _tdiv, _isolated, _strawxtalk, _elecxtalk, _calosel;
+      Int_t _esel,_rsel, _tsel,  _bkgclust, _bkg, _dead, _stereo, _tdiv, _isolated, _strawxtalk, _elecxtalk, _calosel;
       Int_t _sid, _plane, _panel, _layer, _straw;
       Float_t _shwres, _shtres;
       Bool_t _mcxtalk;
@@ -213,6 +213,7 @@ namespace mu2e
     _shdiag->Branch("bkgclust",&_bkgclust,"bkgclust/I");
     _shdiag->Branch("bkg",&_bkg,"bkg/I");
     _shdiag->Branch("stereo",&_stereo,"stereo/I");
+    _shdiag->Branch("dead",&_dead,"dead/I");
     _shdiag->Branch("tdiv",&_tdiv,"tdiv/I");
     _shdiag->Branch("strawxtalk",&_strawxtalk,"strawxtalk/I");
     _shdiag->Branch("elecxtalk",&_elecxtalk,"elecxtalk/I");
@@ -301,6 +302,7 @@ namespace mu2e
       _shlen =(ch.posCLHEP()-straw.getMidPoint()).dot(straw.getDirection());
       _slen = straw.halfLength();
       _stereo = ch.flag().hasAllProperties(StrawHitFlag::stereo);
+      _dead = ch.flag().hasAllProperties(StrawHitFlag::dead);
       _tdiv = ch.flag().hasAllProperties(StrawHitFlag::tdiv);
       _esel = shf.hasAllProperties(StrawHitFlag::energysel);
       _rsel = shf.hasAllProperties(StrawHitFlag::radsel);

--- a/TrkHitReco/src/CombineStrawHits_module.cc
+++ b/TrkHitReco/src/CombineStrawHits_module.cc
@@ -161,6 +161,7 @@ namespace mu2e {
       isUsed[ich] = true;
 
       const ComboHit& hit1 = chcOrig[ich];
+      if ( _testflag && hit1.flag().hasAnyProperty(StrawHitFlag::dead)) continue;
       if ( testflag && (!hit1.flag().hasAllProperties(_shsel) || hit1.flag().hasAnyProperty(_shmask))) continue;
       ComboHit combohit;
       combohit.init(hit1,ich);
@@ -172,6 +173,7 @@ namespace mu2e {
 
         if (hit2.strawId().uniquePanel() != panel1) break;
         if (abs(hit2.strawId().straw()-hit1.strawId().straw())> _maxds ) continue; // hits are not sorted by straw number
+        if ( _testflag && hit2.flag().hasAnyProperty(StrawHitFlag::dead)) continue;
         if ( testflag && (!hit2.flag().hasAllProperties(_shsel) || hit2.flag().hasAnyProperty(_shmask)) ) continue;
 
         float dt = _useTOT ? fabs(hit1.correctedTime() - hit2.correctedTime()) : fabs(hit1.time() - hit2.time());


### PR DESCRIPTION
Straws flagged as dead in reco when not filtered by StrawHitReco were accidentally still being included in CombineStrawHits as testflag was conditional on onspill. Now these hits will be ignored correctly