### PR TITLE
start ad-hoc table feature

### DIFF
--- a/DbService/data/create.sql
+++ b/DbService/data/create.sql
@@ -175,6 +175,15 @@ CREATE TABLE tst.calib2
 GRANT SELECT ON tst.calib2 TO PUBLIC;
 GRANT INSERT ON tst.calib2 TO val_role;
 
+-- example adhoc table
+
+CREATE TABLE tst.adhoc1
+  (exint INTEGER , exfloat NUMERIC, exstring TEXT, 
+  create_time TIMESTAMP WITH TIME ZONE NOT NULL, 
+  create_user TEXT NOT NULL );
+GRANT SELECT ON tst.adhoc1 TO PUBLIC;
+GRANT INSERT ON tst.adhoc1 TO val_role;
+
 --
 -- trk schema tables
 --

--- a/DbService/inc/DbTool.hh
+++ b/DbService/inc/DbTool.hh
@@ -58,6 +58,7 @@ class DbTool {
   int printList();
   int printSet();
   int printRun();
+  int printAdhoc();
 
   std::string getResult() { return _result; }
   int printCIDLine(int cid, int indent = 0);
@@ -76,6 +77,8 @@ class DbTool {
   int commitExtension(int& eid, std::string purpose = "",
                       std::string version = "",
                       std::vector<int> gids = std::vector<int>());
+  int commitAdhoc();
+  int commitAdhocTable(DbTable::cptr_t const& ptr, bool admin = false);
   int commitTable();
   int commitList();
   int commitPurpose();

--- a/DbService/src/DbTool.cc
+++ b/DbService/src/DbTool.cc
@@ -27,11 +27,13 @@ int mu2e::DbTool::run() {
   if (_action == "print-list") return printList();
   if (_action == "print-set") return printSet();
   if (_action == "print-run") return printRun();
+  if (_action == "print-adhoc") return printAdhoc();
 
   int iid, gid, eid;
   if (_action == "commit-calibration") return commitCalibration();
   if (_action == "commit-iov") return commitIov(iid);
   if (_action == "commit-group") return commitGroup(gid);
+  if (_action == "commit-adhoc") return commitAdhoc();
   if (_action == "commit-extension") return commitExtension(eid);
   if (_action == "commit-table") return commitTable();
   if (_action == "commit-list") return commitList();
@@ -697,6 +699,62 @@ int mu2e::DbTool::printRun() {
   return 0;
 }
 
+// ****************************************  printAdhoc
+
+int mu2e::DbTool::printAdhoc() {
+  int rc = 0;
+
+  map_ss args;
+  args["name"] = "";
+  args["full"] = "";
+  if ((rc = getArgs(args))) return rc;
+  std::string name = args["name"];
+
+  if ( name.empty() ) {
+    std::cout << "ERROR - print-adhoc missing table name " << std::endl;
+    return 1;
+  }
+  bool full = ! args["full"].empty();
+
+  if (_verbose > 1)
+    std::cout << "print-adhoc: printing " << name << std::endl;
+
+  auto ptr = mu2e::DbTableFactory::newTable(name);
+
+  if(ptr->type() != DbTable::Adhoc) {
+    std::cout << "ERROR - print-adhoc table was not ad-hoc type" << std::endl;
+    return 1;
+  }
+
+  std::string csv;
+  std::string select(ptr->query());
+  if (full) {
+    select = select + ",create_user,create_time";
+  }
+  std::string table(ptr->dbname());
+  DbReader::StringVec where;
+  std::string order("create_time");
+
+  rc = _reader.query(csv, select, table, where, order);
+  if (rc !=0) {
+    std::cout << "ERROR - print-adhoc query failed " << std::endl;
+    return 1;
+  }
+
+  _result = _result + "TABLE " + name + "\n";
+  if (_pretty) {
+    std::string title = "# " + select;
+    prettyTable(title, csv);
+  } else {
+    _result = _result + "# " + select + "\n";
+    _result = _result + csv;
+  }
+
+  return 0;
+}
+
+
+
 // ****************************************  printCIDLine
 int mu2e::DbTool::printCIDLine(int cid, int indent) {
   auto const& cids = _valcache.valCalibrations();
@@ -1284,6 +1342,143 @@ int mu2e::DbTool::commitGroup(int& gid, std::vector<int> iids) {
 
   return rc;
 }
+
+
+// ****************************************  commitAdhoc
+
+int mu2e::DbTool::commitAdhoc() {
+
+  int rc = 0;
+
+  map_ss args;
+  args["file"] = "";
+  if ((rc = getArgs(args))) return rc;
+
+  if (args["file"].empty()) {
+    std::cout << "commit-adhoc: --file FILE is required " << std::endl;
+    return 1;
+  }
+
+  DbTableCollection coll = DbUtil::readFile(args["file"]);
+  if (_verbose > 0)
+    std::cout << "commit-adhoc: read " << coll.size() << " tables "
+              << " from " << args["file"] << std::endl;
+  if (_verbose > 2) {
+    for (auto lt : coll) {
+      std::cout << "commit-adhoc: read contents for table "
+                << lt.table().name() << std::endl;
+      if (_verbose > 5) std::cout << lt.table().csv();
+    }
+  }
+
+  if (coll.size() <= 0) {
+    std::cout << "commit-adhoc: no table found in file " << args["file"]
+              << std::endl;
+    return 2;
+  }
+
+  for (auto lt : coll) {
+    auto ptr = lt.ptr();
+    rc = commitAdhocTable(ptr,_admin);
+  } // end loop over tables in file
+
+  return rc;
+
+}
+
+// ****************************************  commitAdhocTable
+
+int mu2e::DbTool::commitAdhocTable(DbTable::cptr_t const& ptr, bool admin) {
+
+  int rc;
+
+  if(ptr->type() != DbTable::Adhoc) {
+    std::cout << "ERROR - print-adhoc table was not ad-hoc type" << std::endl;
+    return 1;
+  }
+
+  rc = _sql.connect();
+  if (rc) {
+    std::cout << "commit-adhoc: SQL failed to connect " << std::endl;
+    return 3;
+  }
+
+  std::string command, result;
+  command = "BEGIN";
+  rc = _sql.execute(command, result);
+  if (rc != 0) return rc;
+
+  command = "SET ROLE val_role;";
+  rc = _sql.execute(command, result);
+  if (rc != 0) return rc;
+
+  // devine the schema name from the first dot field of the dbname
+  std::string dbname = ptr->dbname();
+  size_t dpos = dbname.find(".");
+  if (dpos == std::string::npos) {
+    std::cout << "DbTool::commitAdhocTable could not decode schema from "
+              << dbname << std::endl;
+    return 1;
+  }
+  std::string schema = dbname.substr(0, dpos);
+
+  // inserting into a detector schema is done by the detector role
+  // or overridden by admin
+  if (admin) {
+    command = "SET ROLE admin_role;";
+  } else {
+    // the tst schema is written by val role, just to remove one more role
+    // with a duplicate membership
+    if (schema == "tst") {
+      command = "SET ROLE val_role;";
+    } else {
+      command = "SET ROLE " + schema + "_role;";
+    }
+  }
+  rc = _sql.execute(command, result);
+  if (rc != 0) return rc;
+
+  // insert table values
+  std::string csv = ptr->csv();
+  std::vector<std::string> lines = DbUtil::splitCsvLines(csv);
+  for (auto line : lines) {
+    std::string cline = DbUtil::sqlLine(line);
+    command = "INSERT INTO " + ptr->dbname() + "( " + ptr->query() +
+      ",create_time,create_user) VALUES (" + cline +
+      ",CURRENT_TIMESTAMP,SESSION_USER);";
+    rc = _sql.execute(command, result);
+    if (_verbose > 9) {
+      std::cout << command << std::endl;
+      std::cout << result << std::endl;
+    }
+    if (rc != 0) return rc;
+  }
+
+  std::stringstream ss;
+  if (_dryrun) {
+    ss << "would insert " << ptr->nrow() << " new rows to "
+       << ptr->name() << std::endl;
+  } else {
+    ss << "inserts for " << ptr->name() << " with " << ptr->nrow()
+       << " rows" << std::endl;
+  }
+  _result.append(ss.str());
+
+  if (_dryrun) {
+    command = "ROLLBACK;";
+  } else {
+    command = "COMMIT;";
+  }
+  rc = _sql.execute(command, result);
+  if (rc != 0) return rc;
+
+  rc = _sql.disconnect();
+  if (rc != 0) return rc;
+
+  return rc;
+}
+
+
 
 // ****************************************  commmitExtension
 int mu2e::DbTool::commitExtension(int& eid, std::string purpose,
@@ -2665,6 +2860,18 @@ int mu2e::DbTool::help() {
                  "    --table TABLENAME : only print for this table\n"
                  "    --content : print table content (requires --table)\n"
               << std::endl;
+  } else if (_action == "print-adhoc") {
+    std::cout
+        << " \n"
+           " dbTool print-adhoc [OPTIONS]\n"
+           " \n"
+           " Print ad-hoc table contents.\n"
+           " \n"
+           " [OPTIONS]\n"
+           "    --name NAME : name of the table\n"
+           "    --full : include commit user and time for each row\n"
+           " \n"
+        << std::endl;
   } else if (_action == "commit-calibration") {
     std::cout << " \n"
                  " dbTool commit-calibration --file FILE\n"
@@ -2710,6 +2917,17 @@ int mu2e::DbTool::help() {
            "int\n"
            "    --dry-run : don't do final commit\n"
         << std::endl;
+  } else if (_action == "commit-adhoc") {
+    std::cout << " \n"
+                 " dbTool commit-adhoc --file FILE\n"
+                 " \n"
+                 " Add the rows in FILE to the repective tables.  Text must\n"
+                 " be in the canonical format - see wiki docs\n"
+                 " \n"
+                 " [OPTIONS]\n"
+                 "    --file FILE : data to commit (required)\n"
+                 "    --dry-run : do everything except final database commit\n"
+              << std::endl;
   } else if (_action == "commit-table") {
     std::cout
         << " \n"

--- a/DbTables/inc/DbTable.hh
+++ b/DbTables/inc/DbTable.hh
@@ -13,6 +13,7 @@ class DbTable {
  public:
   typedef std::shared_ptr<mu2e::DbTable> ptr_t;
   typedef std::shared_ptr<const mu2e::DbTable> cptr_t;
+  enum tableType {Calibration=0,Validity=1,Adhoc=2};
 
   DbTable(const char* name = "DbTable", const char* dbname = "dne.dbtable",
           const char* query = "noquery") :
@@ -38,6 +39,7 @@ class DbTable {
   std::size_t baseSize() const { return _csv.capacity(); }
   // if table needs to be sorted
   virtual const std::string orderBy() const { return std::string(); }
+  virtual tableType type() const { return Calibration; }
 
   // take the cvs text from a query and build out the table contents
   int fill(const std::string& csv, bool saveCsv = true);

--- a/DbTables/inc/TstAdhoc1.hh
+++ b/DbTables/inc/TstAdhoc1.hh
@@ -1,0 +1,62 @@
+#ifndef DbTables_TstAdhoc1_hh
+#define DbTables_TstAdhoc1_hh
+
+#include "Offline/DbTables/inc/DbTable.hh"
+#include "cetlib_except/exception.h"
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <string>
+
+namespace mu2e {
+
+class TstAdhoc1 : public DbTable {
+ public:
+  class Row {
+   public:
+    Row(int exint, float exfloat, std::string exstring) :
+        _exint(exint), _exfloat(exfloat), _exstring(exstring) {}
+    int exint() const { return _exint; }
+    float exfloat() const { return _exfloat; }
+    std::string exstring() const { return _exstring; }
+
+   private:
+    int _exint;
+    float _exfloat;
+    std::string _exstring;
+  };
+
+  constexpr static const char* cxname = "TstAdhoc1";
+
+  TstAdhoc1() : DbTable(cxname, "tst.adhoc1", "exint,exfloat,exstring") {}
+  const Row& rowAt(const std::size_t index) const { return _rows.at(index); }
+  std::vector<Row> const& rows() const { return _rows; }
+  std::size_t nrow() const override { return _rows.size(); };
+  size_t size() const override {
+    return baseSize() + nrow() * nrow() / 2 + nrow() * sizeof(Row);
+  };
+  tableType type() const override { return Adhoc; }
+
+  void addRow(const std::vector<std::string>& columns) override {
+    _rows.emplace_back(std::stoi(columns[0]), std::stof(columns[1]),
+                       columns[2]);
+  }
+
+  void rowToCsv(std::ostringstream& sstream, std::size_t irow) const override {
+    Row const& r = _rows.at(irow);
+    sstream << r.exint() << ",";
+    sstream << std::fixed << std::setprecision(3) << r.exfloat() << ",";
+    sstream << r.exstring();
+  }
+
+  virtual void clear() override {
+    baseClear();
+    _rows.clear();
+  }
+
+ private:
+  std::vector<Row> _rows;
+};
+
+}  // namespace mu2e
+#endif

--- a/DbTables/src/DbTableFactory.cc
+++ b/DbTables/src/DbTableFactory.cc
@@ -29,6 +29,7 @@
 #include "Offline/DbTables/inc/TstCalib1.hh"
 #include "Offline/DbTables/inc/TstCalib2.hh"
 #include "Offline/DbTables/inc/TstCalib3.hh"
+#include "Offline/DbTables/inc/TstAdhoc1.hh"
 #include "cetlib_except/exception.h"
 
 
@@ -39,6 +40,8 @@ mu2e::DbTable::ptr_t mu2e::DbTableFactory::newTable(std::string const& name) {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TstCalib2());
   } else if (name == "TstCalib3") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TstCalib3());
+  } else if (name == "TstAdhoc1") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TstAdhoc1());
   } else if (name == "TrkDelayPanel") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkDelayPanel());
   } else if (name == "TrkDelayRStraw") {


### PR DESCRIPTION
Ad-hoc tables have arbitrary structure and the user can just insert and read rows as they chose.  They can't be accessed though a conditions set and will not be available in production.  The tables are still defined in DbTables code so they can be manipulated by existing tools.  The immediate use case is to record which CID in an archive table corresponds to which CID in a reco table.  There is an example in the dev database:

```
build01 db > dbTool print-adhoc --database mu2e_conditions_dev --full --pretty --name TstAdhoc1
TABLE TstAdhoc1
# exint   exfloat           exstring   create_user                        create_time   
      0,      1.3,     first comment,          rlc,  2024-05-14 19:15:37.715581-05:00
     21,      2.3,   another comment,          rlc,  2024-05-14 19:15:37.715581-05:00
```
This should have no effect on any validation