### PR TITLE
Explicit fcl for trigger hitreco and prescale now checks for spilltype

### DIFF
--- a/DAQ/src/StrawHitRecoFromFragments_module.cc
+++ b/DAQ/src/StrawHitRecoFromFragments_module.cc
@@ -66,6 +66,10 @@ public:
                               Comment("Earliest time for cross-talk filter (nsec)")};
     fhicl::Atom<float> ctMaxT{Name("crossTalkMaximumTime"),
                               Comment("Latest time for cross-talk filter (nsec)")};
+    fhicl::OptionalAtom<float> minTOff{Name("minimumTimeOffSpill"),
+                            Comment("Earliest StrawDigi time to process (nsec)")};
+    fhicl::OptionalAtom<float> maxTOff{Name("maximumTimeOffSpill"),
+                            Comment("Latest StrawDigi time to process (nsec)")};
     fhicl::Atom<float> minT{Name("minimumTime"),
                             Comment("Earliest StrawDigi time to process (nsec)")};
     fhicl::Atom<float> maxT{Name("maximumTime"),
@@ -88,6 +92,10 @@ public:
   void beginJob() override;
 
 private:
+  bool _overrideminTOff;
+  float _minTOff;
+  bool _overridemaxTOff;
+  float _maxTOff;
   mu2e::StrawHitRecoUtils _shrUtils;
   bool _writesh; // write straw hits or not
   bool _flagXT;  // flag cross-talk
@@ -116,9 +124,12 @@ private:
 
 art::StrawHitRecoFromFragments::StrawHitRecoFromFragments(Parameters const& config) :
     art::EDProducer{config},
+    _overrideminTOff(config().minTOff(_minTOff)),
+    _overridemaxTOff(config().maxTOff(_maxTOff)),
     _shrUtils((mu2e::TrkHitReco::FitType)config().fittype(), config().diag(),
               mu2e::StrawIdMask::uniquestraw, // this module produces individual straw ComboHits
-              config().writesh(), config().minT(), config().maxT(), config().minE(),
+              config().writesh(), config().minT(), config().maxT(),
+              _overrideminTOff, _minTOff, _overridemaxTOff, _maxTOff, config().minE(),
               config().maxE(), config().minR(), config().maxR(), config().filter(), config().ctE(),
               config().ctMinT(), config().ctMaxT(), config().usecc(), config().clusterDt()),
     _writesh(config().writesh()), _flagXT(config().flagXT()), _usecc(config().usecc()),

--- a/DAQ/src/StrawHitRecoFromFragments_module.cc
+++ b/DAQ/src/StrawHitRecoFromFragments_module.cc
@@ -92,10 +92,8 @@ public:
   void beginJob() override;
 
 private:
-  bool _overrideminTOff;
-  float _minTOff;
-  bool _overridemaxTOff;
-  float _maxTOff;
+  float _minTOff, _maxTOff;
+  bool _overrideminTOff, _overridemaxTOff;
   mu2e::StrawHitRecoUtils _shrUtils;
   bool _writesh; // write straw hits or not
   bool _flagXT;  // flag cross-talk
@@ -124,6 +122,8 @@ private:
 
 art::StrawHitRecoFromFragments::StrawHitRecoFromFragments(Parameters const& config) :
     art::EDProducer{config},
+    _minTOff(config().minT()),
+    _maxTOff(config().maxT()),
     _overrideminTOff(config().minTOff(_minTOff)),
     _overridemaxTOff(config().maxTOff(_maxTOff)),
     _shrUtils((mu2e::TrkHitReco::FitType)config().fittype(), config().diag(),

--- a/TrkHitReco/fcl/prolog.fcl
+++ b/TrkHitReco/fcl/prolog.fcl
@@ -104,7 +104,6 @@ TrkHitReco : { @table::TrkHitReco
       StereoLine            : false
       StereoLineNDOF        : 1 # require at least
       ComboHitCollection    : "makePH"
-      EventWindowMarker     : EWMProducer
       StrawHitSelectionBits : ["RadiusSelection","EnergySelection","TimeSelection"]
       StrawHitRejectionBits : []
       # hit selection parameters

--- a/TrkHitReco/inc/StrawHitRecoUtils.hh
+++ b/TrkHitReco/inc/StrawHitRecoUtils.hh
@@ -20,7 +20,9 @@ namespace mu2e {
       using ADCWFIter = TrkTypes::ADCWaveform::const_iterator;
       StrawHitRecoUtils(TrkHitReco::FitType fittype, int diagLevel,
           StrawIdMask mask, bool writesh,
-          float minT, float maxT, float minE, float maxE, float minR, float maxR,
+          float minT, float maxT,
+          bool overrideminTOff, float minTOff, bool overridemaxTOff, float maxTOff,
+          float minE, float maxE, float minR, float maxR,
           bool filter,
           float ctE, float ctMinT, float ctMaxT, bool usecc, float clusterDt);
 
@@ -44,7 +46,12 @@ namespace mu2e {
       StrawIdMask _mask;
       bool _writesh;
       // flag/filter parameters
-      float _minT, _maxT, _minE, _maxE, _minR, _maxR;
+      float _minT, _maxT;
+      bool _overrideminTOff;
+      float _minTOff;
+      bool _overridemaxTOff;
+      float _maxTOff;
+      float _minE, _maxE, _minR, _maxR;
       bool _filter;
       // cross-talk parameters
       float _ctE, _ctMinT, _ctMaxT;

--- a/TrkHitReco/src/CombineStrawHits_module.cc
+++ b/TrkHitReco/src/CombineStrawHits_module.cc
@@ -102,6 +102,8 @@ namespace mu2e {
     _maxR2(     config().maxR()*config().maxR()),
     _minT(      config().minT()),
     _maxT(      config().maxT()),
+    _minTOff (_minT),
+    _maxTOff (_maxT),
     _overrideminTOff(      config().minTOff(_minTOff)),
     _overridemaxTOff(      config().maxTOff(_maxTOff)),
     _minE(      config().minE()),

--- a/TrkHitReco/src/StrawHitReco_module.cc
+++ b/TrkHitReco/src/StrawHitReco_module.cc
@@ -60,6 +60,8 @@ namespace mu2e {
         fhicl::Atom<float>maxR{ Name("MaximumRadius"), Comment("Maximum transverse radius (mm)")};
         fhicl::Atom<float>minT{ Name("MinimumTime"), Comment("Earliest StrawDigi time to process (nsec)")};
         fhicl::Atom<float>maxT{ Name("MaximumTime"), Comment("Latest StrawDigi time to process (nsec)")};
+        fhicl::OptionalAtom<float>minTOff{ Name("MinimumTimeOffSpill"), Comment("Earliest StrawDigi time to process (nsec)")};
+        fhicl::OptionalAtom<float>maxTOff{ Name("MaximumTimeOffSpill"), Comment("Latest StrawDigi time to process (nsec)")};
         fhicl::Atom<float>ctE{ Name("crossTalkEnergy"), Comment("Energy to filter cross-talk in adajcent straws (MeV)")};
         fhicl::Atom<float>ctMinT{ Name("crossTalkMinimumTime"), Comment("Earliest time for cross-talk filter (nsec)")};
         fhicl::Atom<float>ctMaxT{ Name("crossTalkMaximumTime"), Comment("Latest time for cross-talk filter (nsec)")};
@@ -79,6 +81,9 @@ namespace mu2e {
       void beginJob() override;
 
     private:
+      bool _overrideminTOff;
+      bool _overridemaxTOff;
+      float _minTOff, _maxTOff;
       StrawHitRecoUtils _shrUtils;
       bool  _writesh;                // write straw hits or not
       bool  _flagXT; // flag cross-talk
@@ -103,12 +108,18 @@ namespace mu2e {
 
   StrawHitReco::StrawHitReco(Parameters const& config) :
     art::EDProducer{config},
+    _overrideminTOff(config().minTOff(_minTOff)),
+    _overridemaxTOff(config().maxTOff(_maxTOff)),
     _shrUtils ((TrkHitReco::FitType) config().fittype(),
         config().diag(),
         StrawIdMask::uniquestraw, // this module produces individual straw ComboHits
         config().writesh(),
         config().minT(),
         config().maxT(),
+        _overrideminTOff,
+        _minTOff,
+        _overridemaxTOff,
+        _maxTOff,
         config().minE(),
         config().maxE(),
         config().minR(),

--- a/TrkHitReco/src/StrawHitReco_module.cc
+++ b/TrkHitReco/src/StrawHitReco_module.cc
@@ -81,9 +81,9 @@ namespace mu2e {
       void beginJob() override;
 
     private:
+      float _minTOff, _maxTOff;
       bool _overrideminTOff;
       bool _overridemaxTOff;
-      float _minTOff, _maxTOff;
       StrawHitRecoUtils _shrUtils;
       bool  _writesh;                // write straw hits or not
       bool  _flagXT; // flag cross-talk
@@ -108,6 +108,8 @@ namespace mu2e {
 
   StrawHitReco::StrawHitReco(Parameters const& config) :
     art::EDProducer{config},
+    _minTOff(config().minT()),
+    _maxTOff(config().maxT()),
     _overrideminTOff(config().minTOff(_minTOff)),
     _overridemaxTOff(config().maxTOff(_maxTOff)),
     _shrUtils ((TrkHitReco::FitType) config().fittype(),


### PR DESCRIPTION
Added optional fcl MaximumTimeOffSpill which overrides MaximumTime in offspill only. To be used in the case where we want to run the OnSpill trigger exactly in both On/Off spill using the exact same sequence. Other Offspill triggers can run on a separate instance of makeSH

For trigger prescale - eventually EventMode should be a separate object to do the string compare but I'm not sure exactly what the format of eventmode is in the header so hardcoded for now.

Goes with mu2e/production#375 and mu2e/mu2e_trig_config#47