### PR TITLE
changed CRV digis from array to vector and added NZS data

### DIFF
--- a/CRVConditions/inc/CRVCalib.hh
+++ b/CRVConditions/inc/CRVCalib.hh
@@ -17,7 +17,7 @@ class CRVCalib : virtual public ProditionsEntity {
  public:
   typedef std::shared_ptr<CRVCalib> ptr_t;
   typedef std::shared_ptr<const CRVCalib> cptr_t;
-  constexpr static const std::string cxname = {"CRVCalib"};
+  constexpr static const char* cxname = {"CRVCalib"};
 
   typedef std::vector<CRVCalibPar> CalibVec;
 

--- a/CRVConditions/inc/CRVCalib.hh
+++ b/CRVConditions/inc/CRVCalib.hh
@@ -17,7 +17,7 @@ class CRVCalib : virtual public ProditionsEntity {
  public:
   typedef std::shared_ptr<CRVCalib> ptr_t;
   typedef std::shared_ptr<const CRVCalib> cptr_t;
-  constexpr static const char* cxname = {"CRVCalib"};
+  constexpr static const std::string cxname = {"CRVCalib"};
 
   typedef std::vector<CRVCalibPar> CalibVec;
 

--- a/CRVConditions/inc/CRVStatus.hh
+++ b/CRVConditions/inc/CRVStatus.hh
@@ -18,7 +18,7 @@ class CRVStatus : virtual public ProditionsEntity {
 
   typedef std::shared_ptr<CRVStatus> ptr_t;
   typedef std::shared_ptr<const CRVStatus> cptr_t;
-  constexpr static const std::string cxname = {"CRVStatus"};
+  constexpr static const char* cxname = {"CRVStatus"};
 
   typedef std::map<std::uint16_t, int> StatusMap;
 

--- a/CRVConditions/inc/CRVStatus.hh
+++ b/CRVConditions/inc/CRVStatus.hh
@@ -18,7 +18,7 @@ class CRVStatus : virtual public ProditionsEntity {
 
   typedef std::shared_ptr<CRVStatus> ptr_t;
   typedef std::shared_ptr<const CRVStatus> cptr_t;
-  constexpr static const char* cxname = {"CRVStatus"};
+  constexpr static const std::string cxname = {"CRVStatus"};
 
   typedef std::map<std::uint16_t, int> StatusMap;
 

--- a/CRVReco/fcl/prolog_v11.fcl
+++ b/CRVReco/fcl/prolog_v11.fcl
@@ -17,6 +17,7 @@ BEGIN_PROLOG
     {
       module_type               : CrvRecoPulsesFinder
       crvDigiModuleLabel        : "CrvDigi"
+      NZSdata                   : false //use CrvDigis with NZS instance label
       minADCdifference          : 40    //minimum ADC difference above pedestal to be considered for reconstruction
                                         //corresponds to 3.5 PEs
       defaultBeta               : 19.0  //19.0ns for regular pulses

--- a/CRVReco/src/CrvCalibration_module.cc
+++ b/CRVReco/src/CrvCalibration_module.cc
@@ -86,7 +86,7 @@ namespace mu2e
   void CrvCalibration::analyze(const art::Event& event)
   {
     art::Handle<CrvRecoPulseCollection> crvRecoPulseCollection;
-    if(!event.getByLabel(_crvRecoPulsesModuleLabel,"",crvRecoPulseCollection)) return;
+    if(!event.getByLabel(_crvRecoPulsesModuleLabel,"NZS",crvRecoPulseCollection)) return;
 
     //add pedestal to histogram title
     static bool first=true;

--- a/CRVReco/src/CrvFPGArate_module.cc
+++ b/CRVReco/src/CrvFPGArate_module.cc
@@ -132,7 +132,7 @@ namespace mu2e
       eventFPGAmap[FPGAIndex]++;
 
       //check for pulses with multiple hits
-      if(previousBarIndex==barIndex && previousSiPM==SiPM && previousTDC+CrvDigi::NSamples==TDC)
+      if(previousBarIndex==barIndex && previousSiPM==SiPM && previousTDC+iter->GetADCs().size()==TDC)
         eventHitMultiplicityMap[FPGAIndex].back()++;
       else
         eventHitMultiplicityMap[FPGAIndex].push_back(1);

--- a/CRVReco/src/CrvPedestalFinder_module.cc
+++ b/CRVReco/src/CrvPedestalFinder_module.cc
@@ -79,7 +79,7 @@ namespace mu2e
   void CrvPedestalFinder::analyze(const art::Event& event)
   {
     art::Handle<CrvDigiCollection> crvDigiCollection;
-    if(!event.getByLabel(_crvDigiModuleLabel,"",crvDigiCollection)) return;
+    if(!event.getByLabel(_crvDigiModuleLabel,"NZS",crvDigiCollection)) return;
 
     art::ServiceHandle<art::TFileService> tfs;
     for(auto iter=crvDigiCollection->begin(); iter!=crvDigiCollection->end(); ++iter)
@@ -93,7 +93,7 @@ namespace mu2e
       int channelIndex=barIndex*4+SiPM;
       auto hist = _pedestalHists.at(channelIndex);
 
-      for(size_t i=0; i<CrvDigi::NSamples; ++i)
+      for(size_t i=0; i<iter->GetADCs().size(); ++i)
       {
         hist->Fill(iter->GetADCs()[i]);
       }

--- a/CRVReco/src/CrvRecoPulsesFinder_module.cc
+++ b/CRVReco/src/CrvRecoPulsesFinder_module.cc
@@ -51,6 +51,7 @@ namespace mu2e
       using Name=fhicl::Name;
       using Comment=fhicl::Comment;
       fhicl::Atom<std::string> crvDigiModuleLabel{Name("crvDigiModuleLabel"), Comment("module label for CrvDigis")};
+      fhicl::Atom<bool> NZSdata{Name("NZSdata"), Comment("use digis with the NZS instance label")};  //false
       fhicl::Atom<float> minADCdifference{Name("minADCdifference"), Comment("minimum ADC difference above pedestal to be considered for reconstruction")};  //40
       fhicl::Atom<float> defaultBeta{Name("defaultBeta"), Comment("initialization value for fit and default value for invalid fits (regular pulses: 19.0ns, dark counts for calibration: 12.0ns)")};
       fhicl::Atom<float> minBeta{Name("minBeta"), Comment("smallest accepted beta for valid fit [ns]")};  //5.0ns
@@ -83,6 +84,7 @@ namespace mu2e
     boost::shared_ptr<mu2eCrv::MakeCrvRecoPulses> _makeCrvRecoPulses;
 
     std::string _crvDigiModuleLabel;
+    bool        _NZSdata;
     art::InputTag _eventWindowMarkerTag;
     art::InputTag _protonBunchTimeTag;
 
@@ -101,6 +103,7 @@ namespace mu2e
   CrvRecoPulsesFinder::CrvRecoPulsesFinder(const Parameters& conf) :
     art::EDProducer(conf),
     _crvDigiModuleLabel(conf().crvDigiModuleLabel()),
+    _NZSdata(conf().NZSdata()),
     _eventWindowMarkerTag(conf().eventWindowMarkerTag()),
     _protonBunchTimeTag(conf().protonBunchTimeTag()),
     _timeOffsetScale(conf().timeOffsetScale()),
@@ -109,7 +112,7 @@ namespace mu2e
     _useTimeOffsetDB(conf().useTimeOffsetDB()),
     _ignoreChannels(conf().ignoreChannels())
   {
-    produces<CrvRecoPulseCollection>();
+    produces<CrvRecoPulseCollection>(_NZSdata?"NZS":"");
     _makeCrvRecoPulses=boost::shared_ptr<mu2eCrv::MakeCrvRecoPulses>(new mu2eCrv::MakeCrvRecoPulses(conf().minADCdifference(),
                                                                                                     conf().defaultBeta(),
                                                                                                     conf().minBeta(),
@@ -155,7 +158,7 @@ namespace mu2e
     }
 
     art::Handle<CrvDigiCollection> crvDigiCollection;
-    event.getByLabel(_crvDigiModuleLabel,"",crvDigiCollection);
+    event.getByLabel(_crvDigiModuleLabel,(_NZSdata?"NZS":""),crvDigiCollection);
 
     auto const& calib = _calib.get(event.id());
     auto const& sipmStatus = _sipmStatus.get(event.id());
@@ -167,9 +170,8 @@ namespace mu2e
       const CRSScintillatorBarIndex &barIndex = digi.GetScintillatorBarIndex();
       int SiPM = digi.GetSiPMNumber();
       uint16_t startTDC = digi.GetStartTDC();
-      std::vector<int16_t> ADCs;
+      std::vector<int16_t> ADCs=digi.GetADCs();
       std::vector<size_t> waveformIndices;
-      for(size_t i=0; i<CrvDigi::NSamples; ++i) ADCs.push_back(digi.GetADCs()[i]);
       waveformIndices.push_back(waveformIndex);
 
       //checking following digis whether they are a continuation of the current digis
@@ -180,7 +182,7 @@ namespace mu2e
         if(barIndex!=nextDigi.GetScintillatorBarIndex()) break;
         if(SiPM!=nextDigi.GetSiPMNumber()) break;
         if(startTDC+ADCs.size()!=nextDigi.GetStartTDC()) break;
-        for(size_t i=0; i<CrvDigi::NSamples; ++i) ADCs.push_back(nextDigi.GetADCs()[i]);
+        for(size_t i=0; i<nextDigi.GetADCs().size(); ++i) ADCs.push_back(nextDigi.GetADCs()[i]);
         waveformIndices.push_back(waveformIndex);
       }
 
@@ -244,7 +246,7 @@ namespace mu2e
 
     }
 
-    event.put(std::move(crvRecoPulseCollection));
+    event.put(std::move(crvRecoPulseCollection),(_NZSdata?"NZS":""));
   } // end produce
 
 } // end namespace mu2e

--- a/CRVReco/test/calibration.fcl
+++ b/CRVReco/test/calibration.fcl
@@ -19,17 +19,21 @@ services :
 physics: {
   producers :
   {
+    CrvRecoPulses: @local::CrvRecoPulses
   }
   analyzers:
   {
     CrvCalibration: @local::CrvCalibration
   }
 
-  TriggerPath : [ ]
+  TriggerPath : [ CrvRecoPulses ]
   EndPath :     [ CrvCalibration ]
   trigger_paths : [ TriggerPath ]
   end_paths :     [ EndPath ]
 }
+
+physics.producers.CrvRecoPulses.NZSdata : true
+physics.producers.CrvRecoPulses.minADCdifference   : 5    //minimum ADC difference above pedestal to be considered for reconstruction
 
 services.scheduler.wantSummary: true
 services.TimeTracker.printSummary: true

--- a/CRVReco/test/calibration.fcl
+++ b/CRVReco/test/calibration.fcl
@@ -33,14 +33,10 @@ physics: {
 }
 
 physics.producers.CrvRecoPulses.NZSdata : true
-physics.producers.CrvRecoPulses.minADCdifference   : 5    //minimum ADC difference above pedestal to be considered for reconstruction
+physics.producers.CrvRecoPulses.minADCdifference  : 5    //minimum ADC difference above pedestal to be considered for reconstruction
+physics.producers.CrvRecoPulses.ignoreChannels : false   //do not ignore channels that have status bit 1 ("ignore channels") in CRVstatus DB
 
 services.scheduler.wantSummary: true
 services.TimeTracker.printSummary: true
 services.TFileService.fileName : "crvCalib.root"
 #include "Offline/DbService/fcl/NominalDatabase.fcl"
-
-services.ProditionsService.crvStatus.useDb: false
-services.ProditionsService.crvStatus.verbose: 2
-services.ProditionsService.crvCalib.useDb: true
-services.ProditionsService.crvCalib.verbose: 2

--- a/CRVReco/test/calibration.fcl
+++ b/CRVReco/test/calibration.fcl
@@ -32,6 +32,7 @@ physics: {
   end_paths :     [ EndPath ]
 }
 
+physics.producers.CrvRecoPulses.defaultBeta : 12.6       //ns
 physics.producers.CrvRecoPulses.NZSdata : true
 physics.producers.CrvRecoPulses.minADCdifference  : 5    //minimum ADC difference above pedestal to be considered for reconstruction
 physics.producers.CrvRecoPulses.ignoreChannels : false   //do not ignore channels that have status bit 1 ("ignore channels") in CRVstatus DB

--- a/CRVReco/test/calibration_wideband1module.fcl
+++ b/CRVReco/test/calibration_wideband1module.fcl
@@ -32,7 +32,7 @@ physics: {
   end_paths :     [ EndPath ]
 }
 
-physics.producers.EWMProducer.SpillType : 0
+physics.producers.CrvRecoPulses.NZSdata : true
 physics.producers.CrvRecoPulses.minADCdifference   : 5    //minimum ADC difference above pedestal to be considered for reconstruction
 services.TFileService.fileName : "crvCalibWideband.root"
 services.GeometryService.inputFile: "Offline/Mu2eG4/geom/geom_Wideband1module.txt"

--- a/CRVReco/test/pedestal_wideband1module.fcl
+++ b/CRVReco/test/pedestal_wideband1module.fcl
@@ -31,6 +31,5 @@ physics: {
   end_paths :     [ EndPath ]
 }
 
-physics.producers.EWMProducer.SpillType : 0
 services.TFileService.fileName : "pedestalWideband.root"
 services.GeometryService.inputFile: "Offline/Mu2eG4/geom/geom_Wideband1module.txt"

--- a/CRVResponse/fcl/prolog_v11.fcl
+++ b/CRVResponse/fcl/prolog_v11.fcl
@@ -124,7 +124,7 @@ BEGIN_PROLOG
       TrapType0Lifetime            : 5.0        //ns  ????
       TrapType1Lifetime            : 50.0       //ns  ????
 
-      ThermalRate                  : 3.0e-4     //ns^-1     0.3MHz for entire SiPM
+      ThermalRate                  : 1.0e-4     //ns^-1     0.1MHz for entire SiPM
       CrossTalkProb                : 0.04       //
 
       useSipmStatusDB              : true       //channel with status bits 0 (not connected) and 2 (no data) will not be simulated. channels with status bit 1 can be ignored in reco.

--- a/CRVResponse/fcl/prolog_v11.fcl
+++ b/CRVResponse/fcl/prolog_v11.fcl
@@ -9,6 +9,8 @@
 #include "Offline/CommonMC/fcl/prolog.fcl"
 BEGIN_PROLOG
 
+    NumberSamplesNZS  :    134 //first 134 ADC samples of a on/off spill event will be recorded
+    SimulateNZS       :  false //if NZS data is simulated, no dead time for the photon generator and SiPM charge generator is used
     DigitizationStart :  200.0 //ns after event window start (400ns...425ns after POT)
     DigitizationEnd   : 1500.0 //ns after event window start (1700ns...1725ns after POT)
                                //event window starts 200ns after first clock tick after POT (200ns...225ns after POT)
@@ -91,6 +93,8 @@ BEGIN_PROLOG
       digitizationStart                     : @local::DigitizationStart
       digitizationEnd                       : @local::DigitizationEnd
       digitizationStartMargin               : 100.0 //ns  start recording earlier to account for photon travel times and electronics response times
+      numberSamplesNZS                      : @local::NumberSamplesNZS
+      simulateNZS                           : @local::SimulateNZS
     }
     CrvSiPMCharges:
     {
@@ -124,6 +128,9 @@ BEGIN_PROLOG
       CrossTalkProb                : 0.04       //
 
       useSipmStatusDB              : true       //channel with status bits 0 (not connected) and 2 (no data) will not be simulated. channels with status bit 1 can be ignored in reco.
+
+      numberSamplesNZS             : @local::NumberSamplesNZS
+      simulateNZS                  : @local::SimulateNZS
     }
     CrvWaveforms:
     {
@@ -150,6 +157,10 @@ BEGIN_PROLOG
       timeOffsetCutoffHigh         : 3.0    //the time offsets are cut off at +3ns
                                             //note: if measured time offsets are used, the cutoffs should be set to the maximum values
       useTimeOffsetDB              : false  //will be applied at reco
+      numberSamplesZS              : 12
+      numberSamplesNZS             : @local::NumberSamplesNZS
+      simulateNZS                  : @local::SimulateNZS
+      prescalingFactorNZS          : 10
     }
     CrvDigi:
     {
@@ -157,6 +168,7 @@ BEGIN_PROLOG
       crvWaveformsModuleLabel      : "CrvWaveforms"
       ADCconversionFactor          : 2300      //2300 ADC/V
       pedestal                     : 100       //ADC
+      simulateNZS                  : @local::SimulateNZS
     }
     CrvCoincidenceClusterMatchMC:
     {

--- a/CRVResponse/src/CRVTest_module.cc
+++ b/CRVResponse/src/CRVTest_module.cc
@@ -7,6 +7,7 @@
 #include "Offline/CosmicRayShieldGeom/inc/CosmicRayShield.hh"
 #include "Offline/DataProducts/inc/CRSScintillatorBarIndex.hh"
 
+#include "Offline/CRVConditions/inc/CRVDigitizationPeriod.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/GeometryService.hh"
@@ -206,12 +207,12 @@ namespace mu2e
           if(crvDigi.GetScintillatorBarIndex()==barIndex && crvDigi.GetSiPMNumber()==SiPM)
           {
             uint16_t startTDC=crvDigi.GetStartTDC();
-            const std::array<int16_t, CrvDigi::NSamples> &adcs = crvDigi.GetADCs();
-            for(size_t ii=0; ii<CrvDigi::NSamples; ii++)
+            const std::vector<int16_t> &adcs = crvDigi.GetADCs();
+            for(size_t ii=0; ii<adcs.size(); ++ii)
             {
               int16_t  adc=adcs.at(ii);
-              if(SiPM==0 || SiPM==2) _adcs0->Fill(TDC0time+(startTDC+ii)*12.55,adc);
-              if(SiPM==1 || SiPM==3) _adcs1->Fill(TDC0time+(startTDC+ii)*12.55,adc);
+              if(SiPM==0 || SiPM==2) _adcs0->Fill(TDC0time+(startTDC+ii)*CRVDigitizationPeriod,adc);
+              if(SiPM==1 || SiPM==3) _adcs1->Fill(TDC0time+(startTDC+ii)*CRVDigitizationPeriod,adc);
             }
           }
         }

--- a/CRVResponse/src/CrvPhotonGenerator_module.cc
+++ b/CRVResponse/src/CrvPhotonGenerator_module.cc
@@ -308,6 +308,9 @@ namespace mu2e
             //time wrap around eventWindowStart which is far away from any steps that need to be used
             double t1Tmp = fmod(t1-eventWindowStart,_microBunchPeriod)+eventWindowStart;
             double t2Tmp = fmod(t2-eventWindowStart,_microBunchPeriod)+eventWindowStart;
+            //fmod of a negative number returns a negative number
+            if(t1Tmp<eventWindowStart) t1Tmp+=_microBunchPeriod;
+            if(t2Tmp<eventWindowStart) t2Tmp+=_microBunchPeriod;
             //remove steps that are not needed to speed up the simulation
             if(t1Tmp<startTime) continue;
             if(t2Tmp>endTime) continue;
@@ -369,6 +372,8 @@ namespace mu2e
               {
                 //time wrap around eventWindowStart which is far away from the (ZS) digi window to avoid breaking (ZS) pulses apart
                 timeTmp = fmod(timeTmp-eventWindowStart,_microBunchPeriod)+eventWindowStart;
+                //fmod of a negative number returns a negative number
+                if(timeTmp<eventWindowStart) timeTmp+=_microBunchPeriod;
               }
               photons.emplace_back(timeTmp,crvStepPtr);
             }

--- a/CRVResponse/src/CrvPhotonGenerator_module.cc
+++ b/CRVResponse/src/CrvPhotonGenerator_module.cc
@@ -4,6 +4,7 @@
 //
 // Original Author: Ralf Ehrlich
 
+#include "Offline/CRVConditions/inc/CRVDigitizationPeriod.hh"
 #include "Offline/CRVConditions/inc/CRVPhotonYield.hh"
 #include "Offline/CRVResponse/inc/MakeCrvPhotons.hh"
 #include "Offline/CosmicRayShieldGeom/inc/CosmicRayShield.hh"
@@ -73,6 +74,8 @@ namespace mu2e
       fhicl::Atom<double> digitizationEnd{ Name("digitizationEnd"), Comment("end of digitization after DAQ event window start")};
       fhicl::Atom<double> digitizationStartMargin{ Name("digitizationStartMargin"),
                                Comment("time window before digitization starts to account for photon travel time and electronics response.")};
+      fhicl::Atom<int> numberSamplesNZS{Name("numberSamplesNZS")}; //134
+      fhicl::Atom<bool> simulateNZS{Name("simulateNZS")}; //false
       fhicl::Atom<art::InputTag> eventWindowMarkerTag{ Name("eventWindowMarkerTag"), Comment("EventWindowMarker producer"),"EWMProducer" };
       fhicl::Atom<art::InputTag> protonBunchTimeMCTag{ Name("protonBunchTimeMCTag"), Comment("ProtonBunchTimeMC producer"),"EWMProducer" };
     };
@@ -106,22 +109,25 @@ namespace mu2e
     //---first DAQ clock tick after POT occurs between 0ns and 25ns after protons.
     //   25ns jitter is due to the microbunch period not being an integer multiple of the DAQ clock period.
     //---event window starts 200ns after these first DAQ clock ticks (--> 200ns...225ns after POT).
+    //   (this delay is the same the tracker is using)
     //---due to the above variations, the event window length varies between 1675ns and 1700ns.
     //---digitization start: 200ns after event window start (--> 400ns...425ns after POT)
     //---digitization end: 1500ns after event window start (--> 1700ns...1725ns after POT),
     //   which is 1300ns after digitization start
     //-CrvSteps
-    //---start recording CrvSteps 100ns before digitzation window
-    //   (--> 100ns after event window start, 300ns...325ns after POT)
-    //   to account for photon travel time and electronics response time.
-    //---stop recording CrvSteps at end of digitization window.
-    //---CrvSteps before 100ns before the digitization window are removed (dead time).
-    //---CrvSteps after the end of the event window belong to the next event(s).
-    //   for simplicity, no time wrapping and removal of CrvSteps that occur in the dead time will be done.
+    //---to speed up the simulation for ZS data:
+    //------CrvSteps before 100ns before the digitization window are removed.
+    //      (--> 100ns after event window start, 300ns...325ns after POT)
+    //      to account for photon travel time and electronics response time.
+    //------CrvSteps after the digitization window are removed.
+    //------only for the removal decision: apply a time wrapping (modulus microbunch period of 1695ns)
+    //      at the event window starts, to avoid breaking up hits,
+    //      because these CrvSteps are far away from the digitization window.
+    //      this time wrapping will not be applied to the photon generation,
+    //      where the un-wrapped time will be used.
     //-CrvPhotons
-    //---photons get time wrapped modulus microbunch period (1695ns).
-    //---no further consideration of the digitization window for the photons;
-    //   this will be done at the digitization step.
+    //---apply a time wrapping (modulus microbunch period of 1695ns) at the event window starts,
+    //   to avoid breaking up pulses, because these photons are far away from the digitization window
     //
     //Off-spill
     //-Event length: 100000ns
@@ -135,6 +141,8 @@ namespace mu2e
     double      _digitizationStart; //200ns after event window start (400ns...425ns after POT)
     double      _digitizationEnd;   //1500ns after event window start (1700ns...1725ns after POT)
     double      _digitizationStartMargin;  //100ns (used to account for photon travel time and electronics response time)
+    int         _numberSamplesNZS;  //134
+    bool        _simulateNZS;       //false
     art::InputTag _eventWindowMarkerTag;
     art::InputTag _protonBunchTimeMCTag;
     double      _microBunchPeriod;
@@ -161,6 +169,8 @@ namespace mu2e
     _digitizationStart(conf().digitizationStart()),
     _digitizationEnd(conf().digitizationEnd()),
     _digitizationStartMargin(conf().digitizationStartMargin()),
+    _numberSamplesNZS(conf().numberSamplesNZS()),
+    _simulateNZS(conf().simulateNZS()),
     _eventWindowMarkerTag(conf().eventWindowMarkerTag()),
     _protonBunchTimeMCTag(conf().protonBunchTimeMCTag()),
     _engine{createEngine(art::ServiceHandle<SeedService>()->getSeed())},
@@ -271,6 +281,12 @@ namespace mu2e
 
       startTime=eventWindowStart+_digitizationStart-_digitizationStartMargin; //300ns...325ns
       endTime=eventWindowStart+_digitizationEnd; //1700ns...1725ns
+
+      if(_simulateNZS)
+      {
+        startTime=eventWindowStart-_digitizationStartMargin; //100ns...125ns
+        endTime=eventWindowStart+_numberSamplesNZS*CRVDigitizationPeriod; //1875ns...1900s
+      }
     }
 
     for(size_t j=0; j<_selectors.size(); ++j)
@@ -287,8 +303,15 @@ namespace mu2e
           double t2 = step.endTime();
           if(isnan(t1) || isnan(t2)) continue;  //This situation was observed once. Not sure how it happened.
 
-          if(t2<startTime) continue;
-          //for simplicity (due to time wrapping) no other crvSteps will be removed
+          if(!_simulateNZS)  //no steps will be removed for NZS
+          {
+            //time wrap around eventWindowStart which is far away from any steps that need to be used
+            double t1Tmp = fmod(t1-eventWindowStart,_microBunchPeriod)+eventWindowStart;
+            double t2Tmp = fmod(t2-eventWindowStart,_microBunchPeriod)+eventWindowStart;
+            //remove steps that are not needed to speed up the simulation
+            if(t1Tmp<startTime) continue;
+            if(t2Tmp>endTime) continue;
+          }
 
           CLHEP::Hep3Vector pos1 = step.startPosition();  //TODO: Need to convert everything into XYZVec, so that const references can be used
           CLHEP::Hep3Vector pos2 = step.endPosition();
@@ -344,8 +367,8 @@ namespace mu2e
               double timeTmp=times[itime];
               if(spillType==EventWindowMarker::SpillType::onspill)
               {
-                //time wrap around endTime to avoid breaking pulses apart inside the digi window
-                timeTmp = fmod(timeTmp-(endTime-_microBunchPeriod),_microBunchPeriod)+(endTime-_microBunchPeriod);
+                //time wrap around eventWindowStart which is far away from the (ZS) digi window to avoid breaking (ZS) pulses apart
+                timeTmp = fmod(timeTmp-eventWindowStart,_microBunchPeriod)+eventWindowStart;
               }
               photons.emplace_back(timeTmp,crvStepPtr);
             }

--- a/CRVResponse/src/CrvPhotonGenerator_module.cc
+++ b/CRVResponse/src/CrvPhotonGenerator_module.cc
@@ -178,7 +178,7 @@ namespace mu2e
     _randGaussQ(_engine),
     _randPoissonQ(_engine)
   {
-    if(_moduleLabels.size()==0) throw std::logic_error("ERROR: a list of crvSteps module labels needs to be provided");
+    //if(_moduleLabels.size()==0) throw std::logic_error("ERROR: a list of crvSteps module labels needs to be provided");
     if(_moduleLabels.size()!=_processNames.size()) throw std::logic_error("ERROR: mismatch between specified selectors (crvStepModuleLabels/crvStepProcessNames)");
     for(size_t i=0; i<_moduleLabels.size(); ++i)
     {

--- a/CRVResponse/src/CrvSiPMChargeGenerator_module.cc
+++ b/CRVResponse/src/CrvSiPMChargeGenerator_module.cc
@@ -74,7 +74,7 @@ namespace mu2e
       fhicl::Atom<double> trapType1Prob{Name("TrapType1Prob")};              //0
       fhicl::Atom<double> trapType0Lifetime{Name("TrapType0Lifetime")};      //5ns
       fhicl::Atom<double> trapType1Lifetime{Name("TrapType1Lifetime")};      //50ns
-      fhicl::Atom<double> thermalRate{Name("ThermalRate")};                  //3.0e-4 ns^-1   300MHz for entire SiPM
+      fhicl::Atom<double> thermalRate{Name("ThermalRate")};                  //1.0e-4 ns^-1   100kHz for entire SiPM
       fhicl::Atom<double> crossTalkProb{Name("CrossTalkProb")};              //0.04
     };
     using Parameters = art::EDProducer::Table<Config>;
@@ -145,7 +145,7 @@ namespace mu2e
     _probabilities._trapType1Prob=conf().trapType1Prob();              //0
     _probabilities._trapType0Lifetime=conf().trapType0Lifetime();      //5.0ns
     _probabilities._trapType1Lifetime=conf().trapType1Lifetime();      //50.0ns
-    _probabilities._thermalRate=conf().thermalRate();                  //3.0e-4 ns^-1   300MHz for entire SiPM
+    _probabilities._thermalRate=conf().thermalRate();                  //1.0e-4 ns^-1   100kHz for entire SiPM
     _probabilities._crossTalkProb=conf().crossTalkProb();              //0.05
 
     std::string fullPhotonMapFileName(_resolveFullPath(_photonMapFileName));

--- a/CRVResponse/src/CrvSiPMChargeGenerator_module.cc
+++ b/CRVResponse/src/CrvSiPMChargeGenerator_module.cc
@@ -4,6 +4,7 @@
 //
 // Original Author: Ralf Ehrlich
 
+#include "Offline/CRVConditions/inc/CRVDigitizationPeriod.hh"
 #include "Offline/CRVConditions/inc/CRVStatus.hh"
 #include "Offline/CRVResponse/inc/MakeCrvSiPMCharges.hh"
 #include "Offline/CosmicRayShieldGeom/inc/CosmicRayShield.hh"
@@ -60,6 +61,8 @@ namespace mu2e
       fhicl::Atom<double> digitizationStartMargin{Name("digitizationStartMargin"),
                                                   Comment("time window before digitization starts to account for photon travel time and electronics response.")};
                                                   //50.0ns  start recording earlier to account for electronics response times
+      fhicl::Atom<int> numberSamplesNZS{Name("numberSamplesNZS")};           //134
+      fhicl::Atom<bool> simulateNZS{Name("simulateNZS")};                    //false
       fhicl::Atom<art::InputTag> eventWindowMarkerTag{Name("eventWindowMarkerTag"), Comment("EventWindowMarker producer"),"EWMProducer" };
       fhicl::Atom<art::InputTag> protonBunchTimeMCTag{Name("protonBunchTimeMCTag"), Comment("ProtonBunchTimeMC producer"),"EWMProducer" };
       fhicl::Atom<bool> useSipmStatusDB{Name("useSipmStatusDB")};             //false (all channels will be simulated. channels with status bit 1 can be ignored in reco)
@@ -87,6 +90,8 @@ namespace mu2e
     double      _timeConstant;
     double      _capacitance;
     double      _digitizationStart, _digitizationEnd, _digitizationStartMargin;
+    int         _numberSamplesNZS;
+    bool        _simulateNZS;
     art::InputTag _eventWindowMarkerTag;
     art::InputTag _protonBunchTimeMCTag;
 
@@ -117,6 +122,8 @@ namespace mu2e
     _digitizationStart(conf().digitizationStart()),
     _digitizationEnd(conf().digitizationEnd()),
     _digitizationStartMargin(conf().digitizationStartMargin()),
+    _numberSamplesNZS(conf().numberSamplesNZS()),
+    _simulateNZS(conf().simulateNZS()),
     _eventWindowMarkerTag(conf().eventWindowMarkerTag()),
     _protonBunchTimeMCTag(conf().protonBunchTimeMCTag()),
     _useSipmStatusDB(conf().useSipmStatusDB()),
@@ -176,6 +183,12 @@ namespace mu2e
 
       startTime=eventWindowStart+_digitizationStart-_digitizationStartMargin; //300ns...325ns
       endTime=eventWindowStart+_digitizationEnd; //1700ns...1725ns
+
+      if(_simulateNZS)
+      {
+        startTime=eventWindowStart-_digitizationStartMargin; //100ns...125ns
+        endTime=eventWindowStart+_numberSamplesNZS*CRVDigitizationPeriod; //1875ns...1900s
+      }
     }
 
     auto const& sipmStatus = _sipmStatus.get(event.id());

--- a/CRVResponse/src/CrvWidebandTest_module.cc
+++ b/CRVResponse/src/CrvWidebandTest_module.cc
@@ -142,7 +142,10 @@ void LandauGauss(TH1F &h, float &mpv, float &fwhm, float &signals, float &chi2)
     float leftX = fit.GetX(halfMaximum,0.0,mpv);
     float rightX = fit.GetX(halfMaximum,mpv,10.0*mpv);
     fwhm = rightX-leftX;
-    signals = fit.Integral(0,150);
+
+    signals = fit.Integral(0,150,1e-3)/h.GetBinWidth(1);  //need to divide by bin width.
+                                                          //if the bin width is 2 and one has e.g. 20 events for 50PEs and 20 events for 51PEs,
+                                                          //the combined bin of x=50/51 gets 40 entries and the integral assumes that there are 40 entries for x=50 and x=51.
 }
 
 } //end anonymous namespace for LandauGauss function

--- a/CRVResponse/src/MakeCrvSiPMCharges.cc
+++ b/CRVResponse/src/MakeCrvSiPMCharges.cc
@@ -235,7 +235,7 @@ int main()
   probabilities._trapType1Prob = 0.0;
   probabilities._trapType0Lifetime = 5;
   probabilities._trapType1Lifetime = 50;
-  probabilities._thermalRate = 3.0e-4;
+  probabilities._thermalRate = 1.0e-4;
   probabilities._crossTalkProb = 0.05;
 
   std::vector<std::pair<int,int> > inactivePixels = { {18,18}, {18,19}, {18,20}, {18,21},

--- a/CRVResponse/test/darkcounts.fcl
+++ b/CRVResponse/test/darkcounts.fcl
@@ -1,0 +1,60 @@
+#include "Offline/fcl/standardServices.fcl"
+#include "Production/JobConfig/common/prolog.fcl"
+#include "Production/JobConfig/primary/prolog.fcl"
+#include "Production/JobConfig/cosmic/prolog.fcl"
+
+process_name : CrvDarkCounts
+
+services :
+{
+  @table::Services.SimAndReco
+}
+
+source :
+{
+  module_type : EmptyEvent
+  maxEvents : @nil
+  firstRun  : 1200
+}
+
+physics: {
+
+  producers : {
+    @table::CommonMC.DigiProducers
+    @table::Common.producers
+    @table::Primary.producers
+    @table::CrvDAQPackage.producers
+  }
+
+  TriggerPath :  [ @sequence::CommonMC.DigiSim, @sequence::CrvDAQPackage.CrvDAQSequence]
+  EndPath : [ Output ]
+  trigger_paths : [ TriggerPath ]
+  end_paths : [ EndPath ]
+}
+
+outputs:
+{
+  Output :
+  {
+    module_type : RootOutput
+    fileName    : "mcs.owner.CRV_darkcounts-mc.configuration.sequencer.art"
+  }
+}
+
+
+physics.producers.EWMProducer.SpillType : 1 #onspill
+physics.producers.CrvPhotons.crvStepModuleLabels    : [] #no input steps
+physics.producers.CrvPhotons.crvStepProcessNames    : []
+physics.producers.CrvPhotons.simulateNZS : true
+physics.producers.CrvSiPMCharges.simulateNZS : true
+physics.producers.CrvWaveforms.simulateNZS : true
+physics.producers.CrvWaveforms.prescalingFactorNZS : 1  #to avoid generating events without NZS data (actual prescaling factor is 10)
+physics.producers.CrvDigi.simulateNZS : true
+
+services.SeedService.baseSeed : @local::Common.BaseSeed
+services.TFileService.fileName : "nts.owner.CRV_darkcounts-mc.configuration.sequencer.root"
+services.TimeTracker.printSummary: true
+services.scheduler.wantSummary: true
+services.message.destinations.log.outputStatistics : true
+
+#include "Offline/DbService/fcl/NominalDatabase.fcl"

--- a/CRVResponse/test/wideband/wideband4modules.fcl
+++ b/CRVResponse/test/wideband/wideband4modules.fcl
@@ -48,6 +48,7 @@ physics: {
     CrvWidebandTest :
     {
       module_type                        : CrvWidebandTest
+      SelectEvents                       : [ TriggerPath ]
       crvStepModuleLabel                 : "CrvSteps"
       crvRecoPulseModuleLabel            : "CrvRecoPulses"
       crvCoincidenceClusterModuleLabel   : "CrvCoincidenceClusterFinder"

--- a/DAQ/src/CrvDigisFromFragments_module.cc
+++ b/DAQ/src/CrvDigisFromFragments_module.cc
@@ -151,16 +151,12 @@ void CrvDigisFromFragments::produce(Event& event)
           int crvBarIndex = offlineChannel / 4;
           int SiPMNumber = offlineChannel % 4;
 
-          for(size_t i = 0; i < crvHitInfo.NumSamples; i += mu2e::CrvDigi::NSamples)
+          std::vector<int16_t> adc;
+          adc.resize(waveform.size());
+          for(size_t i=0; i<waveform.size(); ++i)
           {
-            std::array<int16_t, mu2e::CrvDigi::NSamples> adc = {0};
-            for(size_t j = 0; j < mu2e::CrvDigi::NSamples && i+j < crvHitInfo.NumSamples; ++j)
-              adc[j] = waveform.at(i+j).ADC;
-
-            // CrvDigis use a constant array size of 8 samples
-            // waveforms with more than 8 samples need to be written to multiple CrvDigis
-            // the TDC increases by 8 for every subsequent CrvDigi
-            crv_digis->emplace_back(adc, crvHitInfo.HitTime + i, mu2e::CRSScintillatorBarIndex(crvBarIndex), SiPMNumber);
+            adc[i] = waveform.at(i).ADC;
+            crv_digis->emplace_back(adc, crvHitInfo.HitTime + i, false, mu2e::CRSScintillatorBarIndex(crvBarIndex), SiPMNumber);
           }
         } // loop over all crvHits
 

--- a/DataProducts/inc/CRVId.hh
+++ b/DataProducts/inc/CRVId.hh
@@ -27,6 +27,8 @@ namespace mu2e {
     constexpr static std::size_t nFEBPerROC = 25;
     constexpr static std::size_t nROC = 18;
 
+    constexpr static std::size_t nChanPerFPGA = 16;
+    constexpr static std::size_t nFPGAPerFEB = 4;
   };
 }
 #endif /* DataProducts_CRVId_hh */

--- a/EventDisplay/src/DataInterface.cc
+++ b/EventDisplay/src/DataInterface.cc
@@ -1132,10 +1132,10 @@ void DataInterface::fillEvent(boost::shared_ptr<ContentSelector> const &contentS
           multigraphIndex=v.size()-1;
         }
 
-        TGraph *graph = new TGraph(mu2e::CrvDigi::NSamples);
+        TGraph *graph = new TGraph(digi.GetADCs().size());
         graph->SetMarkerStyle(20);
         graph->SetMarkerSize(2);
-        for(size_t k=0; k<mu2e::CrvDigi::NSamples; k++)
+        for(size_t k=0; k<digi.GetADCs().size(); k++)
         {
           graph->SetPoint(k,TDC0time+(digi.GetStartTDC()+k)*mu2e::CRVDigitizationPeriod,digi.GetADCs()[k]);
         }

--- a/MCDataProducts/inc/CrvDigiMC.hh
+++ b/MCDataProducts/inc/CrvDigiMC.hh
@@ -15,25 +15,25 @@ namespace mu2e
   {
     public:
 
-    static constexpr size_t NSamples = 8; //FIXME: this is also a parameter in CrvDigi
-
     CrvDigiMC() {}
-    CrvDigiMC(const std::array<double,NSamples> &voltages, const std::vector<art::Ptr<CrvStep> > &steps,
-              art::Ptr<SimParticle> simParticle, double startTime, double TDC0Time,
+    CrvDigiMC(const std::vector<double> &voltages, const std::vector<art::Ptr<CrvStep> > &steps,
+              art::Ptr<SimParticle> simParticle, double startTime, double TDC0Time, bool NZS,
               mu2e::CRSScintillatorBarIndex scintillatorBarIndex, int SiPMNumber) :
                           _voltages(voltages),
                           _steps(steps),
                           _simParticle(simParticle),
                           _startTime(startTime),
                           _TDC0Time(TDC0Time),
+                          _NZS(NZS),
                           _scintillatorBarIndex(scintillatorBarIndex),
                           _SiPMNumber(SiPMNumber) {}
 
-    const std::array<double,NSamples>         &GetVoltages() const        {return _voltages;}
+    const std::vector<double>                 &GetVoltages() const        {return _voltages;}
     const std::vector<art::Ptr<CrvStep> >     &GetCrvSteps() const        {return _steps;}
     const art::Ptr<SimParticle>               &GetSimParticle() const     {return _simParticle;}
-    const double                              &GetStartTime() const       {return _startTime;}
-    const double                              &GetTDC0Time() const        {return _TDC0Time;}
+    double                                     GetStartTime() const       {return _startTime;}
+    double                                     GetTDC0Time() const        {return _TDC0Time;}
+    bool                                       IsNZS() const              {return _NZS;}
 
     mu2e::CRSScintillatorBarIndex GetScintillatorBarIndex() const {return _scintillatorBarIndex;}
     int                           GetSiPMNumber() const           {return _SiPMNumber;}
@@ -43,11 +43,12 @@ namespace mu2e
 
     private:
 
-    std::array<double,NSamples>         _voltages{0};
-    std::vector<art::Ptr<CrvStep> >     _steps  ;        //crv steps responsible for this waveform
+    std::vector<double>                 _voltages;
+    std::vector<art::Ptr<CrvStep> >     _steps;          //crv steps responsible for this waveform
     art::Ptr<SimParticle>               _simParticle;    //most likely sim particle responsible for this waveform
     double                              _startTime{0};
     double                              _TDC0Time{0};
+    bool                                _NZS{false};     //non-zero suppressed
 
     mu2e::CRSScintillatorBarIndex  _scintillatorBarIndex;
     int                            _SiPMNumber{0};

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -297,6 +297,19 @@ include="Math/Vector3D.h, Math/Vector4D.h, CLHEP/Vector/LorentzVector.h, CLHEP/V
 <class name="art::Wrapper<art::Assns<mu2e::CrvCoincidenceCluster,mu2e::CrvCoincidenceClusterMC,void> >" />
 <class name="art::Wrapper<art::Assns<mu2e::CrvCoincidenceClusterMC,mu2e::CrvCoincidenceCluster,void> >" />
 
+<ioread sourceClass="mu2e::CrvDigiMC"
+        source="std::array<double,8> _voltages"
+        checksum="[2311366739]"
+        targetClass="mu2e::CrvDigiMC"
+        target="_voltages, _NZS"
+        include="array, vector">
+<![CDATA[
+  _voltages.resize(onfile._voltages.size());
+  for(size_t i=0; i<onfile._voltages.size(); ++i) _voltages[i]=onfile._voltages[i];
+  _NZS=false;
+]]>
+</ioread>
+
 
 <!--  ********* ExtMon  ********* -->
 

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -297,6 +297,7 @@ include="Math/Vector3D.h, Math/Vector4D.h, CLHEP/Vector/LorentzVector.h, CLHEP/V
 <class name="art::Wrapper<art::Assns<mu2e::CrvCoincidenceCluster,mu2e::CrvCoincidenceClusterMC,void> >" />
 <class name="art::Wrapper<art::Assns<mu2e::CrvCoincidenceClusterMC,mu2e::CrvCoincidenceCluster,void> >" />
 
+<!--  checksum from file->ShowStreamerInfo() -->
 <ioread sourceClass="mu2e::CrvDigiMC"
         source="std::array<double,8> _voltages"
         checksum="[2311366739]"

--- a/RecoDataProducts/inc/CrvDigi.hh
+++ b/RecoDataProducts/inc/CrvDigi.hh
@@ -6,7 +6,6 @@
 //
 
 #include "Offline/DataProducts/inc/CRSScintillatorBarIndex.hh"
-#include <array>
 #include <vector>
 #include <cstdint>
 
@@ -16,23 +15,23 @@ namespace mu2e
   {
     public:
 
-    static constexpr size_t NSamples = 8; //FIXME: this is also a parameter in CrvDigiMC
-
     CrvDigi() {}
 
-    CrvDigi(const std::array<int16_t, NSamples> &ADCs, uint16_t startTDC, mu2e::CRSScintillatorBarIndex scintillatorBarIndex, uint8_t SiPMNumber) :
-            _ADCs(ADCs), _startTDC(startTDC), _scintillatorBarIndex(scintillatorBarIndex), _SiPMNumber(SiPMNumber) {}
+    CrvDigi(const std::vector<int16_t> &ADCs, uint16_t startTDC, bool NZS, mu2e::CRSScintillatorBarIndex scintillatorBarIndex, uint8_t SiPMNumber) :
+            _ADCs(ADCs), _startTDC(startTDC), _NZS(NZS), _scintillatorBarIndex(scintillatorBarIndex), _SiPMNumber(SiPMNumber) {}
 
-    const std::array<int16_t, NSamples>  &GetADCs() const     {return _ADCs;}
+    const std::vector<int16_t>           &GetADCs() const     {return _ADCs;}
     uint16_t                              GetStartTDC() const {return _startTDC;}
+    bool                                  IsNZS() const       {return _NZS;}
 
     mu2e::CRSScintillatorBarIndex GetScintillatorBarIndex() const {return _scintillatorBarIndex;}
     uint8_t                       GetSiPMNumber() const           {return _SiPMNumber;}
 
     private:
 
-    std::array<int16_t, NSamples>  _ADCs{0};
+    std::vector<int16_t>           _ADCs{0};
     uint16_t                       _startTDC{0};
+    bool                           _NZS{false};
 
     mu2e::CRSScintillatorBarIndex  _scintillatorBarIndex;
     uint8_t                        _SiPMNumber{0};

--- a/RecoDataProducts/src/classes_def.xml
+++ b/RecoDataProducts/src/classes_def.xml
@@ -341,6 +341,7 @@
  <class name="mu2e::CrvCoincidenceClusterCollection" />
  <class name="art::Wrapper<mu2e::CrvCoincidenceClusterCollection>" />
 
+<!--  checksum from file->ShowStreamerInfo() -->
 <ioread sourceClass="mu2e::CrvDigi"
         source="std::array<int16_t,8> _ADCs"
         checksum="[3596926525]"

--- a/RecoDataProducts/src/classes_def.xml
+++ b/RecoDataProducts/src/classes_def.xml
@@ -341,6 +341,19 @@
  <class name="mu2e::CrvCoincidenceClusterCollection" />
  <class name="art::Wrapper<mu2e::CrvCoincidenceClusterCollection>" />
 
+<ioread sourceClass="mu2e::CrvDigi"
+        source="std::array<int16_t,8> _ADCs"
+        checksum="[3596926525]"
+        targetClass="mu2e::CrvDigi"
+        target="_ADCs, _NZS"
+        include="array, vector">
+<![CDATA[
+  _ADCs.resize(onfile._ADCs.size());
+  for(size_t i=0; i<onfile._ADCs.size(); ++i) _ADCs[i]=onfile._ADCs[i];
+  _NZS=false;
+]]>
+</ioread>
+
 <!--  ********* ExtMon  ********* -->
  <class name="mu2e::ExtMonFNALRawHit" />
  <class name="std::vector<mu2e::ExtMonFNALRawHit>" />


### PR DESCRIPTION
Changed CrvDigis and CrvDigiMCs from (fixed-length) array of samples to (variable-length) vector of samples.
Previously, all digis used 8 samples. The new FEB II firmware will use 12 samples for zero suppressed (ZS) data and 134 samples of non-zero suppressed (NZS) data. These numbers may change in the future.
This code change introduced the production and reconstruction of NZS data. The NZS data will be handled by the same modules as the ZS data, and also get the same collection names except for the use of the "NZS" instance label. The ZS collection will keep the "" as instance label. All modules have a fcl parameter to turn on/off the production of NZS data. The default setting is off.   

This change is not backward compatible. This means older CrvDigis cannot be read anymore, which will require a redigitization of older simulations - including the digi files used for the nightly validation. So all validations that rely on previously generated digis will fail.

Since we first need to come up with a plan on how to make this transition, I will make this a draft pull request. 