### PR TITLE
Fixes for s132 (Don't include GeometryService in rootcling)

### DIFF
--- a/Analyses/CMakeLists.txt
+++ b/Analyses/CMakeLists.txt
@@ -142,6 +142,15 @@ cet_build_plugin(CountPionDecays art::module
       Offline::MCDataProducts
 )
 
+cet_build_plugin(CountVDHits art::module
+    REG_SOURCE src/CountVDHits_module.cc
+    LIBRARIES REG
+      
+      
+      Offline::DataProducts
+      Offline::MCDataProducts
+)
+
 cet_build_plugin(CRYGenPlots art::module
     REG_SOURCE src/CRYGenPlots_module.cc
     LIBRARIES REG

--- a/GeometryService/CMakeLists.txt
+++ b/GeometryService/CMakeLists.txt
@@ -8,6 +8,7 @@ cet_make_library(
       src/DetectorSolenoidShieldingMaker.cc
       src/DetectorSystemMaker.cc
       src/DiskCalorimeterMaker.cc
+      src/DUSAFMu2eConverter.cc
       src/ElectronicRackMaker.cc
       src/ExtMonFNALBuildingMaker.cc
       src/ExtMonFNALMagnetMaker.cc

--- a/MCDataProducts/inc/SurfaceStep.hh
+++ b/MCDataProducts/inc/SurfaceStep.hh
@@ -12,16 +12,20 @@
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include "Offline/DataProducts/inc/SurfaceId.hh"
 #include "Offline/DataProducts/inc/GenVector.hh"
+#ifndef __ROOTCLING__
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
+#endif
 
 namespace mu2e {
   class SurfaceStep {
     public:
-      SurfaceStep(){};
+    SurfaceStep(){};
+#ifndef __ROOTCLING__
       // create from a StepPointMC. Association to a SurfaceId must be done outside this class
-      SurfaceStep(SurfaceId sid, StepPointMC const& spmc, GeomHandle<DetectorSystem>const& det);
-// accessors
+    SurfaceStep(SurfaceId sid, StepPointMC const& spmc, GeomHandle<DetectorSystem> const& det);
+#endif
+    // accessors
       float energyDeposit() const { return edep_; }
       double const& time() const { return time_; } // time of the earliest StepPointMC used in this step
       XYZVectorF const& startPosition() const { return startpos_; }
@@ -31,10 +35,12 @@ namespace mu2e {
       art::Ptr<SimParticle> const& simParticle() const { return simp_; }
       art::Ptr<SimParticle>& simParticle() { return simp_; } // used for compression
       auto const& surfaceId() const& { return sid_; }
-      double pathLength() const { return (endPosition()-startPosition()).R(); }
+      double pathLength() const { return (endPosition() - startPosition()).R(); }
+#ifndef __ROOTCLING__
       // append a MCStep to this step. The step must have the same SimParticle.  Caller is responsible
       // to insure this step is subsequent in time to the previous step
-      void addStep(StepPointMC const& spmc, GeomHandle<DetectorSystem>const& det);
+      void addStep(StepPointMC const& spmc, GeomHandle<DetectorSystem> const& det);
+#endif
     private:
       SurfaceId  sid_ = SurfaceIdDetail::unknown; // Identifier of the surface this step crosses
       float       edep_ = 0.0;  // energy deposited in this material in this step

--- a/STMMC/CMakeLists.txt
+++ b/STMMC/CMakeLists.txt
@@ -15,7 +15,7 @@ cet_build_plugin(STMResamplingProducer art::module
         Offline::MCDataProducts
 )
 cet_build_plugin(STMResamplingFilter art::module
-    REG_SOURCE src/STMResamplingProducer_module.cc
+    REG_SOURCE src/STMResamplingFilter_module.cc
     LIBRARIES REG
         Offline::MCDataProducts
 )

--- a/TrkReco/CMakeLists.txt
+++ b/TrkReco/CMakeLists.txt
@@ -48,6 +48,13 @@ cet_build_plugin(MergeHelices art::module
       Offline::RecoDataProducts
 )
 
+cet_build_plugin(SimpleKalSeedSelector art::tool
+    REG_SOURCE src/SimpleKalSeedSelector_tool.cc
+    LIBRARIES REG
+      Offline::TrkReco
+      
+)
+
 cet_build_plugin(TrkRecoMcUtils art::tool
     REG_SOURCE src/TrkRecoMcUtils_tool.cc
     LIBRARIES REG

--- a/bin/check_cmake.sh
+++ b/bin/check_cmake.sh
@@ -26,6 +26,6 @@ function check_directory() {
     fi
 }
 
-for dir in */;do
+for dir in $PWD/*;do
          check_directory ${dir%/}
 done


### PR DESCRIPTION
Update CMakeLists.txt for new files.

Make it so check_cmake.sh can be run as `./bin/check_cmake.sh` (no copy to base directory)