### PR TITLE
Add a simple antiproton generator for annihilation studies

### DIFF
--- a/EventGenerator/fcl/prolog.fcl
+++ b/EventGenerator/fcl/prolog.fcl
@@ -404,6 +404,10 @@ EventGenerator : { @table::EventGenerator
         CaloTBGun : {
             module_type    : CaloTBGun
         }
+
+        SimpleAntiprotonGun : {
+            module_type : SimpleAntiprotonGun
+        }
     }
 }
 

--- a/EventGenerator/src/AntiprotonResampling_module.cc
+++ b/EventGenerator/src/AntiprotonResampling_module.cc
@@ -1,0 +1,153 @@
+// Output stopped antiproton events from an input antiproton sim particle list
+// Michael MacKenize, 2024
+
+
+#include <iostream>
+#include <string>
+#include <cmath>
+
+#include "CLHEP/Vector/ThreeVector.h"
+#include "CLHEP/Vector/LorentzVector.h"
+#include "CLHEP/Units/PhysicalConstants.h"
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art_root_io/TFileService.h"
+
+#include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
+#include "Offline/SeedService/inc/SeedService.hh"
+#include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+#include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
+#include "Offline/DataProducts/inc/PDGCode.hh"
+#include "Offline/MCDataProducts/inc/ProcessCode.hh"
+#include "Offline/MCDataProducts/inc/SimParticle.hh"
+#include "Offline/MCDataProducts/inc/StageParticle.hh"
+#include "Offline/Mu2eUtilities/inc/simParticleList.hh"
+
+#include "TH1.h"
+
+namespace mu2e {
+
+  //================================================================
+  class AntiprotonResampling : public art::EDProducer {
+    struct Config {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      fhicl::Atom<art::InputTag> inputSimParticles{Name("inputSimParticles"), Comment("Input sim particle collection")};
+      fhicl::Atom<int> verbosity{Name("verbosity"), Comment("Verbosity level"), 0};
+      fhicl::Atom<bool> makeHistograms{Name("makeHistograms"), Comment("Make histograms of the conversion kinematics"), false};
+    };
+
+
+    PDGCode::type       pdgId_;
+    ProcessCode         processCode_;
+    double              mass_;
+
+    art::ProductToken<SimParticleCollection> const simsToken_;
+
+    int                 verbosity_;
+
+    //-----------------------------------------------------------------------------
+    // histogramming
+    //-----------------------------------------------------------------------------
+    bool    makeHistograms_;
+    TH1*   _hX;
+    TH1*   _hY;
+    TH1*   _hZ;
+    TH1*   _hR;
+    TH1*   _hTime;
+
+  private:
+
+  public:
+    using Parameters= art::EDProducer::Table<Config>;
+    explicit AntiprotonResampling(const Parameters& conf);
+
+    virtual void produce(art::Event& event);
+  };
+
+  //================================================================
+  AntiprotonResampling::AntiprotonResampling(const Parameters& conf)
+    : EDProducer{conf}
+    , pdgId_(PDGCodeDetail::anti_proton)
+    , processCode_(ProcessCode::mu2eAntiproton)
+    , mass_(GlobalConstantsHandle<ParticleDataList>()->particle(pdgId_).mass())
+    , simsToken_{consumes<SimParticleCollection>(conf().inputSimParticles())}
+    , verbosity_(conf().verbosity())
+    , makeHistograms_(conf().makeHistograms())
+  {
+    produces<mu2e::StageParticleCollection>();
+
+    if(verbosity_ > 0) {
+      std::cout<<"AntiprotonResampling: using process code " << processCode_ << std::endl;
+    }
+
+
+    if(makeHistograms_) {
+      art::ServiceHandle<art::TFileService> tfs;
+      _hX      = tfs->make<TH1F>("hX"     , "X"           ,  100,     0.,  100.);
+      _hY      = tfs->make<TH1F>("hY"     , "Y"           ,  100,     0.,  100.);
+      _hZ      = tfs->make<TH1F>("hZ"     , "Z"           ,  500,  5400., 6400.);
+      _hR      = tfs->make<TH1F>("hR"     , "R"           ,  100,     0.,  100.);
+      _hTime   = tfs->make<TH1F>("hTime"  , "Time"        ,  400,     0., 2000.);
+    }
+  }
+
+  //================================================================
+  void AntiprotonResampling::produce(art::Event& event) {
+    auto output{std::make_unique<StageParticleCollection>()};
+
+    // Input sim particle collection
+    const auto simh = event.getValidHandle<SimParticleCollection>(simsToken_);
+    auto sims = simParticleList(simh, pdgId_);
+
+    if(sims.empty()) {
+      throw cet::exception("BADINPUT") << "AntiprotonResampling::" << __func__ << ": No input sim particles found\n";
+      // if(verbosity_ > 0) printf("AntiprotonResampling::%s: No antiprotons found, inserting an empty particle list\n", __func__);
+      // event.put(std::move(output));
+    }
+
+    // Only take the first sim particle (only one per event is expected)
+    const auto sim = sims[0];
+
+    // Annihilation position
+    const CLHEP::Hep3Vector pos(sim->endPosition());
+
+    // start at a stop
+    const double energy = mass_;
+    CLHEP::Hep3Vector p3(0., 0., 0.);
+    CLHEP::HepLorentzVector fourmom(p3, energy);
+    output->emplace_back(sim,
+                         processCode_,
+                         pdgId_,
+                         pos,
+                         fourmom,
+                         sim->endGlobalTime());
+
+    event.put(std::move(output));
+
+    if(verbosity_ > 1) {
+      printf("AntiprotonResampling::%s: Add antiproton with (x,y,z,t) = (%7.1f, %5.1f, %8.1f, %6.1f)\n",
+             __func__, pos.x(), pos.y(), pos.z(), sim->endGlobalTime());
+    }
+    //-----------------------------------------------------------------------------
+    // if requested, fill histograms
+    //-----------------------------------------------------------------------------
+    if(makeHistograms_) {
+      _hX->Fill(pos.x() + 3904.);
+      _hY->Fill(pos.y());
+      _hZ->Fill(pos.z());
+      _hTime->Fill(sim->endGlobalTime());
+      const double r = std::sqrt(std::pow(pos.x() + 3904., 2) + std::pow(pos.y(), 2));
+      _hR->Fill(r);
+    }
+  }
+
+  //================================================================
+} // namespace mu2e
+
+DEFINE_ART_MODULE(mu2e::AntiprotonResampling)

--- a/EventGenerator/src/SimpleAntiprotonGun_module.cc
+++ b/EventGenerator/src/SimpleAntiprotonGun_module.cc
@@ -1,0 +1,204 @@
+// Generate antiproton events in the stopping target using rough approximation
+// Michael MacKenize, 2024
+
+
+#include <iostream>
+#include <cmath>
+
+#include "CLHEP/Vector/ThreeVector.h"
+#include "CLHEP/Vector/LorentzVector.h"
+#include "CLHEP/Random/RandomEngine.h"
+#include "CLHEP/Random/RandExponential.h"
+#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Units/PhysicalConstants.h"
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art_root_io/TFileService.h"
+
+#include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
+#include "Offline/SeedService/inc/SeedService.hh"
+#include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+#include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
+#include "Offline/DataProducts/inc/PDGCode.hh"
+#include "Offline/MCDataProducts/inc/GenId.hh"
+#include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
+#include "Offline/StoppingTargetGeom/inc/StoppingTarget.hh"
+#include "Offline/StoppingTargetGeom/inc/TargetFoil.hh"
+
+#include "TH1.h"
+
+namespace mu2e {
+
+  //================================================================
+  class SimpleAntiprotonGun : public art::EDProducer {
+    struct Config {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      fhicl::Atom<double> foilSurvivalRate{Name("foilSurvivalRate"), Comment("Rate of antiprotons surviving each foil"), 0.01};
+      fhicl::Atom<double> timeArrivalRate{Name("timeArrivalRate"), Comment("Exponential rate for antiproton arrival"), 130.};
+      fhicl::Atom<double> t0{Name("t0"), Comment("Start time for the antiproton distribution"), 600.}; //time distribution falls again below 600 ns
+      fhicl::Atom<int> verbosity{Name("verbosity"), Comment("Verbosity level"), 0};
+      fhicl::Atom<bool> makeHistograms{Name("makeHistograms"), Comment("Make histograms of the conversion kinematics"), false};
+    };
+    struct Stop_t {
+      float x;
+      float y;
+      float z;
+      float t;
+    };
+
+
+    PDGCode::type       pdgId_;
+    GenId               genId_;
+    double              mass_;
+
+    double              foilSurvivalRate_;
+    double              timeArrivalRate_;
+    double              t0_;
+
+    int               verbosity_;
+
+    art::RandomNumberGenerator::base_engine_t& eng_;
+    CLHEP::RandExponential randExp_;
+    CLHEP::RandFlat randFlat_;
+
+    std::vector<double> _foilYs; //foil origins
+    std::vector<double> _foilXs;
+    std::vector<double> _foilZs;
+    std::vector<double> _foilRIns; //foil radial dimensions
+    std::vector<double> _foilROuts;
+
+    //-----------------------------------------------------------------------------
+    // histogramming
+    //-----------------------------------------------------------------------------
+    bool    makeHistograms_;
+    TH1*   _hX;
+    TH1*   _hY;
+    TH1*   _hZ;
+    TH1*   _hR;
+    TH1*   _hTime;
+
+  private:
+
+  public:
+    using Parameters= art::EDProducer::Table<Config>;
+    explicit SimpleAntiprotonGun(const Parameters& conf);
+
+    virtual void beginRun(art::Run& run);
+    virtual void produce(art::Event& event);
+    Stop_t generateStop();
+  };
+
+  //================================================================
+  SimpleAntiprotonGun::SimpleAntiprotonGun(const Parameters& conf)
+    : EDProducer{conf}
+    , pdgId_(PDGCodeDetail::anti_proton)
+    , genId_(GenId::antiproton)
+    , mass_(GlobalConstantsHandle<ParticleDataList>()->particle(pdgId_).mass())
+    , foilSurvivalRate_(conf().foilSurvivalRate())
+    , timeArrivalRate_(conf().timeArrivalRate())
+    , t0_(conf().t0())
+    , verbosity_(conf().verbosity())
+    , eng_{createEngine(art::ServiceHandle<SeedService>()->getSeed())}
+    , randExp_{eng_}
+    , randFlat_{eng_}
+    , makeHistograms_(conf().makeHistograms())
+  {
+    produces<mu2e::GenParticleCollection>();
+
+    if(verbosity_ > 0) {
+      std::cout<<"SimpleAntiprotonGun: using GenId = " << genId_ << std::endl;
+
+      std::cout<<"SimpleAntiprotonGun: producing particle "<< pdgId_ << ", mass = "<< mass_ << std::endl;
+    }
+
+
+    if(makeHistograms_) {
+      art::ServiceHandle<art::TFileService> tfs;
+      _hX      = tfs->make<TH1F>("hX"     , "X"           ,  100,     0.,  100.);
+      _hY      = tfs->make<TH1F>("hY"     , "Y"           ,  100,     0.,  100.);
+      _hZ      = tfs->make<TH1F>("hZ"     , "Z"           ,  500,  5400., 6400.);
+      _hR      = tfs->make<TH1F>("hR"     , "R"           ,  100,     0.,  100.);
+      _hTime   = tfs->make<TH1F>("hTime"  , "Time"        ,  400,     0., 2000.);
+    }
+  }
+
+  //================================================================
+  void SimpleAntiprotonGun::beginRun(art::Run&) {
+
+    // Initialize the target foil positions
+    if(_foilZs.size() == 0) { //only do this once per job
+      GeomHandle<StoppingTarget> target;
+      for(int ifoil = 0; ifoil < target->nFoils(); ++ifoil) {
+        auto foil = target->foil(ifoil);
+        auto origin = foil.centerInMu2e();
+        _foilXs.push_back(origin.x());
+        _foilYs.push_back(origin.y());
+        _foilZs.push_back(origin.z());
+        _foilRIns.push_back(foil.rIn());
+        _foilROuts.push_back(foil.rOut());
+      }
+    }
+  }
+
+  //================================================================
+  SimpleAntiprotonGun::Stop_t SimpleAntiprotonGun::generateStop() {
+    // select a stopping target foil using a wrapped exponential distribution
+    const int nfoils = _foilZs.size();
+    const int foil = int(randExp_.fire(foilSurvivalRate_)*nfoils) % nfoils;
+
+    Stop_t stop;
+    stop.z = _foilZs[foil]; //place in the center of the foil as an approximation
+    const double r = _foilRIns[foil] + (_foilROuts[foil] - _foilRIns[foil])*randFlat_.fire(); //flat radially
+    const double phi =  CLHEP::twopi*randFlat_.fire(); //flat in phi
+    stop.x = r*std::cos(phi) + _foilXs[foil];
+    stop.y = r*std::sin(phi) + _foilYs[foil];
+
+    //assume an exponential decay in time
+    stop.t = t0_ + randExp_.fire(timeArrivalRate_);
+
+    return stop;
+  }
+
+  //================================================================
+  void SimpleAntiprotonGun::produce(art::Event& event) {
+    std::unique_ptr<GenParticleCollection> output(new GenParticleCollection);
+
+    const auto& stop = generateStop();
+
+    const CLHEP::Hep3Vector pos(stop.x, stop.y, stop.z);
+
+    // start at a stop
+    const double energy = mass_;
+    CLHEP::Hep3Vector p3(0., 0., 0.);
+    CLHEP::HepLorentzVector fourmom(p3, energy);
+    output->emplace_back(pdgId_,
+                         genId_,
+                         pos,
+                         fourmom,
+                         stop.t);
+
+    event.put(std::move(output));
+    //-----------------------------------------------------------------------------
+    // if requested, fill histograms
+    //-----------------------------------------------------------------------------
+    if(makeHistograms_) {
+      _hX->Fill(pos.x() - _foilXs[0]);
+      _hY->Fill(pos.y() - _foilYs[0]);
+      _hZ->Fill(pos.z());
+      _hTime->Fill(stop.t);
+      const double r = std::sqrt(std::pow(pos.x() - _foilXs[0], 2) + std::pow(pos.y() - _foilYs[0], 2));
+      _hR->Fill(r);
+    }
+  }
+
+  //================================================================
+} // namespace mu2e
+
+DEFINE_ART_MODULE(mu2e::SimpleAntiprotonGun)

--- a/MCDataProducts/inc/GenId.hh
+++ b/MCDataProducts/inc/GenId.hh
@@ -44,8 +44,8 @@ namespace mu2e {
       cosmicCRY,  pbarFlat, fromAscii, ExternalRMC, InternalRMC, CeLeadingLog, cosmicCORSIKA, //44
       MuCapProtonGenTool, MuCapDeuteronGenTool, DIOGenTool, MuCapNeutronGenTool, // 48
       MuCapPhotonGenTool, MuCapGammaRayGenTool, CeLeadingLogGenTool, MuplusMichelGenTool,// 52
-      gammaPairProduction, //53
-      lastEnum //54
+      gammaPairProduction, antiproton, //54
+      lastEnum //55
     };
 
 #ifndef SWIG
@@ -64,7 +64,7 @@ namespace mu2e {
       "CosmicCRY", "pbarFlat","fromAscii","ExternalRMC","InternalRMC","CeLeadingLog", "CosmicCORSIKA", \
     "MuCapProtonGenTool", "MuCapDeuteronGenTool", "DIOGenTool", "MuCapNeutronGenTool", \
       "MuCapPhotonGenTool", "MuCapGammaRayGenTool","CeLeadingLogGenTool","MuplusMichelGenTool", \
-      "gammaPairProduction"
+      "gammaPairProduction", "antiproton"
 #endif
 
   public:

--- a/MCDataProducts/inc/GenId.hh
+++ b/MCDataProducts/inc/GenId.hh
@@ -45,7 +45,7 @@ namespace mu2e {
       MuCapProtonGenTool, MuCapDeuteronGenTool, DIOGenTool, MuCapNeutronGenTool, // 48
       MuCapPhotonGenTool, MuCapGammaRayGenTool, CeLeadingLogGenTool, MuplusMichelGenTool,// 52
       gammaPairProduction, //53
-      lastEnum //55
+      lastEnum //54
     };
 
 #ifndef SWIG

--- a/MCDataProducts/inc/GenId.hh
+++ b/MCDataProducts/inc/GenId.hh
@@ -44,7 +44,7 @@ namespace mu2e {
       cosmicCRY,  pbarFlat, fromAscii, ExternalRMC, InternalRMC, CeLeadingLog, cosmicCORSIKA, //44
       MuCapProtonGenTool, MuCapDeuteronGenTool, DIOGenTool, MuCapNeutronGenTool, // 48
       MuCapPhotonGenTool, MuCapGammaRayGenTool, CeLeadingLogGenTool, MuplusMichelGenTool,// 52
-      gammaPairProduction, antiproton, //54
+      gammaPairProduction, //53
       lastEnum //55
     };
 
@@ -64,7 +64,7 @@ namespace mu2e {
       "CosmicCRY", "pbarFlat","fromAscii","ExternalRMC","InternalRMC","CeLeadingLog", "CosmicCORSIKA", \
     "MuCapProtonGenTool", "MuCapDeuteronGenTool", "DIOGenTool", "MuCapNeutronGenTool", \
       "MuCapPhotonGenTool", "MuCapGammaRayGenTool","CeLeadingLogGenTool","MuplusMichelGenTool", \
-      "gammaPairProduction", "antiproton"
+      "gammaPairProduction"
 #endif
 
   public:

--- a/MCDataProducts/inc/ProcessCode.hh
+++ b/MCDataProducts/inc/ProcessCode.hh
@@ -88,7 +88,7 @@ namespace mu2e {
       mu2eCePlusLeadingLog, mu2ePionCaptureAtRest, mu2eExternalRPC, mu2eInternalRPC, // 179
       mu2eCaloCalib, mu2ePienu, mu2eunused7, mu2eunused8, // 183
       uninitialized, NoProcess, GammaGeneralProc, // 186
-      mu2eGammaConversion, Radioactivation, nCaptureHP, nFissionHP, // 190
+      mu2eGammaConversion, Radioactivation, nCaptureHP, nFissionHP, mu2eAntiproton, // 191
       lastEnum,
       // An alias for backward compatibility
       mu2eHallAir = mu2eKillerVolume
@@ -145,7 +145,7 @@ namespace mu2e {
   "mu2eCePlusLeadingLog", "mu2ePionCaptureAtRest", "mu2eExternalRPC", "mu2eInternalRPC", \
     "mu2eCaloCalib", "mu2ePienu", "mu2eunused7", "mu2eunused8", \
       "uninitialized", "NoProcess", "GammaGeneralProc", \
-      "mu2eGammaConversion","Radioactivation", "nCaptureHP", "nFissionHP"
+      "mu2eGammaConversion","Radioactivation", "nCaptureHP", "nFissionHP", "mu2eAntiproton"
 #endif
 
   public:

--- a/Mu2eUtilities/inc/simParticleList.hh
+++ b/Mu2eUtilities/inc/simParticleList.hh
@@ -24,6 +24,11 @@
 
 namespace mu2e {
 
+  std::vector<art::Ptr<SimParticle> > simParticleList(art::ValidHandle<SimParticleCollection> simh);
+
+  std::vector<art::Ptr<SimParticle> > simParticleList(art::ValidHandle<SimParticleCollection> simh,
+                                                      PDGCode::type pdgId);
+
   std::vector<art::Ptr<SimParticle> > simParticleList(art::ValidHandle<SimParticleCollection> simh,
                                                       PDGCode::type pdgId,
                                                       ProcessCode stoppingCode);
@@ -34,9 +39,9 @@ namespace mu2e {
   }
 
 
-inline std::vector<art::Ptr<SimParticle> > stoppedMuPlusList(art::ValidHandle<SimParticleCollection> simh) {
+  inline std::vector<art::Ptr<SimParticle> > stoppedMuPlusList(art::ValidHandle<SimParticleCollection> simh) {
     // G4 sets this end code
-  return simParticleList(simh, PDGCode::mu_plus, ProcessCode::Decay);
+    return simParticleList(simh, PDGCode::mu_plus, ProcessCode::Decay);
   }
 
   inline std::vector<art::Ptr<SimParticle> > stoppedPiMinusList(art::ValidHandle<SimParticleCollection> simh) {

--- a/Mu2eUtilities/src/simParticleList.cc
+++ b/Mu2eUtilities/src/simParticleList.cc
@@ -2,6 +2,36 @@
 
 namespace mu2e {
 
+  // Convert the SimParticleCollection into a list without a selection
+  std::vector<art::Ptr<SimParticle> > simParticleList(art::ValidHandle<SimParticleCollection> simh)
+  {
+    std::vector<art::Ptr<SimParticle> > res;
+
+    const auto& sims = *simh;
+    for(auto i = sims.begin(); i != sims.end(); ++i) {
+      res.emplace_back(simh, i->first.asInt());
+    }
+
+    return res;
+  }
+
+  std::vector<art::Ptr<SimParticle> > simParticleList(art::ValidHandle<SimParticleCollection> simh,
+                                                      PDGCode::type pdgId)
+  {
+    std::vector<art::Ptr<SimParticle> > res;
+
+    const auto& sims = *simh;
+    for(auto i = sims.begin(); i != sims.end(); ++i) {
+      const auto& inpart = i->second;
+      if(inpart.pdgId() == pdgId)
+        {
+          res.emplace_back(simh, i->first.asInt());
+        }
+    }
+
+    return res;
+  }
+
   std::vector<art::Ptr<SimParticle> > simParticleList(art::ValidHandle<SimParticleCollection> simh,
                                                       PDGCode::type pdgId,
                                                       ProcessCode stoppingCode)


### PR DESCRIPTION
Add a simple antiproton generator for annihilation studies. The generator simple places antiprotons in the stopping target foils with a flat distribution in r and phi. The foil number is an exponential distribution roughly taken from SU2020 antiproton stops. The timing distribution is also exponential starting from 600 ns, which is a very rough approximation as the antiproton arrival time is a fairly complex distribution that peaks at ~500-600 ns region.

The point of this module is for simple testing and debugging of multi-track fits motivated by antiproton annihilations, but this should generally be replaced in the future by a Production workflow that produces the dataset of antiproton stops that can be resampled as we do with other primary process datasets.