### PR TITLE
Add RMC as a muon stop pileup product option

### DIFF
--- a/EventGenerator/fcl/prolog.fcl
+++ b/EventGenerator/fcl/prolog.fcl
@@ -387,7 +387,7 @@ EventGenerator : { @table::EventGenerator
                     ehi               : 90.1
                     kMaxUserSet       : true
                     kMaxUser          : 90.1
-                    external          : true
+                    mode              : "external" #Options are "external" "internal" or "physical"
                     spectrumShape     : "RMC"
                     spectrumResolution: 0.1
                 }

--- a/EventGenerator/fcl/prolog.fcl
+++ b/EventGenerator/fcl/prolog.fcl
@@ -387,10 +387,10 @@ EventGenerator : { @table::EventGenerator
                     ehi               : 90.1
                     kMaxUserSet       : true
                     kMaxUser          : 90.1
-                    mode              : "external" #Options are "external" "internal" or "physical"
                     spectrumShape     : "RMC"
                     spectrumResolution: 0.1
                 }
+                mode : "external" #Options are "external" "internal" or "physical"
             }
             verbosity : 0
         }

--- a/GlobalConstantsService/data/globalConstants_01.txt
+++ b/GlobalConstantsService/data/globalConstants_01.txt
@@ -125,8 +125,8 @@ double physicsParams.Al.capture.protonRate = 0.05;
 double physicsParams.Al.capture.deuteronRate = 0.025;
 double physicsParams.Al.capture.neutronRate = 1.2;
 double physicsParams.Al.capture.photonRate = 2.0;
-double physicsParams.Al.capture.RMCRate = 9.460e-5;
-double physicsParams.Al.capture.RMCInternalRate = 0.0069;
+double physicsParams.Al.capture.RMCRate = 9.460e-5; //TRIUMF measured 1.41e-5 for E > 57, full rate taken by dividing by closure fraction above 57 MeV for kmax = 90.1
+double physicsParams.Al.capture.RMCInternalRate = 0.0069; //measurement of internal conversion rate for RPC on hydrogen
 double physicsParams.Al.capture.photon.1809keV.energy = 1.809;
 double physicsParams.Al.capture.photon.1809keV.intensity = 0.51;
 

--- a/GlobalConstantsService/data/globalConstants_01.txt
+++ b/GlobalConstantsService/data/globalConstants_01.txt
@@ -126,6 +126,7 @@ double physicsParams.Al.capture.deuteronRate = 0.025;
 double physicsParams.Al.capture.neutronRate = 1.2;
 double physicsParams.Al.capture.photonRate = 2.0;
 double physicsParams.Al.capture.RMCRate = 9.460e-5;
+double physicsParams.Al.capture.RMCInternalRate = 0.0069;
 double physicsParams.Al.capture.photon.1809keV.energy = 1.809;
 double physicsParams.Al.capture.photon.1809keV.intensity = 0.51;
 

--- a/GlobalConstantsService/data/globalConstants_01.txt
+++ b/GlobalConstantsService/data/globalConstants_01.txt
@@ -125,6 +125,7 @@ double physicsParams.Al.capture.protonRate = 0.05;
 double physicsParams.Al.capture.deuteronRate = 0.025;
 double physicsParams.Al.capture.neutronRate = 1.2;
 double physicsParams.Al.capture.photonRate = 2.0;
+double physicsParams.Al.capture.RMCRate = 9.460e-5;
 double physicsParams.Al.capture.photon.1809keV.energy = 1.809;
 double physicsParams.Al.capture.photon.1809keV.intensity = 0.51;
 

--- a/GlobalConstantsService/inc/PhysicsParams.hh
+++ b/GlobalConstantsService/inc/PhysicsParams.hh
@@ -135,6 +135,9 @@ namespace mu2e
     double   getCapturePhotonRate     (targetMat material = "") const {
       return doubleOrThrow(_capturePhotonRate,material,"capturePhotonRate");
     }
+    double   getCaptureRMCRate     (targetMat material = "") const {
+      return doubleOrThrow(_captureRMCRate,material,"captureRMCRate");
+    }
 
     double   get1809keVGammaEnergy     (targetMat material = "") const {
       return doubleOrThrow(_1809keVGammaEnergy,material,"1809keVGammaEnergy");
@@ -205,6 +208,7 @@ namespace mu2e
     std::map<targetMat, double> _captureDeuteronRate;
     std::map<targetMat, double> _captureNeutronRate;
     std::map<targetMat, double> _capturePhotonRate;
+    std::map<targetMat, double> _captureRMCRate;
 
     std::map<targetMat, double> _1809keVGammaEnergy;
     std::map<targetMat, double> _1809keVGammaIntensity;

--- a/GlobalConstantsService/inc/PhysicsParams.hh
+++ b/GlobalConstantsService/inc/PhysicsParams.hh
@@ -135,8 +135,11 @@ namespace mu2e
     double   getCapturePhotonRate     (targetMat material = "") const {
       return doubleOrThrow(_capturePhotonRate,material,"capturePhotonRate");
     }
-    double   getCaptureRMCRate     (targetMat material = "") const {
+    double   getCaptureRMCRate(targetMat material = "") const {
       return doubleOrThrow(_captureRMCRate,material,"captureRMCRate");
+    }
+    double   getCaptureRMCInternalRate(targetMat material = "") const {
+      return doubleOrThrow(_captureRMCInternalRate,material,"captureRMCInternalRate");
     }
 
     double   get1809keVGammaEnergy     (targetMat material = "") const {
@@ -209,6 +212,7 @@ namespace mu2e
     std::map<targetMat, double> _captureNeutronRate;
     std::map<targetMat, double> _capturePhotonRate;
     std::map<targetMat, double> _captureRMCRate;
+    std::map<targetMat, double> _captureRMCInternalRate;
 
     std::map<targetMat, double> _1809keVGammaEnergy;
     std::map<targetMat, double> _1809keVGammaIntensity;

--- a/GlobalConstantsService/src/PhysicsParams.cc
+++ b/GlobalConstantsService/src/PhysicsParams.cc
@@ -123,6 +123,8 @@ namespace mu2e {
       if(config.hasName(name)) _capturePhotonRate[material] = config.getDouble(name);
       name = "physicsParams."+material+".capture.RMCRate";
       if(config.hasName(name)) _captureRMCRate[material] = config.getDouble(name);
+      name = "physicsParams."+material+".capture.RMCInternalRate";
+      if(config.hasName(name)) _captureRMCInternalRate[material] = config.getDouble(name);
 
       // Load capture gamma rays
       name = "physicsParams."+material+".capture.photon.1809keV.energy";

--- a/GlobalConstantsService/src/PhysicsParams.cc
+++ b/GlobalConstantsService/src/PhysicsParams.cc
@@ -121,6 +121,8 @@ namespace mu2e {
       if(config.hasName(name)) _captureNeutronRate[material] = config.getDouble(name);
       name = "physicsParams."+material+".capture.photonRate";
       if(config.hasName(name)) _capturePhotonRate[material] = config.getDouble(name);
+      name = "physicsParams."+material+".capture.RMCRate";
+      if(config.hasName(name)) _captureRMCRate[material] = config.getDouble(name);
 
       // Load capture gamma rays
       name = "physicsParams."+material+".capture.photon.1809keV.energy";


### PR DESCRIPTION
Add logic for RMC to be included as a muon stop pileup product. This mostly entailed adding a flag to the RMC tool to use the RMC rate per muon to generate a random number of photons (usually 0), and add the corresponding global constant. The global constant RMC rate for aluminum is 1.4e-5 for E > 57 MeV over the closure approximation spectrum fraction for E > 57 MeV (~1/10,000 muon captures). I will make a corresponding PR in Production adding this product to the MuStopPileup configuration.