### PR TITLE
Reinstate a virtual detector in front of the ExtMon collimator filter.

### DIFF
--- a/GeometryService/src/VirtualDetectorMaker.cc
+++ b/GeometryService/src/VirtualDetectorMaker.cc
@@ -342,7 +342,7 @@ namespace mu2e {
 
       }
 
-      if(c.hasName("vd.ExtMonCommonPlane.z")) {
+      if(c.getBool("vd.ExtMonCommonPlane.enabled", false)) {
         // Position and half length of this detector are best computed
         // in one place.  Since the VirtualDetector data structure
         // does not store half size, we'll do the computations later.

--- a/Mu2eG4/geom/extmon_fnal_v02.txt
+++ b/Mu2eG4/geom/extmon_fnal_v02.txt
@@ -251,6 +251,15 @@ bool           extMonFNAL.module.solid          = true;
 int            extMonFNAL.verbosityLevel = 0;
 int            extMonFNAL.sd.verbosityLevel = 0;
 
+// Virtual detector plane in front of the beam dump
+// Off by default to avoid unneccessary overhead in POT jobs.
+bool vd.ExtMonCommonPlane.enabled = false;
+double vd.ExtMonCommonPlane.beamDumpFaceDistance = 0.1;
+double vd.ExtMonCommonPlane.dxmin = -1000;
+double vd.ExtMonCommonPlane.dxmax = +1700;
+double vd.ExtMonCommonPlane.dymin = -1000;
+double vd.ExtMonCommonPlane.dymax = +2000;
+
 // This tells emacs to view this file in c++ mode.
 // Local Variables:
 // mode:c++

--- a/Mu2eG4/src/constructVirtualDetectors.cc
+++ b/Mu2eG4/src/constructVirtualDetectors.cc
@@ -14,12 +14,16 @@
 // Mu2e includes.
 #include "Offline/Mu2eG4/inc/constructVirtualDetectors.hh"
 
+#include "Offline/ConfigTools/inc/SimpleConfig.hh"
+#include "Offline/ConfigTools/inc/checkForStale.hh"
+
 #include "Offline/BeamlineGeom/inc/Beamline.hh"
 #include "Offline/CalorimeterGeom/inc/DiskCalorimeter.hh"
 #include "Offline/CosmicRayShieldGeom/inc/CosmicRayShield.hh"
 #include "Offline/DetectorSolenoidGeom/inc/DetectorSolenoid.hh"
 #include "Offline/Mu2eG4Helper/inc/Mu2eG4Helper.hh"
 #include "Offline/Mu2eG4Helper/inc/VolumeInfo.hh"
+#include "Offline/Mu2eG4Helper/inc/AntiLeakRegistry.hh"
 #include "Offline/GeomPrimitives/inc/Tube.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/GeometryService.hh"
@@ -67,6 +71,7 @@ namespace mu2e {
     const bool placePV              = geomOptions->placePV("vd");
     int static const verbosityLevel = _config.getInt("vd.verbosityLevel",0);
 
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
 
     GeomHandle<VirtualDetector> vdg;
     if( vdg->nDet()<=0 ) return;
@@ -1125,10 +1130,59 @@ namespace mu2e {
         }
     }
 
-    // An XY plane between the PS and anything ExtMon
+    // A plane in front of the beam dump and ExtMon collimator entrance
     vdId = VirtualDetectorId::ExtMonCommonPlane;
     if( vdg->exist(vdId) ) {
-      // Not currently supported
+
+      if ( verbosityLevel > 0) {
+        cout << __func__ << " constructing " << VirtualDetector::volumeName(vdId)  << endl;
+      }
+
+      checkForStale( "vd.ExtMonCommonPlane.z", _config);
+
+      const double dz = _config.getDouble("vd.ExtMonCommonPlane.beamDumpFaceDistance");
+      const double dxmin = _config.getDouble("vd.ExtMonCommonPlane.dxmin");
+      const double dxmax = _config.getDouble("vd.ExtMonCommonPlane.dxmax");
+      const double dymin = _config.getDouble("vd.ExtMonCommonPlane.dymin");
+      const double dymax = _config.getDouble("vd.ExtMonCommonPlane.dymax");
+
+      VolumeInfo const & parent = _helper->locateVolInfo("HallAir");
+
+      const double halfThick = vdg->getHalfLength();
+
+      GeomHandle<ProtonBeamDump> dump;
+      CLHEP::Hep3Vector vdCenterInMu2e =
+        dump->mouthCenterInMu2e()
+        + dump->coreRotationInMu2e()
+        * CLHEP::Hep3Vector((dxmax+dxmin)/2,
+                            (dymax+dymin)/2,
+                            dump->mouthHalfSize()[2]+dz+halfThick
+                            );
+
+      CLHEP::Hep3Vector vdCenterInParent = vdCenterInMu2e - parent.centerInMu2e();
+
+
+      std::vector<double> hlen(3);
+      hlen[0] = (dxmax - dxmin)/2;
+      hlen[1] = (dymax - dymin)/2;
+      hlen[2] = halfThick;
+
+      VolumeInfo vdInfo = nestBox(VirtualDetector::volumeName(vdId),
+                                  hlen,
+                                  upstreamVacuumMaterial,
+                                  reg.add(dump->coreRotationInMu2e().inverse()),
+                                  vdCenterInParent,
+                                  parent,
+                                  vdId,
+                                  vdIsVisible,
+                                  G4Color::Red(),
+                                  vdIsSolid,
+                                  forceAuxEdgeVisible,
+                                  placePV,
+                                  false
+                                  );
+
+      doSurfaceCheck && checkForOverlaps(vdInfo.physical, _config, verbosityLevel>0);
     }
 
     // placing virtual detector at the dump core face


### PR DESCRIPTION
Bring back another incarnation of a virtual detector that was dropped during the major rewrite of Mu2e building geometry.   It is off in the default configuration, so no impact on validation.    I have run Offline/Mu2eG4/fcl/surfaceCheck.fcl and verified that VD dimensions do not cause geometry overlaps when it is enabled.