### PR TITLE
Switch ExtMon filter to the commissioning config

### DIFF
--- a/Mu2eG4/geom/extmon_fnal_v02.txt
+++ b/Mu2eG4/geom/extmon_fnal_v02.txt
@@ -42,8 +42,9 @@ double extMonFNAL.collimator1.shotLinerOuterDiameter = 609.6;
 double extMonFNAL.collimator1.shotLinerOuterThickness = 9.7;
 double extMonFNAL.collimator1.length = 4203.7;
 
-// Steel Shot material
-string         extMonFNAL.collimator1.shot.materialName  = "ClosePackedExtMonSteelShot";
+// Steel Shot material - eventually "ClosePackedExtMonSteelShot".
+// Steel shot will not be installed during initial commissioning:
+string         extMonFNAL.collimator1.shot.materialName  = "G4_AIR";
 
 // Transition between the two radii of the plug and hole happens over dz.
 double extMonFNAL.collimator1.radiusTransitiondZ = 0;
@@ -125,10 +126,9 @@ double extMonFNAL.collimator2.shotLinerOuterDiameter = 609.6;
 double extMonFNAL.collimator2.shotLinerOuterThickness = 9.7;
 double extMonFNAL.collimator2.length = 2298.7;
 
-// Steel Shot Material
-string         extMonFNAL.collimator2.shot.materialName  = "ClosePackedExtMonSteelShot";
-
-
+// Steel Shot material - eventually "ClosePackedExtMonSteelShot".
+// Steel shot will not be installed during initial commissioning:
+string         extMonFNAL.collimator2.shot.materialName  = "G4_AIR";
 
 double extMonFNAL.collimator2.radiusTransitiondZ = 0;
 


### PR DESCRIPTION
We do not plan to install the steel shot for the initial commissioning.

This PR modifies material in some existing G4 volumes and may affect random number sequences in G4 jobs where particles cross into those volumes.

