### PR TITLE
Allow missing collections when making merged KalSeed Ptr collections

### DIFF
--- a/Print/fcl/printTriggerResults.fcl
+++ b/Print/fcl/printTriggerResults.fcl
@@ -1,0 +1,41 @@
+
+#
+#  print products with a moderate amount of output - includes cuts on energy
+#
+
+#include "Offline/fcl/minimalMessageService.fcl"
+#include "Offline/fcl/standardServices.fcl"
+
+process_name : print
+
+services : {
+   message : @local::default_message
+  GlobalConstantsService  : { inputFile      : "Offline/GlobalConstantsService/data/globalConstants_01.txt" }
+}
+
+physics :{
+  analyzers: {
+
+    printModule : {
+      module_type : PrintModule
+      triggerResultsPrinter : {
+        verbose : 2
+      }
+    } # printModule
+
+
+  }  # analyzers
+
+  ana       : [ printModule ]
+  end_paths : [ ana ]
+
+}
+
+outputs: {
+  printProductList : {
+    module_type : DataProductDump
+  }
+}
+
+services.message.destinations.log.categories.ArtSummary.limit : 0
+services.message.destinations.statistics.stats : @local::mf_null


### PR DESCRIPTION
Allow missing KalSeed collections to support merging multiple trigger paths