### PR TITLE
Add geantino

### DIFF
--- a/DataProducts/inc/PDGCode.hh
+++ b/DataProducts/inc/PDGCode.hh
@@ -33,6 +33,7 @@ namespace mu2e {
   public:
     enum enum_type
       {
+        geantino = 0 ,
         d = 1 ,
         anti_d = -1 ,
         u = 2 ,
@@ -459,7 +460,7 @@ namespace mu2e {
         He3 =      1000020030,
 
         // Needed for EnumToStringSparse
-        unknown = 0,
+        unknown = -999999999,
 
         // Codes above or equal to this value are defined by G4.
         G4Threshold = 999999999,

--- a/DataProducts/src/PDGCode.cc
+++ b/DataProducts/src/PDGCode.cc
@@ -39,6 +39,7 @@ namespace mu2e {
   }
 
   static const std::map<PDGCodeDetail::enum_type,std::string> nam{
+    {PDGCodeDetail::geantino                             , "geantino" },
      {PDGCodeDetail::d                             , "d" },
       {PDGCodeDetail::anti_d                        , "anti_d" },
       {PDGCodeDetail::u                             , "u" },

--- a/GlobalConstantsService/data/ParticleList.txt
+++ b/GlobalConstantsService/data/ParticleList.txt
@@ -1,3 +1,4 @@
+	 0	         geantino		     same			     geantino       none          0            0            0
         -1           anti_d_quark                    same                              anti_d       dbar   0.333333          330            0
          1                d_quark                    same                                   d       none  -0.333333          330            0
         -2           anti_u_quark                    same                              anti_u       ubar  -0.666667          330            0

--- a/Mu2eG4/src/Mu2eG4PrimaryGeneratorAction.cc
+++ b/Mu2eG4/src/Mu2eG4PrimaryGeneratorAction.cc
@@ -256,6 +256,11 @@ namespace mu2e {
       }
 
     }
+    else if (pdgId == PDGCode::geantino) {
+      // AE: for some reason GetParticleTable()->FindParticle(0) does not find geantino
+      // but GetParticleTable()->FindParticle("geantino") does
+      pDef = G4ParticleTable::GetParticleTable()->FindParticle("geantino");
+    }
 
     // note that the particle definition not the pdg code is used for ions
     // Add the particle to the event.


### PR DESCRIPTION
This PR adds in the geantino. For some reason the PDGcode number on its own doesn't work and so I had to add an else block to Mu2eG4PrimaryGeneratorAction to get it by name.