### PR TITLE
Introduce SurfaceStep

### DIFF
--- a/CommonMC/fcl/TestSurfaceSteps.fcl
+++ b/CommonMC/fcl/TestSurfaceSteps.fcl
@@ -1,0 +1,29 @@
+#include "Offline/fcl/standardServices.fcl"
+#include "Offline/CommonMC/fcl/prolog.fcl"
+services.DbService.purpose: MDC2020_best
+services.DbService.version: v1_3
+
+process_name: TSS
+source : { module_type : RootInput }
+services : @local::Services.Reco
+physics :
+{
+  producers : {
+    MakeSS : @local::CommonMC.MakeSS
+  }
+  TrigPath : [MakeSS]
+  analyzers : {
+    printSSteps : {
+      module_type : PrintModule
+      surfaceStepPrinter : {
+        verbose : 1
+      }
+    }
+    SSDiag : @local::CommonMC.SSDiag
+  }
+  EndPath : [printSSteps, SSDiag]
+  end_paths : [EndPath]
+  trigger_paths : [TrigPath]
+}
+services.TimeTracker.printSummary: true
+services.TFileService.fileName: "nts.owner.SurfaceStepDiag.version.sequence.root"

--- a/CommonMC/fcl/prolog.fcl
+++ b/CommonMC/fcl/prolog.fcl
@@ -34,7 +34,7 @@ CommonMC: {
     IPAStepPointMCs : "compressDigiMCs:protonabsorber"
     TargetStepPointMCs : "compressDigiMCs:stoppingtarget"
     MaxDistGap : 0.1
-    MaxTimeGap : 0.01
+    MaxTimeGap : 0.1
   }
   SSDiag : {
     module_type : SurfaceStepDiag

--- a/CommonMC/fcl/prolog.fcl
+++ b/CommonMC/fcl/prolog.fcl
@@ -6,24 +6,25 @@ nonProtonGenIds : ["unknown", "particleGun", "cosmicToy", "cosmicDYB", "cosmic",
 muLifeGenIds : [ "StoppedParticleReactionGun", "dioTail", "ExternalRMC", "InternalRMC",
   "MuCapProtonGenTool", "MuCapDeuteronGenTool", "DIOGenTool", "MuCapNeutronGenTool", "MuCapPhotonGenTool", "MuCapGammaRayGenTool" ]
 CommonMC: {
-  producers: {
-    #
-    # time offset producers
-    protonTimeOffset : {
-        module_type: ProtonTimeOffset
-        randPDFparameters : {
-            pulseType : default
-            limitingHalfWidth : 125.0
-            potPulse  : "Offline/Mu2eUtilities/data/potTimingDistribution_20160511.txt"
-            acDipole  : "Offline/Mu2eUtilities/data/acDipoleTransmissionFunction_20160511.txt"
-        }
-    }
-    cosmicTimeOffset : { module_type: CosmicTimeOffset }
-    # Event window marker
+  #
+  # producers
+  #
+  # Event window marker
+  DigiProducers : {
     EWMProducer : {
       module_type : EventWindowMarkerProducer
       RecoFromMCTruth : true
       RecoFromMCTruthErr : 0.5
+    }
+  }
+
+  protonTimeOffset : {
+    module_type: ProtonTimeOffset
+    randPDFparameters : {
+      pulseType : default
+      limitingHalfWidth : 125.0
+      potPulse  : "Offline/Mu2eUtilities/data/potTimingDistribution_20160511.txt"
+      acDipole  : "Offline/Mu2eUtilities/data/acDipoleTransmissionFunction_20160511.txt"
     }
   }
 
@@ -35,13 +36,6 @@ CommonMC: {
     TargetStepPointMCs : "compressDigiMCs:stoppingtarget"
     MaxDistGap : 0.1 # mm
     MaxTimeGap : 0.1 # ns
-  }
-  SSDiag : {
-    module_type : SurfaceStepDiag
-    SurfaceStepCollection : "MakeSS"
-    VDStepPointMCs : "compressDigiMCs:virtualdetector"
-    IPAStepPointMCs : "compressDigiMCs:protonabsorber"
-    TargetStepPointMCs : "compressDigiMCs:stoppingtarget"
   }
 
   FindMCPrimary : {
@@ -61,6 +55,18 @@ CommonMC: {
     debugLevel : 0
   }
   DigiSim : [ EWMProducer  ]
+  #
+  # Analyzers
+  #
+  SSDiag : {
+    module_type : SurfaceStepDiag
+    SurfaceStepCollection : "MakeSS"
+    VDStepPointMCs : "compressDigiMCs:virtualdetector"
+    IPAStepPointMCs : "compressDigiMCs:protonabsorber"
+    TargetStepPointMCs : "compressDigiMCs:stoppingtarget"
+  }
+
+
 }
 #------------------------------------------------------------------------------
 

--- a/CommonMC/fcl/prolog.fcl
+++ b/CommonMC/fcl/prolog.fcl
@@ -26,6 +26,21 @@ CommonMC: {
       RecoFromMCTruthErr : 0.5
     }
   }
+
+  MakeSS : {
+    module_type : MakeSurfaceSteps
+    debugLevel : 0
+    VDStepPointMCs : "compressDigiMCs:virtualdetector"
+    IPAStepPointMCs : "compressDigiMCs:protonabsorber"
+    TargetStepPointMCs : "compressDigiMCs:stoppingtarget"
+    MaxDistGap : 0.1
+    MaxTimeGap : 0.01
+  }
+  SSDiag : {
+    module_type : SurfaceStepDiag
+    SurfaceStepCollection : "MakeSS"
+  }
+
   FindMCPrimary : {
     module_type : FindMCPrimary
     debugLevel : 0

--- a/CommonMC/fcl/prolog.fcl
+++ b/CommonMC/fcl/prolog.fcl
@@ -33,12 +33,15 @@ CommonMC: {
     VDStepPointMCs : "compressDigiMCs:virtualdetector"
     IPAStepPointMCs : "compressDigiMCs:protonabsorber"
     TargetStepPointMCs : "compressDigiMCs:stoppingtarget"
-    MaxDistGap : 0.1
-    MaxTimeGap : 0.1
+    MaxDistGap : 0.1 # mm
+    MaxTimeGap : 0.1 # ns
   }
   SSDiag : {
     module_type : SurfaceStepDiag
     SurfaceStepCollection : "MakeSS"
+    VDStepPointMCs : "compressDigiMCs:virtualdetector"
+    IPAStepPointMCs : "compressDigiMCs:protonabsorber"
+    TargetStepPointMCs : "compressDigiMCs:stoppingtarget"
   }
 
   FindMCPrimary : {

--- a/CommonMC/src/MakeSurfaceSteps_module.cc
+++ b/CommonMC/src/MakeSurfaceSteps_module.cc
@@ -1,0 +1,148 @@
+
+//
+//  This module creates SurfaceStep objects from G4 StepPointMCs
+//
+//  Original author: David Brown (LBNL) 7/2024
+//
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Handle.h"
+#include "cetlib_except/exception.h"
+#include "fhiclcpp/types/Atom.h"
+#include "canvas/Utilities/InputTag.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "Offline/GlobalConstantsService/inc/ParticleData.hh"
+#include "Offline/DataProducts/inc/SurfaceId.hh"
+#include "Offline/MCDataProducts/inc/SurfaceStep.hh"
+#include <utility>
+#include <cmath>
+
+namespace mu2e {
+
+  class MakeSurfaceSteps : public art::EDProducer {
+    public:
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      struct Config {
+        fhicl::Atom<int> debug{ Name("debugLevel"), Comment("Debug Level"), 0};
+        fhicl::Atom<art::InputTag> vdstepmcs { Name("VDStepPointMCs"), Comment("Virtual Detector StepPointMC collection")};
+        fhicl::Atom<art::InputTag> ipastepmcs { Name("IPAStepPointMCs"), Comment("IPAStepPointMC collection")};
+        fhicl::Atom<art::InputTag> ststepmcs { Name("TargetStepPointMCs"), Comment("Stopping target StepPointMC collection")};
+        fhicl::Atom<double> maxdgap{ Name("MaxDistGap"), Comment("Maximum dstance gap between aggregated StepPointMCs")};
+        fhicl::Atom<double> maxtgap{ Name("MaxTimeGap"), Comment("Maximum time gap between aggregated StepPointMCs")};
+      };
+      using Parameters = art::EDProducer::Table<Config>;
+      explicit MakeSurfaceSteps(const Parameters& conf);
+
+    private:
+      void produce(art::Event& e) override;
+      using SSPair = std::pair<SurfaceId,cet::map_vector_key>; // key for pair of surfaceId, SimParticle
+      using SPMCP = art::Ptr<StepPointMC>;
+      using SPMCPV = std::vector<SPMCP>;
+      using SPSMap = std::map< SSPair , SPMCPV >; // steps by surface, SimParticle
+      using SPMCCH = art::Handle<StepPointMCCollection>;
+      using SPMCCHV = std::vector< SPMCCH >;
+      void fillMap(SPMCCH const& spmcch, SPSMap& spsmap);
+      void fillStep(SPMCPV const& spmcptrs,
+          ParticleData const& pdata, cet::map_vector_key pid, SurfaceStep& sgs);
+      int debug_;
+      double maxdgap_;
+      double maxtgap_;
+      art::InputTag vdstepmcs_, ipastepmcs_, ststepmcs_;
+      std::map<VirtualDetectorId,SurfaceId> vdmap_; // map of VDIds to surfaceIds
+  };
+
+  MakeSurfaceSteps::MakeSurfaceSteps(const Parameters& config )  :
+    art::EDProducer{config},
+    debug_(config().debug()),
+    maxdgap_(config().maxdgap()),
+    maxtgap_(config().maxtgap()),
+    vdstepmcs_(config().vdstepmcs()),
+    ipastepmcs_(config().ipastepmcs()),
+    ststepmcs_(config().ststepmcs())
+    {
+      consumesMany<StepPointMCCollection>();
+      produces <SurfaceStepCollection>();
+      // build the VDId -> SId map by hand. This should come from a service TODO
+      vdmap_[VirtualDetectorId(VirtualDetectorId::TT_FrontHollow)] = SurfaceId("TT_Front");
+      vdmap_[VirtualDetectorId(VirtualDetectorId::TT_Mid)] = SurfaceId("TT_Mid");
+      vdmap_[VirtualDetectorId(VirtualDetectorId::TT_MidInner)] = SurfaceId("TT_Mid");
+      vdmap_[VirtualDetectorId(VirtualDetectorId::TT_Back)] = SurfaceId("TT_Back");
+      vdmap_[VirtualDetectorId(VirtualDetectorId::TT_OutSurf)] = SurfaceId("TT_Outer");
+      vdmap_[VirtualDetectorId(VirtualDetectorId::TT_InSurf)] = SurfaceId("TT_Inner");
+    }
+
+  void MakeSurfaceSteps::produce(art::Event& event) {
+    // create output
+    std::unique_ptr<SurfaceStepCollection> ssc(new SurfaceStepCollection);
+    // start with virtual detectors; these are copied directly
+    auto const& vdspmccol_h = event.getValidHandle<StepPointMCCollection>(vdstepmcs_);
+    auto const& vdspmccol = *vdspmccol_h;
+    for(auto const& vdspmc : vdspmccol) {
+      // only some VDs are kept
+      auto isid = vdmap_.find(vdspmc.virtualDetectorId());
+      if(isid != vdmap_.end())ssc->emplace_back(isid->second,vdspmc); // no aggregation of VD hits
+    }
+    // now IPA
+    // colate adjacent IPA steppointMCs from the same particle. The following assumes the StepPointMCs from the same SimParticle are adjacent and (roughly) time-ordered. This is observationally true currently, but if G4 ever evolves so that its not, this code will need reworking
+    auto const& ipaspmccol_h = event.getValidHandle<StepPointMCCollection>(ipastepmcs_);
+    auto const& ipaspmccol = *ipaspmccol_h;
+    // match steps by their sim particle. There is only 1 volume for IPA
+    SurfaceStep ipastep;
+    for(auto const& spmc : ipaspmccol) {
+      // decide if this step is contiguous to existing steps already aggregated
+      // first, test SimParticle (surface is defined by the collection)
+      bool contstep = ipastep.simParticle() == spmc.simParticle();
+      // then time;
+      if(contstep)contstep = fabs(ipastep.time()-spmc.time()) < maxtgap_;
+      // them space
+      if(contstep){
+        if(spmc.time() > ipastep.time())
+          contstep = (ipastep.endPosition() - XYZVectorF(spmc.position())).R() < maxdgap_;
+        else
+          contstep = (ipastep.startPosition() - XYZVectorF(spmc.postPosition())).R() < maxdgap_;
+      }
+      if(contstep){
+        // accumulate this step into the existing surface step
+        ipastep.addStep(spmc,maxdgap_,maxtgap_);
+      } else {
+        // if the existing step is valid, save it
+        if(ipastep.surfaceId() != SurfaceIdDetail::unknown && ipastep.simParticle().isNonnull())ssc->push_back(ipastep);
+        // start a new SurfaceStep for this step
+        ipastep = SurfaceStep(SurfaceId(SurfaceIdDetail::IPA),spmc);
+      }
+    }
+    // same for stopping target. Here, the foil number (= volumeid) matters
+    auto const& stspmccol_h = event.getValidHandle<StepPointMCCollection>(ststepmcs_);
+    auto const& stspmccol = *stspmccol_h;
+    // match steps by their sim particle. There is only 1 volume for IPA
+    SurfaceStep ststep;
+    for(auto const& spmc : stspmccol) {
+      // decide if this step is contiguous to existing steps already aggregated
+      // first, test SimParticle and foil number
+      bool contstep = ststep.simParticle() == spmc.simParticle() && ststep.surfaceId().index() == (int)spmc.volumeId();
+      // then time;
+      if(contstep)contstep = fabs(ststep.time()-spmc.time()) < maxtgap_;
+      // them space
+      if(contstep){
+        if(spmc.time() > ststep.time())
+          contstep = (ststep.endPosition() - XYZVectorF(spmc.position())).R() < maxdgap_;
+        else
+          contstep = (ststep.startPosition() - XYZVectorF(spmc.postPosition())).R() < maxdgap_;
+      }
+      if(contstep){
+        // accumulate this step into the existing surface step
+        ststep.addStep(spmc,maxdgap_,maxtgap_);
+      } else {
+        // if the existing step is valid, save it
+        if(ststep.surfaceId() != SurfaceIdDetail::unknown && ststep.simParticle().isNonnull())ssc->push_back(ststep);
+        // start a new SurfaceStep for this step
+        ststep = SurfaceStep(SurfaceId(SurfaceIdDetail::ST_Foils,spmc.volumeId()),spmc);
+      }
+    }
+    // finish
+    event.put(move(ssc));
+  }
+
+}
+DEFINE_ART_MODULE(mu2e::MakeSurfaceSteps)

--- a/CommonMC/src/MakeSurfaceSteps_module.cc
+++ b/CommonMC/src/MakeSurfaceSteps_module.cc
@@ -13,8 +13,8 @@
 #include "Offline/GlobalConstantsService/inc/ParticleData.hh"
 #include "Offline/DataProducts/inc/SurfaceId.hh"
 #include "Offline/MCDataProducts/inc/SurfaceStep.hh"
-#include <utility>
-#include <cmath>
+#include "Offline/GeometryService/inc/DetectorSystem.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 
 namespace mu2e {
 
@@ -72,6 +72,7 @@ namespace mu2e {
     }
 
   void MakeSurfaceSteps::produce(art::Event& event) {
+    GeomHandle<DetectorSystem> det;
     // create output
     std::unique_ptr<SurfaceStepCollection> ssc(new SurfaceStepCollection);
     // start with virtual detectors; these are copied directly
@@ -80,7 +81,7 @@ namespace mu2e {
     for(auto const& vdspmc : vdspmccol) {
       // only some VDs are kept
       auto isid = vdmap_.find(vdspmc.virtualDetectorId());
-      if(isid != vdmap_.end())ssc->emplace_back(isid->second,vdspmc); // no aggregation of VD hits
+      if(isid != vdmap_.end())ssc->emplace_back(isid->second,vdspmc,det); // no aggregation of VD hits
     }
     auto nvdsteps = ssc->size();
     if(debug_ > 0)std::cout << "Added " << nvdsteps << " VD steps " << std::endl;
@@ -105,7 +106,7 @@ namespace mu2e {
         if(tgap < maxtgap_ && dgap < maxdgap_){
           // accumulate this step into the existing surface step
           if(debug_ > 1)std::cout <<"Added step" << std::endl;
-          ipastep.addStep(spmc,maxdgap_,maxtgap_);
+          ipastep.addStep(spmc,det,maxdgap_,maxtgap_);
           added = true;
         }
       }
@@ -113,7 +114,7 @@ namespace mu2e {
         // if the existing step is valid, save it
         if(ipastep.surfaceId() != SurfaceIdDetail::unknown && ipastep.simParticle().isNonnull())ssc->push_back(ipastep);
         // start a new SurfaceStep for this step
-        ipastep = SurfaceStep(SurfaceId(SurfaceIdDetail::IPA),spmc);
+        ipastep = SurfaceStep(SurfaceId(SurfaceIdDetail::IPA),spmc,det);
         if(debug_ > 1)std::cout <<"New step" << std::endl;
       }
     }
@@ -141,7 +142,7 @@ namespace mu2e {
         if(tgap < maxtgap_ && dgap < maxdgap_){
           // accumulate this step into the existing surface step
           if(debug_ > 1)std::cout <<"Added step" << std::endl;
-          ststep.addStep(spmc,maxdgap_,maxtgap_);
+          ststep.addStep(spmc,det,maxdgap_,maxtgap_);
           added = true;
         }
       }
@@ -149,7 +150,7 @@ namespace mu2e {
         // if the existing step is valid, save it
         if(ststep.surfaceId() != SurfaceIdDetail::unknown && ststep.simParticle().isNonnull())ssc->push_back(ststep);
         // start a new SurfaceStep for this step
-        ststep = SurfaceStep(SurfaceId(SurfaceIdDetail::ST_Foils,spmc.volumeId()),spmc);
+        ststep = SurfaceStep(SurfaceId(SurfaceIdDetail::ST_Foils,spmc.volumeId()),spmc,det);
         if(debug_ > 1)std::cout <<"New step" << std::endl;
       }
     }

--- a/CommonMC/src/SurfaceStepDiag_module.cc
+++ b/CommonMC/src/SurfaceStepDiag_module.cc
@@ -1,0 +1,78 @@
+//
+// SurfaceStep diags
+//
+// Original author D. Brown
+//
+// framework
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "Offline/DataProducts/inc/GenVector.hh"
+#include "art_root_io/TFileService.h"
+#include "TTree.h"
+// data
+#include "Offline/MCDataProducts/inc/SurfaceStep.hh"
+
+namespace mu2e
+{
+  class SurfaceStepDiag : public art::EDAnalyzer {
+    public:
+      using SPM = std::map<art::Ptr<SimParticle>,unsigned>;
+
+      struct Config {
+        using Name = fhicl::Name;
+        using Comment = fhicl::Comment;
+        fhicl::Atom<art::InputTag> SurfaceStepCollection{   Name("SurfaceStepCollection"),   Comment("SurfaceStep collection name") };
+      };
+
+      explicit SurfaceStepDiag(const art::EDAnalyzer::Table<Config>& config);
+      virtual ~SurfaceStepDiag();
+      virtual void beginJob();
+      virtual void analyze(const art::Event& e);
+    private:
+      art::ProductToken<SurfaceStepCollection> sstag_;
+      TTree *ssdiag_;
+      int evt_, sid_, sindex_;
+      float edep_, path_;
+      XYZVectorF mom_, pos_;
+  };
+
+  SurfaceStepDiag::SurfaceStepDiag(const art::EDAnalyzer::Table<Config>& config) :
+    art::EDAnalyzer(config),
+    sstag_{ consumes<SurfaceStepCollection>(config().SurfaceStepCollection() ) }
+  {}
+
+  SurfaceStepDiag::~SurfaceStepDiag(){}
+
+  void SurfaceStepDiag::beginJob() {
+    // create diagnostics if requested
+    art::ServiceHandle<art::TFileService> tfs;
+    // detailed diagnostics
+    ssdiag_=tfs->make<TTree>("ssdiag","SurfaceStep diagnostics");
+    ssdiag_->Branch("evt",&evt_,"evt/I");
+    ssdiag_->Branch("sid",&sid_,"sid/I");
+    ssdiag_->Branch("sindex",&sindex_,"sindex/I");
+    ssdiag_->Branch("edep",&edep_,"edep/F");
+    ssdiag_->Branch("path",&path_,"path/F");
+    ssdiag_->Branch("mom.",&mom_);
+    ssdiag_->Branch("pos.",&pos_);
+  }
+
+  void SurfaceStepDiag::analyze(const art::Event& evt ) {
+    auto sscolH = evt.getValidHandle(sstag_);
+    auto const& sscol = *sscolH.product();
+    evt_ = evt.id().event();  // add event id
+    for(auto const& ss : sscol) {
+      sid_ = ss.surfaceId().id();
+      sindex_ = ss.surfaceId().index();
+      edep_ = ss.energyDeposit();
+      path_ = ss.pathLength();
+      mom_ = ss.momentum();
+      pos_ = ss.startPosition();
+      ssdiag_->Fill();
+    }
+  }
+}
+// Part of the magic that makes this class a module.
+using mu2e::SurfaceStepDiag;
+DEFINE_ART_MODULE(SurfaceStepDiag)

--- a/CommonMC/src/SurfaceStepDiag_module.cc
+++ b/CommonMC/src/SurfaceStepDiag_module.cc
@@ -8,8 +8,11 @@
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Core/EDAnalyzer.h"
 #include "Offline/DataProducts/inc/GenVector.hh"
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/OptionalAtom.h"
 #include "art_root_io/TFileService.h"
 #include "TTree.h"
+#include "TH1F.h"
 // data
 #include "Offline/MCDataProducts/inc/SurfaceStep.hh"
 
@@ -23,6 +26,9 @@ namespace mu2e
         using Name = fhicl::Name;
         using Comment = fhicl::Comment;
         fhicl::Atom<art::InputTag> SurfaceStepCollection{   Name("SurfaceStepCollection"),   Comment("SurfaceStep collection name") };
+        fhicl::OptionalAtom<art::InputTag> VDStepCollection{   Name("VDStepCollection"),   Comment("Virtual Detector StepPointMC collection name") };
+        fhicl::OptionalAtom<art::InputTag> IPAStepCollection{   Name("IPAStepCollection"),   Comment("IPA StepPointMC collection name") };
+        fhicl::OptionalAtom<art::InputTag> STStepCollection{   Name("STStepCollection"),   Comment("StoppingTarget StepPointMC collection name") };
       };
 
       explicit SurfaceStepDiag(const art::EDAnalyzer::Table<Config>& config);
@@ -31,10 +37,12 @@ namespace mu2e
       virtual void analyze(const art::Event& e);
     private:
       art::ProductToken<SurfaceStepCollection> sstag_;
+      art::ProductToken<StepPointMCCollection> vdtag_, ipatag_, sttag_;
       TTree *ssdiag_;
-      int evt_, sid_, sindex_;
-      float edep_, path_;
-      XYZVectorF mom_, pos_;
+      int evt_, subrun_, run_, sid_, sindex_;
+      float edep_, path_, time_;
+      XYZVectorF mom_, start_, mid_, end_;
+      TH1F *nvd_, *nipa_, *nstfoil_,* nstwire_;
   };
 
   SurfaceStepDiag::SurfaceStepDiag(const art::EDAnalyzer::Table<Config>& config) :
@@ -50,27 +58,50 @@ namespace mu2e
     // detailed diagnostics
     ssdiag_=tfs->make<TTree>("ssdiag","SurfaceStep diagnostics");
     ssdiag_->Branch("evt",&evt_,"evt/I");
+    ssdiag_->Branch("subrun",&subrun_,"subrun/I");
+    ssdiag_->Branch("run",&run_,"run/I");
     ssdiag_->Branch("sid",&sid_,"sid/I");
     ssdiag_->Branch("sindex",&sindex_,"sindex/I");
     ssdiag_->Branch("edep",&edep_,"edep/F");
     ssdiag_->Branch("path",&path_,"path/F");
+    ssdiag_->Branch("time",&time_,"time/F");
     ssdiag_->Branch("mom.",&mom_);
-    ssdiag_->Branch("pos.",&pos_);
+    ssdiag_->Branch("start.",&start_);
+    ssdiag_->Branch("mid.",&mid_);
+    ssdiag_->Branch("end.",&end_);
+    nvd_ = tfs->make<TH1F>("nvd","N VD SurfaceSteps",100,-0.5,99.5);
+    nipa_ = tfs->make<TH1F>("nipa","N IPA SurfaceSteps",100,-0.5,99.5);
+    nstfoil_ = tfs->make<TH1F>("nstfoil","N ST Foil SurfaceSteps",100,-0.5,99.5);
+    nstwire_ = tfs->make<TH1F>("nstwire","N ST Wire SurfaceSteps",100,-0.5,99.5);
   }
 
   void SurfaceStepDiag::analyze(const art::Event& evt ) {
     auto sscolH = evt.getValidHandle(sstag_);
     auto const& sscol = *sscolH.product();
-    evt_ = evt.id().event();  // add event id
+    evt_ = evt.id().event();
+    subrun_ = evt.id().subRun();
+    run_ = evt.id().run();
+    unsigned nvd(0), nipa(0), nstfoil(0), nstwire(0);
     for(auto const& ss : sscol) {
       sid_ = ss.surfaceId().id();
       sindex_ = ss.surfaceId().index();
       edep_ = ss.energyDeposit();
       path_ = ss.pathLength();
+      time_ = ss.time();
       mom_ = ss.momentum();
-      pos_ = ss.startPosition();
+      start_ = ss.startPosition();
+      mid_ = ss.midPosition();
+      end_ = ss.endPosition();
       ssdiag_->Fill();
+      if(ss.surfaceId().id() < SurfaceIdDetail::IPA)nvd++;
+      if(ss.surfaceId().id() == SurfaceIdDetail::IPA)nipa++;
+      if(ss.surfaceId().id() == SurfaceIdDetail::ST_Foils)nstfoil++;
+      if(ss.surfaceId().id() == SurfaceIdDetail::ST_Wires)nstwire++;
     }
+    nvd_->Fill(nvd);
+    nipa_->Fill(nipa);
+    nstfoil_->Fill(nstfoil);
+    nstwire_->Fill(nstwire);
   }
 }
 // Part of the magic that makes this class a module.

--- a/DataProducts/inc/SurfaceId.hh
+++ b/DataProducts/inc/SurfaceId.hh
@@ -49,7 +49,6 @@ namespace mu2e {
   };
   using SurfaceIdCollection = std::vector<SurfaceId>;
   // printout
-  std::ostream& operator<<(std::ostream& ost,
-                           const SurfaceId& s );
+  std::ostream& operator<<(std::ostream& ost, const SurfaceId& s );
 }
 #endif

--- a/DataProducts/inc/SurfaceId.hh
+++ b/DataProducts/inc/SurfaceId.hh
@@ -1,5 +1,5 @@
 //
-//  Define identifiers for the reconstruction surfaces
+//  Define identifiers for surfaces used in simulation and reconstruction. These can be virtual or physical
 //  original author: David Brown (LBNL) 2023
 //
 #ifndef KinKalGeom_SurfaceId_hh
@@ -16,7 +16,7 @@ namespace mu2e {
         unknown =-1,
         TT_Front=0, TT_Mid, TT_Back, TT_Inner, TT_Outer, // tracker VD equivalents
         DS_Front=80, DS_Back, DS_Inner, DS_Outer,
-        IPA, OPA, TSDA, // Absorbers in the DS.  These are the inner surfaces for the OPA and TSDA
+        IPA, OPA, TSDA, // Absorbers in the DS
         ST_Front=100,ST_Back, ST_Inner, ST_Outer, ST_Foils, // stopping target bounding surfaces and foils
         TCRV=200 // CRV test planes
       };
@@ -45,7 +45,7 @@ namespace mu2e {
       bool operator < (SurfaceId const& other ) const { return sid_ == other.sid_ ? indexCompare(other) : sid_ < other.sid_; }
     private:
       SurfaceIdEnum sid_;
-      int index_; // index.  Negative value is a wild card
+      int index_; // index.  Negative value is a wild card for matching
   };
   using SurfaceIdCollection = std::vector<SurfaceId>;
 }

--- a/DataProducts/inc/SurfaceId.hh
+++ b/DataProducts/inc/SurfaceId.hh
@@ -2,8 +2,8 @@
 //  Define identifiers for surfaces used in simulation and reconstruction. These can be virtual or physical
 //  original author: David Brown (LBNL) 2023
 //
-#ifndef KinKalGeom_SurfaceId_hh
-#define KinKalGeom_SurfaceId_hh
+#ifndef DataProducts_SurfaceId_hh
+#define DataProducts_SurfaceId_hh
 #include <map>
 #include <vector>
 #include <string>
@@ -17,7 +17,7 @@ namespace mu2e {
         TT_Front=0, TT_Mid, TT_Back, TT_Inner, TT_Outer, // tracker VD equivalents
         DS_Front=80, DS_Back, DS_Inner, DS_Outer,
         IPA, OPA, TSDA, // Absorbers in the DS
-        ST_Front=100,ST_Back, ST_Inner, ST_Outer, ST_Foils, // stopping target bounding surfaces and foils
+        ST_Front=100,ST_Back, ST_Inner, ST_Outer, ST_Foils, ST_Wires, // stopping target bounding surfaces and components
         TCRV=200 // CRV test planes
       };
 

--- a/DataProducts/inc/SurfaceId.hh
+++ b/DataProducts/inc/SurfaceId.hh
@@ -48,5 +48,8 @@ namespace mu2e {
       int index_; // index.  Negative value is a wild card for matching
   };
   using SurfaceIdCollection = std::vector<SurfaceId>;
+  // printout
+  std::ostream& operator<<(std::ostream& ost,
+                           const SurfaceId& s );
 }
 #endif

--- a/DataProducts/src/SurfaceId.cc
+++ b/DataProducts/src/SurfaceId.cc
@@ -1,7 +1,7 @@
 #include <type_traits>
 #include <utility>
 
-#include "Offline/KinKalGeom/inc/SurfaceId.hh"
+#include "Offline/DataProducts/inc/SurfaceId.hh"
 
 using namespace std;
 

--- a/DataProducts/src/SurfaceId.cc
+++ b/DataProducts/src/SurfaceId.cc
@@ -38,4 +38,9 @@ namespace mu2e {
     return nam;
   }
 
+  std::ostream& operator<<(std::ostream& ost, const SurfaceId& s ) {
+    ost << s.name() << ":" << s.index();
+    return ost;
+  }
+
 }

--- a/DataProducts/src/classes.h
+++ b/DataProducts/src/classes.h
@@ -58,3 +58,6 @@
 // STM
 #include "Offline/DataProducts/inc/STMChannel.hh"
 #include "Offline/DataProducts/inc/STMTestBeamEventInfo.hh"
+
+// General
+#include "Offline/DataProducts/inc/SurfaceId.hh"

--- a/DataProducts/src/classes_def.xml
+++ b/DataProducts/src/classes_def.xml
@@ -59,6 +59,8 @@
  <class name="art::Wrapper<mu2e::STMTestBeamEventInfo>" />
 
  <!--  ********* general  ********* -->
+ <class name="mu2e::SurfaceIdDetail"/>
+ <class name="mu2e::SurfaceIdEnum"/>
  <class name="mu2e::SurfaceId"/>
 
 </lcgdict>

--- a/DataProducts/src/classes_def.xml
+++ b/DataProducts/src/classes_def.xml
@@ -58,4 +58,7 @@
  <class name="mu2e::STMTestBeamEventInfo" />
  <class name="art::Wrapper<mu2e::STMTestBeamEventInfo>" />
 
+ <!--  ********* general  ********* -->
+ <class name="mu2e::SurfaceId"/>
+
 </lcgdict>

--- a/KinKalGeom/inc/SurfaceMap.hh
+++ b/KinKalGeom/inc/SurfaceMap.hh
@@ -8,7 +8,7 @@
 #include "Offline/KinKalGeom/inc/StoppingTarget.hh"
 #include "Offline/KinKalGeom/inc/DetectorSolenoid.hh"
 #include "Offline/KinKalGeom/inc/TestCRV.hh"
-#include "Offline/KinKalGeom/inc/SurfaceId.hh"
+#include "Offline/DataProducts/inc/SurfaceId.hh"
 #include "KinKal/Geometry/Surface.hh"
 #include <memory>
 #include <map>

--- a/MCDataProducts/inc/SurfaceStep.hh
+++ b/MCDataProducts/inc/SurfaceStep.hh
@@ -12,13 +12,15 @@
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include "Offline/DataProducts/inc/SurfaceId.hh"
 #include "Offline/DataProducts/inc/GenVector.hh"
+#include "Offline/GeometryService/inc/DetectorSystem.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 
 namespace mu2e {
   class SurfaceStep {
     public:
       SurfaceStep(){};
       // create from a StepPointMC. Association to a SurfaceId must be done outside this class
-      SurfaceStep(SurfaceId sid, StepPointMC const& spmc);
+      SurfaceStep(SurfaceId sid, StepPointMC const& spmc, GeomHandle<DetectorSystem>const& det);
 // accessors
       float energyDeposit() const { return edep_; }
       double const& time() const { return time_; } // time of the earliest StepPointMC used in this step
@@ -31,12 +33,12 @@ namespace mu2e {
       double pathLength() const { return (endPosition()-startPosition()).R(); }
       // append a MCStep to this step. The step must have the same SimParticle and
       // be contiguous in time and space to previously added step
-      void addStep(StepPointMC const& spmc, double dtol, double ttol);
+      void addStep(StepPointMC const& spmc, GeomHandle<DetectorSystem>const& det, double dtol, double ttol);
     private:
       SurfaceId  sid_ = SurfaceIdDetail::unknown; // Identifier of the surface this step crosses
       float       edep_ = 0.0;  // energy deposited in this material in this step
       double      time_ = 0.0; // absolute time particle enters this material; must be double to allow for long-lived particles
-      XYZVectorF    startpos_, endpos_; //entrance and exit to the gas volume
+      XYZVectorF    startpos_, endpos_; //entrance and exit position in DETECTOR COORDINATES
       XYZVectorF    mom_; //momentum at the start of this step
       art::Ptr<SimParticle> simp_;  // simparticle creating this step
   };

--- a/MCDataProducts/inc/SurfaceStep.hh
+++ b/MCDataProducts/inc/SurfaceStep.hh
@@ -1,0 +1,54 @@
+
+#ifndef MCDataProducts_SurfaceStep_hh
+#define MCDataProducts_SurfaceStep_hh
+//
+// Class to summarize the passage of a single particle through a surface
+// This consolidates the G4 steps and insulates the downstream analysis from details of the G4 stepping
+// The surface can be virtual or physical
+//
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "Offline/MCDataProducts/inc/SimParticle.hh"
+#include "Offline/MCDataProducts/inc/StepPointMC.hh"
+#include "Offline/DataProducts/inc/SurfaceId.hh"
+#include "Offline/DataProducts/inc/GenVector.hh"
+
+namespace mu2e {
+  class SurfaceStep {
+    public:
+      SurfaceStep(){};
+      // create from a StepPointMC. Association to a SurfaceId must be done outside this class
+      SurfaceStep(SurfaceId sid, StepPointMC const& spmc);
+// accessors
+      float energyDeposit() const { return edep_; }
+      double const& time() const { return time_; } // time of the earliest StepPointMC used in this step
+      XYZVectorF const& startPosition() const { return startpos_; }
+      XYZVectorF const& endPosition() const { return endpos_; }
+      XYZVectorF const& momentum() const { return mom_; }
+      art::Ptr<SimParticle> const& simParticle() const { return simp_; }
+      art::Ptr<SimParticle>& simParticle() { return simp_; } // used for compression
+      auto const& surfaceId() const& { return sid_; }
+      double pathLength() const { return (endPosition()-startPosition()).R(); }
+      // append a MCStep to this step. The step must have the same SimParticle and
+      // be contiguous in time and space to previously added step
+      void addStep(StepPointMC const& spmc, double dtol, double ttol);
+    private:
+      SurfaceId  sid_ = SurfaceIdDetail::unknown; // Identifier of the surface this step crosses
+      float       edep_ = 0.0;  // energy deposited in this material in this step
+      double      time_ = 0.0; // absolute time particle enters this material; must be double to allow for long-lived particles
+      XYZVectorF    startpos_, endpos_; //entrance and exit to the gas volume
+      XYZVectorF    mom_; //momentum at the start of this step
+      art::Ptr<SimParticle> simp_;  // simparticle creating this step
+  };
+
+  typedef std::vector<SurfaceStep> SurfaceStepCollection;
+  typedef art::Assns<SurfaceStep,StepPointMC> SurfaceStepAssns;
+
+  inline std::ostream& operator<<( std::ostream& ost, SurfaceStep const& ss){
+    ost << "SurfaceStep in surface " << ss.surfaceId().name()
+    << " Energy Loss " << ss.energyDeposit() << " path length " << ss.pathLength() << " time " << ss.time()
+    << " Particle momentum " << ss.momentum().R() << " PDG " << ss.simParticle()->pdgId();
+    return ost;
+  }
+}
+#endif

--- a/MCDataProducts/inc/SurfaceStep.hh
+++ b/MCDataProducts/inc/SurfaceStep.hh
@@ -26,14 +26,15 @@ namespace mu2e {
       double const& time() const { return time_; } // time of the earliest StepPointMC used in this step
       XYZVectorF const& startPosition() const { return startpos_; }
       XYZVectorF const& endPosition() const { return endpos_; }
+      XYZVectorF midPosition() const { return 0.5*(startpos_ + endpos_); }
       XYZVectorF const& momentum() const { return mom_; }
       art::Ptr<SimParticle> const& simParticle() const { return simp_; }
       art::Ptr<SimParticle>& simParticle() { return simp_; } // used for compression
       auto const& surfaceId() const& { return sid_; }
       double pathLength() const { return (endPosition()-startPosition()).R(); }
-      // append a MCStep to this step. The step must have the same SimParticle and
-      // be contiguous in time and space to previously added step
-      void addStep(StepPointMC const& spmc, GeomHandle<DetectorSystem>const& det, double dtol, double ttol);
+      // append a MCStep to this step. The step must have the same SimParticle.  Caller is responsible
+      // to insure this step is subsequent in time to the previous step
+      void addStep(StepPointMC const& spmc, GeomHandle<DetectorSystem>const& det);
     private:
       SurfaceId  sid_ = SurfaceIdDetail::unknown; // Identifier of the surface this step crosses
       float       edep_ = 0.0;  // energy deposited in this material in this step

--- a/MCDataProducts/inc/SurfaceStep.hh
+++ b/MCDataProducts/inc/SurfaceStep.hh
@@ -47,11 +47,6 @@ namespace mu2e {
   typedef std::vector<SurfaceStep> SurfaceStepCollection;
   typedef art::Assns<SurfaceStep,StepPointMC> SurfaceStepAssns;
 
-  inline std::ostream& operator<<( std::ostream& ost, SurfaceStep const& ss){
-    ost << "SurfaceStep in surface " << ss.surfaceId().name()
-    << " Energy Loss " << ss.energyDeposit() << " path length " << ss.pathLength() << " time " << ss.time()
-    << " Particle momentum " << ss.momentum().R() << " PDG " << ss.simParticle()->pdgId();
-    return ost;
-  }
+  std::ostream& operator<<( std::ostream& ost, SurfaceStep const& ss);
 }
 #endif

--- a/MCDataProducts/src/SurfaceStep.cc
+++ b/MCDataProducts/src/SurfaceStep.cc
@@ -1,0 +1,21 @@
+#include "Offline/MCDataProducts/inc/SurfaceStep.hh"
+namespace mu2e {
+  SurfaceStep::SurfaceStep(SurfaceId sid, StepPointMC const& spmc) : sid_(sid),
+  edep_(spmc.totalEDep()), time_(spmc.time()),
+  startpos_(spmc.position()),endpos_(spmc.postPosition()),mom_(spmc.momentum()),simp_(spmc.simParticle()){}
+
+  void SurfaceStep::addStep(StepPointMC const& spmc, double dtol, double ttol) {
+    if(spmc.simParticle() != simp_) throw cet::exception("Simulation")<<"SurfaceStep: SimParticles don't match" << std::endl;
+    if(fabs(time_ - spmc.time()) > ttol) throw cet::exception("Simulation")<<"SurfaceStep: times don't match" << std::endl;
+    edep_ += spmc.totalEDep();
+    if(spmc.time() > time_){ // normal situation: steps are in time order
+      if((endpos_ - XYZVectorF(spmc.position())).R() > dtol) throw cet::exception("Simulation")<<"SurfaceStep: end positions don't match" << std::endl;
+      endpos_ = spmc.postPosition();
+    } else { // reverse order; for now allow this
+      if((startpos_ - XYZVectorF(spmc.postPosition())).R() > dtol) throw cet::exception("Simulation")<<"SurfaceStep: start positions don't match" << std::endl;
+      time_ = spmc.time();
+      startpos_ = spmc.position();
+      mom_ = spmc.momentum();
+    }
+  }
+}

--- a/MCDataProducts/src/SurfaceStep.cc
+++ b/MCDataProducts/src/SurfaceStep.cc
@@ -13,4 +13,12 @@ namespace mu2e {
     edep_ += spmc.totalEDep();
     endpos_ = XYZVectorF(det->toDetector(spmc.postPosition()));
   }
+
+  std::ostream& operator<<( std::ostream& ost, SurfaceStep const& ss){
+    ost << "SurfaceStep in surface " << ss.surfaceId().name()
+    << " Energy Loss " << ss.energyDeposit() << " path length " << ss.pathLength() << " time " << ss.time()
+    << " Particle momentum " << ss.momentum().R() << " PDG " << ss.simParticle()->pdgId();
+    return ost;
+  }
+
 }

--- a/MCDataProducts/src/SurfaceStep.cc
+++ b/MCDataProducts/src/SurfaceStep.cc
@@ -7,14 +7,10 @@ namespace mu2e {
     endpos_ = det->toDetector(spmc.postPosition());
   }
 
-  void SurfaceStep::addStep(StepPointMC const& spmc, GeomHandle<DetectorSystem>const& det, double dtol, double ttol) {
+  void SurfaceStep::addStep(StepPointMC const& spmc, GeomHandle<DetectorSystem>const& det) {
     if(spmc.simParticle() != simp_) throw cet::exception("Simulation")<<"SurfaceStep: SimParticles don't match" << std::endl;
-    if(fabs(time_ - spmc.time()) > ttol) throw cet::exception("Simulation")<<"SurfaceStep: times don't match" << std::endl;
+    if(time_ > spmc.time())throw cet::exception("Simulation")<<"SurfaceStep: times out-of-order" << std::endl;
     edep_ += spmc.totalEDep();
-    if(spmc.time() > time_){ // normal situation: steps are in time order
-      auto newend = XYZVectorF(det->toDetector(spmc.postPosition()));
-      if((endpos_ - newend).R() > dtol) throw cet::exception("Simulation")<<"SurfaceStep: end positions don't match" << std::endl;
-      endpos_ = newend;
-    } else throw cet::exception("Simulation")<<"SurfaceStep: times out-of-order" << std::endl;
+    endpos_ = XYZVectorF(det->toDetector(spmc.postPosition()));
   }
 }

--- a/MCDataProducts/src/SurfaceStep.cc
+++ b/MCDataProducts/src/SurfaceStep.cc
@@ -1,21 +1,20 @@
 #include "Offline/MCDataProducts/inc/SurfaceStep.hh"
 namespace mu2e {
-  SurfaceStep::SurfaceStep(SurfaceId sid, StepPointMC const& spmc) : sid_(sid),
+  SurfaceStep::SurfaceStep(SurfaceId sid, StepPointMC const& spmc, GeomHandle<DetectorSystem>const& det) : sid_(sid),
   edep_(spmc.totalEDep()), time_(spmc.time()),
-  startpos_(spmc.position()),endpos_(spmc.postPosition()),mom_(spmc.momentum()),simp_(spmc.simParticle()){}
+  mom_(spmc.momentum()),simp_(spmc.simParticle()){
+    startpos_ = det->toDetector(spmc.position());
+    endpos_ = det->toDetector(spmc.postPosition());
+  }
 
-  void SurfaceStep::addStep(StepPointMC const& spmc, double dtol, double ttol) {
+  void SurfaceStep::addStep(StepPointMC const& spmc, GeomHandle<DetectorSystem>const& det, double dtol, double ttol) {
     if(spmc.simParticle() != simp_) throw cet::exception("Simulation")<<"SurfaceStep: SimParticles don't match" << std::endl;
     if(fabs(time_ - spmc.time()) > ttol) throw cet::exception("Simulation")<<"SurfaceStep: times don't match" << std::endl;
     edep_ += spmc.totalEDep();
     if(spmc.time() > time_){ // normal situation: steps are in time order
-      if((endpos_ - XYZVectorF(spmc.position())).R() > dtol) throw cet::exception("Simulation")<<"SurfaceStep: end positions don't match" << std::endl;
-      endpos_ = spmc.postPosition();
-    } else { // reverse order; for now allow this
-      if((startpos_ - XYZVectorF(spmc.postPosition())).R() > dtol) throw cet::exception("Simulation")<<"SurfaceStep: start positions don't match" << std::endl;
-      time_ = spmc.time();
-      startpos_ = spmc.position();
-      mom_ = spmc.momentum();
-    }
+      auto newend = XYZVectorF(det->toDetector(spmc.postPosition()));
+      if((endpos_ - newend).R() > dtol) throw cet::exception("Simulation")<<"SurfaceStep: end positions don't match" << std::endl;
+      endpos_ = newend;
+    } else throw cet::exception("Simulation")<<"SurfaceStep: times out-of-order" << std::endl;
   }
 }

--- a/MCDataProducts/src/classes.h
+++ b/MCDataProducts/src/classes.h
@@ -29,6 +29,7 @@
 #include "Offline/MCDataProducts/inc/SimParticleRemapping.hh"
 #include "Offline/MCDataProducts/inc/CosmicLivetime.hh"
 #include "Offline/MCDataProducts/inc/SimTimeOffset.hh"
+#include "Offline/MCDataProducts/inc/SurfaceStep.hh"
 
 // simulation bookeeping
 #include "Offline/MCDataProducts/inc/PhysicalVolumeInfo.hh"

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -76,6 +76,10 @@ include="Math/Vector3D.h, Math/Vector4D.h, CLHEP/Vector/LorentzVector.h, CLHEP/V
 <class name="mu2e::PtrStepPointMCVectorCollection"/>
 <class name="art::Wrapper<mu2e::PtrStepPointMCVectorCollection>"/>
 
+<class name="mu2e::SurfaceStep"/>
+<class name="mu2e::SurfaceStepCollection"/>
+<class name="art::Ptr<mu2e::SurfaceStep>"/>
+
 <class name="mu2e::MCTrajectoryPoint"/>
 <class name="std::vector<mu2e::MCTrajectoryPoint>"/>
 <class name="mu2e::MCTrajectory"/>

--- a/Mu2eKinKal/inc/HelixFit_module.hh
+++ b/Mu2eKinKal/inc/HelixFit_module.hh
@@ -19,7 +19,7 @@
 #include "Offline/TrackerConditions/inc/StrawResponse.hh"
 #include "Offline/BFieldGeom/inc/BFieldManager.hh"
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
-#include "Offline/KinKalGeom/inc/SurfaceId.hh"
+#include "Offline/DataProducts/inc/SurfaceId.hh"
 #include "Offline/KinKalGeom/inc/SurfaceMap.hh"
 // utiliites
 #include "Offline/GeometryService/inc/GeomHandle.hh"

--- a/Mu2eKinKal/inc/KKFit.hh
+++ b/Mu2eKinKal/inc/KKFit.hh
@@ -27,7 +27,7 @@
 #include "Offline/RecoDataProducts/inc/StrawHitFlag.hh"
 #include "Offline/RecoDataProducts/inc/StrawHitIndex.hh"
 #include "Offline/RecoDataProducts/inc/KalSeedAssns.hh"
-#include "Offline/KinKalGeom/inc/SurfaceId.hh"
+#include "Offline/DataProducts/inc/SurfaceId.hh"
 #include "Offline/KinKalGeom/inc/SurfaceMap.hh"
 #include "KinKal/Geometry/ParticleTrajectoryIntersect.hh"
 // geometry

--- a/Print/inc/SurfaceStepPrinter.hh
+++ b/Print/inc/SurfaceStepPrinter.hh
@@ -1,0 +1,38 @@
+//
+//  Utility class to print SurfaceStep
+//
+#ifndef Print_inc_SurfaceStepPrinter_hh
+#define Print_inc_SurfaceStepPrinter_hh
+
+#include <cstring>
+#include <iostream>
+
+#include "Offline/MCDataProducts/inc/SurfaceStep.hh"
+#include "Offline/Print/inc/ProductPrinter.hh"
+#include "art/Framework/Principal/Handle.h"
+#include "canvas/Persistency/Common/Ptr.h"
+
+namespace mu2e {
+
+class SurfaceStepPrinter : public ProductPrinter {
+ public:
+  SurfaceStepPrinter(const Config& conf) : ProductPrinter(conf) {}
+
+  // all the ways to request a printout
+  void Print(art::Event const& event, std::ostream& os = std::cout) override;
+  void Print(const art::Handle<SurfaceStepCollection>& handle,
+             std::ostream& os = std::cout);
+  void Print(const art::ValidHandle<SurfaceStepCollection>& handle,
+             std::ostream& os = std::cout);
+  void Print(const SurfaceStepCollection& coll, std::ostream& os = std::cout);
+  void Print(const art::Ptr<SurfaceStep>& ptr, int ind = -1,
+             std::ostream& os = std::cout);
+  void Print(const mu2e::SurfaceStep& obj, int ind = -1,
+             std::ostream& os = std::cout);
+
+  void PrintHeader(const std::string& tag, std::ostream& os = std::cout);
+  void PrintListHeader(std::ostream& os = std::cout);
+};
+
+}  // namespace mu2e
+#endif

--- a/Print/src/PrintModule_module.cc
+++ b/Print/src/PrintModule_module.cc
@@ -43,6 +43,7 @@
 #include "Offline/Print/inc/StrawDigiMCPrinter.hh"
 #include "Offline/Print/inc/StrawDigiPrinter.hh"
 #include "Offline/Print/inc/StrawGasStepPrinter.hh"
+#include "Offline/Print/inc/SurfaceStepPrinter.hh"
 #include "Offline/Print/inc/StrawHitFlagPrinter.hh"
 #include "Offline/Print/inc/StrawHitPrinter.hh"
 #include "Offline/Print/inc/TimeClusterPrinter.hh"
@@ -113,6 +114,8 @@ class PrintModule : public art::EDAnalyzer {
         fhicl::Name("crvCoincidenceClusterPrinter")};
     fhicl::Table<ProductPrinter::Config> strawGasStepPrinter{
         fhicl::Name("strawGasStepPrinter")};
+    fhicl::Table<ProductPrinter::Config> surfaceStepPrinter{
+        fhicl::Name("surfaceStepPrinter")};
     fhicl::Table<ProductPrinter::Config> strawDigiPrinter{
         fhicl::Name("strawDigiPrinter")};
     fhicl::Table<ProductPrinter::Config> strawDigiADCWaveformPrinter{
@@ -218,6 +221,8 @@ mu2e::PrintModule::PrintModule(const Parameters& conf) : art::EDAnalyzer(conf),
       conf().crvCoincidenceClusterPrinter()));
   _printers.push_back(
       make_unique<StrawGasStepPrinter>(conf().strawGasStepPrinter()));
+  _printers.push_back(
+      make_unique<SurfaceStepPrinter>(conf().surfaceStepPrinter()));
   _printers.push_back(make_unique<StrawDigiPrinter>(conf().strawDigiPrinter()));
   _printers.push_back(make_unique<StrawDigiADCWaveformPrinter>(
       conf().strawDigiADCWaveformPrinter()));

--- a/Print/src/SurfaceStepPrinter.cc
+++ b/Print/src/SurfaceStepPrinter.cc
@@ -1,0 +1,94 @@
+#include "Offline/Print/inc/SurfaceStepPrinter.hh"
+#include "art/Framework/Principal/Provenance.h"
+#include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
+#include <iomanip>
+#include <string>
+
+void mu2e::SurfaceStepPrinter::Print(art::Event const& event,
+                                      std::ostream& os) {
+  if (verbose() < 1) return;
+  if (tags().empty()) {
+    // if a list of instances not specified, print all instances
+    std::vector<art::Handle<SurfaceStepCollection> > vah =
+        event.getMany<SurfaceStepCollection>();
+    for (auto const& ah : vah) Print(ah);
+  } else {
+    // print requested instances
+    for (const auto& tag : tags()) {
+      auto ih = event.getValidHandle<SurfaceStepCollection>(tag);
+      Print(ih);
+    }
+  }
+}
+
+void mu2e::SurfaceStepPrinter::Print(
+    const art::Handle<SurfaceStepCollection>& handle, std::ostream& os) {
+  if (verbose() < 1) return;
+  // the product tags with all four fields, with underscores
+  std::string tag = handle.provenance()->productDescription().branchName();
+  tag.pop_back();  // remove trailing dot
+  PrintHeader(tag, os);
+  Print(*handle);
+}
+
+void mu2e::SurfaceStepPrinter::Print(
+    const art::ValidHandle<SurfaceStepCollection>& handle, std::ostream& os) {
+  if (verbose() < 1) return;
+  // the product tags with all four fields, with underscores
+  std::string tag = handle.provenance()->productDescription().branchName();
+  tag.pop_back();  // remove trailing dot
+  PrintHeader(tag, os);
+  Print(*handle);
+}
+
+void mu2e::SurfaceStepPrinter::Print(const SurfaceStepCollection& coll,
+                                      std::ostream& os) {
+  if (verbose() < 0 ) return;
+  os << "SurfaceStepCollection has " << coll.size() << " steps\n";
+  if (verbose() >= 1) PrintListHeader();
+  int i = 0;
+  for (const auto& obj : coll) Print(obj, i++);
+}
+
+void mu2e::SurfaceStepPrinter::Print(const art::Ptr<SurfaceStep>& obj,
+                                      int ind, std::ostream& os) {
+  if (verbose() < 1) return;
+  Print(*obj, ind);
+}
+
+void mu2e::SurfaceStepPrinter::Print(const mu2e::SurfaceStep& obj, int ind,
+                                      std::ostream& os) {
+  if (verbose() < 1) return;
+
+  os << std::setiosflags(std::ios::fixed | std::ios::right);
+  if (ind >= 0) os << std::setw(4) << ind;
+
+  long unsigned int pkey = 0;
+  auto const& pptr = obj.simParticle();
+  if (pptr) pkey = pptr->id().asUint();
+  double mbtime = GlobalConstantsHandle<PhysicsParams>()->getNominalDRPeriod();
+
+  os << ", " << std::setw(5) << pkey << ", "
+     << std::setw(8) << obj.surfaceId() << "  "
+     << std::setw(5) << std::setprecision(5)     << obj.energyDeposit() << "  "
+     << std::setw(5) << std::setprecision(3)     << obj.pathLength() << " "
+     << std::setw(5) << std::setprecision(2)     << obj.time() << " "
+     << std::setw(7) << std::setprecision(2)     << fmod(obj.time(),mbtime) << " "
+     << std::setw(5) << std::setprecision(2)     << obj.momentum().R() << " "
+     << std::setw(8)  << std::setprecision(1) << obj.startPosition().x()
+     << std::setw(8)  << std::setprecision(1) << obj.startPosition().y()
+     << std::setw(8)  << std::setprecision(1) << obj.startPosition().z()
+     << std::endl;
+}
+
+void mu2e::SurfaceStepPrinter::PrintHeader(const std::string& tag,
+                                            std::ostream& os) {
+  if (verbose() < 1) return;
+  os << "\nProductPrint " << tag << "\n";
+}
+
+void mu2e::SurfaceStepPrinter::PrintListHeader(std::ostream& os) {
+  if (verbose() < 1) return;
+  os << " ind SimPart SurfaceId    eDep     length    time time%mb mom      X      Y       Z\n";
+}

--- a/RecoDataProducts/inc/KalIntersection.hh
+++ b/RecoDataProducts/inc/KalIntersection.hh
@@ -7,7 +7,7 @@
 #include "Offline/DataProducts/inc/GenVector.hh"
 #include "KinKal/General/ParticleStateEstimate.hh"
 #include "KinKal/Geometry/Intersection.hh"
-#include "Offline/KinKalGeom/inc/SurfaceId.hh"
+#include "Offline/DataProducts/inc/SurfaceId.hh"
 #include <vector>
 namespace mu2e {
   struct KalIntersection {

--- a/RecoDataProducts/src/classes_def.xml
+++ b/RecoDataProducts/src/classes_def.xml
@@ -204,9 +204,6 @@
  <class name="std::vector<mu2e::KalSegment>"/>
  <class name="KinKal::IntersectFlag"/>
  <class name="KinKal::Intersection"/>
- <class name="mu2e::SurfaceIdDetail"/>
- <class name="mu2e::SurfaceIdEnum"/>
- <class name="mu2e::SurfaceId"/>
  <class name="mu2e::KalIntersection"/>
  <class name="mu2e::KalIntersectionCollection"/>
 

--- a/TrackerMC/src/MakeStrawGasSteps_module.cc
+++ b/TrackerMC/src/MakeStrawGasSteps_module.cc
@@ -25,7 +25,6 @@
 
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include "Offline/MCDataProducts/inc/StrawGasStep.hh"
-#include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include <utility>
 // root
 #include "TH1F.h"

--- a/Validation/inc/ValKalSeed.hh
+++ b/Validation/inc/ValKalSeed.hh
@@ -3,7 +3,7 @@
 
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 #include "Offline/DataProducts/inc/VirtualDetectorId.hh"
-#include "Offline/KinKalGeom/inc/SurfaceId.hh"
+#include "Offline/DataProducts/inc/SurfaceId.hh"
 #include "art/Framework/Principal/Event.h"
 #include "art_root_io/TFileDirectory.h"
 #include "TH1D.h"


### PR DESCRIPTION
SurfaceStep is a new MC truth class that functions like StrawGasStep, CaloShowerStep, etc, but for passive materials and virtual detectors. It uses the SurfaceId class to define the surfaces, and summarizes the information contained in contiguous StepPointMC objects. This greatly reduced the payload and renders the output information more useful for physics studies, and insulates the results from the details of the G4 stepping parameters. This PR introduces the class itself plus producer, diag module, printer, and default production configuration.

Note that SurfaceId was moved to DataProducts (from RecoDataProducts and KinKalGeom) to allow this to work. It's fine, as the surface concept isn't specific to reco or mc.