### PR TITLE
Add SurfaceStep to compression modules

### DIFF
--- a/Compression/fcl/prolog.fcl
+++ b/Compression/fcl/prolog.fcl
@@ -8,6 +8,7 @@ DetStepCompression : {
     strawGasStepCompressionLevel : "noCompression" # keep all StrawGasSteps
     caloShowerStepCompressionLevel : "noCompression"
     crvStepCompressionLevel : "noCompression"
+    surfaceStepCompressionLevel : "noCompression"
     simParticleCompressionLevel : "noCompression"
     stepPointMCCompressionLevel : "noCompression"
     keepNGenerations : -1
@@ -18,6 +19,7 @@ DetStepCompression : {
     strawGasStepCompressionLevel : "noCompression" # keep all StrawGasSteps
     caloShowerStepCompressionLevel : "noCompression"
     crvStepCompressionLevel : "noCompression"
+    surfaceStepCompressionLevel : "noCompression"
     simParticleCompressionLevel : "fullCompression" # only keep SimParticles related to other data products we are keeping
     stepPointMCCompressionLevel : "simParticleCompression" # only keep StepPointMCs related to SimParticles we are keeping
     keepNGenerations : -1
@@ -28,6 +30,7 @@ DetStepCompression : {
     strawGasStepCompressionLevel : "noCompression" # keep all StrawGasSteps
     caloShowerStepCompressionLevel : "noCompression"
     crvStepCompressionLevel : "noCompression"
+    surfaceStepCompressionLevel : "noCompression"
     simParticleCompressionLevel : "fullCompression" # only keep SimParticles related to other data products we are keeping
     stepPointMCCompressionLevel : "simParticleCompression" # only keep StepPointMCs related to SimParticles we are keeping
     keepNGenerations : 2

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -79,6 +79,9 @@ include="Math/Vector3D.h, Math/Vector4D.h, CLHEP/Vector/LorentzVector.h, CLHEP/V
 <class name="mu2e::SurfaceStep"/>
 <class name="mu2e::SurfaceStepCollection"/>
 <class name="art::Ptr<mu2e::SurfaceStep>"/>
+<class name="art::Wrapper<mu2e::SurfaceStep>"/>
+<class name="art::Wrapper<mu2e::SurfaceStepCollection>"/>
+<class name="art::Wrapper<art::Ptr<mu2e::SurfaceStep>>"/>
 
 <class name="mu2e::MCTrajectoryPoint"/>
 <class name="std::vector<mu2e::MCTrajectoryPoint>"/>


### PR DESCRIPTION
Here is the minimal working version of compression for SurfaceSteps (#1300). Here is a summary of what can be done in each module:

 - CompressDetStepMCs: only ```noCompression``` option is allowed
 - CompressDigiMCs: the same compression is done as for StepPointMCs (i.e. it will only keep SurfaceSteps if we are keeping the corresponding SimParticle with the option to turn the compression off)

To test I have run the Validation scripts ceSteps.fcl, ceDigis.fcl, and reco.fcl. At each stage I kept all SurfaceSteps and then did a by-eye check of the print.fcl output to make sure the SurfaceSteps are kept and their SimParticlePtrs are updated correctly.

I will open a PR in Production for the necessary configuration changes. There may be some discussion needed there about what we want to run in production