### PR TITLE
explicit dts InputTags for tracker digi maker configuration

### DIFF
--- a/TrackerMC/fcl/prolog.fcl
+++ b/TrackerMC/fcl/prolog.fcl
@@ -13,7 +13,7 @@ TrackerMC : {
     #    StrawDigiMaker  : {
     makeSD  : {
       module_type : StrawDigisFromStrawGasSteps
-      StrawGasStepModule : "StrawGasStepMaker"
+      StrawGasStepModules : [ "StrawGasStepMaker" ]
       # set to digitize all hits in outer straws of the first 2 planes
       AllHitsPlanes : [0,1]
       AllHitsStraw : 91 # this straw and higher are always digitized


### PR DESCRIPTION
This PR changes the configuration interface for `StrawDigisFromStrawGasSteps` module to select an explicit set of `StrawGasStepCollection`s created by specific modules, as opposed to the current implementation of selecting either a single module or accepting all. This is necessary to accommodate improvements to the mixing simulations (https://github.com/Mu2e/Production/pull/361), which add new producers of such collections and break the existing logic. A sibling PR for `Production` is https://github.com/Mu2e/Production/pull/360.