### PR TITLE
First pass at inclusive digi merging module

### DIFF
--- a/Blinding/src/MergeDigis_module.cc
+++ b/Blinding/src/MergeDigis_module.cc
@@ -1,0 +1,88 @@
+// Ed Callaghan
+// Collate digis from multiple sources, and apply collision resolution
+// August 2024
+
+// stl
+#include <string>
+#include <vector>
+
+// art
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+
+// fhiclcpp
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Comment.h"
+#include "fhiclcpp/types/Name.h"
+#include "fhiclcpp/types/Sequence.h"
+
+// mu2e
+#include "Offline/RecoDataProducts/inc/StrawDigi.hh"
+#include "Offline/ProditionsService/inc/ProditionsHandle.hh"
+#include "Offline/TrackerConditions/inc/StrawElectronics.hh"
+#include "Offline/TrackerMC/inc/StrawDigiBundle.hh"
+#include "Offline/TrackerMC/inc/StrawDigiBundleCollection.hh"
+
+namespace mu2e{
+  class MergeDigis: public art::EDProducer{
+    public:
+      struct Config{
+        fhicl::Sequence<art::InputTag> tracker_digi_tags{
+          fhicl::Name("StrawDigiCollections"),
+          fhicl::Comment("art::InputTags of source StrawDigi and StrawDigiADCWaveforms")
+        };
+      };
+
+      using Parameters = art::EDProducer::Table<Config>;
+      MergeDigis(const Parameters&);
+
+    protected:
+      // tracker
+      std::vector<art::InputTag> _tracker_digi_tags;
+      ProditionsHandle<StrawElectronics> _tracker_conditions_handle;
+
+    private:
+      void produce(art::Event&);
+  };
+
+  // constructor
+  MergeDigis::MergeDigis(const Parameters& config):
+      art::EDProducer(config),
+      _tracker_digi_tags(config().tracker_digi_tags()){
+    // tracker
+    for (const auto& tag: _tracker_digi_tags){
+      this->consumes<StrawDigiCollection>(tag);
+      this->consumes<StrawDigiADCWaveformCollection>(tag);
+    }
+    this->produces<StrawDigiCollection>();
+    this->produces<StrawDigiADCWaveformCollection>();
+
+    // calorimeter...
+
+    // crv...
+  }
+
+  void MergeDigis::produce(art::Event& event){
+    // tracker: two easy steps:
+    //   i) read all digis into a StrawDigiBundleCollection
+    //  ii) defer collision resolution to that collection
+    StrawDigiBundleCollection bundles;
+    for (const auto& tag: _tracker_digi_tags){
+      auto digi_handle = event.getValidHandle<StrawDigiCollection>(tag);
+      auto adcs_handle = event.getValidHandle<StrawDigiADCWaveformCollection>(tag);
+      bundles.Append(*digi_handle, *adcs_handle);
+    }
+    const auto& electronics = _tracker_conditions_handle.get(event.id());
+    StrawDigiBundleCollection resolved = bundles.ResolveCollisions(electronics);
+    auto digis = resolved.GetStrawDigiPtrs();
+    auto adcs = resolved.GetStrawDigiADCWaveformPtrs();
+    event.put(std::move(digis));
+    event.put(std::move(adcs));
+
+    // calorimeter...
+
+    // crv...
+  }
+} // namespace mu2e
+
+DEFINE_ART_MODULE(mu2e::MergeDigis);

--- a/Blinding/src/SConscript
+++ b/Blinding/src/SConscript
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import os, re
+
+Import('env')
+Import('mu2e_helper')
+
+helper = mu2e_helper(env)
+
+mainlib = helper.make_mainlib([
+])
+
+helper.make_plugins([
+    mainlib,
+    'art_Framework_Core',
+    'art_Framework_Services_Registry',
+    'art_Framework_Principal',
+    'art_Persistency_Provenance',
+    'art_Utilities',
+    'canvas',
+    'cetlib',
+    'cetlib_except',
+    'fhiclcpp',
+    'fhiclcpp_types',
+    'mu2e_DataProducts',
+    'mu2e_DbTables',
+    'mu2e_TrackerConditions',
+    'mu2e_TrackerMC',
+    'mu2e_ProditionsService',
+])


### PR DESCRIPTION
This PR implements a module which, mechanically, flattens multiple `StrawDigiCollection`s and `StrawDigiADCWaveformCollection`s into single collections, and defers to an already-factored-out collision-resolution algorithm. ~~This PR is marked as a draft for now; more detail will be added here before it's necessary to initiate review.~~

New module:
- `MergeDigis`: Given specified data product collections for tracker digis, produce a new collection which is the concatenation of those collections subject to an already-factored-out collision resolution policy. Future development should include an implementation for the calorimeter, and potentially crv, digis.