### PR TITLE
Add code to convert between DUSAF and Mu2e coordinate systems.

### DIFF
--- a/GeometryService/inc/DUSAFMu2eConverter.hh
+++ b/GeometryService/inc/DUSAFMu2eConverter.hh
@@ -1,0 +1,56 @@
+#ifndef GeometryService_DUSAFMu2eConverter_hh
+#define GeometryService_DUSAFMu2eConverter_hh
+
+//
+// Convert coordinates between DUSAF and Mu2e coordinate systems
+// See Mu2e-doc-4741-v6
+//
+// DUSAF coordinates in US feet (see footnote on page 4 for US foot vs International foot).
+// Mu2e coordinates in mm
+//
+// Original author Rob Kutschke
+//
+
+#include "Offline/Mu2eInterfaces/inc/Detector.hh"
+
+#include "CLHEP/Vector/ThreeVector.h"
+#include "CLHEP/Vector/Rotation.h"
+
+namespace mu2e {
+
+  class DUSAFMu2eConverter: virtual public Detector{
+
+  public:
+
+    // Unit conversion factors
+    constexpr static double us_foot_mm   = 304.80061;  // Number of mm in 1 US foot (AKA surveyors foot).
+    constexpr static double intl_foot_mm = 304.8;      // Number of mm in 1 international foot.
+    constexpr static double us_foot_m    = 0.30480061; // Number of m in 1 US foot (AKA surveyors foot).
+    constexpr static double intl_foot_m  = 0.3048;     // Number of m in 1 international foot.
+
+    DUSAFMu2eConverter();
+
+    // Convert Mu2e in mm to DUSAF in us feet.
+    CLHEP::Hep3Vector Mu2e_to_DUSAF( CLHEP::Hep3Vector const & ) const;
+
+    // Convert DUSAF in us feet to mm.
+    CLHEP::Hep3Vector DUSAF_to_Mu2e( CLHEP::Hep3Vector const & ) const;
+
+    CLHEP::HepRotation const& rotationToMu2e()  const {return _toMu2e;  }
+    CLHEP::HepRotation const& rotationToDUSAF() const {return _toDUSAF; }
+
+  private:
+
+    // Tie in points inthe two coordinate systems
+    const CLHEP::Hep3Vector _tieIn_inDUSAF_usft; // in US feet
+    const CLHEP::Hep3Vector _tieIn_inMu2e_mm;    // in mm
+
+    // Rotation component of the transformation.
+    const CLHEP::HepRotation _toDUSAF;
+    const CLHEP::HepRotation _toMu2e;
+
+  };
+
+}
+
+#endif

--- a/GeometryService/src/DUSAFMu2eConverter.cc
+++ b/GeometryService/src/DUSAFMu2eConverter.cc
@@ -6,13 +6,14 @@
 #include "Offline/GeometryService/inc/DUSAFMu2eConverter.hh"
 
 namespace mu2e {
-
   DUSAFMu2eConverter::DUSAFMu2eConverter():
+    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
     _tieIn_inDUSAF_usft( 99242.290578, 99026.647809, 729.758494 ),   // From Table 4
     _tieIn_inMu2e_mm(5794.738, 345.131, 1600.553 ),                  // From Table 4
     _toDUSAF(CLHEP::HepRotation().setRows( {0.54671783, -0.00003629,  0.83731691},    // From equation 11
                                            {0.83731691, -0.00004662, -0.54671784},
                                            {0.00005887,  1.00000000,  0.00000490} )),
+    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
     _toMu2e(_toDUSAF.inverse())
   {
   }

--- a/GeometryService/src/DUSAFMu2eConverter.cc
+++ b/GeometryService/src/DUSAFMu2eConverter.cc
@@ -1,0 +1,32 @@
+//
+// Convert coordinates between DUSAF and Mu2e coordinate systems
+// See Mu2e-doc-4741-v6
+//
+
+#include "Offline/GeometryService/inc/DUSAFMu2eConverter.hh"
+
+namespace mu2e {
+
+  DUSAFMu2eConverter::DUSAFMu2eConverter():
+    _tieIn_inDUSAF_usft( 99242.290578, 99026.647809, 729.758494 ),   // From Table 4
+    _tieIn_inMu2e_mm(5794.738, 345.131, 1600.553 ),                  // From Table 4
+    _toDUSAF(CLHEP::HepRotation().setRows( {0.54671783, -0.00003629,  0.83731691},    // From equation 11
+                                           {0.83731691, -0.00004662, -0.54671784},
+                                           {0.00005887,  1.00000000,  0.00000490} )),
+    _toMu2e(_toDUSAF.inverse())
+  {
+  }
+
+  // Equation 11
+  CLHEP::Hep3Vector DUSAFMu2eConverter::Mu2e_to_DUSAF( CLHEP::Hep3Vector const & v ) const{
+    auto result = _tieIn_inDUSAF_usft  + _toDUSAF*(v-_tieIn_inMu2e_mm)/us_foot_mm;;
+    return result;
+  }
+
+  // Equation 10
+  CLHEP::Hep3Vector DUSAFMu2eConverter::DUSAF_to_Mu2e( CLHEP::Hep3Vector const & v ) const{
+    auto result = _tieIn_inMu2e_mm + _toMu2e*(v-_tieIn_inDUSAF_usft)*us_foot_mm;
+    return result;
+  }
+
+}

--- a/GeometryService/src/GeometryService.cc
+++ b/GeometryService/src/GeometryService.cc
@@ -87,6 +87,7 @@
 #include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
 #include "Offline/GeometryService/inc/PTMMaker.hh"
 #include "Offline/PTMGeom/inc/PTM.hh"
+#include "Offline/GeometryService/inc/DUSAFMu2eConverter.hh"
 
 using namespace std;
 
@@ -359,7 +360,9 @@ namespace mu2e {
       addDetector( mecopam.getMECOStyleProtonAbsorberPtr() );
     }
 
-
+    // This class has a default c'tor with all available information internally.
+    std::unique_ptr<DUSAFMu2eConverter> dusafMu2e{ std::make_unique<DUSAFMu2eConverter>() };
+    addDetector( std::move(dusafMu2e) );
 
   } // preBeginRun()
 


### PR DESCRIPTION
This PR is a pure addition, no changes.

I debated whether to add this in GeometryService or GlobalConstantsService. I settled on GeometryService on the grounds that it is more Geometry related than just-plain-constants.  It also preserves the possibility that it could evolve with a re-survey of the tie-in point, although that is not expected.