### PR TITLE
val track charge fix

### DIFF
--- a/Validation/src/ValKalSeed.cc
+++ b/Validation/src/ValKalSeed.cc
@@ -38,7 +38,7 @@ namespace mu2e {
     _hpce = tfs.make<TH1D>("pce", "p CE", 100, 95.0, 110.);
     _hpcep = tfs.make<TH1D>("pcep", "p CE+", 100, 82.0, 97.);
     _hsignedp = tfs.make<TH1D>("signedp", "signedp", 200, -110., 110.);
-    _hsignedp2 = tfs.make<TH1D>("signedp", "signedp", 300, -500., 500.);
+    _hsignedp2 = tfs.make<TH1D>("signedp2", "signedp", 300, -500., 500.);
     _hpe = tfs.make<TH1D>("pe", "p error", 100, 0.0, 1.0);
     _hRho = tfs.make<TH1D>("rho", "Transverse radius", 100, 0.0, 800.);
     _hPhi = tfs.make<TH1D>("phi", "phi", 100, -M_PI, M_PI);
@@ -117,10 +117,10 @@ namespace mu2e {
       double p_mc = mcTrkP(event,vdid,p_pri);
       SurfaceId sid = _vdmap[vdid];
       auto ikinter = ks.intersection(sid);
-      double ksCharge = ks.intersections().front().pstate_.charge();
       if(ikinter != ks.intersections().end()){
         auto mom3 = ikinter->momentum3();
         double p = mom3.R();
+        double ksCharge = ikinter->pstate_.charge();
         _hp->Fill(p);
         _hp2->Fill(p);
         if (isCPR) _hpC->Fill(p);


### PR DESCRIPTION
I found that some validation jobs were ended with a "tried to save duplicate histogram" error, which I fixed with adding the "2".  Then I reran my test and it seg-faulted on this line
`double ksCharge = ks.intersections().front().pstate_.charge();`
I see that the intersections access is protected against empty vectors in the other access, and if an empty vector is possible here, then this line could cause undefined behavior and I got lucky.  So I moved it into the protected block.  But I also lazily switched to the charge of the sid surface intersection instead of the front of the intersections vector.  I suspect this is OK for this purpose (an more consistent?), but if the front of the vector is important, then I can re-write to get that safely.