### PR TITLE
Set calo-tracker time offset in extracted data

### DIFF
--- a/Mu2eKinKal/fcl/prolog.fcl
+++ b/Mu2eKinKal/fcl/prolog.fcl
@@ -352,6 +352,11 @@ Mu2eKinKal : {
       @table::Mu2eKinKal.KKFIT
       SampleSurfaces : ["TT_Front","TT_Back","TT_Outer","TCRV"]
       SampleTimeBuffer : 100
+      # DNB I don't know where this time offset difference WRT helical fits comes from. If it's physical, we will need a better
+      # mechanism to deal with it in real data
+      CaloTrackerTimeOffset: -2.43
+      # Additional width is needed here as straight tracks have worse time resolution
+      MaxCaloClusterDt: 8
     }
     FitSettings : @local::Mu2eKinKal.SEEDFIT
     ExtensionSettings : {


### PR DESCRIPTION
We observe that the calo-tracker time offset is different in extracted sims compared to beam sims. The cause of this difference is not understood. This PR just configures the reco to be self-consistent, which aids in making track-calo associations in the fit.