### PR TITLE
Add option to save trajectory inside the tracker volume

### DIFF
--- a/Mu2eKinKal/fcl/prolog.fcl
+++ b/Mu2eKinKal/fcl/prolog.fcl
@@ -38,7 +38,6 @@ Mu2eKinKal : {
     MaxDStraw : 2 # integer (straw)
     MaxStrawDOCA : 5.0 # mm
     MaxStrawDOCAConsistency : 1.0 # units of chi
-    SaveTrajectory : "Full" # save the entire fit result trajectory in the KalSeed
   }
 
    CHSEEDFIT: {
@@ -509,22 +508,31 @@ Mu2eKinKal.producers.KKDeMSeedFit.FitDirection : 0
 Mu2eKinKal.producers.KKDePSeedFit.ModuleSettings.FitParticle : -11
 Mu2eKinKal.producers.KKDePSeedFit.FitDirection : 0
 
+# save trajectories in the Detector region for downstream fits, just the T0 segment for the rest
 Mu2eKinKal.producers.KKDeM.ModuleSettings.FitParticle : 11
 Mu2eKinKal.producers.KKDeM.FitDirection : 0
+Mu2eKinKal.producers.KKDeM.KKFitSettings.SaveTrajectory : "Detector"
 Mu2eKinKal.producers.KKDeP.ModuleSettings.FitParticle : -11
 Mu2eKinKal.producers.KKDeP.FitDirection : 0
-Mu2eKinKal.producers.KKUeM.ModuleSettings.FitParticle : 11
-Mu2eKinKal.producers.KKUeM.FitDirection : 1
-Mu2eKinKal.producers.KKUeP.ModuleSettings.FitParticle : -11
-Mu2eKinKal.producers.KKUeP.FitDirection : 1
+Mu2eKinKal.producers.KKDeP.KKFitSettings.SaveTrajectory : "Detector"
 Mu2eKinKal.producers.KKDmuM.ModuleSettings.FitParticle : 13
 Mu2eKinKal.producers.KKDmuM.FitDirection : 0
+Mu2eKinKal.producers.KKDmuM.KKFitSettings.SaveTrajectory : "Detector"
 Mu2eKinKal.producers.KKDmuP.ModuleSettings.FitParticle : -13
 Mu2eKinKal.producers.KKDmuP.FitDirection : 0
+Mu2eKinKal.producers.KKDmuP.KKFitSettings.SaveTrajectory : "Detector"
+Mu2eKinKal.producers.KKUeM.ModuleSettings.FitParticle : 11
+Mu2eKinKal.producers.KKUeM.FitDirection : 1
+Mu2eKinKal.producers.KKUeM.KKFitSettings.SaveTrajectory : "T0"
+Mu2eKinKal.producers.KKUeP.ModuleSettings.FitParticle : -11
+Mu2eKinKal.producers.KKUeP.FitDirection : 1
+Mu2eKinKal.producers.KKUeP.KKFitSettings.SaveTrajectory : "T0"
 Mu2eKinKal.producers.KKUmuM.ModuleSettings.FitParticle : 13
 Mu2eKinKal.producers.KKUmuM.FitDirection : 1
+Mu2eKinKal.producers.KKUmuM.KKFitSettings.SaveTrajectory : "T0"
 Mu2eKinKal.producers.KKUmuP.ModuleSettings.FitParticle : -13
 Mu2eKinKal.producers.KKUmuP.FitDirection : 1
+Mu2eKinKal.producers.KKUmuP.KKFitSettings.SaveTrajectory : "T0"
 # extrapolate upstream fits back to the tracker
 physics.producers.KKUmuM.Extrapolation.BackToTracker : true
 physics.producers.KKUmuP.Extrapolation.BackToTracker : true

--- a/Mu2eKinKal/inc/KKFit.hh
+++ b/Mu2eKinKal/inc/KKFit.hh
@@ -569,42 +569,46 @@ namespace mu2e {
           sxing->active() );
     }
     // save the fit segments as requested
-    if (savetraj_ == full){
-      fseed._segments.reserve(fittraj.pieces().size());
-      for (auto const& traj : fittraj.pieces() ){
-        // skip zero-range segments.  By convention, sample the state at the mid-time
-        if(traj->range().range() > 0.0) fseed._segments.emplace_back(*traj,traj->range().mid());
-      }
-    } else if (savetraj_ == detector ) {
-      // only save segments inside the tracker volume. First, find the time limits for that
-      double tmin = std::numeric_limits<float>::max();
-      double tmax = -tmin;
-      static const SurfaceId tt_front("TT_Front");
-      static const SurfaceId tt_back("TT_Back");
-      for(auto const& interpair : kktrk.intersections()) {
-        auto const& sid = std::get<0>(interpair);
-        if(sid == tt_front || sid == tt_back){
-          auto const& inter = std::get<1>(interpair);
-          tmin = std::min(tmin,inter.time_);
-          tmax = std::max(tmax,inter.time_);
+    if(kktrk.fitStatus().usable()){
+      if (savetraj_ == full){
+        fseed._segments.reserve(fittraj.pieces().size());
+        for (auto const& traj : fittraj.pieces() ){
+          // skip zero-range segments.  By convention, sample the state at the mid-time
+          if(traj->range().range() > 0.0) fseed._segments.emplace_back(*traj,traj->range().mid());
         }
-      }
-      // extend as needed to the calohit. Eventually we should also extend to the calorimeter, but that needs to be an extrapolation
-      if(kktrk.caloHits().size() > 0){
-        auto const& calohit = kktrk.caloHits().front();
-        if(calohit->active()){
-          tmin = std::min(tmin,calohit->time());
-          tmax = std::max(tmax,calohit->time());
+      } else if (savetraj_ == detector ) {
+        // only save segments inside the tracker volume. First, find the time limits for that
+        double tmin = std::numeric_limits<float>::max();
+        double tmax = -tmin;
+        static const SurfaceId tt_front("TT_Front");
+        static const SurfaceId tt_back("TT_Back");
+        for(auto const& interpair : kktrk.intersections()) {
+          auto const& sid = std::get<0>(interpair);
+          if(sid == tt_front || sid == tt_back){
+            auto const& inter = std::get<1>(interpair);
+            tmin = std::min(tmin,inter.time_);
+            tmax = std::max(tmax,inter.time_);
+          }
         }
+        // extend as needed to the calohit. Eventually we should also extend to the calorimeter, but that needs to be an extrapolation
+        if(kktrk.caloHits().size() > 0){
+          auto const& calohit = kktrk.caloHits().front();
+          if(calohit->active()){
+            tmin = std::min(tmin,calohit->time());
+            tmax = std::max(tmax,calohit->time());
+          }
+        }
+        if(tmin > tmax)throw cet::exception("RECO")<<"mu2e::KKFit: tracker intersections missing"<< endl;
+        fseed._segments.reserve(fittraj.pieces().size());// this will be oversized
+        for (auto const& traj : fittraj.pieces() ){
+          // skip segments outside the tracker volume range
+          if(traj->range().range() > 0.0 && (traj->range().inRange(tmin) || traj->range().inRange(tmax) || (traj->range().begin() > tmin && traj->range().end() < tmax)) ) fseed._segments.emplace_back(*traj,traj->range().mid());
+        }
+      } else if (savetraj_ == t0seg ) {
+        fseed._segments.emplace_back(t0piece,t0val);
       }
-      if(tmin > tmax)throw cet::exception("RECO")<<"mu2e::KKFit: tracker intersections missing"<< endl;
-      fseed._segments.reserve(fittraj.pieces().size());// this will be oversized
-      for (auto const& traj : fittraj.pieces() ){
-        // skip segments outside the tracker volume range
-        if(traj->range().range() > 0.0 && (traj->range().inRange(tmin) || traj->range().inRange(tmax) || (traj->range().begin() > tmin && traj->range().end() < tmax)) ) fseed._segments.emplace_back(*traj,traj->range().mid());
-      }
-    } else if (savetraj_ == t0seg ) {
-      fseed._segments.emplace_back(t0piece,t0val);
+    } else {
+      fseed._segments.emplace_back(t0piece,t0val); // save the t0 piece even for failed fits
     }
     // sample the fit at the locations provided
     sampleFit(kktrk,fseed._inters);

--- a/Mu2eKinKal/inc/KKFitSettings.hh
+++ b/Mu2eKinKal/inc/KKFitSettings.hh
@@ -86,7 +86,7 @@ namespace mu2e {
       fhicl::Atom<float> maxStrawDOCA { Name("MaxStrawDOCA"), Comment("Max DOCA to add straw material (mm)") };
       fhicl::Atom<float> maxStrawDOCAConsistency { Name("MaxStrawDOCAConsistency"), Comment("Max DOCA chi-consistency to add straw material") };
       // extension and sampling
-      fhicl::Atom<std::string> saveTraj { Name("SaveTrajectory"), Comment("How to save the trajectory in the KalSeed: None, Full, or T0 (just the t0 segment)") };
+      fhicl::Atom<std::string> saveTraj { Name("SaveTrajectory"), Comment("How to save the trajectory in the KalSeed: None, Full, TrackerVolume, or T0 (1 segment containing t0)") };
     };
     // struct for configuring a KinKal fit module
     struct KKModuleConfig {

--- a/Mu2eKinKal/inc/KKFitSettings.hh
+++ b/Mu2eKinKal/inc/KKFitSettings.hh
@@ -86,7 +86,7 @@ namespace mu2e {
       fhicl::Atom<float> maxStrawDOCA { Name("MaxStrawDOCA"), Comment("Max DOCA to add straw material (mm)") };
       fhicl::Atom<float> maxStrawDOCAConsistency { Name("MaxStrawDOCAConsistency"), Comment("Max DOCA chi-consistency to add straw material") };
       // extension and sampling
-      fhicl::Atom<std::string> saveTraj { Name("SaveTrajectory"), Comment("How to save the trajectory in the KalSeed: None, Full, TrackerVolume, or T0 (1 segment containing t0)") };
+      fhicl::Atom<std::string> saveTraj { Name("SaveTrajectory"), Comment("How to save the trajectory in the KalSeed: None, Full, Detector, or T0 (1 segment containing t0)") };
     };
     // struct for configuring a KinKal fit module
     struct KKModuleConfig {


### PR DESCRIPTION
This PR expands the options for how detailed to store the trajectory in the KalSeed. It's needed for tailoring the size of the reco payload. It includes a small bug fix which might have caused problems saving fits which straddle the 1695 ns divide.