### PR TITLE
This commit fixes some of the warnings generated by clang-tidy PR #1326.

### DIFF
--- a/BFieldGeom/inc/BFCacheManager.hh
+++ b/BFieldGeom/inc/BFCacheManager.hh
@@ -50,7 +50,7 @@ namespace mu2e {
             // If "my" map is an inner map, it is not in the list.
             MapList inner;
 
-            CacheElement(std::shared_ptr<const BFMap> my, const MapList& in)
+            CacheElement(std::shared_ptr<const BFMap> const&  my, const MapList& in)
                 : myMap(my), inner(in) {}
         };
 

--- a/BFieldGeom/inc/BFGridMap.hh
+++ b/BFieldGeom/inc/BFGridMap.hh
@@ -32,7 +32,7 @@ namespace mu2e {
             GridPoint(unsigned a, unsigned b, unsigned c) : ix(a), iy(b), iz(c) {}
         };
 
-        BFGridMap(std::string filename,
+        BFGridMap(std::string const& filename,
                   int nx,
                   double xmin,
                   double dx,
@@ -67,19 +67,17 @@ namespace mu2e {
               _allDefined(false),
               _interpStyle(style){};
 
-        ~BFGridMap(){};
-
-        virtual bool getBFieldWithStatus(const CLHEP::Hep3Vector&, CLHEP::Hep3Vector&) const;
+        bool getBFieldWithStatus(const CLHEP::Hep3Vector&, CLHEP::Hep3Vector&) const override;
 
         // Validity checker
-        virtual bool isValid(const CLHEP::Hep3Vector& point) const;
+        bool isValid(const CLHEP::Hep3Vector& point) const override;
         bool isValid(const GridPoint& ipoint) const {
             return _field.isValid(ipoint.ix, ipoint.iy, ipoint.iz);
         }
 
-        int nx() const { return _nx; }
-        int ny() const { return _ny; }
-        int nz() const { return _nz; }
+        unsigned int nx() const { return _nx; }
+        unsigned int ny() const { return _ny; }
+        unsigned int nz() const { return _nz; }
 
         double dx() const { return _dx; };
         double dy() const { return _dy; };
@@ -99,7 +97,7 @@ namespace mu2e {
                                 CLHEP::Hep3Vector neighborPoints[3],
                                 CLHEP::Hep3Vector neighborBF[3][3][3]) const;
 
-        virtual void print(std::ostream& os) const;
+        void print(std::ostream& os) const override;
 
        private:
         // Grid dimensions
@@ -134,11 +132,11 @@ namespace mu2e {
         double gmcpoly2(double const f1d[3], double const& x) const;
 
         // Compute grid indices for a given point.
-        std::size_t iX(double x) const { return static_cast<int>((x - _xmin) / _dx + 0.5); }
+        std::size_t iX(double x) const { return static_cast<std::size_t>(lround((x - _xmin) / _dx)); }
 
-        std::size_t iY(double y) const { return static_cast<int>((y - _ymin) / _dy + 0.5); }
+        std::size_t iY(double y) const { return static_cast<std::size_t>(lround((y - _ymin) / _dy)); }
 
-        std::size_t iZ(double z) const { return static_cast<int>((z - _zmin) / _dz + 0.5); }
+        std::size_t iZ(double z) const { return static_cast<std::size_t>(lround((z - _zmin) / _dz)); }
 
         bool interpolateTriLinear(const CLHEP::Hep3Vector&, CLHEP::Hep3Vector&) const;
 

--- a/BFieldGeom/inc/BFMap.hh
+++ b/BFieldGeom/inc/BFMap.hh
@@ -23,7 +23,7 @@ namespace mu2e {
        public:
         friend class BFieldManagerMaker;
 
-        BFMap(std::string filename,
+        BFMap(std::string const& filename,
               double xmin,
               double xmax,
               double ymin,
@@ -44,7 +44,11 @@ namespace mu2e {
               _type(atype),
               _scaleFactor(scale){};
 
-        virtual ~BFMap(){};
+        virtual ~BFMap() = default;
+        BFMap( BFMap const&  ) = default;
+        BFMap( BFMap&&       ) = default;
+        BFMap& operator=(BFMap const&  ) = default;
+        BFMap& operator=(BFMap&&       ) = default;
 
         // Accessors
         virtual bool getBFieldWithStatus(const CLHEP::Hep3Vector&, CLHEP::Hep3Vector&) const = 0;

--- a/BFieldGeom/inc/BFParamMap.hh
+++ b/BFieldGeom/inc/BFParamMap.hh
@@ -28,7 +28,7 @@ namespace mu2e {
        public:
         friend class BFieldManagerMaker;
 
-        BFParamMap(std::string filename,
+        BFParamMap(std::string const& filename,
                    double xmin,
                    double xmax,
                    double ymin,
@@ -40,19 +40,17 @@ namespace mu2e {
                    bool warnIfOutside = false)
             : BFMap(filename, xmin, xmax, ymin, ymax, zmin, zmax, atype, scale, warnIfOutside){};
 
-        ~BFParamMap(){};
+        bool getBFieldWithStatus(const CLHEP::Hep3Vector&, CLHEP::Hep3Vector&) const override;
 
-        virtual bool getBFieldWithStatus(const CLHEP::Hep3Vector&, CLHEP::Hep3Vector&) const;
+        bool isValid(const CLHEP::Hep3Vector& point) const override;
 
-        virtual bool isValid(const CLHEP::Hep3Vector& point) const;
-
-        virtual void print(std::ostream& os) const;
+        void print(std::ostream& os) const override;
 
        private:
         // objects used to store the fit parameters
-        int _ns;
-        int _ms;
-        double _Reff;
+        int _ns = 0;
+        int _ms = 0;
+        double _Reff =0.;
         vector<vector<double> > _As;
         vector<vector<double> > _Bs;
         vector<double> _Ds;

--- a/BFieldGeom/inc/BFieldManager.hh
+++ b/BFieldGeom/inc/BFieldManager.hh
@@ -66,7 +66,7 @@ namespace mu2e {
 
           CLHEP::Hep3Vector p(pos.x(), pos.y(), pos.z());
           getBFieldWithStatus(p, b);
-          XYZVectorF result(b.x(), b.y(), b.z());
+          XYZVectorF result(float(b.x()), float(b.y()), float(b.z()));
 
           return result;
         }
@@ -87,15 +87,8 @@ namespace mu2e {
         BFieldManager(MapContainerType const& innerMaps,
                       MapContainerType const& outerMaps);
 
-        // This class could support copying but it is not really needed and
-        // I would like to prevent unintended copies ( people forgetting to
-        // receive it into a const reference and making a copy instead ).
-        BFieldManager(const BFieldManager&);
-        BFieldManager& operator=(const BFieldManager&);
-
         MapContainerType innerMaps_;
         MapContainerType outerMaps_;
-
 
         // Handles caching and overlap resolution logic
         BFCacheManager cm_;

--- a/BeamlineGeom/inc/Coil.hh
+++ b/BeamlineGeom/inc/Coil.hh
@@ -14,15 +14,15 @@ namespace mu2e {
 
   public:
 
-    Coil() : _rIn(0.), _rOut(0.), _halfZ(0.) {}
+    Coil() : _rIn(0.), _rOut(0.), _halfZ(0.), _origin(), _rotation() {}
 
     Coil( double x, double y, double z,
           double rIn, double rOut, double halfZ,
-          CLHEP::HepRotation rotation = CLHEP::HepRotation() ) :
-      _rIn( rIn ), _rOut( rOut ) , _halfZ( halfZ )
+          CLHEP::HepRotation const& rotation = CLHEP::HepRotation() ) :
+      _rIn( rIn ), _rOut( rOut ) , _halfZ( halfZ ),
+      _origin( x, y, z ),
+      _rotation(rotation)
     {
-      _origin = CLHEP::Hep3Vector( x, y, z );
-      _rotation = rotation;
     }
 
     double rIn()        const { return _rIn;   }
@@ -31,7 +31,7 @@ namespace mu2e {
     CLHEP::Hep3Vector  const & getGlobal()   const { return _origin; }
     CLHEP::HepRotation const * getRotation() const { return &_rotation; }
 
-    void  setRotation( CLHEP::HepRotation rotation ) { _rotation = rotation; }
+    void  setRotation( CLHEP::HepRotation const& rotation ) { _rotation = rotation; }
 
     void setOrigin  ( const double x, const double y, const double z ) {
       _origin = CLHEP::Hep3Vector( x, y, z );

--- a/BeamlineGeom/inc/Collimator.hh
+++ b/BeamlineGeom/inc/Collimator.hh
@@ -19,9 +19,9 @@ namespace mu2e {
 
     // use compiler-generated copy c'tor, copy assignment, and d'tor
 
-    Collimator(double halfZ, CLHEP::Hep3Vector origin) :  _halfZ(halfZ), _origin(origin) {}
+    Collimator(double halfZ, CLHEP::Hep3Vector const& origin) :  _halfZ(halfZ), _origin(origin) {}
 
-    void set(double halfZ, CLHEP::Hep3Vector origin) {
+    void set(double halfZ, CLHEP::Hep3Vector const& origin) {
       _halfZ=halfZ;
       _origin=origin;
     }

--- a/BeamlineGeom/inc/Collimator_TS1.hh
+++ b/BeamlineGeom/inc/Collimator_TS1.hh
@@ -20,7 +20,7 @@ namespace mu2e {
     CollimatorTS1() : Collimator() {}
 
     // use compiler-generated copy c'tor, copy assignment, and d'tor
-    CollimatorTS1(double halfZ, CLHEP::Hep3Vector origin) :
+    CollimatorTS1(double halfZ, CLHEP::Hep3Vector const& origin) :
       Collimator( halfZ, origin) {}
 
     double rIn1() const { return _rIn1; }

--- a/BeamlineGeom/inc/Collimator_TS3.hh
+++ b/BeamlineGeom/inc/Collimator_TS3.hh
@@ -19,7 +19,7 @@ namespace mu2e {
     CollimatorTS3() : Collimator() {}
 
     // use compiler-generated copy c'tor, copy assignment, and d'tor
-    CollimatorTS3(double halfZ, CLHEP::Hep3Vector origin) :
+    CollimatorTS3(double halfZ, CLHEP::Hep3Vector const& origin) :
       Collimator( halfZ, origin) {}
 
     double      rOut() const { return _rOut; }

--- a/BeamlineGeom/inc/Collimator_TS5.hh
+++ b/BeamlineGeom/inc/Collimator_TS5.hh
@@ -19,7 +19,7 @@ namespace mu2e {
     CollimatorTS5() : Collimator() {}
 
     // use compiler-generated copy c'tor, copy assignment, and d'tor
-    CollimatorTS5(double halfZ, CLHEP::Hep3Vector origin) :
+    CollimatorTS5(double halfZ, CLHEP::Hep3Vector const& origin) :
       Collimator( halfZ, origin) {}
 
     double rIn()        const { return _rIn;        }

--- a/BeamlineGeom/inc/ConeSection.hh
+++ b/BeamlineGeom/inc/ConeSection.hh
@@ -20,6 +20,8 @@ namespace mu2e {
 
   public:
 
+    constexpr static std::size_t _npar_data = 7;
+
     // fixme: improve  _materialName initialization
     ConeSection() : TSSection(),
                     _rIn1(0.), _rOut1(0.),  _rIn2(0.), _rOut2(0.), _halfZ(0.),
@@ -53,8 +55,6 @@ namespace mu2e {
       fillData();
     }
 
-    ~ConeSection(){}
-
     void set(double rIn1, double rOut1, double rIn2, double rOut2, double halfZ,
              double phi0, double deltaPhi,
              CLHEP::Hep3Vector const & origin, CLHEP::HepRotation const & rotation=CLHEP::HepRotation(),
@@ -79,7 +79,7 @@ namespace mu2e {
     double getHalfLength() const { return _halfZ; }
     double phiStart()    const {return _phi0; }
     double deltaPhi()    const {return _deltaPhi; }
-    const std::array<double,7>& getParameters() const { return _data; }
+    const std::array<double,_npar_data>& getParameters() const { return _data; }
 
   private:
 
@@ -91,7 +91,7 @@ namespace mu2e {
     double _phi0;
     double _deltaPhi;
 
-    std::array<double,7> _data;
+    std::array<double,_npar_data> _data;
 
     void fillData() {
       _data[0] = _rIn1;

--- a/BeamlineGeom/inc/PbarWindow.hh
+++ b/BeamlineGeom/inc/PbarWindow.hh
@@ -34,7 +34,7 @@ namespace mu2e {
     double getDZ1() const  { return _dz1; };
     double getWedgeZOffset() const { return _wedgeZOffset; }
 
-    void set(double halfZ, CLHEP::Hep3Vector origin) {
+    void set(double halfZ, CLHEP::Hep3Vector const& origin) {
       _halfZ  = halfZ;
       _origin = origin;
     }

--- a/BeamlineGeom/inc/StraightSection.hh
+++ b/BeamlineGeom/inc/StraightSection.hh
@@ -40,8 +40,6 @@ namespace mu2e {
       _diffZ(0.)
     {}
 
-    ~StraightSection(){}
-
     void set(double rIn, double rOut, double halfZ,
              CLHEP::Hep3Vector const & origin, CLHEP::HepRotation const & rotation=CLHEP::HepRotation(),
              std::string const & materialName = "", double diffZ = 0.) {

--- a/BeamlineGeom/inc/TSSection.hh
+++ b/BeamlineGeom/inc/TSSection.hh
@@ -16,21 +16,25 @@ namespace mu2e {
   public:
 
     virtual ~TSSection(){}
+    TSSection( TSSection const&  ) = default;
+    TSSection( TSSection&&       ) = default;
+    TSSection& operator=(TSSection const&  ) = default;
+    TSSection& operator=(TSSection &&      ) = default;
 
     TSSection() :
       _origin(CLHEP::Hep3Vector()), _rotation(CLHEP::HepRotation()), _materialName("")
     {}
 
-    explicit TSSection(CLHEP::Hep3Vector origin,
-                       CLHEP::HepRotation rotation = CLHEP::HepRotation(),
-                       std::string materialName="") :
+    explicit TSSection(CLHEP::Hep3Vector const& origin,
+                       CLHEP::HepRotation const& rotation = CLHEP::HepRotation(),
+                       std::string const& materialName="") :
       _origin(origin),  _rotation(rotation),  _materialName(materialName)
     {}
 
     CLHEP::Hep3Vector  const & getGlobal()   const { return _origin; }
     CLHEP::HepRotation const * getRotation() const { return &_rotation; }
     std::string const & getMaterial() const { return _materialName; }
-    void setMaterial( std::string material ) { _materialName = material; }
+    void setMaterial( std::string const&  material ) { _materialName = material; }
 
   protected:
 

--- a/BeamlineGeom/inc/TorusSection.hh
+++ b/BeamlineGeom/inc/TorusSection.hh
@@ -20,6 +20,9 @@ namespace mu2e {
   friend class BeamlineMaker;
 
   public:
+
+    constexpr static std::size_t _npar_data{5};
+
     // fixme: improve  _materialName initialization
     TorusSection() :
       _rTorus(0.),_rIn(0.),_rOut(0.),
@@ -51,8 +54,6 @@ namespace mu2e {
       fillData();
     }
 
-    ~TorusSection(){}
-
     void set(double rTorus, double rIn, double rOut, double phi0, double dPhi,
              CLHEP::Hep3Vector  const & origin,
              CLHEP::HepRotation  const & rotation = CLHEP::HepRotation(),
@@ -73,7 +74,7 @@ namespace mu2e {
     double rOut()        const {return _rOut;  }
     double phiStart()    const {return _phiBegin; }
     double deltaPhi()    const {return _deltaPhi; }
-    const std::array<double,5>& getParameters() const { return _data; }
+    const std::array<double,_npar_data>& getParameters() const { return _data; }
 
   private:
 
@@ -85,7 +86,7 @@ namespace mu2e {
     double _phiBegin;
     double _deltaPhi;
 
-    std::array<double,5> _data;
+    std::array<double,_npar_data> _data;
 
     void fillData() {
       _data[0] = _rIn;

--- a/BeamlineGeom/inc/TransportSolenoid.hh
+++ b/BeamlineGeom/inc/TransportSolenoid.hh
@@ -34,7 +34,7 @@ namespace mu2e {
     {
       // Reserve number of coils
       for ( unsigned iTS = TSRegion::TS1 ; iTS <= TSRegion::TS5 ; ++iTS )
-        _coilMap[ (TSRegion)iTS ].reserve( getNCoils( (TSRegion)iTS ) );
+        _coilMap[ static_cast<TSRegion::enum_type>(iTS) ].reserve( getNCoils( static_cast<TSRegion::enum_type>(iTS) ) );
     }
 
     // use compiler-generated copy c'tor, copy assignment, and d'tor

--- a/CalorimeterGeom/inc/Calorimeter.hh
+++ b/CalorimeterGeom/inc/Calorimeter.hh
@@ -24,6 +24,8 @@ namespace mu2e {
         public:
 
            //no constructor for this interface
+           // Fixme: clang-tidy finds a rule of 5 violation.
+           //        The obvious fix create errors compiling derived classes due to missing default c
            virtual ~Calorimeter(){};
 
 

--- a/CalorimeterGeom/inc/CrystalMapper.hh
+++ b/CalorimeterGeom/inc/CrystalMapper.hh
@@ -21,7 +21,9 @@ namespace mu2e {
         public:
 
            //no constructor for this interface
-           virtual ~CrystalMapper() {};
+           // Fixme: clang-tidy finds a rule of 5 violation.
+           //        The obvious fix create errors compiling derived classes due to missing default c'tor
+           virtual ~CrystalMapper() {}
 
            virtual int                nCrystalMax(int maxRing)                         const = 0;
 

--- a/CalorimeterGeom/inc/Disk.hh
+++ b/CalorimeterGeom/inc/Disk.hh
@@ -27,7 +27,6 @@ namespace mu2e {
 
            Disk(int id, double rin, double rout, double rCrystalIn, double rCrystalOut, double nominalCellSize,
                 int offset, const CLHEP::Hep3Vector& diskOriginToCrystalOrigin);
-           ~Disk(){};
 
            int                             id()                     const {return id_;}
 

--- a/CalorimeterGeom/inc/DiskCalorimeter.hh
+++ b/CalorimeterGeom/inc/DiskCalorimeter.hh
@@ -31,37 +31,35 @@ namespace mu2e {
         public:
 
             DiskCalorimeter();
-            virtual ~DiskCalorimeter() {}
-
 
             // calo section
-            virtual unsigned                  nDisk()     const  {return nDisks_;}
-            virtual const Disk&               disk(int i) const  {return *disks_.at(i);}
+            unsigned                  nDisk()     const  override {return nDisks_;}
+            const Disk&               disk(int i) const  override {return *disks_.at(i);}
 
 
               // crystal section
-            virtual int                       nCrystal()     const  {return fullCrystalList_.size();}
-            virtual const Crystal&            crystal(int i) const  {return *fullCrystalList_.at(i);}
+            int                       nCrystal()     const override {return int(fullCrystalList_.size());}
+            const Crystal&            crystal(int i) const override {return *fullCrystalList_.at(i);}
 
 
             // calorimeter geometry information
-            virtual const CaloInfo&           caloInfo()     const  {return caloInfo_;}
-            virtual const CaloGeomUtil&       geomUtil()     const  {return geomUtil_;}
-                          CaloInfo&           caloInfo()            {return caloInfo_;}
-                          CaloGeomUtil&       geomUtil()            {return geomUtil_;}
+            const CaloInfo&           caloInfo()     const override {return caloInfo_;}
+            const CaloGeomUtil&       geomUtil()     const override {return geomUtil_;}
+                  CaloInfo&           caloInfo()                    {return caloInfo_;}
+                  CaloGeomUtil&       geomUtil()                    {return geomUtil_;}
 
 
 
               // neighbors, indexing
-            virtual const std::vector<int>&  neighbors(int crystalId, bool rawMap)     const  {return fullCrystalList_.at(crystalId)->neighbors(rawMap);}
-            virtual const std::vector<int>&  nextNeighbors(int crystalId, bool rawMap) const  {return fullCrystalList_.at(crystalId)->nextNeighbors(rawMap);}
-            virtual       std::vector<int>   neighborsByLevel(int crystalId, int level, bool rawMap) const;
-            virtual int                      crystalIdxFromPosition(const CLHEP::Hep3Vector& pos) const;
-            virtual int                      nearestIdxFromPosition(const CLHEP::Hep3Vector& pos) const;
+            const std::vector<int>&  neighbors(int crystalId, bool rawMap)     const override {return fullCrystalList_.at(crystalId)->neighbors(rawMap);}
+            const std::vector<int>&  nextNeighbors(int crystalId, bool rawMap) const override {return fullCrystalList_.at(crystalId)->nextNeighbors(rawMap);}
+            std::vector<int>   neighborsByLevel(int crystalId, int level, bool rawMap) const override;
+            int                      crystalIdxFromPosition(const CLHEP::Hep3Vector& pos) const override;
+            int                      nearestIdxFromPosition(const CLHEP::Hep3Vector& pos) const override;
 
 
             // get to know me!
-            virtual void                     print(std::ostream &os = std::cout) const;
+            void                     print(std::ostream &os = std::cout) const override;
 
 
         private:

--- a/CalorimeterGeom/inc/DiskGeomInfo.hh
+++ b/CalorimeterGeom/inc/DiskGeomInfo.hh
@@ -34,8 +34,6 @@ namespace mu2e {
              crateDeltaZ_(0)
            {}
 
-           ~DiskGeomInfo() {}
-
            const CLHEP::Hep3Vector&  size()                    const {return size_; }
            const CLHEP::Hep3Vector&  origin()                  const {return origin_;}
            const CLHEP::Hep3Vector&  originLocal()             const {return originLocal_; }

--- a/ConfigTools/inc/ConfigFileLookupPolicy.hh
+++ b/ConfigTools/inc/ConfigFileLookupPolicy.hh
@@ -17,8 +17,7 @@ namespace mu2e {
 class mu2e::ConfigFileLookupPolicy :
   public cet::filepath_maker {
 public:
-  virtual std::string operator() (std::string const &filename);
-  virtual ~ConfigFileLookupPolicy() noexcept {}
+  std::string operator() (std::string const &filename) override;
 
 private:
   inline cet::search_path const &path() const;

--- a/ConfigTools/inc/SimpleConfig.hh
+++ b/ConfigTools/inc/SimpleConfig.hh
@@ -68,14 +68,14 @@ namespace mu2e {
                   bool allowReplacement       = true,
                   bool messageOnReplacement   = false,
                   bool messageOnDefault       = false );
+    ~SimpleConfig() = default;
 
-    ~SimpleConfig(){}
+    // This class is not copyable. See note 3.
+    SimpleConfig( const SimpleConfig& ) = delete;
+    SimpleConfig( SimpleConfig&& )      = delete;
+    SimpleConfig& operator=(SimpleConfig const&) = delete;
+    SimpleConfig& operator=(SimpleConfig&&     ) = delete;
 
-  private:
-
-    // This class is not copyable.  These methods are private and unimplemented.  See note 3.
-    SimpleConfig( const SimpleConfig& );
-    SimpleConfig& operator=(const SimpleConfig&);
 
   public:
 

--- a/CosmicRayShieldGeom/inc/CRSScintillatorLayer.hh
+++ b/CosmicRayShieldGeom/inc/CRSScintillatorLayer.hh
@@ -34,7 +34,7 @@ namespace mu2e
 
     CRSScintillatorLayerId const & id() const { return _id;}
 
-    int nBars() const { return _bars.size(); }
+    int nBars() const { return int(_bars.size()); }
 
     CRSScintillatorBar const & getBar( int n ) const
     {
@@ -48,7 +48,8 @@ namespace mu2e
 
     const std::vector<std::shared_ptr<CRSScintillatorBar> >& getBars() const { return _bars; }
 
-    const CLHEP::Hep3Vector &getPosition() const {return _position;}
+    const CLHEP::Hep3Vector &getPosition() const
+    {return _position;}
 
     const std::vector<double> &getHalfLengths() const {return _halfLengths;}
     double getHalfThickness() const { return _halfLengths[_localToWorld[0]];}

--- a/CosmicRayShieldGeom/inc/CRSScintillatorModule.hh
+++ b/CosmicRayShieldGeom/inc/CRSScintillatorModule.hh
@@ -47,7 +47,7 @@ namespace mu2e
 
     int nLayers() const
     {
-      return _layers.size();
+      return int(_layers.size());
     }
 
     const CRSScintillatorLayer& getLayer ( int n ) const
@@ -72,7 +72,7 @@ namespace mu2e
 
     int nAbsorberLayers() const
     {
-      return _absorberLayers.size();
+      return int(_absorberLayers.size());
     }
 
     const CRSAbsorberLayer& getAbsorberLayer ( int n ) const
@@ -87,7 +87,7 @@ namespace mu2e
 
     int nAluminumSheets() const
     {
-      return _aluminumSheets.size();
+      return int(_aluminumSheets.size());
     }
 
     const CRSAluminumSheet& getAluminumSheet ( int n ) const
@@ -102,7 +102,7 @@ namespace mu2e
 
     int nFEBs() const
     {
-      return _FEBs.size();
+      return int(_FEBs.size());
     }
 
     const CRSFEB& getFEB ( int n ) const

--- a/CosmicRayShieldGeom/inc/CRSScintillatorShield.hh
+++ b/CosmicRayShieldGeom/inc/CRSScintillatorShield.hh
@@ -41,7 +41,7 @@ namespace mu2e
 
     const std::string& getName() const {return _name;}
 
-    int nModules() const {return _modules.size();}
+    int nModules() const {return int(_modules.size());}
 
     const std::vector<CRSScintillatorModule>& getCRSScintillatorModules() const
     {

--- a/CosmicRayShieldGeom/inc/CosmicRayShield.hh
+++ b/CosmicRayShieldGeom/inc/CosmicRayShield.hh
@@ -36,7 +36,6 @@ namespace mu2e
     public:
 
     CosmicRayShield() {}
-    ~CosmicRayShield() override {}
 
     // Get ScintillatorShield
     CRSScintillatorShield const & getCRSScintillatorShield(const CRSScintillatorShieldId& id) const

--- a/ExtinctionMonitorFNAL/Geometry/inc/ExtMonFNALPlaneStack.hh
+++ b/ExtinctionMonitorFNAL/Geometry/inc/ExtMonFNALPlaneStack.hh
@@ -25,7 +25,7 @@ namespace mu2e {
     unsigned nmodules() const { return (this->nplanes() * this->nModulesPerPlane()); }
 
     const std::vector<ExtMonFNALPlane>& planes() const { return planes_; }
-    const int size() const { return planes_.size(); }
+    const int size() const { return int(planes_.size()); }
 
     const std::vector<double>& plane_zoffset() const { return m_plane_zoffset; }
     const std::vector<double>& plane_xoffset() const { return m_plane_xoffset; }

--- a/GeneralUtilities/inc/EnumToStringSparse.hh
+++ b/GeneralUtilities/inc/EnumToStringSparse.hh
@@ -163,10 +163,11 @@ namespace mu2e {
     static map_type const& names() { return Detail::names(); }
 
     static void printAll( std::ostream& ost ){
+      constexpr unsigned fieldWidth{10};
       ost << "Defined enum values for " << Detail::typeName() << std::endl;
       for ( typename map_type::const_iterator i=names().begin(), e=names().end();
             i != e; ++i ){
-        ost << std::setw(10) << i->first << " " << i->second << std::endl;
+        ost << std::setw(fieldWidth) << i->first << " " << i->second << std::endl;
       }
     }
 

--- a/GeomPrimitives/inc/Box.hh
+++ b/GeomPrimitives/inc/Box.hh
@@ -8,7 +8,6 @@ namespace mu2e {
 
     Box( double x, double y, double z) :
       _xhl(x), _yhl(y), _zhl(z){}
-    ~Box(){}
 
     double getXhalfLength() const { return _xhl; }
     double getYhalfLength() const { return _yhl; }

--- a/GeomPrimitives/inc/Tube.hh
+++ b/GeomPrimitives/inc/Tube.hh
@@ -55,7 +55,7 @@ namespace mu2e {
     TubsParams const & getTubsParams() const { return _params; }
 
     std::string getName() const { return _name; }
-    void        setName( std::string name ) { _name = name; }
+    void        setName( std::string const& name ) { _name = name; }
 
     // Genreflex can't do persistency of vector<Tube> without a default constructor
     Tube() : _params(0,0,0) {}

--- a/GeometryService/inc/DiskCalorimeterMaker.hh
+++ b/GeometryService/inc/DiskCalorimeterMaker.hh
@@ -33,13 +33,13 @@ namespace mu2e{
     public:
 
        DiskCalorimeterMaker(SimpleConfig const& config, double solenoidOffset);
-      ~DiskCalorimeterMaker();
 
-      // Accessor and unique_ptr to calorimeter needed by GeometryService.
-      std::unique_ptr<DiskCalorimeter> calo_;
       std::unique_ptr<DiskCalorimeter> calorimeterPtr() { return std::move(calo_); }
 
     private:
+
+      // unique_ptr to calorimeter needed by GeometryService.
+      std::unique_ptr<DiskCalorimeter> calo_;
 
       void CheckIt(void);
       void MakeIt(void);

--- a/GeometryService/inc/G4GeometryOptions.hh
+++ b/GeometryService/inc/G4GeometryOptions.hh
@@ -146,11 +146,13 @@ namespace mu2e {
     public:
 
       G4GeometryOptions( const SimpleConfig& config );
+      ~G4GeometryOptions() = default;
 
       // Disable copy c'tor and copy assignment
       G4GeometryOptions           (const G4GeometryOptions&) = delete;
       G4GeometryOptions& operator=(const G4GeometryOptions&) = delete;
-
+      G4GeometryOptions           (G4GeometryOptions&&)      = delete;
+      G4GeometryOptions& operator=(G4GeometryOptions&&)      = delete;
 
       void loadEntry( const SimpleConfig& config, const std::string& volName, const std::string& prefix );
 

--- a/GeometryService/inc/GeometryService.hh
+++ b/GeometryService/inc/GeometryService.hh
@@ -67,6 +67,12 @@ public:
     GeometryService(const Parameters&, art::ActivityRegistry&);
     ~GeometryService();
 
+    // This is not copyable or assignable.
+    GeometryService(GeometryService const& ) = delete;
+    GeometryService(GeometryService&&      ) = delete;
+    GeometryService& operator=(GeometryService const& ) = delete;
+    GeometryService& operator=(GeometryService&&      ) = delete;
+
     // Functions registered for callbacks.
     void preBeginRun( art::Run const &run);
     void postEndJob();
@@ -172,10 +178,6 @@ private:
 
     // Keep a count of how many runs we have seen.
     int _run_count = 0;
-
-    // This is not copyable or assignable - private and unimplemented.
-    GeometryService const& operator=(GeometryService const& rhs);
-    GeometryService(GeometryService const& rhs);
 
     // Don't need to expose definition of private template in header
     template <typename DET> void addDetector(std::unique_ptr<DET> d);

--- a/GeometryService/inc/MBSMaker.hh
+++ b/GeometryService/inc/MBSMaker.hh
@@ -27,6 +27,13 @@ namespace mu2e {
 
     MBSMaker( SimpleConfig const & config,
               double solenoidOffset);
+    ~MBSMaker() = default;
+
+    // delete automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
+    MBSMaker( MBSMaker const & ) = delete;
+    MBSMaker( MBSMaker&&       ) = delete;
+    MBSMaker& operator=( MBSMaker const & ) = delete;
+    MBSMaker& operator=( MBSMaker&&       )  = delete;
 
     void parseConfig( SimpleConfig const & _config );
 
@@ -38,10 +45,6 @@ namespace mu2e {
     std::unique_ptr<MBS> getMBSPtr() { return std::move(_mbs); }
 
   private:
-
-    // hide automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
-    MBSMaker( MBSMaker const & );
-    MBSMaker const & operator= ( MBSMaker const & );
 
     std::unique_ptr<MBS> _mbs;
 

--- a/GeometryService/inc/ProductionSolenoidMaker.hh
+++ b/GeometryService/inc/ProductionSolenoidMaker.hh
@@ -24,6 +24,13 @@ namespace mu2e {
 
     ProductionSolenoidMaker( SimpleConfig const & config,
                              double solenoidOffset);
+    ~ProductionSolenoidMaker() = default;
+
+    // delete automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
+    ProductionSolenoidMaker( ProductionSolenoidMaker const& ) = delete;
+    ProductionSolenoidMaker( ProductionSolenoidMaker&&      ) = delete;
+    ProductionSolenoidMaker& operator= ( ProductionSolenoidMaker const& ) = delete;
+    ProductionSolenoidMaker& operator= ( ProductionSolenoidMaker&&      ) = delete;
 
     void parseConfig( SimpleConfig const & _config );
 
@@ -35,10 +42,6 @@ namespace mu2e {
     std::unique_ptr<ProductionSolenoid> getProductionSolenoidPtr() { return std::move(_ps); }
 
   private:
-
-    // hide automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
-    ProductionSolenoidMaker( ProductionSolenoidMaker const & );
-    ProductionSolenoidMaker const & operator= ( ProductionSolenoidMaker const & );
 
     std::unique_ptr<ProductionSolenoid> _ps;
 

--- a/GeometryService/inc/STMMaker.hh
+++ b/GeometryService/inc/STMMaker.hh
@@ -23,6 +23,13 @@ namespace mu2e {
 
     STMMaker( SimpleConfig const & config,
               double solenoidOffset);
+    ~STMMaker() = default;
+
+    // delete automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
+    STMMaker( STMMaker const & ) = delete;
+    STMMaker( STMMaker&&       ) = delete;
+    STMMaker& operator=( STMMaker const & ) = delete;
+    STMMaker& operator=( STMMaker&&       ) = delete;
 
     void parseConfig( SimpleConfig const & _config );
 
@@ -34,10 +41,6 @@ namespace mu2e {
     std::unique_ptr<STM> getSTMPtr() { return std::move(_stm); }
 
   private:
-
-    // hide automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
-    STMMaker( STMMaker const & );
-    STMMaker const & operator= ( STMMaker const & );
 
     std::unique_ptr<STM> _stm;
 

--- a/GeometryService/inc/VirtualDetector.hh
+++ b/GeometryService/inc/VirtualDetector.hh
@@ -27,7 +27,6 @@ namespace mu2e {
 
   public:
     VirtualDetector();
-    ~VirtualDetector(){;}
 
     double getHalfLength() const { return _halfLength; }
 

--- a/GeometryService/src/BFieldManagerMaker.cc
+++ b/GeometryService/src/BFieldManagerMaker.cc
@@ -433,16 +433,16 @@ namespace mu2e {
             throw cet::exception("GEOM") << "Can't find data keyword in " << filename << "\n";
 
         // Expected grid dimentsions.
-        const int nx = bfmap._nx;
-        const int ny = bfmap._ny;
-        const int nz = bfmap._nz;
+        const size_t nx = bfmap._nx;
+        const size_t ny = bfmap._ny;
+        const size_t nz = bfmap._nz;
 
         // Calculate expected number of lines to read
-        const int nrecord = nx * ny * nz;
+        const size_t nrecord = nx * ny * nz;
 
         // Read data
         double x[3], b[3];
-        int nread = 0;
+        size_t nread = 0;
         getline(in, cbuf);
         while (!in.eof()) {
 
@@ -523,7 +523,7 @@ namespace mu2e {
                                 // search the path
 
         // Number of points in each big array.
-        int nPoints = bf.nx() * bf.ny() * bf.nz();
+        size_t nPoints = bf.nx() * bf.ny() * bf.nz();
 
         // Number of bytes in each big array.
         size_t nbytes = sizeof(CLHEP::Hep3Vector) * nPoints;
@@ -621,9 +621,9 @@ namespace mu2e {
         }
 
         // These maps fill the full box so mark all grid points as valid.
-        for (int ix = 0; ix < bf.nx(); ++ix) {
-            for (int iy = 0; iy < bf.ny(); ++iy) {
-                for (int iz = 0; iz < bf.nz(); ++iz) {
+        for (size_t ix = 0; ix < bf.nx(); ++ix) {
+            for (size_t iy = 0; iy < bf.ny(); ++iy) {
+                for (size_t iz = 0; iz < bf.nz(); ++iz) {
                     bf._isDefined.set(ix, iy, iz, true);
                 }
             }
@@ -706,7 +706,7 @@ namespace mu2e {
 
     void BFieldManagerMaker::writeG4BLBinary(const BFGridMap& bf, const std::string& outputfile) {
         // Number of points in the big array.
-        int nPoints = bf.nx() * bf.ny() * bf.nz();
+        size_t nPoints = bf.nx() * bf.ny() * bf.nz();
 
         // Number of bytes in the big array.
         size_t nBytes = sizeof(CLHEP::Hep3Vector) * nPoints;
@@ -764,9 +764,9 @@ namespace mu2e {
 
     void BFieldManagerMaker::flipMap(BFGridMap& bf) {
         std::cout << "Flipping B field vector in map " << bf.getKey() << std::endl;
-        for (int ix = 0; ix < bf.nx(); ++ix) {
-            for (int iy = 0; iy < bf.ny(); ++iy) {
-                for (int iz = 0; iz < bf.nz(); ++iz) {
+        for (size_t ix = 0; ix < bf.nx(); ++ix) {
+            for (size_t iy = 0; iy < bf.ny(); ++iy) {
+                for (size_t iz = 0; iz < bf.nz(); ++iz) {
                     bf._field.set(ix, iy, iz, -bf._field.get(ix, iy, iz));
                 }
             }

--- a/GeometryService/src/DiskCalorimeterMaker.cc
+++ b/GeometryService/src/DiskCalorimeterMaker.cc
@@ -248,11 +248,6 @@ namespace mu2e {
          MakeIt();
     }
 
-
-    DiskCalorimeterMaker::~DiskCalorimeterMaker() {}
-
-
-
     void DiskCalorimeterMaker::MakeIt(void)
     {
 

--- a/GeometryService/src/GeometryService.cc
+++ b/GeometryService/src/GeometryService.cc
@@ -250,7 +250,7 @@ namespace mu2e {
         //        std::cout << " adding Hayman in GeometryService" << std::endl;
         addDetector(PSShieldMaker::make(*_config, ps.psEndRefPoint(), prodTarget.haymanProdTargetPosition()));
           } else
-        {throw cet::exception("GEOM") << " " << __func__ << " illegal production target version specified in GeometryService_service = " << _config->getString("targetPS_model")  << std::endl;}
+        {throw cet::exception("GEOM") << " " << static_cast<char const*>(__func__) << " illegal production target version specified in GeometryService_service = " << _config->getString("targetPS_model")  << std::endl;}
 
 
 

--- a/GeometryService/src/MBSMaker.cc
+++ b/GeometryService/src/MBSMaker.cc
@@ -51,7 +51,7 @@ namespace mu2e {
     parseConfig(_config);
 
     // now create the specific components - Version 1 first, then Version 2
-    mbs._Version = _MBSVersion;
+    mbs._version = _MBSVersion;
 
     if ( _MBSVersion == 1 ) {
 

--- a/MBSGeom/inc/MBS.hh
+++ b/MBSGeom/inc/MBS.hh
@@ -25,6 +25,14 @@ namespace mu2e {
 
   public:
 
+    ~MBS() override = default;
+
+    // hide automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
+    MBS( MBS const& ) = delete;
+    MBS( MBS&&      ) = delete;
+    MBS& operator=( MBS const& ) = delete;
+    MBS& operator=( MBS&&      ) = delete;
+
     // Volume names a per figure 8.29 in the CDR <== somewhat outdated now
     // MBSM is mother volume
     // BSTS is stainless steel pipe in three sections
@@ -45,7 +53,7 @@ namespace mu2e {
     Polycone const * getCLV2Ptr()     const { return _pCLV2Params.get();     }
     Tube     const * getCLV2ABSPtr()  const { return _pCLV2ABSParams.get();  }
     Tube     const * getCalRingShieldPtr()  const { return _pCalShieldRingParams.get();  }
-    int      const   getVersion()     const { return _Version;               }
+    int      const   getVersion()     const { return _version;               }
 
     CLHEP::Hep3Vector const & originInMu2e() const { return _originInMu2e; };
 
@@ -79,10 +87,6 @@ namespace mu2e {
     // The class should only be constructed via MBS::MBSMaker.
     MBS(){};
 
-    // hide automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
-    MBS( MBS const & );
-    MBS const & operator= ( MBS const & );
-
     // several concentric components
 
     std::unique_ptr<Polycone> _pMBSMParams; // mother envelope
@@ -98,26 +102,26 @@ namespace mu2e {
     std::unique_ptr<Tube>     _pCLV2ABSParams;
     std::unique_ptr<Tube>     _pCalShieldRingParams; //Shield to protect the calorimeter
 
-    double _rMax;
-    double _rMin;
-    double _zMax;
-    double _totLength;
+    double _rMax = 0;
+    double _rMin = 0;
+    double _zMax = 0;
+    double _totLength = 0;
 
     CLHEP::Hep3Vector   _originInMu2e;
 
-    int    _Version;  // added DNo Brown
+    int    _version = 0;
     std::vector<CLHEP::Hep3Vector> _holeCentersInSteel;
     std::vector<CLHEP::Hep3Vector> _holeCentersInUpstreamPoly;
     std::vector<CLHEP::Hep3Vector> _holeCentersInDownstreamPoly;
-    double _holeXDimInSteel;
-    double _holeYDimInSteel;
-    double _holeZDimInSteel;
-    double _holeXDimInUpPoly;
-    double _holeYDimInUpPoly;
-    double _holeZDimInUpPoly;
-    double _holeXDimInDownPoly;
-    double _holeYDimInDownPoly;
-    double _holeZDimInDownPoly;
+    double _holeXDimInSteel = 0.;
+    double _holeYDimInSteel = 0.;
+    double _holeZDimInSteel = 0.;
+    double _holeXDimInUpPoly = 0.;
+    double _holeYDimInUpPoly = 0.;
+    double _holeZDimInUpPoly = 0.;
+    double _holeXDimInDownPoly = 0.;
+    double _holeYDimInDownPoly = 0.;
+    double _holeZDimInDownPoly = 0.;
 
   };
 

--- a/MECOStyleProtonAbsorberGeom/inc/MECOStyleProtonAbsorber.hh
+++ b/MECOStyleProtonAbsorberGeom/inc/MECOStyleProtonAbsorber.hh
@@ -52,7 +52,6 @@ namespace mu2e {
 
     InnerProtonAbsSupport( std::size_t nSets, std::size_t nWiresPerSet )
       : _nSets ( nSets ) , _nWiresPerSet ( nWiresPerSet ) {}
-    ~InnerProtonAbsSupport(){}
 
     void setWireAngleOffset(double offset) { _wireAngleOffset = offset; }
     const Tube& getWire( std::size_t iSet, std::size_t iWire ) const { return _supportWireMap.at(iSet).at(iWire); }
@@ -65,9 +64,9 @@ namespace mu2e {
   private:
     std::size_t _nSets;
     std::size_t _nWiresPerSet;
-    double      _wireAngleOffset;
+    double      _wireAngleOffset = 0;
     std::vector<std::vector<Tube>> _supportWireMap;
-    std::size_t _nEndRings;
+    std::size_t _nEndRings = 0;
     std::vector<Tube> _endRingMap;
   };
 

--- a/MECOStyleProtonAbsorberGeom/inc/MECOStyleProtonAbsorberPart.hh
+++ b/MECOStyleProtonAbsorberGeom/inc/MECOStyleProtonAbsorberPart.hh
@@ -26,7 +26,7 @@ namespace mu2e {
                                  double rOut1,
                                  double rIn1,
                                  double halflen,
-                                 std::string m):
+                                 std::string const& m):
       _id(id),
       _c(c),
       _rOut0(rOut0),
@@ -46,7 +46,7 @@ namespace mu2e {
                                  double rIn1,
                                  double halflen,
                                  int    nSides,
-                                 std::string m):
+                                 std::string const& m):
       _id(id),
       _c(c),
       _rOut0(rOut0),

--- a/Mu2eInterfaces/inc/Detector.hh
+++ b/Mu2eInterfaces/inc/Detector.hh
@@ -18,6 +18,11 @@ namespace mu2e
   public:
     Detector() {}
     virtual ~Detector() = default;
+    Detector( Detector const&  ) = default;
+    Detector( Detector&&       ) = default;
+    Detector& operator=(Detector const&  ) = default;
+    Detector& operator=(Detector &&      ) = default;
+
   };
 }
 

--- a/Mu2eInterfaces/inc/ProditionsEntity.hh
+++ b/Mu2eInterfaces/inc/ProditionsEntity.hh
@@ -10,8 +10,13 @@ namespace mu2e {
     typedef std::shared_ptr<ProditionsEntity> ptr;
     typedef std::set<int> set_t;
 
-    ProditionsEntity(std::string name):_name(name) {}
+    ProditionsEntity(std::string const& name):_name(name) {}
     virtual ~ProditionsEntity() = default;
+    ProditionsEntity( ProditionsEntity const&  ) = default;
+    ProditionsEntity( ProditionsEntity&&       ) = default;
+    ProditionsEntity& operator=(ProditionsEntity const&  ) = delete;
+    ProditionsEntity& operator=(ProditionsEntity &&      ) = delete;
+
     std::string const& name() const { return _name; }
     set_t const& getCids() const { return _cids; }
     void addCids(set_t const& s) { _cids.insert(s.begin(),s.end()); }

--- a/ProductionSolenoidGeom/inc/PSEnclosure.hh
+++ b/ProductionSolenoidGeom/inc/PSEnclosure.hh
@@ -36,7 +36,7 @@ namespace mu2e {
     const Tube& shell()     const { return shell_; }
     const Cone& shellCone() const { return shellCone_; }
 
-    void setFlange( Tube aFlange ) { flange_ = aFlange; }
+    void setFlange( Tube const& aFlange ) { flange_ = aFlange; }
     const Tube& flange()    const { return flange_; }
 
     const Tube& endPlate()  const { return endPlate_; }

--- a/ProductionSolenoidGeom/inc/ProductionSolenoid.hh
+++ b/ProductionSolenoidGeom/inc/ProductionSolenoid.hh
@@ -20,6 +20,13 @@ namespace mu2e {
   class ProductionSolenoid : virtual public Detector {
 
   public:
+    ~ProductionSolenoid() override = default;
+
+    // delete  automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
+    ProductionSolenoid( ProductionSolenoid const & ) = delete;
+    ProductionSolenoid( ProductionSolenoid&&       ) = delete;
+    ProductionSolenoid& operator=( ProductionSolenoid const & ) = delete;
+    ProductionSolenoid& operator=( ProductionSolenoid&&       ) = delete;
 
     // do we need more than that? does the Tube have all the accessors?
 
@@ -47,10 +54,6 @@ namespace mu2e {
 
     // The class should only be constructed via ProductionSolenoid::ProductionSolenoidMaker.
     ProductionSolenoid(){};
-
-    // hide automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
-    ProductionSolenoid( ProductionSolenoid const & );
-    ProductionSolenoid const & operator= ( ProductionSolenoid const & );
 
     // it has several components
 

--- a/ProductionTargetGeom/inc/ProductionTarget.hh
+++ b/ProductionTargetGeom/inc/ProductionTarget.hh
@@ -66,13 +66,17 @@ namespace mu2e {
     const std::map<double, CLHEP::Hep3Vector> & anchoringPntsRgt() const { return _anchoringPntsRgt; }
     const std::map<double, CLHEP::Hep3Vector> & anchoringPntsLft() const { return _anchoringPntsLft; }
 
-    ~ProductionTarget() {
+    ~ProductionTarget() override {
 
       if (!_tier1TargetType.empty()){
         delete _pHubsRgtParams;
         delete _pHubsLftParams;
       }
     }
+    ProductionTarget( ProductionTarget const&  ) = default;
+    ProductionTarget( ProductionTarget&&       ) = default;
+    ProductionTarget& operator=(ProductionTarget const&  ) = default;
+    ProductionTarget& operator=(ProductionTarget &&      ) = default;
 
 
     //
@@ -148,9 +152,9 @@ namespace mu2e {
      if (_haymanTargetType == hayman_v_2_0){
         return _halfHaymanLength;}
      else if  (_tier1TargetType == "MDC2018"){
-        return _halfLength;}
-      else throw cet::exception("BADCONFIG")
-             << "in ProductionTarget.hh, no valid target specified"<< std::endl;
+       return _halfLength;}
+     else throw cet::exception("BADCONFIG")
+            << "in ProductionTarget.hh, no valid target specified"<< std::endl;
     }
 
 
@@ -208,6 +212,7 @@ namespace mu2e {
 
 //    std::unique_ptr<Polycone> _pHubsRgtParams;
 //    std::unique_ptr<Polycone> _pHubsLftParams;
+    // Fixme: replace with unique_ptr.
     Polycone * _pHubsRgtParams;
     Polycone * _pHubsLftParams;
     std::map<double,CLHEP::Hep3Vector> _anchoringPntsRgt;

--- a/STMGeom/inc/STM.hh
+++ b/STMGeom/inc/STM.hh
@@ -38,6 +38,15 @@ namespace mu2e {
 
   public:
 
+    ~STM() override = default;
+
+    // delete automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
+    STM( STM const& ) = delete;
+    STM( STM const&& ) = delete;
+    STM& operator= ( STM const& ) = delete;
+    STM& operator= ( STM&&      ) = delete;
+
+
     STMDownstreamEnvelope  const * getSTMDnStrEnvPtr()       const { return _pSTMDnStrEnvParams.get(); }
     PermanentMagnet  const * getSTMMagnetPtr()               const { return _pSTMMagnetParams.get(); }
     TransportPipe    const * getSTMTransportPipePtr()        const { return _pSTMTransportPipeParams.get(); }
@@ -73,10 +82,6 @@ namespace mu2e {
 
     // The class should only be constructed via STM::STMMaker.
     STM(){};
-
-    // hide automatic copy/assignments as not needed (would be incorrect due to unique_ptr anyway)
-    STM( STM const & );
-    STM const & operator= ( STM const & );
 
     std::unique_ptr<STMDownstreamEnvelope>  _pSTMDnStrEnvParams;
     std::unique_ptr<PermanentMagnet>  _pSTMMagnetParams;

--- a/STMGeom/inc/ShieldPipe.hh
+++ b/STMGeom/inc/ShieldPipe.hh
@@ -16,13 +16,13 @@ namespace mu2e {
   class ShieldPipe {
   public:
     ShieldPipe(bool build, double radiusIn, bool hasLiner, double linerWidth, double radiusOut, double pipeHalfLength,
-               std::string materialLiner, std::string material,
+               std::string const& materialLiner, std::string const& material,
                bool matchPipeBlock,
                double upStrSpace, double dnStrSpace,
                double dnStrWallHalflength, double dnStrWallHoleRadius,
                double dnStrWallHalfHeight, double dnStrWallHalfWidth,
-               double dnStrWallGap, std::string dnStrWallMaterial,
-               CLHEP::Hep3Vector originInMu2e, CLHEP::HepRotation rotation
+               double dnStrWallGap, std::string const& dnStrWallMaterial,
+               CLHEP::Hep3Vector const& originInMu2e, CLHEP::HepRotation const& rotation
               ) :
       _build( build ),
       _radiusIn( radiusIn ),

--- a/STMGeom/inc/TransportPipe.hh
+++ b/STMGeom/inc/TransportPipe.hh
@@ -16,12 +16,12 @@ namespace mu2e {
   class TransportPipe {
   public:
     TransportPipe(bool build, double radiusIn, double radiusOut,
-                  std::string material, std::string gasMaterial,
+                  std::string const& material, std::string const& gasMaterial,
                   double upStrSpace, double dnStrHalflength,
-                  std::string upStrWindowMaterial, double upStrWindowHalflength,
-                  std::string dnStrWindowMaterial, double dnStrWindowHalflength,
+                  std::string const& upStrWindowMaterial, double upStrWindowHalflength,
+                  std::string const& dnStrWindowMaterial, double dnStrWindowHalflength,
                   double flangeHalflength, double flangeOverhangR,
-                  CLHEP::Hep3Vector originInMu2e, CLHEP::HepRotation rotation
+                  CLHEP::Hep3Vector const& originInMu2e, CLHEP::HepRotation const& rotation
                 ) :
       _build( build ),
       _radiusIn( radiusIn ),

--- a/StoppingTargetGeom/inc/StoppingTarget.hh
+++ b/StoppingTargetGeom/inc/StoppingTarget.hh
@@ -34,7 +34,7 @@ namespace mu2e {
 
     // Use compiler-generated copy c'tor, copy assignment, and d'tor
 
-    int nFoils() const { return _foils.size(); }
+    int nFoils() const { return int(_foils.size()); }
 
     TargetFoil const& foil( unsigned int n ) const { return _foils.at(n); }
 
@@ -44,7 +44,7 @@ namespace mu2e {
 
     std::string const fillMaterial() const {return _fillMaterial;}
 
-    int nSupportStructures() const { return _supportStructures.size(); }
+    int nSupportStructures() const { return int(_supportStructures.size()); }
     TargetFoilSupportStructure const& supportStructure( unsigned int n ) const { return _supportStructures.at(n); }
 
   protected:

--- a/StoppingTargetGeom/inc/TargetFoil.hh
+++ b/StoppingTargetGeom/inc/TargetFoil.hh
@@ -28,7 +28,7 @@ namespace mu2e {
                 double rOut,
                 double rIn,
                 double t,
-                std::string m,
+                std::string const& m,
                 const CLHEP::Hep3Vector& detSysOrigin
                 ):
       _id(id),

--- a/StoppingTargetGeom/inc/TargetFoilSupportStructure.hh
+++ b/StoppingTargetGeom/inc/TargetFoilSupportStructure.hh
@@ -28,7 +28,7 @@ namespace mu2e {
                 double length,
                 double angleOffset,
                 double foil_outer_radius,
-                std::string m,
+                std::string const& m,
                 const CLHEP::Hep3Vector& detSysOrigin
                 ):
       _support_id(support_id),

--- a/TrackerGeom/inc/Panel.hh
+++ b/TrackerGeom/inc/Panel.hh
@@ -47,7 +47,7 @@ namespace mu2e {
         return *(_straws.at(strid.straw()));
       } else {
         std::ostringstream msg;
-        msg << __func__ << " Inconsistent straw/panel request "
+        msg << static_cast<const char*>(__func__) << " Inconsistent straw/panel request "
           << strid << " / " << _id << std::endl;
         throw cet::exception("RANGE") << msg.str();
       }

--- a/TrackerGeom/inc/Straw.hh
+++ b/TrackerGeom/inc/Straw.hh
@@ -65,13 +65,13 @@ namespace mu2e {
       xyzVec strawEnd(StrawEnd const& end ) const { return strawEnd(end.end()); }
       xyzVec strawEnd(StrawEnd::End end ) const { return end == StrawEnd::cal ? _smid + _hlen*_sdir : _smid - _hlen*_sdir; }
 
-      bool operator==(const Straw other) const {
+      bool operator==(const Straw& other) const {
         return _id == other.id();
       }
-      bool operator>(const Straw other) const {
+      bool operator>(const Straw& other) const {
         return _id > other.id();
       }
-      bool operator<(const Straw other) const {
+      bool operator<(const Straw& other) const {
         return _id < other.id();
       }
 


### PR DESCRIPTION

This PR should produce no changes in validation output.  I verfied that one job each
of ceSimReco and cosmicSimReco produced identical output/

This PR address three types of warnings:

cppcoreguidelines-special-member-functions   - Rule of 5 violations - see notes below for 2 cases I did not fix.
performance-unnecessary-value-param             - arguments passed by value that should be passed by const&
cppcoreguidelines-explicit-virtual-functions       - missing override key word on virtual functions in derived classes

As targets of opportunity, I also fixed some other issues that occured in classes editted in the above work
 - magic numbers - I defined a constexpr.
 - uninitialized data members - I initialized them.
 - implict conversion between int and size_t.  I either changed one type or made the conversion explicit.
 - made improperly public data members private
 - implicit conversion of an array name to a pointer
 - misleading indentation ( only in ProductionTargetGeom/inc/ProductionTarget.hh )
 - one instance of bugprone-reserved-identifier ( a data member with name like:  _LeadingUppercase).

Notes:
1) There are still rule of 5 violations in
       - CalorimeterGeom/inc/CrystalMapper.hh
       - CalorimeterGeom/inc/Calorimeter.hh
   These are both interface classes with no declared default c'tor.
   When I fix this like all of the others, I can no longer compile derived classses.
   The error is that it cannot find the default c'tor for these classes

2) ProductionTargetGeom/inc/ProductionTarget.hh
     - uses new/delete on a bare pointer; the delete is in the d'tor.
     - Should change this unique_ptr and the the default d'tor will work

3) There are many warnings remaining.
        - bugprone-reserved-identifier
        -  clang-tidy does not like our use of protected data members in base classes
     I don't have  a plan for when to address these.  Maybe we want to turn them off?
