### PR TITLE
Upgrade to envset p057.

### DIFF
--- a/.muse
+++ b/.muse
@@ -1,5 +1,5 @@
 # prefer to build with this environment
-ENVSET p056
+ENVSET p057
 # add Offline/bin to path
 PATH bin
 # recent commits can take enforce these flags


### PR DESCRIPTION
This envset differs from p056 only in a hack to deal with different versions of root being shipped in the sl7/ups and al9/spack distributions of art v3_14_03.
