### PR TITLE
path for root dictionaries

### DIFF
--- a/.muse
+++ b/.muse
@@ -4,3 +4,5 @@ ENVSET p057
 PATH bin
 # recent commits can take enforce these flags
 CPPFLAGS -Wtype-limits -Wimplicit-fallthrough -Wunused-but-set-parameter
+# add lib to root path for dictionaries
+ROOT_LIBRARY_PATH


### PR DESCRIPTION
With this addition, and the latest version of muse, muse will add the Offline lib path to ROOT_LIBRARY_PATH so that bare root can find dictionaries.  TrkAna and Stntuple can also include this flag in their .muse and then you don't have to set "LDD_LIBRARY_PATH=$CET_PLUGIN_PATH" by hand when using ntuples within the muse+spack build.  
This won't find art libraries, but probably will in the future.  Until that time, this won't fix file_info_dumper (at least not without further changes).