### PR TITLE
Add KalSeed selector to Ptr collection creation

### DIFF
--- a/RecoDataProducts/inc/KalSeed.hh
+++ b/RecoDataProducts/inc/KalSeed.hh
@@ -1,5 +1,5 @@
 //
-//  Persistent representation of the BTrk Kalman filter fit (KalRep)
+//  Persistent representation of the Kalman filter fit
 //  Original author: Dave Brown (LBNL) 31 Aug 2016
 //
 #ifndef RecoDataProducts_KalSeed_HH

--- a/TrkReco/inc/KalSeedSelector.hh
+++ b/TrkReco/inc/KalSeedSelector.hh
@@ -1,0 +1,18 @@
+//
+// Base class for selecting a KalSeed.  Subclasses must be an art tool
+//
+#ifndef TrkReco_KalSeedSelector_hh
+#define TrkReco_KalSeedSelector_hh
+
+namespace mu2e {
+  class KalSeed;
+  class KalSeedSelector {
+  public:
+    // the following returns true if the kseed passes the selection
+    virtual bool select(KalSeed const& kseed) const = 0;
+    // the following returns true if 'test' is better than 'current', false otherwise
+    virtual bool isBetter(KalSeed const& current, KalSeed const& test) const = 0;
+    virtual ~KalSeedSelector() noexcept = default;
+  };
+}
+#endif

--- a/TrkReco/inc/SimpleKalSeedSelector.hh
+++ b/TrkReco/inc/SimpleKalSeedSelector.hh
@@ -1,0 +1,38 @@
+//
+//  Simple selector based on momentum and fit quality
+//
+#include "art/Utilities/ToolMacros.h"
+#include "art/Utilities/ToolConfigTable.h"
+#include "Offline/TrkReco/inc/KalSeedSelector.hh"
+#include "Offline/RecoDataProducts/inc/KalSeed.hh"
+#include "fhiclcpp/types/Atom.h"
+
+namespace mu2e {
+  class SimpleKalSeedSelector : public KalSeedSelector {
+  public:
+    struct Config {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      fhicl::Atom<double> minmom{Name("MinimumMomentum"), Comment("Minimum fit momentum ")};
+      fhicl::Atom<double> maxmom{Name("MaximumMomentum"), Comment("Maximum fit momentum ")};
+      fhicl::Atom<double> minfcon{Name("MinimumFitConsistency"), Comment("Minimum fit consistency ")};
+      fhicl::Atom<double> minsignhit{Name("MinDeltaNHitFraction"), Comment("Minimum difference in the fractional number of hits to consider significant")};
+    };
+    typedef art::ToolConfigTable<Config> Parameters;
+    explicit SimpleKalSeedSelector(Parameters const& conf) :
+      minmom_(conf().minmom()),
+      maxmom_(conf().maxmom()),
+      minfcon_(conf().minfcon()),
+      minsignhit_(conf().minsignhit())
+    {}
+
+    bool select(KalSeed const& kseed) const override;
+    bool isBetter(KalSeed const& current,KalSeed const& test) const override;
+
+  private:
+    double minmom_, maxmom_;
+    double minfcon_;
+    double minsignhit_;
+  };
+}
+DEFINE_ART_CLASS_TOOL(mu2e::SimpleKalSeedSelector)

--- a/TrkReco/src/MergeKalSeeds_module.cc
+++ b/TrkReco/src/MergeKalSeeds_module.cc
@@ -72,7 +72,7 @@ namespace mu2e {
           } else if ( selector_->select(kseed)){
             if(!selbest_ || mkseeds->size() == 0)
               mkseeds->emplace_back(ksch,ikseed);
-            else if(selbest_ && selector_->isBetter(kseed,*mkseeds->back())){
+            else if(selbest_ && selector_->isBetter(*mkseeds->back(),kseed)){
               mkseeds->back() = art::Ptr<KalSeed>(ksch,ikseed);
             }
           }

--- a/TrkReco/src/MergeKalSeeds_module.cc
+++ b/TrkReco/src/MergeKalSeeds_module.cc
@@ -7,11 +7,15 @@
 //
 #include "fhiclcpp/types/Atom.h"
 #include "fhiclcpp/types/Sequence.h"
+#include "fhiclcpp/types/OptionalDelegatedParameter.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "art/Utilities/make_tool.h"
 #include "canvas/Utilities/InputTag.h"
 #include "canvas/Persistency/Common/Ptr.h"
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
+#include "Offline/TrkReco/inc/KalSeedSelector.hh"
 // mu2e data products
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 // C++
@@ -25,22 +29,30 @@ namespace mu2e {
       struct Config {
         fhicl::Atom<int> debug{ Name("debugLevel"), Comment("Debug Level"), 0};
         fhicl::Sequence<art::InputTag> seedCollTags {Name("KalSeedCollections"), Comment("KalSeed collections tomerge") };
+        fhicl::Atom<bool> selbest{ Name("SelectBest"), Comment("Select best candidate"), false};
+        fhicl::OptionalDelegatedParameter selector{Name("Selector"), Comment("Selector parameters")};
       };
       using Parameters = art::EDProducer::Table<Config>;
-      explicit MergeKalSeeds(const Parameters& conf);
+      explicit MergeKalSeeds(const Parameters& config);
       void produce(art::Event& evt) override;
     private:
       int debug_;
+      bool selbest_;
       std::vector<art::InputTag> seedcolltags_;
+      std::unique_ptr<KalSeedSelector> selector_;
   };
 
-  MergeKalSeeds::MergeKalSeeds(const Parameters& config) : art::EDProducer{config}, debug_(config().debug())
-    {
+  MergeKalSeeds::MergeKalSeeds(const Parameters& config) : art::EDProducer{config},
+    debug_(config().debug()),
+    selbest_(config().selbest()) {
       for(auto const& seedcolltag :config().seedCollTags()){
         mayConsume<KalSeedCollection>    (seedcolltag);
         seedcolltags_.push_back(seedcolltag);
         if(debug_ > 0) std::cout << "Merging KalSeeds from " << seedcolltag << std::endl;
       }
+      // if requested, instantiate the selector
+      const auto pset = config().selector.get_if_present<fhicl::ParameterSet>();
+      if(pset.has_value()) selector_ = art::make_tool<KalSeedSelector>(*pset);
       produces<KalSeedPtrCollection> ();
     }
 
@@ -53,7 +65,18 @@ namespace mu2e {
       if(ksch.isValid()){
         auto const& ksc = *ksch;
         if(debug_ > 2) std::cout << seedcolltag << " Has " << ksc.size() << " KalSeeds" << std::endl;
-        for(size_t ikseed = 0; ikseed <ksc.size(); ++ikseed){ mkseeds->emplace_back(ksch,ikseed); }
+        for(size_t ikseed = 0; ikseed <ksc.size(); ++ikseed){
+          auto const& kseed = ksc[ikseed];
+          if( (!selector_) ) {
+            mkseeds->emplace_back(ksch,ikseed);
+          } else if ( selector_->select(kseed)){
+            if(!selbest_ || mkseeds->size() == 0)
+              mkseeds->emplace_back(ksch,ikseed);
+            else if(selbest_ && selector_->isBetter(kseed,*mkseeds->back())){
+              mkseeds->back() = art::Ptr<KalSeed>(ksch,ikseed);
+            }
+          }
+        }
       } else if (debug_ > 2){
         std::cout << "No collection found for " << seedcolltag << std::endl;
       }

--- a/TrkReco/src/SimpleKalSeedSelector_tool.cc
+++ b/TrkReco/src/SimpleKalSeedSelector_tool.cc
@@ -1,0 +1,28 @@
+#include "Offline/TrkReco/inc/SimpleKalSeedSelector.hh"
+
+namespace mu2e {
+
+  bool SimpleKalSeedSelector::select(KalSeed const& kseed) const {
+    // evaluate the momentum at t0
+    if(kseed.intersections().size() > 0){
+      auto const& kinter = kseed.intersections().front();
+      auto mom = kinter.mom();
+      auto fcon = kseed.fitConsistency();
+      return mom >= minmom_ && mom <= maxmom_ && fcon >= minfcon_;
+    } else
+      return false;
+  }
+
+  bool SimpleKalSeedSelector::isBetter(KalSeed const& current,KalSeed const& test) const {
+    double nhitfrac = 2*(test.nHits() - current.nHits())/(test.nHits() + current.nHits());
+    if(nhitfrac > minsignhit_){
+      // difference is significant
+      return true;
+    } else {
+      // fall back to fit consistency
+      return test.fitConsistency() > current.fitConsistency();
+    }
+  }
+
+
+}


### PR DESCRIPTION
This PR adds functionality to select KalSeeds to the MergeKalSeeds module, used in make TrkAna trees.  The default behavior is unchanged.  The selector is implemented as a tool, to allow multiple different kinds of tools to be designed for different purposes without having to change the core code.