### PR TITLE
More performant straw digi collision resolution

### DIFF
--- a/Blinding/src/MergeDigis_module.cc
+++ b/Blinding/src/MergeDigis_module.cc
@@ -73,7 +73,8 @@ namespace mu2e{
       bundles.Append(*digi_handle, *adcs_handle);
     }
     const auto& electronics = _tracker_conditions_handle.get(event.id());
-    StrawDigiBundleCollection resolved = bundles.ResolveCollisions(electronics);
+    StrawDigiBundleCollection resolved;
+    bundles.ResolveCollisions(electronics, resolved);
     auto digis = resolved.GetStrawDigiPtrs();
     auto adcs = resolved.GetStrawDigiADCWaveformPtrs();
     event.put(std::move(digis));

--- a/TrackerMC/inc/StrawDigiBundleCollection.hh
+++ b/TrackerMC/inc/StrawDigiBundleCollection.hh
@@ -64,10 +64,10 @@ namespace mu2e{
 
       // identify sets of  digis with overlapping digitization windows, and
       // reduce each such set to a single digi, representing their "sum"
-      StrawDigiBundleCollection ResolveCollisions(const StrawElectronics& conditions);
+      void ResolveCollisions(const StrawElectronics& conditions, StrawDigiBundleCollection& rv);
     protected:
       std::vector<StrawDigiBundle> _bundles;
-      StrawDigiBundleCollection ResolveCollision(StrawDigiBundleCollection& collided);
+      void ResolveCollision(StrawDigiBundleCollection& collided, StrawDigiBundleCollection& rv);
     private:
       /**/
   };

--- a/TrackerMC/src/StrawDigiBundleCollection.cc
+++ b/TrackerMC/src/StrawDigiBundleCollection.cc
@@ -156,7 +156,7 @@ namespace mu2e{
     return rv;
   }
 
-  StrawDigiBundleCollection StrawDigiBundleCollection::ResolveCollisions(const StrawElectronics& conditions){
+  void StrawDigiBundleCollection::ResolveCollisions(const StrawElectronics& conditions, StrawDigiBundleCollection& rv){
     // identify time-overlapped chains: this is a 3 step process
     // first, partition bundles according to StrawId
     std::map<StrawId, StrawDigiBundleCollection> unsorted_map;
@@ -200,7 +200,6 @@ namespace mu2e{
 
     // finally, recast each bucket as a regular container
     // and resolve the set of degenerate digis into one
-    StrawDigiBundleCollection rv;
     for (const auto& pair: buckets_map){
       const auto& buckets = pair.second;
       for (const auto& bucket: buckets){
@@ -208,21 +207,16 @@ namespace mu2e{
         for (const auto& bundle: bucket){
           bundles.Append(bundle);
         }
-        auto resolved = this->ResolveCollision(bundles);
-        rv += resolved;
+        this->ResolveCollision(bundles, rv);
       }
     }
-
-    return rv;
   }
 
-  StrawDigiBundleCollection StrawDigiBundleCollection::ResolveCollision(StrawDigiBundleCollection& collided){
-    StrawDigiBundleCollection rv;
+  void StrawDigiBundleCollection::ResolveCollision(StrawDigiBundleCollection& collided, StrawDigiBundleCollection& rv){
     auto first = collided[0];
     // update StrawDigiMC component to reflect that the MC information may be tainted or incomplete
     auto mc = StrawDigiMC(first.GetStrawDigiMC(), first.GetStrawDigiMC().provenance());
     auto updated = StrawDigiBundle(first.GetStrawDigi(), first.GetStrawDigiADCWaveform(), mc);
     rv.Append(updated);
-    return rv;
   }
 }

--- a/TrackerMC/src/StrawDigisFromStrawGasSteps_module.cc
+++ b/TrackerMC/src/StrawDigisFromStrawGasSteps_module.cc
@@ -556,7 +556,8 @@ namespace mu2e {
       bundles.Append(*digis, *digiadcs, *mcdigis);
 
       // resolve collisions between any preexisting and new digis
-      StrawDigiBundleCollection resolved = bundles.ResolveCollisions(strawele);
+      StrawDigiBundleCollection resolved;
+      bundles.ResolveCollisions(strawele, resolved);
       digis = resolved.GetStrawDigiPtrs();
       digiadcs = resolved.GetStrawDigiADCWaveformPtrs();
       mcdigis = resolved.GetStrawDigiMCPtrs();


### PR DESCRIPTION
In the context of digi mixing, a resolution protocol must be followed to eschew distinct digis which "overlap" in some way that digis produced the real electronics could not. For the tracker, this is encapsulated as a member function of the `StrawDigiBundleCollection` class. This PR changes the call signature so as to propagate its output via chained pass-by-vector-reference calls, which decreases runtime by a factor of ~20.