### PR TITLE
Fixed CalTimePeakFinder hit selection/rejection

### DIFF
--- a/CalPatRec/fcl/prolog.fcl
+++ b/CalPatRec/fcl/prolog.fcl
@@ -300,26 +300,24 @@ CalPatRec : { @table::CalPatRec
 
     producers : {
         CalTimePeakFinder          : { module_type:CalTimePeakFinder
-            diagLevel                                   : 0
-            debugLevel                                  : 0
-            printFrequency                              : 100
+            DiagLevel                                   : 0
+            DebugLevel                                  : 0
+            PrintFrequency                              : 100
             StrawHitCollectionLabel                     : makePH            # CalTimePeakFinder uses ComboHits
-            caloClusterModuleLabel                      : CaloClusterMaker
-#            HitSelectionBits                            : []
-#            BackgroundSelectionBits                     : ["Noisy","Dead"]
+            CaloClusterModuleLabel                      : CaloClusterMaker
+            HitSelBits                                  : ["TimeSelection"]
+            BkgSelBits                                  : ["Noisy","Dead"]
             MinNHits                                    : @local::CalPatRec.minNStrawHits
             DtMin                                       : -20.   # value before 2022-02-14 was -30. ns
             DtMax                                       :  20.   # value before 2022-02-14 was 30. ns
-            minClusterEnergy                            : 50.    # MeV
-            minClusterSize                              : 2      # number of crystals
-            pitchAngle                                  : 0.67   # mean pitch for CE
-            beta                                        : 1.0    # for muon reco needs to be changed
-            dtOffset                                    : @local::TrackCaloMatching.DtOffset
-            diagPlugin : { tool_type                    : "CalTimePeakFinderDiag"
-                mcTruth                                 : 0
-                mcUtils                                 : { tool_type : "TrkPatRecMcUtils"
-                    strawDigiMCCollTag : "compressDigiMCs"
-                }
+            MinClusterEnergy                            : 50.    # MeV
+            MinClusterSize                              : 2      # number of crystals
+            PitchAngle                                  : 0.67   # mean pitch for CE
+            Beta                                        : 1.0    # for muon reco needs to be changed
+            DtOffset                                    : @local::TrackCaloMatching.DtOffset
+            DiagPlugin : { tool_type                    : "CalTimePeakFinderDiag"
+                mcTruth   : 0
+                diagLevel : 0
             }
         }
 

--- a/CalPatRec/fcl/prolog.fcl
+++ b/CalPatRec/fcl/prolog.fcl
@@ -748,8 +748,8 @@ CalPatRec : { @table::CalPatRec
 #------------------------------------------------------------------------------
 CalPatRec: { @table::CalPatRec
     producers : { @table::CalPatRec.producers
-        CalTimePeakFinderUe            : { @table::CalPatRec.producers.CalTimePeakFinder   pitchAngle: -0.67                }
-        CalTimePeakFinderMu            : { @table::CalPatRec.producers.CalTimePeakFinder   beta: 0.7                        }
+        CalTimePeakFinderUe            : { @table::CalPatRec.producers.CalTimePeakFinder   PitchAngle: -0.67                }
+        CalTimePeakFinderMu            : { @table::CalPatRec.producers.CalTimePeakFinder   Beta: 0.7                        }
         CalHelixFinderDe               : { @table::CalPatRec.producers.CalHelixFinder fitparticle: @local::Particle.eminus  }
         CalHelixFinderUe               : { @table::CalPatRec.producers.CalHelixFinder
             fitparticle                : @local::Particle.eminus

--- a/CalPatRec/inc/CalTimePeakFinder_module.hh
+++ b/CalPatRec/inc/CalTimePeakFinder_module.hh
@@ -128,8 +128,30 @@ namespace mu2e {
 // functions
 //-----------------------------------------------------------------------------
   public:
+    struct Config{
+      using Name    = fhicl::Name;
+      using Comment = fhicl::Comment;
+      fhicl::Atom<int>                DiagLevel               { Name("DiagLevel"),                  Comment("diagLevel")          , 0 };
+      fhicl::Atom<int>                DebugLevel              { Name("DebugLevel"),                 Comment("debugLevel")         , 0 };
+      fhicl::Atom<int>                Printfreq               { Name("PrintFrequency"),             Comment("Print frequency")    , 1 };
+      fhicl::Atom<std::string>        StrawHitCollectionLabel { Name("StrawHitCollectionLabel"),    Comment("strawHitCollectionLabel")};
+      fhicl::Atom<std::string>        CaloClusterModuleLabel  { Name("CaloClusterModuleLabel" ),    Comment("caloClusterModuleLabel" )};
+      fhicl::Sequence<std::string>    HitSelBits              { Name("HitSelBits"             ),    Comment("hitSelBits"             )};
+      fhicl::Sequence<std::string>    BkgSelBits              { Name("BkgSelBits"             ),    Comment("bkgSelBits"             )};
+      fhicl::Atom<double>             DtMin                   { Name("DtMin"                  ),    Comment("dtMin"                  )};
+      fhicl::Atom<double>             DtMax                   { Name("DtMax"                  ),    Comment("dtMax"                  )};
+      fhicl::Atom<int>                MinNHits                { Name("MinNHits"               ),    Comment("minNHits"               )};
+      fhicl::Atom<double>             MinClusterEnergy        { Name("MinClusterEnergy"       ),    Comment("minClusterEnergy"       )};
+      fhicl::Atom<int>                MinClusterSize          { Name("MinClusterSize"         ),    Comment("minClusterSize"         )};
+      fhicl::Atom<double>             PitchAngle              { Name("PitchAngle"             ),    Comment("pitchAngle"             )};
+      fhicl::Atom<double>             Beta                    { Name("Beta"                   ),    Comment("beta"                   )};
+      fhicl::Atom<double>             DtOffset                { Name("DtOffset"               ),    Comment("dtOffset"               )};
+      fhicl::Table<CalTimePeakFinderTypes::Config>DiagPlugin  { Name("DiagPlugin"),                 Comment("Diag plugin"            )};
+    };
 
-    explicit CalTimePeakFinder(const fhicl::ParameterSet& PSet);
+    using Parameters = art::EDProducer::Table<Config>;
+
+    explicit CalTimePeakFinder(const Parameters& Conf);
     virtual ~CalTimePeakFinder();
 
     virtual void beginJob ();

--- a/CalPatRec/inc/CalTimePeakFinder_types.hh
+++ b/CalPatRec/inc/CalTimePeakFinder_types.hh
@@ -22,6 +22,12 @@ namespace mu2e {
   class KalFitResultNew;
 
   namespace CalTimePeakFinderTypes {
+    struct Config {
+      fhicl::Atom<int>         diagLevel{fhicl::Name("diagLevel"), fhicl::Comment("diagnostic level")};
+      fhicl::Atom<std::string> tool_type{fhicl::Name("tool_type"), fhicl::Comment("tool type: CalTimePeakFinder Diag")};
+      fhicl::Atom<int>         mcTruth  {fhicl::Name("mcTruth"),   fhicl::Comment("MC truth")};
+    };
+
     enum { kMaxTimePeaks = 100 };
 //-----------------------------------------------------------------------------
 // data structure shared by CalTimePeakFinder with its plugins

--- a/CalPatRec/src/CalTimePeakFinderDiag_tool.cc
+++ b/CalPatRec/src/CalTimePeakFinderDiag_tool.cc
@@ -2,6 +2,7 @@
 // diag mode: = 0 - most of the histograms
 //            = 1 - doca histograms
 ///////////////////////////////////////////////////////////////////////////////
+#include "fhiclcpp/types/Atom.h"
 #include "fhiclcpp/ParameterSet.h"
 
 #include "CLHEP/Matrix/Vector.h"
@@ -75,7 +76,6 @@ namespace mu2e {
     };
 
   protected:
-    int          _mcTruth;
     std::string  _shDigiLabel;
 
     std::unique_ptr<McUtilsToolBase> _mcUtils;
@@ -85,7 +85,7 @@ namespace mu2e {
 
   public:
 
-    CalTimePeakFinderDiag(const fhicl::ParameterSet& PSet);
+    CalTimePeakFinderDiag(const fhicl::Table<mu2e::CalTimePeakFinderTypes::Config>& Conf);
     ~CalTimePeakFinderDiag();
 
   private:
@@ -104,11 +104,7 @@ namespace mu2e {
 
 
 //-----------------------------------------------------------------------------
-  CalTimePeakFinderDiag::CalTimePeakFinderDiag(const fhicl::ParameterSet& PSet) {
-    _mcTruth = PSet.get <int >("mcTruth");
-
-    if (_mcTruth != 0) _mcUtils = art::make_tool<McUtilsToolBase>(PSet.get<fhicl::ParameterSet>("mcUtils"));
-    else               _mcUtils = std::make_unique<McUtilsToolBase>();
+  CalTimePeakFinderDiag::CalTimePeakFinderDiag(const fhicl::Table<mu2e::CalTimePeakFinderTypes::Config>& Conf) {
   }
 
 //-----------------------------------------------------------------------------

--- a/TrkFilters/src/TimeClusterFilter_module.cc
+++ b/TrkFilters/src/TimeClusterFilter_module.cc
@@ -30,7 +30,7 @@ namespace mu2e
         fhicl::Atom<bool>               requireCaloCluster   {    Name("requireCaloCluster"),         Comment("Require caloCluster") };
         fhicl::Atom<unsigned>           minNStrawHits        {    Name("minNStrawHits"),                   Comment("minNStrawHits")};
         fhicl::Atom<int>                debugLevel           {    Name("debugLevel"),                 Comment("Debug"),0 };
-        fhicl::Atom<int>                noFilter             {    Name("noFilter"),                 Comment("Don't filter anything"),0 };
+        fhicl::Atom<bool>               noFilter             {    Name("noFilter"),                 Comment("Don't filter anything"),0 };
       };
 
       using Parameters = art::EDFilter::Table<Config>;
@@ -47,7 +47,7 @@ namespace mu2e
       int           _debug;
       // counters
       unsigned      _nevt, _npass;
-      int           _noFilter;
+      bool          _noFilter;
   };
 
   TimeClusterFilter::TimeClusterFilter(const Parameters& conf)
@@ -93,7 +93,7 @@ namespace mu2e
       }
     }
     evt.put(std::move(triginfo));
-    if (_noFilter != 1){
+    if (!_noFilter){
       return retval;
     }else {
       return true;

--- a/TrkPatRec/inc/RobustHelixFinder_types.hh
+++ b/TrkPatRec/inc/RobustHelixFinder_types.hh
@@ -26,9 +26,9 @@ namespace mu2e {
   namespace RobustHelixFinderTypes {
 
     struct Config {
-      fhicl::Atom<int> diagLevel{fhicl::Name("diagLevel"), fhicl::Comment("diagnostic level")};
+      fhicl::Atom<int>         diagLevel{fhicl::Name("diagLevel"), fhicl::Comment("diagnostic level")};
       fhicl::Atom<std::string> tool_type{fhicl::Name("tool_type"), fhicl::Comment("tool type: Robust Helix Finder Diag")};
-      fhicl::Atom<int> mcTruth{fhicl::Name("mcTruth"), fhicl::Comment("MC truth")};
+      fhicl::Atom<int>         mcTruth{fhicl::Name("mcTruth"), fhicl::Comment("MC truth")};
     };
 
     struct Data_t {


### PR DESCRIPTION
- fixed the hits-selection stage in CalTimePeakFinder: this change is expected to have a minor impact on the Offline reco and no impact on the Online reco (where we provide a filtered list of hits). We still need to check the impact of using the "backgroundFlag" in CalTimePeakFinder. This will come in a new PR
- Minor changes in TimeClusterFilter module (data type variation)

This PR affects also the `mu2e_trig_config` repository: https://github.com/Mu2e/mu2e_trig_config/pull/45

tagging @brownd1978 @pavel1murat 