### PR TITLE
Adjust cal tables

### DIFF
--- a/CaloConditions/fcl/prolog.fcl
+++ b/CaloConditions/fcl/prolog.fcl
@@ -3,7 +3,6 @@ BEGIN_PROLOG
 calCalib : {
   verbose: 0
   useDb: false
-  energyalgorithm: 1
   ADC2MeV: 0.0625
   timeoffset: 0.0
 }

--- a/CaloConditions/inc/CalCalib.hh
+++ b/CaloConditions/inc/CalCalib.hh
@@ -39,10 +39,6 @@ namespace mu2e {
         return _cvec.at(roid).timeOffset();
       }
 
-      float ECombAlgID(std::uint16_t roid) const {
-        return _cvec.at(roid).ECombAlgID();
-      }
-
       void print( std::ostream& ) const;
 
   private:

--- a/CaloConditions/inc/CalCalibPar.hh
+++ b/CaloConditions/inc/CalCalibPar.hh
@@ -9,17 +9,13 @@ namespace mu2e {
 
 class CalCalibPar {
  public:
-  CalCalibPar(float ADC2MeV, int ECombAlgID,
-              float timeOffset) :
+  CalCalibPar(float ADC2MeV, float timeOffset) :
       _ADC2MeV(ADC2MeV),
-      _ECombAlgID(ECombAlgID),
       _timeOffset(timeOffset) {}
   float ADC2MeV() const { return _ADC2MeV; }
-  int ECombAlgID() const { return _ECombAlgID; }
   float timeOffset() const { return _timeOffset; }
 
   float _ADC2MeV;
-  int  _ECombAlgID;
   float _timeOffset;
 };
 

--- a/CaloConditions/src/CalCalibMaker.cc
+++ b/CaloConditions/src/CalCalibMaker.cc
@@ -13,7 +13,7 @@ namespace mu2e {
   if (_config.verbose()) {
     std::cout << "CalCalibMaker::fromFcl making nominal CalCalib\n";
   }
-  CalCalibPar nominal(_config.ADC2MeV(), _config.ECombAlgID(), _config.timeoffset());
+  CalCalibPar nominal(_config.ADC2MeV(), _config.timeoffset());
 
   size_t nChan = CaloConst::_nChannel;
 
@@ -21,7 +21,6 @@ namespace mu2e {
     std::cout << "CalCalibMaker::fromFcl filling " << nChan << " channels\n";
     std::cout << "CalCalibMaker::fromFcl nominal " << fixed << setprecision(3)
          << setw(10) << nominal.ADC2MeV() << setprecision(3) << setw(10)
-         << nominal.ECombAlgID() << setprecision(3) << setw(10)
          << nominal.timeOffset() << setprecision(3) << setw(10) << "\n";
   }
 
@@ -54,10 +53,10 @@ namespace mu2e {
         << "  geometry: " << nChan << "  CalSiPM: " << ecalib->nrow()<< "\n";
   }
 
-  CalCalib::CalibVec cvec(nChan, CalCalibPar(0.0, 0.0, 0.0));
+  CalCalib::CalibVec cvec(nChan, CalCalibPar(0.0, 0.0));
 
   for (auto const& row : ecalib->rows()) {
-    cvec[row.roid().id()] = CalCalibPar(row.ADC2MeV(), row.algID(),0); //TODO - time offset needs setting from time table
+    cvec[row.roid().id()] = CalCalibPar(row.ADC2MeV(), 0); //TODO - time offset needs setting from time table
   }
 
   auto ptr = make_shared<CalCalib>(cvec);

--- a/CaloConfig/inc/CalCalibConfig.hh
+++ b/CaloConfig/inc/CalCalibConfig.hh
@@ -13,12 +13,11 @@ namespace mu2e {
   struct CalCalibConfig {
     using Name=fhicl::Name;
     using Comment=fhicl::Comment;
-    fhicl::Atom<int> verbose{Name("verbose"), Comment("verbosity: 0 or 1")}; 
-    fhicl::Atom<bool> useDb{Name("useDb"), Comment("use database or fcl")}; 
+    fhicl::Atom<int> verbose{Name("verbose"), Comment("verbosity: 0 or 1")};
+    fhicl::Atom<bool> useDb{Name("useDb"), Comment("use database or fcl")};
     //fhicl::Atom<uint16_t> roid {Name("roid"), Comment("unique offline readout ID")};
     fhicl::Atom<float> ADC2MeV {Name("ADC2MeV"), Comment("constant per SiPM")};
     fhicl::Atom<float> timeoffset {Name("timeoffset"), Comment("constant per SiPM")};
-    fhicl::Atom<int> ECombAlgID{Name("energyalgorithm"), Comment("codename of the energy combination alogrithm used for these results") };
   };
 
 }

--- a/DbTables/inc/CalEnergyCalib.hh
+++ b/DbTables/inc/CalEnergyCalib.hh
@@ -25,22 +25,18 @@ namespace mu2e {
 
     class Row {
     public:
-      Row(CaloSiPMId  roid, float ADC2MeV, float ErrADC2MeV, int algID):_roid(roid),_ADC2MeV(ADC2MeV), _ErrADC2MeV(ErrADC2MeV),_algID(algID) {}
+      Row(CaloSiPMId  roid, float ADC2MeV):_roid(roid),_ADC2MeV(ADC2MeV) {}
       CaloSiPMId   roid() const { return _roid;}
       float ADC2MeV() const { return _ADC2MeV; }
-      float ErrADC2MeV() const { return _ErrADC2MeV; }
-      int algID() const { return _algID; }
 
     private:
       CaloSiPMId   _roid;
       float _ADC2MeV;
-      float _ErrADC2MeV;
-      int _algID;
     };
 
     constexpr static const char* cxname = "CalEnergyCalib";
 
-    CalEnergyCalib():DbTable(cxname,"cal.energycalib","roid,adc2mev,erradc2mev,algid"){}
+    CalEnergyCalib():DbTable(cxname,"cal.energycalib","roid,adc2mev"){}
 
     const Row& row(CaloSiPMId id) const {
                 return _rows[id.id()];
@@ -57,7 +53,7 @@ namespace mu2e {
     if (index!=int(_rows.size())) {
         throw cet::exception("CALOENERGYCALIB_BAD_INDEX")<<"CalEnergyCalib::addRow found index out of order:"<<index << " != " << int(_rows.size()) <<"\n";
       }
-       _rows.emplace_back(CaloSiPMId(index),std::stof(columns[1]),std::stof(columns[2]),std::stoi(columns[3]));
+       _rows.emplace_back(CaloSiPMId(index),std::stof(columns[1]));
 
     }
 
@@ -66,9 +62,7 @@ namespace mu2e {
       Row const& r = _rows.at(irow);
       sstream << std::fixed << std::setprecision(5);
       sstream << r.roid()<<",";
-      sstream << r.ADC2MeV()<<",";
-      sstream << r.ErrADC2MeV()<<",";
-      sstream << r.algID();
+      sstream << r.ADC2MeV();
     }
 
     virtual void clear() override { baseClear(); _rows.clear();}

--- a/DbTables/inc/CalLaserTimeCalib.hh
+++ b/DbTables/inc/CalLaserTimeCalib.hh
@@ -1,6 +1,7 @@
 #ifndef DbTables_CalLaserTimeCalib_hh
 #define DbTables_CalLaserTimeCalib_hh
 
+// calorimater archive table for time study from a laser run
 
 #include <string>
 #include <iomanip>
@@ -16,24 +17,26 @@ namespace mu2e {
 
       class Row {
         public:
-        Row(CaloSiPMId  roid, double T0, double ErrT0, double chisq):
-        _roid(roid),_T0(T0),_ErrT0(ErrT0),_chisq(chisq) {}
+        Row(CaloSiPMId  roid, double T0, double ErrT0, double chisq, int nev):
+          _roid(roid),_T0(T0),_ErrT0(ErrT0),_chisq(chisq),_nev(nev) {}
         CaloSiPMId       roid()     const { return _roid;} // Offline ID
         float     T0()     const { return _T0; }
         float     ErrT0()  const { return _ErrT0; }
         float     chisq()     const { return _chisq; }
+        int       nev()     const { return _nev; }
 
       private:
         CaloSiPMId _roid;
         float _T0;
         float _ErrT0;
         float _chisq;
+        int   _nev;
     };
 
     constexpr static const char* cxname = "CalLaserTimeCalib";
 
     CalLaserTimeCalib():DbTable(cxname,"calolasertimecalib",
-    "roid,t0,errt0,chisq") {}
+    "roid,t0,errt0,chisq,nev") {}
 
     const Row& row(CaloSiPMId  roid) const {
                 return _rows.at(roid.id()); }
@@ -53,7 +56,8 @@ namespace mu2e {
       _rows.emplace_back(CaloSiPMId(index),
       std::stof(columns[1]),
       std::stof(columns[2]),
-      std::stof(columns[3]));
+      std::stof(columns[3]),
+      std::stoi(columns[4]));
     }
 
     void rowToCsv(std::ostringstream& sstream, std::size_t irow) const override {
@@ -62,7 +66,8 @@ namespace mu2e {
       sstream << r.roid()<<",";
       sstream << r.T0()<<",";
       sstream << r.ErrT0()<<",";
-      sstream << r.chisq();
+      sstream << r.chisq()<<",";
+      sstream << r.nev();
     }
 
     virtual void clear() override { baseClear(); _rows.clear();}

--- a/DbTables/inc/CalTimeCalib.hh
+++ b/DbTables/inc/CalTimeCalib.hh
@@ -3,7 +3,7 @@
 
 
 /*
-per SiPM calibration constants reco table -
+per SiPM time calibration constants reco table -
 S Middleton 2023
 
 */

--- a/DbTables/inc/CalTimeCalib.hh
+++ b/DbTables/inc/CalTimeCalib.hh
@@ -1,0 +1,76 @@
+#ifndef DbTables_CalTimeCalib_hh
+#define DbTables_CalTimeCalib_hh
+
+
+/*
+per SiPM calibration constants reco table -
+S Middleton 2023
+
+*/
+
+#include <string>
+#include <iomanip>
+#include <sstream>
+#include <map>
+#include "cetlib_except/exception.h"
+#include "Offline/DbTables/inc/DbTable.hh"
+#include "Offline/DataProducts/inc/CaloSiPMId.hh"
+
+namespace mu2e {
+
+  class CalTimeCalib : public DbTable {
+  public:
+  typedef std::shared_ptr<CalTimeCalib> ptr_t;
+  typedef std::shared_ptr<const CalTimeCalib> cptr_t;
+
+    class Row {
+    public:
+      Row(CaloSiPMId  roid, float tcorr):_roid(roid),_tcorr(tcorr) {}
+      CaloSiPMId   roid() const { return _roid;}
+      float tcorr() const { return _tcorr; } // correction in ns
+
+    private:
+      CaloSiPMId   _roid;
+      float _tcorr;
+    };
+
+    constexpr static const char* cxname = "CalTimeCalib";
+
+    CalTimeCalib():DbTable(cxname,"cal.timecalib","roid,tcorr"){}
+
+    const Row& row(CaloSiPMId id) const {
+                return _rows[id.id()];
+    }
+    std::vector<Row> const& rows() const {return _rows;}
+    std::size_t nrow() const override { return _rows.size(); };
+    size_t size() const override { return baseSize() + nrow()*sizeof(Row); };
+    virtual std::size_t nrowFix() const override { return CaloConst::_nChannel; };
+    const std::string orderBy() const { return std::string("roid"); }
+
+    void addRow(const std::vector<std::string>& columns) override {
+      std::uint16_t index = std::stoul(columns[0]);
+    // enforce order, so channels can be looked up by index
+    if (index!=int(_rows.size())) {
+        throw cet::exception("CALOTIMECALIB_BAD_INDEX")<<"CalTimeCalib::addRow found index out of order:"<<index << " != " << int(_rows.size()) <<"\n";
+      }
+       _rows.emplace_back(CaloSiPMId(index),std::stof(columns[1]));
+
+    }
+
+
+    void rowToCsv(std::ostringstream& sstream, std::size_t irow) const override {
+      Row const& r = _rows.at(irow);
+      sstream << std::fixed << std::setprecision(5);
+      sstream << r.roid()<<",";
+      sstream << r.tcorr();
+    }
+
+    virtual void clear() override { baseClear(); _rows.clear();}
+
+  private:
+    std::vector<Row> _rows;
+
+  };
+
+}
+#endif

--- a/DbTables/src/DbTableFactory.cc
+++ b/DbTables/src/DbTableFactory.cc
@@ -11,11 +11,13 @@
 
 #include "Offline/DbTables/inc/CalSourceEnergyCalib.hh"
 #include "Offline/DbTables/inc/CalCosmicEnergyCalib.hh"
+#include "Offline/DbTables/inc/CalCosmicTimeCalib.hh"
 #include "Offline/DbTables/inc/CalLaserEnergyCalib.hh"
 #include "Offline/DbTables/inc/CalCosmicTimeCalib.hh"
 #include "Offline/DbTables/inc/CalLaserTimeCalib.hh"
 #include "Offline/DbTables/inc/CalLaserEnergyCalib.hh"
 #include "Offline/DbTables/inc/CalEnergyCalib.hh"
+#include "Offline/DbTables/inc/CalTimeCalib.hh"
 #include "Offline/DbTables/inc/CalCosmicT0Align.hh"
 
 #include "Offline/DbTables/inc/TrkAlignElement.hh"
@@ -102,6 +104,8 @@ mu2e::DbTable::ptr_t mu2e::DbTableFactory::newTable(std::string const& name) {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::CalLaserTimeCalib());
   } else if (name=="CalEnergyCalib") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::CalEnergyCalib());
+  } else if (name=="CalTimeCalib") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::CalTimeCalib());
   } else if (name=="CalCosmicT0Align") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::CalCosmicT0Align());
   }else {


### PR DESCRIPTION
 - create reco time calibration CalTimeCalib
 - adjust columns remove algoId from reco energy table, add nev to CalLaserTimeCalib archive
 - make changes  to the proditions for removing the algoID
 
to-do for next PR:
- add time to proditions
- understand needs for CalCosmicTimeCalib, CalCosmicT0Align
- add ad-hoc table for labeling laser runs

The tables do not exist in the database and are not used in validation so this should have no visible effect