### PR TITLE
implement rotated extruded volumes

### DIFF
--- a/GeomPrimitives/inc/RotExtrudedSolid.hh
+++ b/GeomPrimitives/inc/RotExtrudedSolid.hh
@@ -1,0 +1,55 @@
+#ifndef ROTEXTRUDEDSOLID_HH
+#define ROTEXTRUDEDSOLID_HH
+
+#include <vector>
+
+#include "CLHEP/Vector/Rotation.h"
+#include "CLHEP/Vector/ThreeVector.h"
+#include "CLHEP/Vector/TwoVector.h"
+#include "CLHEP/Units/PhysicalConstants.h"
+
+namespace mu2e {
+
+  class RotExtrudedSolid {
+  public:
+    RotExtrudedSolid() : yHalfThickness_() {}
+
+    RotExtrudedSolid( const std::string& name,
+                      const std::string& mat,
+                      const CLHEP::Hep3Vector& offset,
+                      double yht,
+                      const std::vector<CLHEP::Hep2Vector>& v,
+                      CLHEP::HepRotation const & rotation = CLHEP::HepRotation() )
+      : name_(name)
+      , material_(mat)
+      , offsetFromMu2eOrigin_(offset)
+      , yHalfThickness_(yht)
+      , vertices_(v),
+      _rotation    ( rotation     )
+    {}
+
+    const std::string& getName()     const { return name_; }
+    const std::string& getMaterial() const { return material_; }
+
+    const CLHEP::Hep3Vector& getOffsetFromMu2eOrigin() const { return offsetFromMu2eOrigin_; }
+
+    double getYhalfThickness() const { return yHalfThickness_; }
+
+    const std::vector<CLHEP::Hep2Vector>& getVertices() const { return vertices_; }
+
+    CLHEP::HepRotation const & getRotation()     const { return _rotation; }
+
+    CLHEP::Hep2Vector& modifyVertex( int i ) { return vertices_.at( (std::size_t)i); }
+
+  private:
+    std::string name_;
+    std::string material_;
+    CLHEP::Hep3Vector offsetFromMu2eOrigin_;
+    double yHalfThickness_;
+    std::vector<CLHEP::Hep2Vector> vertices_;
+    CLHEP::HepRotation             _rotation; // wrt to parent volume
+  };
+
+}
+
+#endif/*ROTEXTRUDEDSOLID_HH*/

--- a/GeometryService/inc/Mu2eHallMaker.hh
+++ b/GeometryService/inc/Mu2eHallMaker.hh
@@ -8,6 +8,7 @@
 namespace mu2e {
 
   class ExtrudedSolid;
+  class RotExtrudedSolid;
   class GenericTrap;
   class SimpleConfig;
   class Mu2eEnvelope;
@@ -25,6 +26,11 @@ namespace mu2e {
               const SimpleConfig& config,
               const Mu2eEnvelope& mu2eEnv );
     static void
+    makeRotated( Mu2eHall& mh,
+              G4GeometryOptions& geomOptions,
+              const SimpleConfig& config,
+              const Mu2eEnvelope& mu2eEnv );
+    static void
     makeTrapDirt( Mu2eHall& mh,
                   G4GeometryOptions& geomOptions,
                   const SimpleConfig& config,
@@ -32,6 +38,11 @@ namespace mu2e {
 
     static void
     loadSolids( std::map<std::string,ExtrudedSolid>& solidMap,
+                G4GeometryOptions& geomOptions,
+                const SimpleConfig& config,
+                const std::string& varPrefixStr );
+    static void
+    loadRotSolids( std::map<std::string,RotExtrudedSolid>& solidMap,
                 G4GeometryOptions& geomOptions,
                 const SimpleConfig& config,
                 const std::string& varPrefixStr );
@@ -52,7 +63,6 @@ namespace mu2e {
                            const std::string& varPrefixStr,
                            const std::string& dim,
                            const double min, const double max );
-
     static void
     replaceBoundaryValues( std::map<std::string,GenericTrap>& solidMap,
                            const SimpleConfig& config,

--- a/GeometryService/src/GeometryService.cc
+++ b/GeometryService/src/GeometryService.cc
@@ -267,6 +267,7 @@ namespace mu2e {
 
     // Make dirt based on Mu2e envelope
     Mu2eHallMaker::makeDirt( *tmphall.get(), *_g4GeomOptions, *_config, *mu2eEnv.get() );
+    Mu2eHallMaker::makeRotated( *tmphall.get(), *_g4GeomOptions, *_config, *mu2eEnv.get() );
     Mu2eHallMaker::makeTrapDirt( *tmphall.get(), *_g4GeomOptions, *_config, *mu2eEnv.get() );
 
     addDetector(std::move( tmphall ) );

--- a/Mu2eG4/inc/constructHall.hh
+++ b/Mu2eG4/inc/constructHall.hh
@@ -16,6 +16,7 @@
 namespace mu2e {
 
   class ExtrudedSolid;
+  class RotExtrudedSolid;
   class GenericTrap;
   class SimpleConfig;
   class VolumeInfo;
@@ -26,6 +27,12 @@ namespace mu2e {
   void constructSolids( const SimpleConfig& config,
                         const VolumeInfo& hallInfo,
                         const std::map<std::string,ExtrudedSolid>& solidMap,
+                        const CLHEP::HepRotation& rot,
+                        const NotchHoleManager& notchMgr);
+
+  void constructRotSolids( const SimpleConfig& config,
+                        const VolumeInfo& hallInfo,
+                        const std::map<std::string,RotExtrudedSolid>& solidMap,
                         const CLHEP::HepRotation& rot,
                         const NotchHoleManager& notchMgr);
 

--- a/Mu2eG4/src/constructHall.cc
+++ b/Mu2eG4/src/constructHall.cc
@@ -90,6 +90,7 @@ namespace mu2e {
 
     constructSolids( config, hallInfo, building->getBldgSolids(), horizontalConcreteRotation, notchMgr );
     constructSolids( config, hallInfo, building->getDirtSolids(), horizontalConcreteRotation, notchMgr );
+    constructRotSolids( config, hallInfo, building->getRotSolids(), horizontalConcreteRotation, notchMgr );
     constructTrapSolids( config, hallInfo, building->getDirtTrapSolids(), horizontalConcreteRotation, notchMgr );
 
     return hallInfo;
@@ -248,6 +249,162 @@ namespace mu2e {
                       doSurfaceCheck
                       );
 
+      } // end else of if for has notches and holes
+
+    } // end loop over parts
+
+  } // end function def for constructSolids
+
+  //================================================================================
+  void constructRotSolids( const SimpleConfig& config,
+                           const VolumeInfo& hallInfo,
+                           const std::map<std::string,RotExtrudedSolid>& solidMap,
+                           const CLHEP::HepRotation& rot,
+                           const NotchHoleManager& notchMgr) {
+
+    //-----------------------------------------------------------------
+    // Some building and dirt volumes (mainly stairs) require to rotate extruded solids.
+    //-----------------------------------------------------------------
+    const auto& geoOptions         = art::ServiceHandle<GeometryService>()->geomOptions();
+    const bool doSurfaceCheck      = geoOptions->doSurfaceCheck("HallAir");
+    const bool forceAuxEdgeVisible = geoOptions->forceAuxEdgeVisible("HallAir");
+    const bool placePV             = geoOptions->placePV("HallAir");
+
+    AntiLeakRegistry& reg = art::ServiceHandle<Mu2eG4Helper>()->antiLeakRegistry();
+
+    OrientationResolver OR;
+
+    // Loop over all volumes in the map
+    for ( const auto& keyVolumePair : solidMap ) {
+
+      const auto& volume = keyVolumePair.second;
+      const auto& volName = keyVolumePair.first;
+
+      geoOptions->loadEntry( config, volume.getName(), volume.getName() );
+      const CLHEP::HepRotation vRot = rot*volume.getRotation();
+      const G4RotationMatrix* vRotG4 = reg.add(G4RotationMatrix(vRot));
+
+      if ( notchMgr.hasNotches( volName )||notchMgr.hasHoles( volName ) ) {
+       const vector<Notch>& volNotches = notchMgr.getNotchVector(volName);
+       const vector<Hole>& volHoles = notchMgr.getHoleVector(volName);
+
+       // First do volumes with notches
+       // Make the VolumeInfo, without solid info
+        VolumeInfo tmpVol(volume.getName(),
+                          volume.getOffsetFromMu2eOrigin() - hallInfo.centerInMu2e(),
+                          hallInfo.centerInWorld);
+       // Make the main extruded solid from which notches will be subtracted
+        G4ExtrudedSolid* aVol = new G4ExtrudedSolid(tmpVol.name,
+                                                    volume.getVertices(),
+                                                    volume.getYhalfThickness(),
+                                                    G4TwoVector(0,0), 1., G4TwoVector(0,0), 1.);
+       //-------------------------------------------------------------------------------------
+       // Now loop over the notches and subtract them from above
+       // First, create the eventual solid
+       G4SubtractionSolid* aSolid = 0;
+       //-------------------------------------------------------------------------------------
+       // Get the vector of notches
+        for ( unsigned int iNotch = 0; iNotch < volNotches.size(); iNotch++ ) {
+          ostringstream notchName;
+          notchName << "Notch" << iNotch+1;
+          Notch tmpNotch = volNotches[iNotch];
+          vector<double> halfDims = tmpNotch.getDims();
+          G4Box* notchBox = new G4Box( notchName.str(),
+                                       halfDims[0],halfDims[1],halfDims[2]);
+
+          CLHEP::HepRotation* notchRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+          OR.getRotationFromOrientation( *notchRotat, tmpNotch.getOrient());
+
+          if ( 0 == aSolid ) {
+            aSolid = new G4SubtractionSolid( tmpVol.name,
+                                             aVol,
+                                             notchBox,
+                                             notchRotat,
+                                             tmpNotch.getCenter() );
+          } else {
+            G4SubtractionSolid * bSolid = new G4SubtractionSolid
+              ( tmpVol.name,
+                aSolid,
+                notchBox,
+                notchRotat,
+                tmpNotch.getCenter() );
+            aSolid = bSolid;
+          } // end if...else for first or later notch
+        } // end loop over all notches
+       //-----------------------------------------------------------------------------------
+       //-------------------------------------------------------------------------------------
+       // Get the vector of holes
+        for ( unsigned int iHole = 0; iHole < volHoles.size(); iHole++ ) {
+          ostringstream holeName;
+          holeName << "hole" << iHole+1;
+          Hole tmpHole = volHoles[iHole];
+          double radius = tmpHole.getRad();
+          double halfLength = tmpHole.getHalfLen();
+          G4Tubs*holeTub = new G4Tubs(holeName.str(),
+                                      0.0, //inner radius
+                                      radius,//outer radius
+                                      halfLength,  // Half Lengths are kept at least 1 mm longer.
+                                      0.0, //angle_0
+                                      CLHEP::twopi); //angle_span;
+
+          CLHEP::HepRotation* holeRotat = reg.add(CLHEP::HepRotation(CLHEP::HepRotation::IDENTITY));
+          OR.getRotationFromOrientation( *holeRotat, tmpHole.getOrient());
+          if ( 0 == aSolid ) {
+            aSolid = new G4SubtractionSolid( tmpVol.name,
+                                             aVol,
+                                             holeTub,
+                                             holeRotat,
+                                             tmpHole.getCenter() );
+          } else {
+            G4SubtractionSolid * bSolid = new G4SubtractionSolid
+              ( tmpVol.name,
+                aSolid,
+                holeTub,
+                holeRotat,
+                tmpHole.getCenter() );
+            aSolid = bSolid;
+          } // end if...else for first or later hole
+        } // end loop over all holes
+        //-----------------------------------------------------------------------------------
+
+        tmpVol.solid = aSolid;
+
+        finishNesting(tmpVol,
+                      findMaterialOrThrow( volume.getMaterial() ),
+                      vRotG4,
+                      tmpVol.centerInParent,
+                      hallInfo.logical,
+                      0,
+                      geoOptions->isVisible( volume.getName() ),
+                      G4Colour::Grey(),
+                      geoOptions->isSolid( volume.getName() ),
+                      forceAuxEdgeVisible,
+                      placePV,
+                      doSurfaceCheck
+                      );
+
+      } else {  // Now for walls without notches or holes
+        VolumeInfo tmpVol(volume.getName(),
+                          volume.getOffsetFromMu2eOrigin() - hallInfo.centerInMu2e(),
+                          hallInfo.centerInWorld);
+        tmpVol.solid = new G4ExtrudedSolid(tmpVol.name,
+                                           volume.getVertices(),
+                                           volume.getYhalfThickness(),
+                                           G4TwoVector(0,0), 1., G4TwoVector(0,0), 1.);
+
+        finishNesting(tmpVol,
+                      findMaterialOrThrow( volume.getMaterial() ),
+                      vRotG4,
+                      tmpVol.centerInParent,
+                      hallInfo.logical,
+                      0,
+                      geoOptions->isVisible( volume.getName() ),
+                      G4Colour::Grey(),
+                      geoOptions->isSolid( volume.getName() ),
+                      forceAuxEdgeVisible,
+                      placePV,
+                      doSurfaceCheck
+                      );
       } // end else of if for has notches and holes
 
     } // end loop over parts

--- a/Mu2eHallGeom/inc/Mu2eHall.hh
+++ b/Mu2eHallGeom/inc/Mu2eHall.hh
@@ -42,6 +42,7 @@
 //#include "CLHEP/Vector/TwoVector.h"
 
 #include "Offline/GeomPrimitives/inc/ExtrudedSolid.hh"
+#include "Offline/GeomPrimitives/inc/RotExtrudedSolid.hh"
 #include "Offline/GeomPrimitives/inc/GenericTrap.hh"
 #include "Offline/Mu2eInterfaces/inc/Detector.hh"
 
@@ -56,6 +57,7 @@ namespace mu2e {
 
     const std::map<std::string,ExtrudedSolid>& getBldgSolids()      const { return bldgSolids_; }
     const std::map<std::string,ExtrudedSolid>& getDirtSolids()      const { return dirtSolids_; }
+    const std::map<std::string,RotExtrudedSolid>& getRotSolids()      const { return rotatedSolids_; }
     const std::map<std::string,GenericTrap>&   getDirtTrapSolids()  const { return dirtTrapSolids_; }
 
     const ExtrudedSolid&
@@ -63,6 +65,9 @@ namespace mu2e {
 
     const ExtrudedSolid&
     getDirtSolid( const std::string& str ) const;
+
+    const RotExtrudedSolid&
+    getRotSolid( const std::string& str ) const;
 
     const GenericTrap&
     getDirtTrapSolid( const std::string& str ) const;
@@ -81,6 +86,7 @@ namespace mu2e {
 
     std::map<std::string,ExtrudedSolid> bldgSolids_;
     std::map<std::string,ExtrudedSolid> dirtSolids_;
+    std::map<std::string,RotExtrudedSolid> rotatedSolids_;
     std::map<std::string,GenericTrap>   dirtTrapSolids_;
 
   };

--- a/Mu2eHallGeom/src/Mu2eHall.cc
+++ b/Mu2eHallGeom/src/Mu2eHall.cc
@@ -40,6 +40,15 @@ namespace mu2e {
     return it->second;
   }
 
+  const RotExtrudedSolid& Mu2eHall::getRotSolid(const std::string& name) const {
+    auto it = rotatedSolids_.find(name);
+    if(it == rotatedSolids_.end()) {
+      throw cet::exception("GEOM")
+        <<"Mu2eHall::getRotSolid(): unknown volume \""<< name <<"\"\n";
+    }
+    return it->second;
+  }
+
   const GenericTrap& Mu2eHall::getDirtTrapSolid(const std::string& name) const {
     auto it = dirtTrapSolids_.find(name);
     if(it == dirtTrapSolids_.end()) {


### PR DESCRIPTION
Few files have been modified to implement rotated extruded volumes. The code is essentially the same used to rotate trapezoidal volumes but new classes and methods have been implemented.