### PR TITLE
Add final fit processing stage

### DIFF
--- a/CommonMC/src/SurfaceStepDiag_module.cc
+++ b/CommonMC/src/SurfaceStepDiag_module.cc
@@ -9,7 +9,6 @@
 #include "art/Framework/Core/EDAnalyzer.h"
 #include "Offline/DataProducts/inc/GenVector.hh"
 #include "fhiclcpp/types/Atom.h"
-#include "fhiclcpp/types/OptionalAtom.h"
 #include "art_root_io/TFileService.h"
 #include "TTree.h"
 #include "TH1F.h"

--- a/Mu2eKinKal/inc/KKFitSettings.hh
+++ b/Mu2eKinKal/inc/KKFitSettings.hh
@@ -53,6 +53,12 @@ namespace mu2e {
     // function to convert fhicl configuration to KinKal Config object
     KinKal::Config makeConfig(KinKalConfig const& fconfig);
 
+    // struct for final fit configuration. This just changes convergence parameters
+    struct KKFinalConfig {
+      fhicl::Atom<int> maxniter { Name("MaxNIter"), Comment("Maximum number of algebraic iteration steps in each fit meta-iteration") };
+      fhicl::Atom<float> convdchisq { Name("ConvergenceDeltaChisq"), Comment("Maximum Chisq/DOF change between iterations to define convergence") };
+    };
+
     // struct for configuring KKFit object
     struct KKFitConfig {
       fhicl::Atom<int> printLevel { Name("PrintLevel"), Comment("Diagnostic printout Level") };


### PR DESCRIPTION
This was an attempt to reconcile small discrepancies between quantities measured with reference vs final fit trajectories, but it provides marginal improvement. For now add the functionality without changing the default config.