### PR TITLE
Art v3_15_00 preparation

### DIFF
--- a/EventDisplay/src/EventDisplayFrame.cc
+++ b/EventDisplay/src/EventDisplayFrame.cc
@@ -35,6 +35,8 @@ using namespace std;
 #include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
 #include "Offline/CRVConditions/inc/CRVCalib.hh"
 
+#include "fhiclcpp/ParameterSet.h"
+
 #include "TGGC.h"
 #include "TGFont.h"
 #include "TClass.h"

--- a/Mu2eBTrk/inc/ParticleInfo.hh
+++ b/Mu2eBTrk/inc/ParticleInfo.hh
@@ -8,8 +8,7 @@
 // This code looks after the translation and caches results.
 //
 
-#include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
-#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleData.hh"
 
 #include "BTrk/BaBar/ParticleInfoInterface.hh"
 
@@ -17,6 +16,8 @@
 #include <map>
 
 namespace mu2e {
+
+  class ParticleDataList;
 
   class ParticleInfo : public ParticleInfoInterface {
 
@@ -41,9 +42,8 @@ namespace mu2e {
     //the following has to be mutable because BTrk holds this
     //with a const pointer
 
-    // Handle to the full particle data table.
     // Guaranteed valid throughout the job.
-    mutable GlobalConstantsHandle<ParticleDataList> pdt_;
+    ParticleDataList const& pdt_;
 
     // Local cache of the information for particles that we care about;
     // indexed by TrkParticle::type, not by PDG::id.

--- a/Mu2eBTrk/src/ParticleInfo.cc
+++ b/Mu2eBTrk/src/ParticleInfo.cc
@@ -1,7 +1,10 @@
 #include "Offline/Mu2eBTrk/inc/ParticleInfo.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 
-mu2e::ParticleInfo::ParticleInfo():pdt_(){
+#include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+
+mu2e::ParticleInfo::ParticleInfo():pdt_(*GlobalConstantsHandle<ParticleDataList>()){
 }
 
 mu2e::ParticleData const*
@@ -16,52 +19,52 @@ mu2e::ParticleInfo::getParticle( TrkParticle::type id ) const{
   ParticleData const* p(nullptr);
   switch (id) {
     case TrkParticle::e_minus: {
-      p = &pdt_->particle(PDGCode::e_minus);
+      p = &pdt_.particle(PDGCode::e_minus);
       break;
     }
 
     case TrkParticle::e_plus: {
-      p = &pdt_->particle(PDGCode::e_plus);
+      p = &pdt_.particle(PDGCode::e_plus);
       break;
     }
 
     case TrkParticle::mu_minus: {
-      p = &pdt_->particle(PDGCode::mu_minus);
+      p = &pdt_.particle(PDGCode::mu_minus);
       break;
     }
 
     case TrkParticle::mu_plus: {
-      p = &pdt_->particle(PDGCode::mu_plus);
+      p = &pdt_.particle(PDGCode::mu_plus);
       break;
     }
 
     case TrkParticle::pi_minus: {
-      p = &pdt_->particle(PDGCode::pi_minus);
+      p = &pdt_.particle(PDGCode::pi_minus);
       break;
     }
 
     case TrkParticle::pi_plus: {
-      p = &pdt_->particle(PDGCode::pi_plus);
+      p = &pdt_.particle(PDGCode::pi_plus);
       break;
     }
 
     case TrkParticle::K_minus: {
-      p = &pdt_->particle(PDGCode::K_minus);
+      p = &pdt_.particle(PDGCode::K_minus);
       break;
     }
 
     case TrkParticle::K_plus: {
-      p = &pdt_->particle(PDGCode::K_plus);
+      p = &pdt_.particle(PDGCode::K_plus);
       break;
     }
 
     case TrkParticle::anti_p_minus: {
-      p = &pdt_->particle(PDGCode::anti_proton);
+      p = &pdt_.particle(PDGCode::anti_proton);
       break;
     }
 
     case TrkParticle::p_plus: {
-      p = &pdt_->particle(PDGCode::proton);
+      p = &pdt_.particle(PDGCode::proton);
       break;
     }
 

--- a/TEveEventDisplay/src/TEveMu2eCRV.cc
+++ b/TEveEventDisplay/src/TEveMu2eCRV.cc
@@ -1,4 +1,6 @@
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/TEveEventDisplay/src/shape_classes/TEveMu2eCRV.h"
+#include "art/Framework/Principal/Run.h"
 
 using namespace mu2e;
 namespace mu2e{

--- a/TEveEventDisplay/src/TEveMu2eCRVEvent.cc
+++ b/TEveEventDisplay/src/TEveMu2eCRVEvent.cc
@@ -1,3 +1,4 @@
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eCRVEvent.h"
 #include "Offline/TEveEventDisplay/src/dict_classes/GeomUtils.h"
 using namespace mu2e;

--- a/TEveEventDisplay/src/TEveMu2eCalorimeter.cc
+++ b/TEveEventDisplay/src/TEveMu2eCalorimeter.cc
@@ -1,4 +1,6 @@
 #include "Offline/TEveEventDisplay/src/shape_classes/TEveMu2eCalorimeter.h"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
+#include "art/Framework/Principal/Run.h"
 
 using namespace mu2e;
 namespace mu2e{

--- a/TEveEventDisplay/src/TEveMu2eDataInterface.cc
+++ b/TEveEventDisplay/src/TEveMu2eDataInterface.cc
@@ -1,3 +1,4 @@
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eDataInterface.h"
 
 #include <vector>

--- a/TEveEventDisplay/src/TEveMu2eHit.cc
+++ b/TEveEventDisplay/src/TEveMu2eHit.cc
@@ -1,3 +1,5 @@
+#include "Offline/GeometryService/inc/DetectorSystem.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eHit.h"
 
 using namespace mu2e;

--- a/TEveEventDisplay/src/TEveMu2eMCInterface.cc
+++ b/TEveEventDisplay/src/TEveMu2eMCInterface.cc
@@ -1,4 +1,5 @@
-
+#include "Offline/GeometryService/inc/DetectorSystem.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eMCInterface.h"
 
 using namespace mu2e;

--- a/TEveEventDisplay/src/TEveMu2eTracker.cc
+++ b/TEveEventDisplay/src/TEveMu2eTracker.cc
@@ -1,5 +1,6 @@
-#include "Offline/TEveEventDisplay/src/shape_classes/TEveMu2eTracker.h"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
+#include "Offline/TEveEventDisplay/src/shape_classes/TEveMu2eTracker.h"
 Int_t transpOpt = 100;
 using namespace mu2e;
 namespace mu2e{

--- a/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eCRVEvent.h
+++ b/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eCRVEvent.h
@@ -11,7 +11,6 @@
 #include "Offline/RecoDataProducts/inc/CrvCoincidenceCluster.hh"
 #include "Offline/CosmicRayShieldGeom/inc/CosmicRayShield.hh"
 #include "Offline/DataProducts/inc/CRSScintillatorBarIndex.hh"
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/RecoDataProducts/inc/CrvRecoPulse.hh"
 #include "Offline/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eCustomHelix.h"
 #include "Offline/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2e2DProjection.h"

--- a/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eDataInterface.h
+++ b/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eDataInterface.h
@@ -11,7 +11,6 @@
 #include <TEveManager.h>
 #include <TEveStraightLineSet.h>
 //Mu2e General:
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
 //TEveMu2e
 #include "Offline/TEveEventDisplay/src/dict_classes/Collection_Filler.h"

--- a/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eHit.h
+++ b/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eHit.h
@@ -10,8 +10,6 @@
 #include <TMath.h>
 #include "Offline/RecoDataProducts/inc/ComboHit.hh"
 //Mu2e General:
-#include "Offline/GeometryService/inc/GeomHandle.hh"
-#include "Offline/GeometryService/inc/DetectorSystem.hh"
 #include "Offline/TEveEventDisplay/src/dict_classes/GeomUtils.h"
 #include "Offline/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eCustomHelix.h"
 #include "Offline/TrackerGeom/inc/Tracker.hh"

--- a/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eMCInterface.h
+++ b/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eMCInterface.h
@@ -11,7 +11,6 @@
 #include <TEveStraightLineSet.h>
 #include <TEveText.h>
 //Mu2e General:
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
 #include "Offline/MCDataProducts/inc/MCTrajectoryPoint.hh"
 //TEveMu2e

--- a/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eMCTraj.h
+++ b/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eMCTraj.h
@@ -9,7 +9,6 @@
 #include "Offline/RecoDataProducts/inc/ComboHit.hh"
 #include "Offline/TEveEventDisplay/src/dict_classes/GeomUtils.h"
 #include "Offline/ConfigTools/inc/SimpleConfig.hh"
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
 namespace mu2e {
   class TEveMu2eMCTraj : public TEvePointSet{

--- a/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eMainWindow.h
+++ b/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eMainWindow.h
@@ -47,7 +47,6 @@
 #include "art/Framework/Principal/Run.h"
 
 #include "Offline/ConfigTools/inc/SimpleConfig.hh"
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 //...TEveMu2e
 
 #include "Offline/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2eHit.h"

--- a/TEveEventDisplay/src/dict_classes/Data_Collections.h
+++ b/TEveEventDisplay/src/dict_classes/Data_Collections.h
@@ -20,9 +20,6 @@
 //Art/FCL:
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Run.h"
-#include "fhiclcpp/types/Atom.h"
-#include "fhiclcpp/types/Sequence.h"
-#include "fhiclcpp/types/Table.h"
 
 #include <TObject.h>
 #include <TROOT.h>

--- a/TEveEventDisplay/src/dict_classes/Geom_Interface.h
+++ b/TEveEventDisplay/src/dict_classes/Geom_Interface.h
@@ -27,7 +27,6 @@
 #include <TEveProjectionAxes.h>
 
 //Geom:
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
 #include "Offline/GeometryService/inc/WorldG4.hh"
 #include "Offline/GeometryService/inc/WorldG4Maker.hh"

--- a/TEveEventDisplay/src/shape_classes/TEveMu2eCRV.h
+++ b/TEveEventDisplay/src/shape_classes/TEveMu2eCRV.h
@@ -15,13 +15,14 @@
 //ROOT
 #include <TFile.h>
 //CRV/CRS:
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/CosmicRayShieldGeom/inc/CosmicRayShield.hh"
 #include "Offline/CosmicRayShieldGeom/inc/CRSScintillatorShield.hh"
 #include "Offline/CosmicRayShieldGeom/inc/CRSScintillatorModule.hh"
 //TEveMu2e:
 #include "Offline/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2e2DProjection.h"
 #include "Offline/TEveEventDisplay/src/dict_classes/GeomUtils.h"
+
+namespace art { class Run; }
 
 namespace mu2e{
         class TEveMu2eCRV

--- a/TEveEventDisplay/src/shape_classes/TEveMu2eCalorimeter.h
+++ b/TEveEventDisplay/src/shape_classes/TEveMu2eCalorimeter.h
@@ -16,7 +16,6 @@
 // ... libRIO
 #include <TFile.h>
 //Calorimeter:
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/CalorimeterGeom/inc/CaloGeomUtil.hh"
 #include "Offline/CalorimeterGeom/inc/CaloInfo.hh"
 #include "Offline/CalorimeterGeom/inc/Calorimeter.hh"
@@ -28,6 +27,11 @@
 #include "Offline/TEveEventDisplay/src/dict_classes/GeomUtils.h"
 //Mu2e:
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
+
+namespace art{
+  class Run;
+}
+
 namespace mu2e{
         class TEveMu2eCalorimeter
         {

--- a/TEveEventDisplay/src/shape_classes/TEveMu2eTracker.h
+++ b/TEveEventDisplay/src/shape_classes/TEveMu2eTracker.h
@@ -16,7 +16,6 @@
 #include <TFile.h>
 //Tracker
 #include "Offline/TrackerGeom/inc/Tracker.hh"
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 //TEveMu2e:
 #include "Offline/TEveEventDisplay/src/TEveMu2e_base_classes/TEveMu2e2DProjection.h"
 #include "Offline/TEveEventDisplay/src/dict_classes/GeomUtils.h"

--- a/TrackerConditions/inc/StrawElectronics.hh
+++ b/TrackerConditions/inc/StrawElectronics.hh
@@ -18,7 +18,6 @@
 #include "Offline/TrackerGeom/inc/Straw.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 #include "Offline/Mu2eInterfaces/inc/ProditionsEntity.hh"
-#include "fhiclcpp/ParameterSet.h"
 
 namespace mu2e {
 

--- a/TrackerConditions/inc/StrawPhysics.hh
+++ b/TrackerConditions/inc/StrawPhysics.hh
@@ -16,7 +16,6 @@
 #include "CLHEP/Random/RandFlat.h"
 // Mu2e includes
 #include "Offline/Mu2eInterfaces/inc/ProditionsEntity.hh"
-#include "fhiclcpp/ParameterSet.h"
 
 #include "Offline/TrackerConditions/inc/StrawDrift.hh"
 


### PR DESCRIPTION
Make changes to that are required for art suite v3_15_00 that upgrades root to v6_30_06.   The submitted code works with both the new art suite and the with the current art suite v3_14_03.  I checked that 2000 events of ceSimReco produced identical results.

  In all cases the problem was that fhicl code was exposed to dictionary makers because of people having includes that were either unneeded or were in the .hh file rather than the .cc file, where they belonged.   I don't understand the details of what in fhicl is causing the problem but there is no reason for fhicl code to be exposed to dictionary makers.

This is something that likely would have been fixed by IWYU so that is back on my list as a priority.

There will be an accompanying PR in REve.  

There were no build-time issues with TrackerAlignment, TrkAna and Tutorial.

