### PR TITLE
reintroduce 200ns delay for CRV event window start

### DIFF
--- a/CRVReco/fcl/prolog_v11.fcl
+++ b/CRVReco/fcl/prolog_v11.fcl
@@ -51,7 +51,6 @@ BEGIN_PROLOG
                                          //note: if measured time offsets are used, the cutoffs should be set to the maximum values
       useTimeOffsetDB           : true   //applies time offsets from the DB
       ignoreChannels            : true   //ignore channels that have status bit 1 ("ignore channels") in CRVstatus DB
-      oldDigis                  : false  //older digis used a different reference time, which is off by 200ns
     }
 
     CrvCoincidenceClusterFinder:

--- a/CRVReco/fcl/prolog_v11.fcl
+++ b/CRVReco/fcl/prolog_v11.fcl
@@ -51,6 +51,7 @@ BEGIN_PROLOG
                                          //note: if measured time offsets are used, the cutoffs should be set to the maximum values
       useTimeOffsetDB           : true   //applies time offsets from the DB
       ignoreChannels            : true   //ignore channels that have status bit 1 ("ignore channels") in CRVstatus DB
+      oldDigis                  : false  //older digis used a different reference time, which is off by 200ns
     }
 
     CrvCoincidenceClusterFinder:

--- a/CRVReco/src/CrvRecoPulsesFinder_module.cc
+++ b/CRVReco/src/CrvRecoPulsesFinder_module.cc
@@ -150,9 +150,7 @@ namespace mu2e
       event.getByLabel(_protonBunchTimeTag, protonBunchTime);
       if(protonBunchTime.isValid())
       {
-        ProditionsHandle<EventTiming> eventTimingHandle;
-        const EventTiming &eventTiming = eventTimingHandle.get(event.id());
-        TDC0time = -protonBunchTime->pbtime_ - eventTiming.timeFromProtonsToDRMarker(); //0ns...25ns (only for onspill)
+        TDC0time = -protonBunchTime->pbtime_; //200ns...225ns (only for onspill)
       }
     }
 

--- a/CRVReco/src/CrvRecoPulsesFinder_module.cc
+++ b/CRVReco/src/CrvRecoPulsesFinder_module.cc
@@ -69,7 +69,6 @@ namespace mu2e
       fhicl::Atom<float> timeOffsetCutoffHigh{Name("timeOffsetCutoffHigh"), Comment("upper cutoff of time offsets (for random values - otherwise set to maximum value)")}; //+3.0ns
       fhicl::Atom<bool> useTimeOffsetDB{Name("useTimeOffsetDB"), Comment("apply time offsets from the DB")}; //true
       fhicl::Atom<bool> ignoreChannels{Name("ignoreChannels"), Comment("ignore channels that have status 2 (bit 1) in CRVstatus DB")}; //true
-      fhicl::Atom<bool> oldDigis{Name("oldDigis"), Comment("older digis, that used a different time reference")}; //false
     };
 
     typedef art::EDProducer::Table<Config> Parameters;
@@ -93,7 +92,6 @@ namespace mu2e
     bool  _useTimeOffsetDB;
 
     bool  _ignoreChannels;
-    bool  _oldDigis;
 
     ProditionsHandle<CRVCalib>  _calib;
     ProditionsHandle<CRVStatus> _sipmStatus;
@@ -109,8 +107,7 @@ namespace mu2e
     _timeOffsetCutoffLow(conf().timeOffsetCutoffLow()),
     _timeOffsetCutoffHigh(conf().timeOffsetCutoffHigh()),
     _useTimeOffsetDB(conf().useTimeOffsetDB()),
-    _ignoreChannels(conf().ignoreChannels()),
-    _oldDigis(conf().oldDigis())
+    _ignoreChannels(conf().ignoreChannels())
   {
     produces<CrvRecoPulseCollection>();
     _makeCrvRecoPulses=boost::shared_ptr<mu2eCrv::MakeCrvRecoPulses>(new mu2eCrv::MakeCrvRecoPulses(conf().minADCdifference(),
@@ -156,9 +153,6 @@ namespace mu2e
         ProditionsHandle<EventTiming> eventTimingHandle;
         const EventTiming &eventTiming = eventTimingHandle.get(event.id());
         TDC0time = -protonBunchTime->pbtime_ - eventTiming.timeFromProtonsToDRMarker(); //0ns...25ns (only for onspill)
-
-        if(_oldDigis) TDC0time+=eventTiming.timeFromProtonsToDRMarker();  //old digis were produced relative to -protonBunchTime
-                                                                          //new digis are produced relative to -protonBunchTime-eventTiming.timeFromProtonsToDRMarker
       }
     }
 

--- a/CRVResponse/fcl/prolog_v11.fcl
+++ b/CRVResponse/fcl/prolog_v11.fcl
@@ -87,14 +87,14 @@ BEGIN_PROLOG
       photonYieldVariationCutoffHigh        : 0.2   //the photon yield variation is cut off at 20% above the mean
                                                     //note: if measured deviations are used, the cutoffs should be set to the maximum values
       digitizationStart                     : @local::DigitizationStart
-      digitizationStartMargin               :   50.0    //ns  start recording earlier to account for photon travel times and electronics response times
+      digitizationStartMargin               : 100.0 //ns  start recording earlier to account for photon travel times and electronics response times
     }
     CrvSiPMCharges:
     {
       module_type                  : CrvSiPMChargeGenerator
       crvPhotonsModuleLabel        : "CrvPhotons"
       digitizationStart            : @local::DigitizationStart
-      digitizationStartMargin      :   50.0    //ns  start recording earlier to account for electronics response times
+      digitizationStartMargin      : 100.0      //ns  start recording earlier to account for electronics response times
 
       nPixelsX                     : 40
       nPixelsY                     : 40

--- a/CRVResponse/fcl/prolog_v11.fcl
+++ b/CRVResponse/fcl/prolog_v11.fcl
@@ -9,7 +9,9 @@
 #include "Offline/CommonMC/fcl/prolog.fcl"
 BEGIN_PROLOG
 
-    DigitizationStart: 400.0 //ns after event window start (i.e. 400ns after first clock tick after POT) --> 400ns...425ns after POT
+    DigitizationStart :  200.0 //ns after event window start (400ns...425ns after POT)
+    DigitizationEnd   : 1500.0 //ns after event window start (1700ns...1725ns after POT)
+                               //event window starts 200ns after first clock tick after POT (200ns...225ns after POT)
     CrvSteps:
     {
       module_type               : CrvStepsFromStepPointMCs
@@ -87,6 +89,7 @@ BEGIN_PROLOG
       photonYieldVariationCutoffHigh        : 0.2   //the photon yield variation is cut off at 20% above the mean
                                                     //note: if measured deviations are used, the cutoffs should be set to the maximum values
       digitizationStart                     : @local::DigitizationStart
+      digitizationEnd                       : @local::DigitizationEnd
       digitizationStartMargin               : 100.0 //ns  start recording earlier to account for photon travel times and electronics response times
     }
     CrvSiPMCharges:
@@ -94,6 +97,7 @@ BEGIN_PROLOG
       module_type                  : CrvSiPMChargeGenerator
       crvPhotonsModuleLabel        : "CrvPhotons"
       digitizationStart            : @local::DigitizationStart
+      digitizationEnd              : @local::DigitizationEnd
       digitizationStartMargin      : 100.0      //ns  start recording earlier to account for electronics response times
 
       nPixelsX                     : 40

--- a/CRVResponse/fcl/prolog_v11.fcl
+++ b/CRVResponse/fcl/prolog_v11.fcl
@@ -130,6 +130,7 @@ BEGIN_PROLOG
       module_type                  : CrvWaveformsGenerator
       crvSiPMChargesModuleLabel    : "CrvSiPMCharges"
       digitizationStart            : @local::DigitizationStart
+      digitizationEnd              : @local::DigitizationEnd
       singlePEWaveformFileName     : "Offline/CRVResponse/data/singlePEWaveform_v3.txt"
       singlePEWaveformPrecision    : 0.5    //0.5 ns
       singlePEWaveformStretchFactor: 1.047  //1.047 for singlePEWaveform_v3.txt //from comparison with testbeam data

--- a/CRVResponse/src/CrvWaveformsGenerator_module.cc
+++ b/CRVResponse/src/CrvWaveformsGenerator_module.cc
@@ -49,7 +49,8 @@ namespace mu2e
     {
       fhicl::Atom<std::string> crvSiPMChargesModuleLabel{Name("crvSiPMChargesModuleLabel")};
       fhicl::Atom<std::string> singlePEWaveformFileName{Name("singlePEWaveformFileName")};
-      fhicl::Atom<double> digitizationStart{Name("digitizationStart"), Comment("start of digitization after DAQ event window start")}; //400ns (400ns...425ns after POT)
+      fhicl::Atom<double> digitizationStart{Name("digitizationStart"), Comment("start of digitization after DAQ event window start")}; //200ns (400ns...425ns after POT)
+      fhicl::Atom<double> digitizationEnd{Name("digitizationEnd"), Comment("end of digitization after DAQ event window start")}; //1500ns (1700ns...1725ns after POT)
       fhicl::Atom<art::InputTag> eventWindowMarkerTag{Name("eventWindowMarkerTag"), Comment("EventWindowMarker producer"),"EWMProducer" };
       fhicl::Atom<art::InputTag> protonBunchTimeMCTag{Name("protonBunchTimeMCTag"), Comment("ProtonBunchTimeMC producer"),"EWMProducer" };
       fhicl::Atom<double> minVoltage{Name("minVoltage")};                       //0.022V (corresponds to 3.5PE)
@@ -79,6 +80,7 @@ namespace mu2e
     boost::shared_ptr<mu2eCrv::MakeCrvWaveforms> _makeCrvWaveforms;
 
     double                              _digitizationStart;
+    double                              _digitizationEnd;
     double                              _minVoltage;
     double                              _noise;
     double                              _timeOffsetScale;
@@ -114,6 +116,7 @@ namespace mu2e
     _eventWindowMarkerTag(conf().eventWindowMarkerTag()),
     _protonBunchTimeMCTag(conf().protonBunchTimeMCTag()),
     _digitizationStart(conf().digitizationStart()),
+    _digitizationEnd(conf().digitizationEnd()),
     _minVoltage(conf().minVoltage()),
     _noise(conf().noise()),
     _timeOffsetScale(conf().timeOffsetScale()),
@@ -157,12 +160,10 @@ namespace mu2e
     {
       art::Handle<ProtonBunchTimeMC> protonBunchTimeMC;
       event.getByLabel(_protonBunchTimeMCTag, protonBunchTimeMC);
-      ProditionsHandle<EventTiming> eventTimingHandle;
-      const EventTiming &eventTiming = eventTimingHandle.get(event.id());
-      eventWindowStart = -protonBunchTimeMC->pbtime_ - eventTiming.timeFromProtonsToDRMarker(); //0ns...25ns (only for onspill)
+      eventWindowStart = -protonBunchTimeMC->pbtime_; //200ns...225ns
 
       digitizationStart=eventWindowStart+_digitizationStart; //400ns...425ns
-      digitizationEnd=eventWindowStart+eventWindowLength; //up to ~1720ns
+      digitizationEnd=eventWindowStart+_digitizationEnd; //1700ns...1725ns
     }
 
     auto const& calib = _calib.get(event.id());


### PR DESCRIPTION
- old digis were produced relative to -protonBunchTime
- new digis are produced relative to -protonBunchTime-eventTiming.timeFromProtonsToDRMarker

The fcl setting `physics.producers.CrvRecoPulses.oldDigis : true` allows us to read old digis with the new code.