### PR TITLE
dummy change to test codetools in CI

### DIFF
--- a/HelloWorld/src/HelloWorld_module.cc
+++ b/HelloWorld/src/HelloWorld_module.cc
@@ -2,6 +2,8 @@
 //  The HelloWorld plugin; the first example of a module.
 //
 //
+//  Add a TODO
+//
 //  Original author Rob Kutschke
 //
 

--- a/MCDataProducts/inc/GenId.hh
+++ b/MCDataProducts/inc/GenId.hh
@@ -4,7 +4,6 @@
 // An enum-matched-to-names class for generator Id's.
 //
 //
-//
 // Original author Rob Kutschke
 //
 // Notes:
@@ -25,12 +24,12 @@
 
 namespace mu2e {
 
-  class GenId {
+  class GenId {   
 
-  public:
+  public:   
 
     // Need to keep the enum and the _name member in sync.
-    enum enum_type {
+    enum enum_type {   
       unknown,       particleGun,       CeEndpoint,
       cosmicToy,     cosmicDYB,         cosmic,          obsolete1, //6
       dioTail,       obsolete2,         obsolete3,       obsolete4,           ExternalRPC, //11

--- a/MCDataProducts/inc/GenId.hh
+++ b/MCDataProducts/inc/GenId.hh
@@ -2,7 +2,12 @@
 #define MCDataProducts_GenId_hh
 //
 // An enum-matched-to-names class for generator Id's.
-//
+// todo
+// TODO
+// Todo
+// Fixme
+// FIXME
+// fixme
 //
 // Original author Rob Kutschke
 //

--- a/MCDataProducts/src/GenId.cc
+++ b/MCDataProducts/src/GenId.cc
@@ -1,4 +1,4 @@
-a//
+//
 // An enum-matched-to-names class for generator Id's.
 //
 // Add a line that says fixme in a file that will trigger clang tidy.

--- a/MCDataProducts/src/GenId.cc
+++ b/MCDataProducts/src/GenId.cc
@@ -1,8 +1,9 @@
-//
+a//
 // An enum-matched-to-names class for generator Id's.
 //
 // Add a line that says fixme in a file that will trigger clang tidy.
-//
+// and FIXME
+// and Fixme
 //
 // Original author Rob Kutschke
 #include <iomanip>

--- a/MCDataProducts/src/GenId.cc
+++ b/MCDataProducts/src/GenId.cc
@@ -1,6 +1,7 @@
 //
 // An enum-matched-to-names class for generator Id's.
 //
+// Add a line that says fixme in a file that will trigger clang tidy.
 //
 //
 // Original author Rob Kutschke
@@ -45,7 +46,7 @@ namespace mu2e {
       os << "GenId::findByName invalid enum name : " << name;
       throw std::out_of_range( os.str() );
     }
-    return GenId(unknown);
+    return GenId(unknown);  
   }
 
 }

--- a/MCDataProducts/src/ProcessCode.cc
+++ b/MCDataProducts/src/ProcessCode.cc
@@ -5,6 +5,12 @@
 // that the particle is a primary particle and other enum entries to
 // indicate that a particle was killed in one of the user actions written by G4.
 //
+// todo
+// TODO
+// Todo
+// Fixme
+// FIXME
+// fixme
 //
 // Original author Rob Kutschke
 //

--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ And another line to allow CI to run again.
 Now, lets see if the fix to CI/bin/gh_pr_bootstrap.sh line 99 works.
 And another line.
 And one more line.
+And another line.
 
 

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ Inspect modified printout.
 Now seee what SL7 does.
 Check version of clang-tidy
 Final version of codetools in place, still with verbose diagnostics.
+Test of test with functionality, launched from Production.
+

--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ And another line.
 And one more line.
 And another line.
 Maybe this is the last one.
+No it was not the last one.
 
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ No it was not the last one.
 Inspect modified printout.
 Now seee what SL7 does.
 Check version of clang-tidy
+Final version of codetools in place, still with verbose diagnostics.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Offline
 Offline software for the Mu2e experiment at Fermilab.
 This time for sure.
+And another line to allow CI to run again.
+
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Offline
 Offline software for the Mu2e experiment at Fermilab.
+This time for sure.
 

--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@ Offline software for the Mu2e experiment at Fermilab.
 This time for sure.
 And another line to allow CI to run again.
 Now, lets see if the fix to CI/bin/gh_pr_bootstrap.sh line 99 works.
+And another line.
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 # Offline
 Offline software for the Mu2e experiment at Fermilab.
-Dummy change.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Offline
 Offline software for the Mu2e experiment at Fermilab.
+Dummy change.
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ Maybe this is the last one.
 No it was not the last one.
 Inspect modified printout.
 Now seee what SL7 does.
+Check version of clang-tidy

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ And another line.
 Maybe this is the last one.
 No it was not the last one.
 Inspect modified printout.
+Now seee what SL7 does.

--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ Now, lets see if the fix to CI/bin/gh_pr_bootstrap.sh line 99 works.
 And another line.
 And one more line.
 And another line.
+Maybe this is the last one.
 
 

--- a/README.md
+++ b/README.md
@@ -8,5 +8,4 @@ And one more line.
 And another line.
 Maybe this is the last one.
 No it was not the last one.
-
-
+Inspect modified printout.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 Offline software for the Mu2e experiment at Fermilab.
 This time for sure.
 And another line to allow CI to run again.
+Now, lets see if the fix to CI/bin/gh_pr_bootstrap.sh line 99 works.
 
 

--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ This time for sure.
 And another line to allow CI to run again.
 Now, lets see if the fix to CI/bin/gh_pr_bootstrap.sh line 99 works.
 And another line.
+And one more line.
 
 


### PR DESCRIPTION
We are using this PR to test running the CI on AL9 inside Jenkins.

During the evening of June 12, AL9 was enabled.  It mostly works.  Only clang-tidy to go.  See comments below for the state of the CI SL7/AL9
