### PR TITLE
Add accessor

### DIFF
--- a/RecoDataProducts/inc/ComboHit.hh
+++ b/RecoDataProducts/inc/ComboHit.hh
@@ -62,6 +62,8 @@ namespace mu2e {
     float hphiRes() const { return sqrt(hphiVar()); }
     // other info
     float energyDep() const { return _edep; }
+    // return the sum energy of all referenced Straw hits
+    float strawEnergyDep() const { return _edep * _nsh; }
     float qual() const { return _qual; }
     StrawHitFlag const& flag() const { return _flag; }
     StrawId const& strawId() const { return _sid; }


### PR DESCRIPTION
This accessor is to facilitate downstream consumers who need to access the straw-level energy deposition of combined hits, such as in https://github.com/Mu2e/Offline/pull/1289