### PR TITLE
Utilize art::PtrRemapper when mixing StrawDigiMCs

### DIFF
--- a/EventMixing/inc/Mu2eProductMixer.hh
+++ b/EventMixing/inc/Mu2eProductMixer.hh
@@ -200,6 +200,9 @@ namespace mu2e {
     typedef GenParticleCollection::size_type GenOffset;
     std::vector<GenOffset> genOffsets_;
 
+    typedef StrawGasStepCollection::size_type SGSOffset;
+    std::vector<SGSOffset> sgsOffsets_;
+
     void updateSimParticle(SimParticle& particle, SPOffset offset, art::PtrRemapper const& remap);
 
     typedef std::map<cet::map_vector_key,PhysicalVolumeInfo> VolumeMap;

--- a/EventMixing/src/Mu2eProductMixer.cc
+++ b/EventMixing/src/Mu2eProductMixer.cc
@@ -366,11 +366,11 @@ namespace mu2e {
                                           StrawGasStepCollection& out,
                                           art::PtrRemapper const& remap)
   {
-    std::vector<StrawGasStepCollection::size_type> stepOffsets;
-    art::flattenCollections(in, out, stepOffsets);
+    //std::vector<StrawGasStepCollection::size_type> stepOffsets;
+    art::flattenCollections(in, out, sgsOffsets_);
 
     for(StrawGasStepCollection::size_type i=0; i<out.size(); ++i) {
-      auto ie = getInputEventIndex(i, stepOffsets);
+      auto ie = getInputEventIndex(i, sgsOffsets_);
       auto& step = out[i];
       step.simParticle() = remap(step.simParticle(), simOffsets_[ie]);
       if(applyTimeOffset_){
@@ -438,7 +438,20 @@ namespace mu2e {
                      StrawDigiMCCollection& out,
                      art::PtrRemapper const& remap)
   {
-    art::flattenCollections(in, out);
+    std::vector<StrawDigiMCCollection::size_type> sdmcOffsets;
+    art::flattenCollections(in, out, sdmcOffsets);
+
+    // update internal art::Ptr<StrawGasStep>s
+    for (StrawDigiMCCollection::size_type i=0; i < out.size(); ++i) {
+      auto& sdmc = out[i];
+      auto ie = getInputEventIndex(i, sdmcOffsets);
+      auto sgsOffset = sgsOffsets_[ie];
+
+      auto& steps = sdmc.strawGasSteps();
+      steps[StrawEnd::cal] = remap(steps[StrawEnd::cal], sgsOffset);
+      steps[StrawEnd::hv]  = remap(steps[StrawEnd::hv],  sgsOffset);
+    }
+
     return true;
   }
 

--- a/MCDataProducts/inc/StrawDigiMC.hh
+++ b/MCDataProducts/inc/StrawDigiMC.hh
@@ -49,6 +49,7 @@ namespace mu2e {
 
     SGSP const&  strawGasStep(StrawEnd strawend) const { return _sgspa[strawend]; }
     SGSPA const&  strawGasSteps() const { return _sgspa; }
+    SGSPA&        strawGasSteps()       { return _sgspa; }
     StrawEnd earlyEnd() const { return (_wtime[StrawEnd::cal] < _wtime[StrawEnd::hv]) ?  StrawEnd::cal : StrawEnd::hv; }
     SGSP const&  earlyStrawGasStep() const { return strawGasStep(earlyEnd()); }
     double energySum() const;// sum of all MC true energy deposited


### PR DESCRIPTION
This PR improves the mixing of `StrawDigiMC`s by remapping internal `art::Ptr<>` data members thereof. Provisions for mixing tracker-related digi data products were introduced in https://github.com/Mu2e/Offline/pull/1245. When following up about the propagation of MC truth info in https://github.com/Mu2e/Offline/pull/1291, it was realized that the mixed `StrawDigiMC`s contained invalid `art::Ptr<>`s, which is solved by the functionality implemented here.

Changes to existing functionality:
-`Mu2eProductMixer::mixStrawDigiMCs`: A loop over the mixed `StrawDigiMC`s is introduced, which utilizes `art::PtrRemapper` to update internal `art::Ptr<StrawGasStep>` fields to point into the newly-inserted (as of mixing) `StrawGasStepCollection` data product.

Changes to existing data products:
-`StrawDigiMC`: A non-const method `StrawDigiMC::strawGasSteps()` is introduced, which effectively returns a non-const reference to the relevant `art::Ptr<>`s. A mechanism for updating the `StrawDigiMC::_sgspa` field in-place must be made; the implementation of a non-const reference return is meant to mirror the analogous functionality when remapping internal `art::Ptr<>`s of `SimParticle`s during mixing.