### PR TITLE
Update RMC generation tools

### DIFF
--- a/CommonMC/src/GammaConversionPoints_module.cc
+++ b/CommonMC/src/GammaConversionPoints_module.cc
@@ -1,0 +1,272 @@
+//
+// Finds and accepts generated photons that pair produce
+// Largely based on Filters/src/InflightPionHits and CommonMC/src/StoppedParticleFinder
+
+// Mu2e includes.
+#include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/StatusG4.hh"
+#include "Offline/MCDataProducts/inc/StepPointMC.hh"
+#include "Offline/MCDataProducts/inc/SimParticle.hh"
+#include "Offline/MCDataProducts/inc/ProcessCode.hh"
+
+// Framework includes.
+#include "canvas/Persistency/Common/Ptr.h"
+#include "art/Framework/Core/EDFilter.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art_root_io/TFileService.h"
+
+// ROOT includes
+#include "TTree.h"
+
+// Other includes
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+// C++ includes
+#include <iostream>
+
+using namespace std;
+
+namespace mu2e {
+
+  class GammaConversionPoints : public art::EDFilter {
+  public:
+
+    struct Config {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      fhicl::Atom<std::string> g4ModuleLabel{Name("g4ModuleLabel"), Comment("Geant module label")};
+      fhicl::Atom<std::string> simCollectionLabel{Name("simCollectionLabel"), Comment("Sim particle collection module label ("" to use geant label)"),""};
+      fhicl::Atom<bool> doFilter{Name("doFilter"), Comment("Whether or not to filter passing events (true/false)"), true};
+      fhicl::Atom<ProcessCode> processCode{Name("processCode"), Comment("Photon creation code of interest"),  ProcessCode::mu2eExternalRMC};
+      fhicl::Atom<int> verbosity{Name("verbosity"), Comment("Verbose level"),  0};
+      fhicl::Atom<double> rMin{Name("rMin"), Comment("Stop minimum radius in the DS (mm)"), -1.};
+      fhicl::Atom<double> rMax{Name("rMax"), Comment("Stop maximum radius in the DS (mm)"),  1.e9};
+      fhicl::Atom<double> zMin{Name("zMin"), Comment("Stop minimum z value (mm)"), -1.e9};
+      fhicl::Atom<double> zMax{Name("zMax"), Comment("Stop maximum z value (mm)"),  1.e9};
+      fhicl::Atom<double> xOffset{Name("SolenoidXOffset"), Comment("X coordinate offset for radius calculations (mm)"), -3904.};
+      fhicl::Atom<double> eMin{Name("eMin"), Comment("Converted photon minimum energy (MeV)"), 0.};
+      fhicl::Atom<bool> saveTree{Name("saveTree"), Comment("Save a tree of photon conversion information"), false};
+    };
+    typedef art::EDFilter::Table<Config> Parameters;
+
+    explicit GammaConversionPoints(const Parameters& pset);
+    virtual ~GammaConversionPoints() { }
+
+    bool filter( art::Event& event);
+
+    virtual bool beginRun(art::Run &run);
+    bool beginSubRun(art::SubRun& sr) override;
+
+    virtual void endJob();
+
+  private:
+
+    // Module label of the module that made the StepPointMCCollections.
+    const std::string g4ModuleLabel_;
+    const std::string simCollectionLabel_;
+    const ProcessCode process_;
+
+    const bool   doFilter_; //whether or not to filter non-conversions
+    const int    verbosity_;
+    const double rMin_; //spacial cuts
+    const double rMax_;
+    const double zMin_;
+    const double zMax_;
+    const double xoffset_; // detector solenoid x offset
+    const double eMin_; //minimum energy for converted photon
+
+    const bool saveTree_; // store an ntuple of photon conversion information
+    TTree* ntup_;
+
+    // Number of events that pass the filter.
+    int nPassed_;
+
+    //struct of stop info
+    struct ConversionPointF {
+      float x;
+      float y;
+      float z;
+      float time;
+      float px;
+      float py;
+      float pz;
+      float genEnergy;
+    };
+
+    ConversionPointF data_;
+  };
+
+  GammaConversionPoints::GammaConversionPoints(const Parameters& pset):
+    art::EDFilter{pset},
+    g4ModuleLabel_(pset().g4ModuleLabel()),
+    simCollectionLabel_(pset().simCollectionLabel()),
+    process_(pset().processCode()),
+    doFilter_(pset().doFilter()),
+    verbosity_(pset().verbosity()),
+    rMin_(pset().rMin()),
+    rMax_(pset().rMax()),
+    zMin_(pset().zMin()),
+    zMax_(pset().zMax()),
+    xoffset_(pset().xOffset()),
+    eMin_(pset().eMin()),
+    saveTree_(pset().saveTree()),
+    ntup_(nullptr),
+    nPassed_(0) {
+    if(saveTree_) {
+      art::ServiceHandle<art::TFileService> tfs;
+      art::TFileDirectory tfdir = tfs->mkdir( "gammaStops" );
+      ntup_ = tfdir.make<TTree>("conversions", "Photon Conversions");
+      ntup_->Branch("stops", &data_, "x/F:y/F:z/F:time/F:px/F:py/F:pz/F:genEnergy/F");
+    }
+  }
+
+  bool GammaConversionPoints::beginSubRun(art::SubRun& sr) {
+    return true;
+  }
+
+  bool GammaConversionPoints::beginRun(art::Run& ){
+    return true;
+  }
+
+  bool GammaConversionPoints::filter(art::Event& event) {
+    art::Handle<StatusG4> g4StatusHandle;
+    event.getByLabel( g4ModuleLabel_, g4StatusHandle);
+    StatusG4 const& g4Status = *g4StatusHandle;
+
+    // Accept only events with good status from G4.
+    if ( g4Status.status() > 1 ) {
+      if(verbosity_ > 1) printf("GammaConversionFilter::%s: Skipping due to G4 status\n", __func__);
+      return false;
+    }
+
+    art::Handle<SimParticleCollection> simsHandle;
+    event.getByLabel((simCollectionLabel_.size() > 0) ? simCollectionLabel_ : g4ModuleLabel_,simsHandle);
+    SimParticleCollection const& sims(*simsHandle);
+
+    // Loop through sim particles looking for the simulated photon of interest
+    for(auto const& sim : sims) {
+      SimParticle const& parent = sim.second;
+
+      if(verbosity_ > 2) {
+        printf("GammaConversionPoints::%s: Sim particle: pdg = %5i, creation = %3i, stopping = %3i, p_start = %5.1f, p_end = %5.1f\n",
+               __func__, parent.pdgId(), int(parent.creationCode()), int(parent.stoppingCode()),
+               parent.startMomentum().vect().rho(), parent.endMomentum().vect().rho());
+      }
+
+      // Check if the generated particle
+      if(parent.creationCode() == process_) {
+        if(verbosity_ > 1) printf("GammaConversionPoints::%s: Particle with selected process code is found\n", __func__);
+
+        // Check if it's a pair conversion
+        if(parent.pdgId() == 22 && ProcessCode::conv == parent.stoppingCode()) {
+
+          // Get end position and momentum vectors
+          CLHEP::Hep3Vector const& pos(parent.endPosition());
+
+          // Check if it's within the region of interest
+          const double r = sqrt((pos.x()-xoffset_)*(pos.x()-xoffset_) + pos.y()*pos.y());
+          if(r < rMin_ || r > rMax_ || pos.z() < zMin_ || pos.z() > zMax_) {
+            if(verbosity_ > 1) printf("GammaConversionPoints::%s: Particle with r = %.2f fails filter\n", __func__, r);
+            return !doFilter_;
+          }
+
+          CLHEP::Hep3Vector const& p(parent.endMomentum().vect());
+          CLHEP::Hep3Vector const& pStart(parent.startMomentum().vect()); //if needed for momentum
+          CLHEP::Hep3Vector pstart(pStart.x(), pStart.y(), pStart.z()); //to edit the vector
+          bool useStart = false;
+
+          // Check if the momentum is stored, if not try to calculate it
+          if(p.mag() == 0.) { //in case the final momentum not saved, add the daughters
+            std::vector<art::Ptr<SimParticle> > const& daughters = parent.daughters();
+            if(daughters.size() < 1) {
+              useStart = true; //no daughters saved, use the start momentum
+            } else {
+              CLHEP::Hep3Vector pp(0.,0.,0.);
+              int nConv = 0;
+              for(unsigned int i = 0; i < daughters.size(); ++i) {
+                SimParticle const sp = *daughters[i];
+                if(sp.creationCode() == ProcessCode::conv) {
+                  ++nConv;
+                  pp += sp.startMomentum().vect();
+                } else { //remove other daughters as happening before the conversion in case not all conversions found
+                  pstart -= sp.startMomentum().vect();
+                }
+              }
+              if(nConv < 2) { //both conversion daughters weren't stored
+                useStart = true;
+              }
+              else { //both daughters stored
+                data_.px = pp.x();
+                data_.py = pp.y();
+                data_.pz = pp.z();
+              }
+            }
+          } else { //end momentum is stored
+            data_.px = p.x();
+            data_.py = p.y();
+            data_.pz = p.z();
+          }
+          if(useStart) { //if conversion daughters not stored and end momentum not stored
+            data_.px = pstart.x();
+            data_.py = pstart.y();
+            data_.pz = pstart.z();
+          }
+
+          // Filter on the photon energy
+          const float energy = sqrt(pow(data_.px, 2) + pow(data_.py,2) + pow(data_.pz, 2));
+          if(energy < eMin_) {
+            if(verbosity_ > 1) printf("GammaConversionPoints::%s: Particle with E = %.2f MeV fails filter\n", __func__, energy);
+            return !doFilter_;
+          }
+
+          // Accept the event
+
+          // Store information for debugging/output tree
+          data_.x = pos.x();
+          data_.y = pos.y();
+          data_.z = pos.z();
+          data_.time = parent.endGlobalTime();
+          data_.genEnergy = pStart.mag();
+
+          ++nPassed_;
+
+          // Print information about the event if requested
+          if(verbosity_ > 0) {
+            const float pt = sqrt(pow(data_.px, 2) + pow(data_.py,2));
+            const float sz = pt/energy;
+            const float cz = sqrt(1. - sz*sz) * ((data_.py < 0.) ? -1. : 1.);
+            const float r  = sqrt(pow(data_.x - xoffset_, 2) + pow(data_.y,2));
+            printf("GammaConversionPoints::%s: Accepted event: p = %5.1f, pT = %5.1f, cos(theta_z) = %6.3f, r = %5.1f, z = %6.1f, t = %5.0f, E(gen) = %5.1f\n",
+                   __func__, energy, pt, cz, r, data_.z, data_.time, data_.genEnergy);
+          }
+
+          // Store the event if requested
+          if(saveTree_) ntup_->Fill();
+
+          return true; //converted so done looking
+        } else {
+          if(verbosity_ > 1) printf("GammaConversionPoints::%s: Particle process code %i fails filter\n", __func__, int(parent.stoppingCode()));
+          return !doFilter_; //not a conversion
+        }
+      }
+    }
+
+    if(verbosity_ > 1) printf("GammaConversionPoints::%s: Event had no observed photon conversions\n", __func__);
+    return !doFilter_;
+
+  } // end of ::filter.
+
+  void GammaConversionPoints::endJob() {
+    mf::LogInfo("Summary")
+      << "GammaConversionPoints_module: Number of conversion events found: "
+      << nPassed_
+      << "\n";
+  }
+
+} //end mu2e namespace
+
+using mu2e::GammaConversionPoints;
+DEFINE_ART_MODULE(GammaConversionPoints);

--- a/EventGenerator/fcl/prolog.fcl
+++ b/EventGenerator/fcl/prolog.fcl
@@ -166,9 +166,12 @@ EventGenerator : {
 }
 
 GenFilter : {
-        module_type : GenFilter
-        StageParticleCollection : "generate"
-        isNull : true
+    module_type : GenFilter
+    StageParticleCollection : "generate"
+    filterMaxR     : false
+    filterEnergy   : false
+    filterMomentum : false
+    filterPT       : false
 }
 
 PionFilter : {
@@ -371,6 +374,31 @@ EventGenerator : { @table::EventGenerator
                 physicsVerbosityLevel : 0
             }
             muonStops                 : { @table::muonStops  }
+        }
+
+        RMCGenerator : {
+            module_type : SingleProcessGenerator
+            inputSimParticles: TargetStopResampler
+            stoppingTargetMaterial : "Al"
+            decayProducts : {
+                tool_type : RMCGenerator
+                spectrum : {
+                    elow              : 85
+                    ehi               : 90.1
+                    kMaxUserSet       : true
+                    kMaxUser          : 90.1
+                    external          : true
+                    spectrumShape     : "RMC"
+                    spectrumResolution: 0.1
+                }
+            }
+            verbosity : 0
+        }
+
+        GammaConversion : {
+            module_type : GammaConversion
+            material    : 13
+            verbosity   : 0
         }
 
         CaloTBGun : {

--- a/EventGenerator/src/FlatMuonDaughterGenerator_module.cc
+++ b/EventGenerator/src/FlatMuonDaughterGenerator_module.cc
@@ -43,6 +43,8 @@ namespace mu2e {
       using Comment=fhicl::Comment;
       fhicl::Atom<double> startMom{Name("startMom"),0};
       fhicl::Atom<double> endMom{Name("endMom"),105};
+      fhicl::Atom<double> czMin{Name("czMin"), Comment("Minimum cos(theta_z) to generate in"), -1.};
+      fhicl::Atom<double> czMax{Name("czMax"), Comment("Maximum cos(theta_z) to generate in"),  1.};
       fhicl::Atom<art::InputTag> inputSimParticles{Name("inputSimParticles"),Comment("A SimParticleCollection with input stopped muons.")};
       fhicl::Atom<std::string> stoppingTargetMaterial{Name("stoppingTargetMaterial"),Comment("material")};
       fhicl::Atom<unsigned> verbosity{Name("verbosity")};
@@ -87,7 +89,7 @@ namespace mu2e {
     , eng_{createEngine(art::ServiceHandle<SeedService>()->getSeed())}
     , randFlat_{eng_}
     , randExp_{eng_}
-    , randomUnitSphere_{eng_}
+    , randomUnitSphere_{eng_, conf().czMin(), conf().czMax()}
     , pdgId_(conf().pdgId())
 
   {

--- a/EventGenerator/src/GammaConversion_module.cc
+++ b/EventGenerator/src/GammaConversion_module.cc
@@ -1,0 +1,135 @@
+// Generates e+/e- from converted photons
+// Uses the G4BetheHeitlerModel written into Mu2eUtilities::GammaConversionSpectrum
+// This module throws an exception if no suitable photon is found.
+//
+// M. MacKenzie (2024), based on GammaConvFlat_module.cc
+
+#include <iostream>
+#include <string>
+#include <cmath>
+#include <memory>
+
+#include "CLHEP/Vector/LorentzVector.h"
+#include "CLHEP/Random/RandFlat.h"
+
+#include "fhiclcpp/types/Atom.h"
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+
+#include "Offline/SeedService/inc/SeedService.hh"
+#include "Offline/DataProducts/inc/PDGCode.hh"
+#include "Offline/MCDataProducts/inc/ProcessCode.hh"
+#include "Offline/MCDataProducts/inc/StageParticle.hh"
+#include "Offline/Mu2eUtilities/inc/simParticleList.hh"
+#include "Offline/Mu2eUtilities/inc/GammaPairConversionSpectrum.hh"
+
+namespace mu2e {
+
+  //================================================================
+  class GammaConversion : public art::EDProducer {
+  public:
+    struct Config {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      fhicl::Atom<art::InputTag> inputSimParticles{Name("inputSimParticles"),Comment("A SimParticleCollection with input converted photons.")};
+      fhicl::Atom<int> material{Name("material"), Comment("Conversion material Z"), 13};
+      fhicl::Atom<bool> correlateAnglesOverKE{Name("correlateAnglesOverKE"), Comment("Option to correlate angles over KE"), true};
+      fhicl::Atom<int> verbosity{Name("verbosity"), Comment("Verbosity level"), 0};
+    };
+
+    using Parameters= art::EDProducer::Table<Config>;
+    explicit GammaConversion(const Parameters& conf);
+
+    virtual void produce(art::Event& event) override;
+
+    //----------------------------------------------------------------
+  private:
+
+    art::ProductToken<SimParticleCollection> const simsToken_;
+    const int material_;
+    const int verbosity_;
+
+    art::RandomNumberGenerator::base_engine_t& eng_;
+    CLHEP::RandFlat randFlat_;
+    GammaPairConversionSpectrum spectrum_;
+    GammaPairConversionSpectrum::elementData element_;
+    const ProcessCode process_;
+  };
+
+  //================================================================
+  GammaConversion::GammaConversion(const Parameters& conf)
+    : EDProducer{conf}
+    , simsToken_{consumes<SimParticleCollection>(conf().inputSimParticles())}
+    , material_{conf().material()}
+    , verbosity_{conf().verbosity()}
+    , eng_{createEngine(art::ServiceHandle<SeedService>()->getSeed())}
+    , randFlat_{eng_}
+    , spectrum_(&randFlat_, conf().correlateAnglesOverKE())
+    , element_(spectrum_.GetElementMap()[material_])
+    , process_(ProcessCode::mu2eGammaConversion)
+  {
+    produces<mu2e::StageParticleCollection>();
+  }
+
+  //================================================================
+  void GammaConversion::produce(art::Event& event) {
+    auto output{std::make_unique<StageParticleCollection>()};
+
+    const auto simh = event.getValidHandle<SimParticleCollection>(simsToken_);
+    const auto gammas = simParticleList(simh,PDGCode::gamma,ProcessCode::conv);
+
+    // If no suitable photons, print the particle collection and throw an error
+    if(gammas.empty()) {
+      const auto& sims = *simh;
+      std::cout << "GammaConversion_module::" << __func__ << ": Printing the particle collection:\n";
+      for(auto i = sims.begin(); i != sims.end(); ++i) {
+        const auto& inpart = i->second;
+        std::cout << "SimParticle: pdg = " << inpart.pdgId() << " createCode = " << inpart.creationCode()
+                  << " stopCode = " << inpart.stoppingCode() << std::endl;
+      }
+      throw cet::exception("BADINPUT")
+        << "GammaConversion::produce(): no suitable converted gamma in the input SimParticleCollection\n";
+    }
+
+    // Retrieve a random photon from the collection
+    const auto gamma = gammas.at(eng_.operator unsigned int() % gammas.size());
+    const auto p_g   = gamma->endMomentum();
+    const auto t     = gamma->endGlobalTime();
+
+    // Get a random conversion event given the input photon
+    CLHEP::HepLorentzVector p_em, p_ep;
+    spectrum_.fire(p_g, element_, p_em, p_ep);
+
+    // Add the particles to the output
+    output->emplace_back(gamma,
+                         process_,
+                         PDGCode::e_minus,
+                         gamma->endPosition(),
+                         p_em,
+                         t
+                         );
+
+    output->emplace_back(gamma,
+                         process_,
+                         PDGCode::e_plus,
+                         gamma->endPosition(),
+                         p_ep,
+                         t
+                         );
+
+    // print the conversion event if requested
+    if (verbosity_ > 1){
+      std::cout << "p(gamma) = (" << p_g .vect().x() << "," << p_g .vect().y() << "," << p_g .vect().z() << "," << p_g .e() << ")" << std::endl;
+      std::cout << "p(e-)    = (" << p_em.vect().x() << "," << p_em.vect().y() << "," << p_em.vect().z() << "," << p_em.e() << ")" << std::endl;
+      std::cout << "p(e+)    = (" << p_ep.vect().x() << "," << p_ep.vect().y() << "," << p_ep.vect().z() << "," << p_ep.e() << ")" << std::endl;
+    }
+
+    event.put(std::move(output));
+  }
+
+  //================================================================
+} // namespace mu2e
+
+DEFINE_ART_MODULE(mu2e::GammaConversion)

--- a/EventGenerator/src/GammaConversion_module.cc
+++ b/EventGenerator/src/GammaConversion_module.cc
@@ -2,6 +2,8 @@
 // Uses the G4BetheHeitlerModel written into Mu2eUtilities::GammaConversionSpectrum
 // This module throws an exception if no suitable photon is found.
 //
+// Expected workflow: Photons are generated and conversion events are filtered (e.g. with GammaConversionFilter + StoppedParticlesFinder), then resampled with this module
+//
 // M. MacKenzie (2024), based on GammaConvFlat_module.cc
 
 #include <iostream>
@@ -17,6 +19,7 @@
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art_root_io/TFileService.h"
 
 #include "Offline/SeedService/inc/SeedService.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
@@ -24,6 +27,11 @@
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
 #include "Offline/Mu2eUtilities/inc/simParticleList.hh"
 #include "Offline/Mu2eUtilities/inc/GammaPairConversionSpectrum.hh"
+
+// ROOT includes
+#include "TFile.h"
+#include "TH1.h"
+#include "TH2.h"
 
 namespace mu2e {
 
@@ -37,6 +45,7 @@ namespace mu2e {
       fhicl::Atom<int> material{Name("material"), Comment("Conversion material Z"), 13};
       fhicl::Atom<bool> correlateAnglesOverKE{Name("correlateAnglesOverKE"), Comment("Option to correlate angles over KE"), true};
       fhicl::Atom<int> verbosity{Name("verbosity"), Comment("Verbosity level"), 0};
+      fhicl::Atom<bool> makeHistograms{Name("makeHistograms"), Comment("Make histograms of the conversion kinematics"), false};
     };
 
     using Parameters= art::EDProducer::Table<Config>;
@@ -56,6 +65,17 @@ namespace mu2e {
     GammaPairConversionSpectrum spectrum_;
     GammaPairConversionSpectrum::elementData element_;
     const ProcessCode process_;
+    const bool makeHistograms_;
+
+    // histograms of the conversion kinematics
+    TH1* hmomentum_;
+    TH1* hCosz_;
+    TH1* hEnergyElectron_;
+    TH1* hEnergyPositron_;
+    TH1* hMass_;
+    TH2* hMassVsE_;
+    TH1* hMassOverE_;
+    TH1* hy_; // splitting function
   };
 
   //================================================================
@@ -69,32 +89,66 @@ namespace mu2e {
     , spectrum_(&randFlat_, conf().correlateAnglesOverKE())
     , element_(spectrum_.GetElementMap()[material_])
     , process_(ProcessCode::mu2eGammaConversion)
+    , makeHistograms_(conf().makeHistograms())
   {
     produces<mu2e::StageParticleCollection>();
+
+    // make histograms of the conversion kinematics if requested
+    if(makeHistograms_) {
+      art::ServiceHandle<art::TFileService> tfs;
+      art::TFileDirectory tfdir = tfs->mkdir("GammaConversion");
+      hmomentum_       = tfdir.make<TH1F>("hmomentum", "Input photon momentum", 60,  0.,  120.  );
+      hCosz_           = tfdir.make<TH1F>("hCosz", "Input photon cos(#theta_{z})", 200,  -1.,  1.  );
+      hEnergyElectron_ = tfdir.make<TH1F>("hEnergyElectron", "Produced conversion electron energy", 60,  0.,  120.  );
+      hEnergyPositron_ = tfdir.make<TH1F>("hEnergyPositron", "Produced conversion positron energy", 60,  0.,  120.  );
+      hMass_           = tfdir.make<TH1F>("hMass"          , "M(e+e-) "           , 120,0.,120.);
+      hMassVsE_        = tfdir.make<TH2F>("hMassVsE"       , "M(e+e-) vs. E;E (MeV); M(e+e-) (MeV/c^{2})"  , 120,0.,120.,120,0,120);
+      hMassOverE_      = tfdir.make<TH1F>("hMassOverE"     , "M(e+e-)/E"          , 100, 0.,1);
+      hy_              = tfdir.make<TH1F>("hy"             , "y = (ee-ep)/|pe+pp|", 100,-1.,1.);
+    }
   }
 
   //================================================================
   void GammaConversion::produce(art::Event& event) {
     auto output{std::make_unique<StageParticleCollection>()};
 
+    // Sim particle collection from a generated photon event with a photon conversion
     const auto simh = event.getValidHandle<SimParticleCollection>(simsToken_);
     const auto gammas = simParticleList(simh,PDGCode::gamma,ProcessCode::conv);
 
     // If no suitable photons, print the particle collection and throw an error
-    if(gammas.empty()) {
-      const auto& sims = *simh;
+    if(gammas.empty() || verbosity_ > 2) {
       std::cout << "GammaConversion_module::" << __func__ << ": Printing the particle collection:\n";
+      const auto& sims = *simh;
       for(auto i = sims.begin(); i != sims.end(); ++i) {
         const auto& inpart = i->second;
-        std::cout << "SimParticle: pdg = " << inpart.pdgId() << " createCode = " << inpart.creationCode()
-                  << " stopCode = " << inpart.stoppingCode() << std::endl;
+        std::cout << "SimParticle: id = " << inpart.id() << " pdg = " << inpart.pdgId() << " createCode = " << inpart.creationCode()
+                  << " stopCode = " << inpart.stoppingCode() << " E = " << inpart.endMomentum().e() << std::endl;
       }
+    }
+    if(gammas.empty()) {
       throw cet::exception("BADINPUT")
         << "GammaConversion::produce(): no suitable converted gamma in the input SimParticleCollection\n";
     }
 
-    // Retrieve a random photon from the collection
-    const auto gamma = gammas.at(eng_.operator unsigned int() % gammas.size());
+    // Retrieve the first relevant photon from the collection, ignoring those from Bremsstrahlung or annihilations
+    unsigned gamma_index = gammas.size();
+    for(unsigned index = 0; index < gammas.size(); ++index) {
+      const auto gamma = gammas.at(index);
+      if(gamma->creationCode() == ProcessCode::eBrem || gamma->creationCode() == ProcessCode::annihil) continue;
+      if(verbosity_ > 2) printf("--> Selecting photon at index %u\n", index);
+      gamma_index = index;
+      break;
+    }
+
+    // Check if a good photon is found
+    if(gamma_index >= gammas.size()) {
+      if(verbosity_ > 0) printf("GammaConversion::%s: No suitable photon found to convert, passing an empty event\n", __func__);
+      event.put(std::move(output));
+    }
+
+    // Process the photon conversion
+    const auto gamma = gammas.at(gamma_index);
     const auto p_g   = gamma->endMomentum();
     const auto t     = gamma->endGlobalTime();
 
@@ -126,6 +180,23 @@ namespace mu2e {
       std::cout << "p(e+)    = (" << p_ep.vect().x() << "," << p_ep.vect().y() << "," << p_ep.vect().z() << "," << p_ep.e() << ")" << std::endl;
     }
 
+    // fill the conversion kinematics histograms if requested
+    if(makeHistograms_) {
+      const double energy = p_g.e();
+      const double mass = (p_em+p_ep).m();
+      hmomentum_->Fill(energy);
+      hCosz_->Fill((p_em+p_ep).cosTheta());
+      hEnergyElectron_->Fill(p_em.e());
+      hEnergyPositron_->Fill(p_ep.e());
+
+      hMass_->Fill(mass);
+      hMassVsE_->Fill(energy,mass);
+      hMassOverE_->Fill(mass/energy);
+
+      const CLHEP::Hep3Vector p = p_em.vect()+p_ep.vect();
+      const double y = (p_em.e()-p_ep.e())/p.mag();
+      hy_->Fill(y);
+    }
     event.put(std::move(output));
   }
 

--- a/EventGenerator/src/GenFilter_module.cc
+++ b/EventGenerator/src/GenFilter_module.cc
@@ -1,4 +1,4 @@
-// Purpose: Event filter for DIO simulations
+// Purpose: Filter events based on generator particles, focused on muon target stop daughters (e.g. DIO)
 // author: S Middleton  2024
 #include "art/Framework/Core/EDFilter.h"
 #include "art/Framework/Principal/Event.h"
@@ -31,10 +31,20 @@ namespace mu2e {
         using Comment=fhicl::Comment;
         fhicl::Atom<art::InputTag> SimToken{Name("StageParticleCollection"),Comment("")};
         fhicl::Atom<art::InputTag>SimTag{Name("StageParticleCollection"),Comment("SimTag")};
-        fhicl::Atom<double> maxr_min{Name("maxr_min"),0};
-        fhicl::Atom<double> maxr_max{Name("maxr_max"),1e7};
-        fhicl::Atom<bool> makeplots{Name("makeplots"),false};
-        fhicl::Atom<bool> isNull{Name("isNull"),true};
+        fhicl::Atom<bool> isNull_{Name("isNull"), Comment("Flag to turn off event filtering"), false};
+        fhicl::Atom<bool> maxr_cut_{Name("filterMaxR"), Comment("Filter on the maximum radius of particles in a B-field"), false};
+        fhicl::Atom<double> maxr_min{Name("maxr_min"), Comment("Minimum particle radius"), -1.};
+        fhicl::Atom<double> maxr_max{Name("maxr_max"), Comment("Maximum particle radius"), 1.e7};
+        fhicl::Atom<bool> energy_cut_{Name("filterEnergy"), Comment("Filter on particle energies"), false};
+        fhicl::Atom<double> emin{Name("emin"), Comment("Minimum particle energy"), 0.};
+        fhicl::Atom<double> emax{Name("emax"), Comment("Maximum particle energy"), 1.e10};
+        fhicl::Atom<bool> momentum_cut_{Name("filterMomentum"), Comment("Filter on particle momenta"), false};
+        fhicl::Atom<double> pmin{Name("pmin"), Comment("Minimum particle momentum"), 0.};
+        fhicl::Atom<double> pmax{Name("pmax"), Comment("Maximum particle momentum"), 1.e10};
+        fhicl::Atom<bool> pT_cut_{Name("filterPT"), Comment("Filter on particle transverse momenta"), false};
+        fhicl::Atom<double> ptmin{Name("ptmin"), Comment("Minimum transverse momentum"), 0.};
+        fhicl::Atom<double> ptmax{Name("ptmax"), Comment("Maximum transverse momentum"), 1.e10};
+        fhicl::Atom<bool> makeplots{Name("makeplots"), Comment("Fill an output ntuple of particle information"), false};
       };
       explicit GenFilter(const art::EDFilter::Table<Config>& config);
       virtual bool filter(art::Event& event) override;
@@ -42,12 +52,24 @@ namespace mu2e {
     private:
       art::InputTag _SimToken;
       const StageParticleCollection* _SimCol;
-      double maxr_min_;
-      double maxr_max_;
-      bool makeplots_;
-      bool isNull_;
+      const bool isNull_; //turn off all filtering
+      const bool maxr_cut_;
+      const double maxr_min_;
+      const double maxr_max_;
+      const bool energy_cut_;
+      const double emin_;
+      const double emax_;
+      const bool momentum_cut_;
+      const double pmin_;
+      const double pmax_;
+      const bool pT_cut_;
+      const double ptmin_;
+      const double ptmax_;
+      const bool makeplots_;
       TTree* genTree;
       Float_t _maxr;
+      Float_t _energy;
+      Float_t _mom;
       Float_t _momT;
       Float_t _posT;
       Float_t _cosTheta;
@@ -57,15 +79,27 @@ namespace mu2e {
   GenFilter::GenFilter(const art::EDFilter::Table<Config>& config) :
      EDFilter{config}
     , _SimToken(config().SimToken())
+    , isNull_{config().isNull_()}
+    , maxr_cut_{config().maxr_cut_()}
     , maxr_min_(config().maxr_min())
     , maxr_max_(config().maxr_max())
+    , energy_cut_{config().energy_cut_()}
+    , emin_(config().emin())
+    , emax_(config().emax())
+    , momentum_cut_{config().momentum_cut_()}
+    , pmin_(config().pmin())
+    , pmax_(config().pmax())
+    , pT_cut_{config().pT_cut_()}
+    , ptmin_(config().ptmin())
+    , ptmax_(config().ptmax())
     , makeplots_{config().makeplots()}
-    , isNull_{config().isNull()}
   {
     if(makeplots_){
       art::ServiceHandle<art::TFileService> tfs;
       genTree  = tfs->make<TTree>("GenAna", "GenAna");
       genTree->Branch("maxr", &_maxr, "maxr/F");
+      genTree->Branch("energy", &_energy, "energy/F");
+      genTree->Branch("mom", &_mom, "mom/F");
       genTree->Branch("momT", &_momT, "momT/F");
       genTree->Branch("posT", &_posT, "posT/F");
       genTree->Branch("cosTheta", &_cosTheta, "cosTheta/F");
@@ -75,42 +109,70 @@ namespace mu2e {
 
   bool GenFilter::filter(art::Event& event) {
     if(isNull_) return true;
-    bool passed = false;
+    if(!(maxr_cut_ || energy_cut_ || momentum_cut_ || pT_cut_)) return true;
     auto sim = event.getValidHandle<StageParticleCollection>(_SimToken);
     _SimCol = sim.product();
+    bool pass_maxr_cut = !maxr_cut_;
+    bool pass_energy_cut = !energy_cut_;
+    bool pass_momentum_cut = !momentum_cut_;
+    bool pass_pT_cut = !momentum_cut_;
     for(const auto& aParticle : *_SimCol){
-    //  make momentum and position vectors
+      //  make momentum and position vectors
       GeomHandle<DetectorSystem> det;
       ROOT::Math::XYZVectorF pos = XYZVectorF(det->toDetector(aParticle.position()));
       ROOT::Math::XYZTVector pos0(pos.x(), pos.y(), pos.z(), aParticle.time());
       ROOT::Math::PxPyPzMVector mom0(aParticle.momentum().x(), aParticle.momentum().y(), aParticle.momentum().z(), aParticle.momentum().t());
+      _energy = aParticle.momentum().e();
+      _mom = aParticle.momentum().rho();
+      _momT = sqrt(mom0.x()*mom0.x() + mom0.y()*mom0.y());
 
-      // extract charge
-      static GlobalConstantsHandle<ParticleDataList> pdt;
-      auto charge = pdt->particle(aParticle.pdgId()).charge();
+      if(maxr_cut_) { // cut on maximum R in the solenoid
+        // extract charge
+        static GlobalConstantsHandle<ParticleDataList> pdt;
+        auto charge = pdt->particle(aParticle.pdgId()).charge();
 
-      // extact field
-      GeomHandle<BFieldManager> bfmgr;
-      mu2e::GeomHandle<mu2e::Tracker> tracker;
-      auto tracker_origin = det->toMu2e(tracker->origin());
-      //XYZVectorF pos3Vec = XYZVectorF(aParticle.position().x(),aParticle.position().y(),aParticle.position().z());
-      ROOT::Math::XYZVector bnom(bfmgr->getBField(tracker_origin));
+        // check if the particle is charged, else ignore this cut
+        if(fabs(charge) > 1.e-5) {
+          // extact field
+          GeomHandle<BFieldManager> bfmgr;
+          mu2e::GeomHandle<mu2e::Tracker> tracker;
+          auto tracker_origin = det->toMu2e(tracker->origin());
+          //XYZVectorF pos3Vec = XYZVectorF(aParticle.position().x(),aParticle.position().y(),aParticle.position().z());
+          ROOT::Math::XYZVector bnom(bfmgr->getBField(tracker_origin));
 
-      // make the loophelix
-      KinKal::LoopHelix lh(pos0, mom0, charge, bnom);
-      // calculate rmax and add maxr to siminfo
-      _maxr =sqrt(lh.cx()*lh.cx()+lh.cy()*lh.cy())+fabs(lh.rad());
+          // make the loophelix
+          KinKal::LoopHelix lh(pos0, mom0, charge, bnom);
+          // calculate rmax and add maxr to siminfo
+          _maxr = sqrt(lh.cx()*lh.cx()+lh.cy()*lh.cy())+fabs(lh.rad());
+          pass_maxr_cut |= _maxr < maxr_max_ && _maxr > maxr_min_;
+        } else {  //not defined for neutral particles
+          pass_maxr_cut = true; //default to passing for neutral particles
+          _maxr = -1.;
+        }
+      } else {
+        _maxr = -1.; //not filtered on, so not calculated
+      }
+
+      // particle energy/momentum cuts
+      if(energy_cut_) {
+        pass_energy_cut |= _energy > emin_ && _energy < emax_;
+      }
+      if(momentum_cut_) {
+        pass_momentum_cut |= _mom > pmin_ && _mom < pmax_;
+      }
+      if(pT_cut_) {
+        pass_pT_cut |= _momT > ptmin_ && _momT < ptmax_;
+      }
+
       if(makeplots_){
         // fill other branches for plots
-        _momT =  sqrt(mom0.x()*mom0.x() + mom0.y()*mom0.y());
         _posT = sqrt(pos.x()*pos.x() + pos.y()*pos.y());
         _cosTheta = cos(atan2(_momT,mom0.z()));
         _time = aParticle.time();
         genTree->Fill();
       }
-      if((_maxr < maxr_max_ and _maxr > maxr_min_ )){ passed = true; }
     }
-    return passed;
+    return pass_maxr_cut && pass_energy_cut && pass_momentum_cut && pass_pT_cut;
   }
 }
 

--- a/EventGenerator/src/GenFilter_module.cc
+++ b/EventGenerator/src/GenFilter_module.cc
@@ -142,7 +142,7 @@ namespace mu2e {
           // make the loophelix
           KinKal::LoopHelix lh(pos0, mom0, charge, bnom);
           // calculate rmax and add maxr to siminfo
-          _maxr = sqrt(lh.cx()*lh.cx()+lh.cy()*lh.cy())+fabs(lh.rad());
+          _maxr = lh.maxAxisDist();
           pass_maxr_cut |= _maxr < maxr_max_ && _maxr > maxr_min_;
         } else {  //not defined for neutral particles
           pass_maxr_cut = true; //default to passing for neutral particles

--- a/EventGenerator/src/GenFilter_module.cc
+++ b/EventGenerator/src/GenFilter_module.cc
@@ -137,7 +137,6 @@ namespace mu2e {
           GeomHandle<BFieldManager> bfmgr;
           mu2e::GeomHandle<mu2e::Tracker> tracker;
           auto tracker_origin = det->toMu2e(tracker->origin());
-          //XYZVectorF pos3Vec = XYZVectorF(aParticle.position().x(),aParticle.position().y(),aParticle.position().z());
           ROOT::Math::XYZVector bnom(bfmgr->getBField(tracker_origin));
 
           // make the loophelix

--- a/EventGenerator/src/RMCGenerator_tool.cc
+++ b/EventGenerator/src/RMCGenerator_tool.cc
@@ -1,0 +1,182 @@
+// Generator tool to produce radiative muon capture (RMC) events from muon stops
+//
+// Michael MacKenzie, 2024 (based on DIOGenerator_tool.cc and StoppedMuonRMCGun_module.cc)
+
+#include "art/Utilities/ToolMacros.h"
+#include "art_root_io/TFileService.h"
+
+#include "CLHEP/Random/RandPoissonQ.h"
+#include "CLHEP/Random/RandomEngine.h"
+#include "CLHEP/Random/RandGeneral.h"
+
+#include "Offline/EventGenerator/inc/ParticleGeneratorTool.hh"
+
+#include "Offline/DataProducts/inc/PDGCode.hh"
+#include "Offline/MCDataProducts/inc/GenId.hh"
+#include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
+#include "Offline/Mu2eUtilities/inc/MuonCaptureSpectrum.hh"
+#include "Offline/Mu2eUtilities/inc/BinnedSpectrum.hh"
+#include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+#include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
+
+#include "fhiclcpp/types/DelegatedParameter.h"
+
+// ROOT includes
+#include "TTree.h"
+#include "TFile.h"
+#include "TH1.h"
+#include "TH2.h"
+
+namespace mu2e {
+  class RMCGenerator : public ParticleGeneratorTool {
+  public:
+    struct PhysConfig {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+
+      fhicl::DelegatedParameter spectrum{Name("spectrum"), Comment("Parameters for BinnedSpectrum)")};
+    };
+    typedef art::ToolConfigTable<PhysConfig> Parameters;
+
+    explicit RMCGenerator(Parameters const& conf) :
+      _emass(GlobalConstantsHandle<ParticleDataList>()->particle(PDGCode::e_minus).mass()),
+      _mumass(GlobalConstantsHandle<ParticleDataList>()->particle(PDGCode::mu_minus).mass()),
+      _external(conf().spectrum.get<fhicl::ParameterSet>().get<bool>("external")),
+      _czmin(conf().spectrum.get<fhicl::ParameterSet>().get<double>("czmin", -1.)),
+      _czmax(conf().spectrum.get<fhicl::ParameterSet>().get<double>("czmax",  1.)),
+      _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>())),
+      _makeHistograms(conf().spectrum.get<fhicl::ParameterSet>().get<bool>("makeHistograms",  false))
+    {
+      if(_makeHistograms) {
+        art::ServiceHandle<art::TFileService> tfs;
+        art::TFileDirectory tfdir = tfs->mkdir( "RMCGenerator" );
+        _hmomentum = tfdir.make<TH1F>("hmomentum", "Produced photon momentum", 60,  0.,  120.  );
+        _hCosz     = tfdir.make<TH1F>("hCosz", "Produced photon cos(#theta_{z})", 200,  -1.,  1.  );
+        if(!_external) { //virtual conversion distributions
+          _hEnergyElectron = tfdir.make<TH1F>("hEnergyElectron", "Produced internal conversion electron energy", 60,  0.,  120.  );
+          _hEnergyPositron = tfdir.make<TH1F>("hEnergyPositron", "Produced internal conversion positron energy", 60,  0.,  120.  );
+          _hMass           = tfdir.make<TH1F>("hMass"          , "M(e+e-) "           , 120,0.,120.);
+          _hMassVsE        = tfdir.make<TH2F>("hMassVsE"       , "M(e+e-) vs. E;E (MeV); M(e+e-) (MeV/c^{2})"  , 120,0.,120.,120,0,120);
+          _hMassOverE      = tfdir.make<TH1F>("hMassOverE"     , "M(e+e-)/E"          , 100, 0.,1);
+          _hy              = tfdir.make<TH1F>("hy"             , "y = (ee-ep)/|pe+pp|", 100,-1.,1.);
+        }
+      }
+
+      // Validate the input
+      const auto s_conf = conf().spectrum.get<fhicl::ParameterSet>();
+      const double elow  = s_conf.get<double>("elow");
+      const double ehigh = s_conf.get<double>("ehi");
+      if(elow < 0.) throw cet::exception("BADCONFIG") << "RMCGenerator minimum energy " << elow
+                                                      << " below 0\n";
+      if(ehigh > _mumass) throw cet::exception("BADCONFIG") << "RMCGenerator maximum energy " << ehigh
+                                                            << " above the muon mass " << _mumass
+                                                            << "\n";
+      if(ehigh < elow) throw cet::exception("BADCONFIG") << "RMCGenerator minimum energy " << elow
+                                                         << " above maximum energy " << ehigh
+                                                         << "\n";
+      if(_czmin > _czmax || _czmin < -1. || _czmax > 1.) throw cet::exception("BADCONFIG") << "RMCGenerator cos(theta_z) range is not defined\n";
+
+      if(!_external) {
+        if(elow < 2.*_emass) throw cet::exception("BADCONFIG") << "RMCGenerator minimum energy " << elow
+                                                               << " below the necessary threshold of "
+                                                               << 2.*_emass
+                                                               << "\n";
+      }
+    }
+
+    std::vector<ParticleGeneratorTool::Kinematic> generate() override;
+    void generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) override;
+
+    void finishInitialization(art::RandomNumberGenerator::base_engine_t& eng, const std::string&) override {
+      _randomUnitSphereExternal = new RandomUnitSphere(eng, _czmin, _czmax);
+      _randomUnitSphereInternal = new RandomUnitSphere(eng);
+      _randFlat = new CLHEP::RandFlat(eng);
+      _randSpectrum = new CLHEP::RandGeneral(eng, _spectrum.getPDF(), _spectrum.getNbins());
+      _muonCaptureSpectrum = new MuonCaptureSpectrum(_randFlat, _randomUnitSphereInternal);
+    }
+
+  private:
+    const double _emass;
+    const double _mumass;
+
+    const bool _external; //real or virtual photons
+    const double _czmin; //range of cos(theta_z) generated
+    const double _czmax;
+    BinnedSpectrum _spectrum; //RMC photon spectrum
+    MuonCaptureSpectrum*  _muonCaptureSpectrum; // internal conversion spectrum
+
+    const bool _makeHistograms;
+
+    RandomUnitSphere*   _randomUnitSphereExternal;
+    RandomUnitSphere*   _randomUnitSphereInternal;
+    CLHEP::RandFlat*    _randFlat;
+    CLHEP::RandGeneral* _randSpectrum;
+
+    TH1* _hmomentum;
+    TH1* _hCosz;
+    TH1* _hEnergyElectron;
+    TH1* _hEnergyPositron;
+    TH1* _hMass;
+    TH2* _hMassVsE;
+    TH1* _hMassOverE;
+    TH1* _hy; // splitting function
+  };
+
+
+  std::vector<ParticleGeneratorTool::Kinematic> RMCGenerator::generate() {
+    std::vector<ParticleGeneratorTool::Kinematic>  res;
+
+    // real or virtual photon energy
+    const double energy = _spectrum.sample(_randSpectrum->fire());
+    if(_makeHistograms) _hmomentum->Fill(energy);
+
+    if(_external) { //real photon spectrum
+      const CLHEP::Hep3Vector p3 = _randomUnitSphereExternal->fire(energy);
+      const CLHEP::HepLorentzVector fourmom(p3, energy);
+
+      ParticleGeneratorTool::Kinematic k{PDGCode::gamma, ProcessCode::mu2eExternalRMC, fourmom};
+      res.emplace_back(k);
+      if(_makeHistograms) _hCosz->Fill(fourmom.cosTheta());
+    } else { //virtual photon conversion spectrum
+      CLHEP::HepLorentzVector p_em, p_ep;
+      _muonCaptureSpectrum->getElecPosiVectors(energy, p_em, p_ep);
+
+      ParticleGeneratorTool::Kinematic k_em{PDGCode::e_minus, ProcessCode::mu2eInternalRMC, p_em};
+      res.emplace_back(k_em);
+      ParticleGeneratorTool::Kinematic k_ep{PDGCode::e_plus , ProcessCode::mu2eInternalRMC, p_ep};
+      res.emplace_back(k_ep);
+      if(_makeHistograms) { //store virtual kinematics if requested
+        _hCosz->Fill((p_em+p_ep).cosTheta());
+        _hEnergyElectron->Fill(p_em.e());
+        _hEnergyPositron->Fill(p_ep.e());
+
+        const double mass = (p_em+p_ep).m();
+        _hMass->Fill(mass);
+        _hMassVsE->Fill(energy,mass);
+        _hMassOverE->Fill(mass/energy);
+
+        const CLHEP::Hep3Vector p = p_em.vect()+p_ep.vect();
+        const double y = (p_em.e()-p_ep.e())/p.mag();
+        _hy->Fill(y);
+      }
+    }
+
+    return res;
+  }
+
+  // Legacy implementation of muon stop sampling
+  void RMCGenerator::generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) {
+    const CLHEP::Hep3Vector pos(stop.x, stop.y, stop.z);
+    const auto daughters = generate();
+    for(const auto& d: daughters) {
+      out->emplace_back(d.pdgId,
+                        (_external) ? GenId::ExternalRMC : GenId::InternalRMC,
+                        pos,
+                        d.fourmom,
+                        stop.t);
+    }
+  }
+
+}
+DEFINE_ART_CLASS_TOOL(mu2e::RMCGenerator)

--- a/EventGenerator/src/RMCGenerator_tool.cc
+++ b/EventGenerator/src/RMCGenerator_tool.cc
@@ -23,7 +23,6 @@
 #include "fhiclcpp/types/DelegatedParameter.h"
 
 // ROOT includes
-#include "TTree.h"
 #include "TFile.h"
 #include "TH1.h"
 #include "TH2.h"


### PR DESCRIPTION
Add tools for RMC dataset generation using the modern resampling style. This includes a filter that selects photon conversions within a given region and a generator that resamples these conversions with the G4 Bethe-Heitler spectrum written into a Mu2e Utility.

I've also updated the `GenFilter` filter to additionally filter on energy/momentum, to filter low energy conversions out when resampling photon conversions or generating internal/virtual photon conversions. This will require a change to the Production fcl to keep the behavior the same, as now the filter has multiple purposes so I had to add a flag for filtering the maximum radius in a B-field. I can make a parallel PR for this as well as adding fcl for RMC dataset generation shortly. 