### PR TITLE
fix inverted flag to propagate preloaded StrawDigiMCs

### DIFF
--- a/TrackerMC/src/StrawDigisFromStrawGasSteps_module.cc
+++ b/TrackerMC/src/StrawDigisFromStrawGasSteps_module.cc
@@ -476,11 +476,11 @@ namespace mu2e {
         auto adcs_handle = event.getHandle<StrawDigiADCWaveformCollection>(_mixedDigisTag);
         // bundle up preexisting digi products, optionally including DigiMCs
         if (!_mixDigiMCs){
-          auto dgmcs_handle = event.getHandle<StrawDigiMCCollection>(_mixedDigisTag);
-          bundles.Append(*digi_handle, *adcs_handle, *dgmcs_handle);
+          bundles.Append(*digi_handle, *adcs_handle);
         }
         else{
-          bundles.Append(*digi_handle, *adcs_handle);
+          auto dgmcs_handle = event.getHandle<StrawDigiMCCollection>(_mixedDigisTag);
+          bundles.Append(*digi_handle, *adcs_handle, *dgmcs_handle);
         }
       }
 


### PR DESCRIPTION
This PR fixes a bug present in https://github.com/Mu2e/Offline/pull/1245, which introduced the overlay of simulated tracker digis onto a collection of preexisting digis, which may or may not have been produced by earlier simulation. Whether or not the preexisting digis were produced by simulation is maintained by a field in `StrawDigiMC`, which is set in the `StrawDigisFromStrawGasSteps` module, following fcl configuration. The original implementation used the flag in an inverted fashion, marking presimulated digis as non-simulated, and vice versa. This does not effect any tagged datasets. 