### PR TITLE
Add the option to use the helix slope to decide the LoopHelixFit direction hypothesis

### DIFF
--- a/CalPatRec/fcl/prolog.fcl
+++ b/CalPatRec/fcl/prolog.fcl
@@ -683,7 +683,7 @@ CalPatRec : { @table::CalPatRec
             chi2LineSaveThresh      : 5.0
             maxEDepAvg              : @local::TrkReco.HelixFinderParams.maxEDepAvg
             tzSlopeSigThresh        : 5.0
-            validHelixDirections    : [-1, 0, 1]
+            validHelixDirections    : ["downstream", "upstream", "unknown"]
             diagPlugin              : { tool_type : "AgnosticHelixFinderDiag" }
         }
 

--- a/CalPatRec/inc/CalHelixFinder_module.hh
+++ b/CalPatRec/inc/CalHelixFinder_module.hh
@@ -91,7 +91,6 @@ namespace mu2e {
     int                                   _minNHitsTimeCluster; //min nhits within a TimeCluster after check of Delta-ray hits
 
     int                                   _fitparticle;
-    int                                   _fitdirection;
     TrkParticle                           _tpart;                // particle type being searched for
     TrkFitDirection                       _fdir;                // fit direction in search
     bool                                  _doSingleOutput;
@@ -138,7 +137,7 @@ namespace mu2e {
       fhicl::Atom<std::string>                   timeclLabel{          Name("TimeClusterCollectionLabel"),                Comment("TimeCluster Collection Label") };
       fhicl::Atom<int>                           minNHitsTimeCluster{  Name("minNHitsTimeCluster"),        Comment("Min NHits in TimeCluster") };
       fhicl::Atom<int>                           fitparticle{          Name("fitparticle"),                      Comment("Particle Type Searched For") };
-      fhicl::Atom<int>                           fitdirection{         Name("fitdirection"),                       Comment("Fit Direction in Search") };
+      fhicl::Atom<std::string>                   fitdirection{         Name("fitdirection"),               Comment("Fit Direction in Search (\"downstream\" or \"upstream\")") };
       fhicl::Atom<bool>                          doSingleOutput{       Name("doSingleOutput"),             Comment("Do Single Output") };
       fhicl::Atom<float>                         maxEDepAvg{           Name("maxEDepAvg"),                 Comment("Max Avg EDep") };
       fhicl::Table<CalHelixFinderAlg::Config>    hfinder{              Name("HelixFinderAlg"),                    Comment("CalHelixFinderAlg Config") };

--- a/CalPatRec/src/AgnosticHelixFinder_module.cc
+++ b/CalPatRec/src/AgnosticHelixFinder_module.cc
@@ -26,6 +26,7 @@
 #include "Offline/RecoDataProducts/inc/HelixSeed.hh"
 #include "Offline/RecoDataProducts/inc/StrawHitIndex.hh"
 #include "Offline/RecoDataProducts/inc/TimeCluster.hh"
+#include "Offline/RecoDataProducts/inc/TrkFitDirection.hh"
 #include "Offline/RecoDataProducts/inc/TrkFitFlag.hh"
 #include "Offline/RecoDataProducts/inc/HelixRecoDir.hh"
 
@@ -328,23 +329,23 @@ namespace mu2e {
     _chi2LineSaveThresh            (config().chi2LineSaveThresh()                    ),
     _maxEDepAvg                    (config().maxEDepAvg()                            ),
     _tzSlopeSigThresh              (config().tzSlopeSigThresh()                      )
-    {
+  {
 
-      // convert the helix direction names into enums
-      for(auto helix_dir : config().validHelixDirections()) {
-        _validHelixDirections.push_back(TrkFitDirection::fitDirectionFromName(helix_dir));
-      }
-      consumes<ComboHitCollection>     (_chLabel);
-      consumes<TimeClusterCollection>  (_tcLabel);
-      consumes<CaloClusterCollection>  (_ccLabel);
-      produces<HelixSeedCollection>    ();
-
-      if (_diagLevel == 1) _hmanager = art::make_tool<ModuleHistToolBase>(config().diagPlugin, "diagPlugin");
-      else _hmanager = std::make_unique<ModuleHistToolBase>();
-
-      if (_useStoppingTarget == true) { _stopTargPos.SetCoordinates(0.0, 0.0, std::numeric_limits<float>::max()); }
-
+    // convert the helix direction names into enums
+    for(auto helix_dir : config().validHelixDirections()) {
+      _validHelixDirections.push_back(TrkFitDirection::fitDirectionFromName(helix_dir));
     }
+    consumes<ComboHitCollection>     (_chLabel);
+    consumes<TimeClusterCollection>  (_tcLabel);
+    consumes<CaloClusterCollection>  (_ccLabel);
+    produces<HelixSeedCollection>    ();
+
+    if (_diagLevel == 1) _hmanager = art::make_tool<ModuleHistToolBase>(config().diagPlugin, "diagPlugin");
+    else _hmanager = std::make_unique<ModuleHistToolBase>();
+
+    if (_useStoppingTarget == true) { _stopTargPos.SetCoordinates(0.0, 0.0, std::numeric_limits<float>::max()); }
+
+  }
 
   //-----------------------------------------------------------------------------
   // destructor
@@ -620,10 +621,8 @@ namespace mu2e {
     // order from largest z to smallest z (skip over stopping target and calo cluster since they
     // aren't in _chColl)
     std::sort(_tcHits.begin() + sortStartIndex, _tcHits.end(), [&](const cHit& a, const cHit& b) {
-        return _chColl->at(a.hitIndice).pos().z() > _chColl->at(b.hitIndice).pos().z();
-      });
-
-    }
+      return _chColl->at(a.hitIndice).pos().z() > _chColl->at(b.hitIndice).pos().z();
+    });
   }
 
   //-----------------------------------------------------------------------------

--- a/CalPatRec/src/AgnosticHelixFinder_module.cc
+++ b/CalPatRec/src/AgnosticHelixFinder_module.cc
@@ -277,7 +277,7 @@ namespace mu2e {
     void         recoverPoints             (bool& recoveries);
     void         checkHelixViability       (LoopCondition& outcome);
     void         saveHelix                 (size_t tc, HelixSeedCollection& HSColl);
-    bool         validHelixDirection       (HelixRecoDir::PropDir direction);
+    bool         validHelixDirection       (TrkFitDirection::FitDirection direction);
 
   };
 
@@ -1421,7 +1421,7 @@ namespace mu2e {
   //-----------------------------------------------------------------------------
   // check if the propagation direction is among the desired save directions
   //-----------------------------------------------------------------------------
-  bool AgnosticHelixFinder::validHelixDirection(HelixRecoDir::PropDir direction) {
+  bool AgnosticHelixFinder::validHelixDirection(TrkFitDirection::FitDirection direction) {
 
     for (size_t i=0; i<_validHelixDirections.size(); i++) {
       if (_validHelixDirections.at(i) == direction) return true;

--- a/CalPatRec/src/CalHelixFinder_module.cc
+++ b/CalPatRec/src/CalHelixFinder_module.cc
@@ -58,7 +58,7 @@ namespace mu2e {
     _timeclLabel(config().timeclLabel()),
     _minNHitsTimeCluster(config().minNHitsTimeCluster()),
     _fitparticle(config().fitparticle()),
-    _fitdirection(config().fitdirection()),
+    _fdir(config().fitdirection()),
     _doSingleOutput(config().doSingleOutput()),
     _maxEDepAvg(config().maxEDepAvg()),
     _hfinder(config().hfinder()){
@@ -79,7 +79,6 @@ namespace mu2e {
       }
 
       _tpart = (TrkParticle::type)_fitparticle;
-      _fdir = (TrkFitDirection::FitDirection)_fitdirection;
 //-----------------------------------------------------------------------------
 // provide for interactive disanostics
 //-----------------------------------------------------------------------------

--- a/CalPatRec/src/TZClusterFinder_module.cc
+++ b/CalPatRec/src/TZClusterFinder_module.cc
@@ -235,7 +235,6 @@ namespace mu2e {
       std::cout << ">>> ERROR in TZClusterFinder::findData: ComboHitCollection not found." << std::endl;
     }
 
-
     if (_diagLevel  != 0) {
       auto chcolH2 = evt.getValidHandle<ComboHitCollection>(_chLabel2);
       if (chcolH2.product() != 0){

--- a/Mu2eKinKal/fcl/prolog.fcl
+++ b/Mu2eKinKal/fcl/prolog.fcl
@@ -505,20 +505,20 @@ Mu2eKinKal.producers.KKLineSeedFit.ModuleSettings.FitParticle : 13
 Mu2eKinKal.producers.KKLine.ModuleSettings.FitParticle : 13
 
 Mu2eKinKal.producers.KKDeSeedFit.ModuleSettings.FitParticle : 11
-Mu2eKinKal.producers.KKDeSeedFit.FitDirection : 0
+Mu2eKinKal.producers.KKDeSeedFit.FitDirection : @local::FitDir.downstream
 
 # save trajectories in the Detector region for downstream fits, just the T0 segment for the rest
 Mu2eKinKal.producers.KKDe.ModuleSettings.FitParticle : 11
-Mu2eKinKal.producers.KKDe.FitDirection : 0
+Mu2eKinKal.producers.KKDe.FitDirection : @local::FitDir.downstream
 Mu2eKinKal.producers.KKDe.KKFitSettings.SaveTrajectory : "Detector"
 Mu2eKinKal.producers.KKDmu.ModuleSettings.FitParticle : 13
-Mu2eKinKal.producers.KKDmu.FitDirection : 0
+Mu2eKinKal.producers.KKDmu.FitDirection : @local::FitDir.downstream
 Mu2eKinKal.producers.KKDmu.KKFitSettings.SaveTrajectory : "Detector"
 Mu2eKinKal.producers.KKUe.ModuleSettings.FitParticle : 11
-Mu2eKinKal.producers.KKUe.FitDirection : 1
+Mu2eKinKal.producers.KKUe.FitDirection : @local::FitDir.upstream
 Mu2eKinKal.producers.KKUe.KKFitSettings.SaveTrajectory : "T0"
 Mu2eKinKal.producers.KKUmu.ModuleSettings.FitParticle : 13
-Mu2eKinKal.producers.KKUmu.FitDirection : 1
+Mu2eKinKal.producers.KKUmu.FitDirection : @local::FitDir.upstream
 Mu2eKinKal.producers.KKUmu.KKFitSettings.SaveTrajectory : "T0"
 # extrapolate upstream fits back to the tracker
 physics.producers.KKUmu.Extrapolation.BackToTracker : true

--- a/Mu2eKinKal/src/LoopHelixFit_module.cc
+++ b/Mu2eKinKal/src/LoopHelixFit_module.cc
@@ -158,7 +158,7 @@ namespace mu2e {
     // LoopHelix module specific config
     fhicl::OptionalAtom<double> slopeSigThreshold{ Name("SlopeSigThreshold"), Comment("Input helix seed slope significance threshold to assume the direction")};
     fhicl::Atom<bool> prioritizeCaloHits{ Name("PrioritizeCaloHits"), Comment("Prioritize tracks with calo-hits when determining the best fit direction"), true};
-    fhicl::OptionalAtom<int> fitDirection { Name("FitDirection"), Comment("Particle direction to fit, either upstream or downstream")};
+    fhicl::OptionalAtom<std::string> fitDirection { Name("FitDirection"), Comment("Particle direction to fit, either \"upstream\" or \"downstream\"")};
     fhicl::Atom<bool> pdgCharge { Name("UsePDGCharge"), Comment("Use particle charge from fitParticle")};
   };
 
@@ -244,7 +244,7 @@ namespace mu2e {
     useHelixSlope_(settings().slopeSigThreshold(slopeSigThreshold_)),
     prioritizeCaloHits_(settings().prioritizeCaloHits()),
     useFitDir_(settings().fitDirection()),
-    fdir_(static_cast<TrkFitDirection::FitDirection>((useFitDir_) ? *(settings().fitDirection()) : 0)),
+    fdir_(useFitDir_ ? *settings().fitDirection() : "downstream"),
     usePDGCharge_(settings().pdgCharge()),
     kkfit_(settings().kkfitSettings()),
     kkmat_(settings().matSettings()),

--- a/Mu2eKinKal/src/LoopHelixFit_module.cc
+++ b/Mu2eKinKal/src/LoopHelixFit_module.cc
@@ -156,8 +156,6 @@ namespace mu2e {
     fhicl::OptionalTable<KKFinalConfig> finalSettings { Name("FinalSettings") };
     fhicl::OptionalTable<KKExtrapConfig> Extrapolation { Name("Extrapolation") };
     // LoopHelix module specific config
-    // fhicl::Atom<bool> useHelixSlope{ Name("UseHelixSlope"), Comment("Use the helix slope to decide the particle fit direction (upstream or downstream)"), false };
-    // fhicl::Atom<double> slopeSigThreshold{ Name("SlopeSigThreshold"), Comment("Helix slope significance threshold to assume the direction"), [this](){ return useHelixSlope(); }};
     fhicl::OptionalAtom<double> slopeSigThreshold{ Name("SlopeSigThreshold"), Comment("Helix slope significance threshold to assume the direction")};
     fhicl::OptionalAtom<double> slopeSigCut{ Name("SlopeSigCut"), Comment("Helix slope significance cut when assuming a fit direction")};
     fhicl::Atom<int> fitDirection { Name("FitDirection"), Comment("Particle direction to fit, either upstream or downstream"), [this](){ return !slopeSigThreshold(); }};
@@ -186,14 +184,6 @@ namespace mu2e {
       void toOPA(KKTRK& ktrk, double tstart, TimeDir tdir) const;
       void sampleFit(KKTRK const& kktrk,KalIntersectionCollection& inters) const;
 
-      // FIXME: Remove debug function
-      unsigned activeHits(KKTRK& ktrk) const {
-        unsigned nactive(0);
-        for(auto const& hit : ktrk.strawHits()) {
-          if(hit->hit().flag().hasAllProperties(StrawHitFlag::active)) ++nactive;
-        }
-        return nactive;
-      }
       // data payload
       std::vector<art::ProductToken<HelixSeedCollection>> hseedCols_;
       art::ProductToken<ComboHitCollection> chcol_T_;
@@ -347,10 +337,10 @@ namespace mu2e {
     if(print_ > 0) kkbf_->print(std::cout);
 
     // Print the fit direction configuration
-    printf("[LoopHelixFit::%s::%s] Fit dz/dt direction = %.0f, PDG = %i, use helix slope = %o with threshold %.1f, use helix slope cut = %o with theshold %.1f\n",
-           __func__, moduleDescription().moduleLabel().c_str(), fdir_.dzdt(), (int) fpart_,
-           useHelixSlope_, (useHelixSlope_) ? slopeSigThreshold_ : -1.f,
-           useSlopeSigCut_, (useSlopeSigCut_) ? slopeSigCut_ : -999.f);
+    if(print_ > -1) printf("[LoopHelixFit::%s::%s] Fit dz/dt direction = %.0f, PDG = %i, use helix slope = %o with threshold %.1f, use helix slope cut = %o with theshold %.1f\n",
+                           __func__, moduleDescription().moduleLabel().c_str(), fdir_.dzdt(), (int) fpart_,
+                           useHelixSlope_, (useHelixSlope_) ? slopeSigThreshold_ : -1.f,
+                           useSlopeSigCut_, (useSlopeSigCut_) ? slopeSigCut_ : -999.f);
   }
 
   void LoopHelixFit::produce(art::Event& event ) {
@@ -831,8 +821,8 @@ namespace mu2e {
   }
 
   void LoopHelixFit::endJob() {
-    if(/*useHelixSlope_ &&*/ print_ > -1) printf("[LoopHelixFit::%s] Saw %i helix seeds, %i had ambiguous dz/dt slopes, accepted %i downstream and %i upstream fits\n",
-                                             __func__, nSeen_, nAmbiguous_, nDownstream_, nUpstream_);
+    if(print_ > -1) printf("[LoopHelixFit::%s] Saw %i helix seeds, %i had ambiguous dz/dt slopes, accepted %i downstream and %i upstream fits\n",
+                           __func__, nSeen_, nAmbiguous_, nDownstream_, nUpstream_);
   }
 }
 

--- a/Mu2eKinKal/src/LoopHelixFit_module.cc
+++ b/Mu2eKinKal/src/LoopHelixFit_module.cc
@@ -277,9 +277,6 @@ namespace mu2e {
         kkbf_ = std::move(std::make_unique<KKConstantBField>(VEC3(0.0,0.0,bz)));
       }
 
-      if(useFitDir_ && useHelixSlope_) //can either force the direction or determine it from the helix slope
-        throw cet::exception("RECO")<<"mu2e::LoopHelixFit: Configuration error. Configured to use the helix slope for track direction and to force a specific direction!"<< endl;
-
       // setup optional fit finalization; this just updates the internals, not the fit result itself
       if(settings().finalSettings()){
         if(exconfig_.schedule_.size() > 0)
@@ -516,6 +513,9 @@ namespace mu2e {
         std::array<std::unique_ptr<KKTRK>, 2> ktrks;
         for(unsigned index = 0; index < dirs_size; ++index) {
           const auto helix_dir_i = helix_dirs.at(index);
+          // if using a fixed direction, only fit helices in this direction
+          if(useFitDir_ && !((fdir_ == TrkFitDirection::downstream && helix_dir_i == HelixRecoDir::PropDir::downstream) ||
+                             (fdir_ == TrkFitDirection::upstream && helix_dir_i == HelixRecoDir::PropDir::upstream))) continue;
           ktrks[index] = fitTrack(event, hseed,  helix_dir_i, fpart_);
         }
         // determine the fit to use

--- a/ParticleID/fcl/prolog.fcl
+++ b/ParticleID/fcl/prolog.fcl
@@ -11,7 +11,7 @@ ParticleID: {
             ElectronTemplates : "Offline/ConditionsService/data/v5_7_9/pid_ele_dedx.rtbl"
             MuonTemplates     : "Offline/ConditionsService/data/v5_7_9/pid_muo_dedx.rtbl"
             fitparticle       : 11
-            fitdirection      : 0
+            fitdirection      : @local::FitDir.downstream
             debugLevel        : 0
             diagLevel         : 1
             verbosity         : 0

--- a/RecoDataProducts/inc/HelixRecoDir.hh
+++ b/RecoDataProducts/inc/HelixRecoDir.hh
@@ -1,6 +1,7 @@
 #ifndef RecoDataProducts_HelixRecoDir_hh
 #define RecoDataProducts_HelixRecoDir_hh
 
+#include "Offline/RecoDataProducts/inc/TrkFitDirection.hh"
 
 namespace mu2e {
 
@@ -18,26 +19,19 @@ namespace mu2e {
     float slopeSig() const { return std::fabs(_slope/_slopeErr); }
     float chi2ndof() const { return _chi2ndof; }
 
-    // Enum declaration for direction
-    enum PropDir {
-      upstream = -1,
-      ambiguous = 0,
-      downstream = 1
-    };
-
     // Method to predict direction based on slope and slopeSig
-    PropDir predictDirection(float sigThreshold) const {
-      float sig = slopeSig(); // Compute the slope significance
+    TrkFitDirection::FitDirection predictDirection(float sigThreshold) const {
+      const float sig = slopeSig(); // Compute the slope significance
 
       if (sig < sigThreshold) {
-        return ambiguous; // Ambiguous if below the threshold
-      } else if (_slope > 0) {
-        return downstream; // Downstream if slope > 0
-      } else if (_slope < 0) {
-        return upstream; // Upstream if slope < 0
+        return TrkFitDirection::FitDirection::unknown; // Ambiguous if below the threshold
+      } else if (_slope > 0.f) {
+        return TrkFitDirection::FitDirection::downstream; // Downstream if slope > 0
+      } else if (_slope < 0.f) {
+        return TrkFitDirection::FitDirection::upstream; // Upstream if slope < 0
       }
 
-      return ambiguous; // Default to ambiguous if slope is 0 or other cases
+      return TrkFitDirection::FitDirection::unknown; // Default to ambiguous if slope is exactly 0 or other cases
     }
 
     //data members

--- a/RecoDataProducts/inc/HelixSeed.hh
+++ b/RecoDataProducts/inc/HelixSeed.hh
@@ -36,7 +36,7 @@ namespace mu2e {
     RobustHelix              _helix;       // robust helix created from these hits
     TrkFitFlag               _status;      // status of processes used to create this seed
     HelixRecoDir             _recoDir;     // sign of the longitudinal velocity (z-axis) derived from a T vs Z linear fit
-    FitDir                    _propDir = TrkFitDirection::unknown; // direction of propagation (upstream, downstream, or ambiguous)
+    FitDir                    _propDir = FitDir::unknown; // direction of propagation (upstream, downstream, or ambiguous)
     art::Ptr<TimeCluster>    _timeCluster; // associated time cluster
     float                    _eDepAvg =0;  // average energy deposition from helix hits
   };

--- a/RecoDataProducts/inc/HelixSeed.hh
+++ b/RecoDataProducts/inc/HelixSeed.hh
@@ -18,7 +18,7 @@
 namespace mu2e {
   class CaloCluster;
   class TimeCluster;
-
+  using FitDir = TrkFitDirection::FitDirection;
   struct HelixSeed {
 
     TrkT0                 const& t0()          const { return _t0; }
@@ -26,7 +26,7 @@ namespace mu2e {
     RobustHelix           const& helix()       const { return _helix; }
     TrkFitFlag            const& status()      const { return _status; }
     HelixRecoDir          const& recoDir()     const { return _recoDir; }
-    HelixRecoDir::PropDir const& propDir()     const { return _propDir; }
+    FitDir                const& propDir()     const { return _propDir; }
     float                 const& eDepAvg()     const { return _eDepAvg; }
     art::Ptr<CaloCluster> const& caloCluster() const { return _timeCluster->caloCluster(); }
     art::Ptr<TimeCluster> const& timeCluster() const { return _timeCluster; }
@@ -36,7 +36,7 @@ namespace mu2e {
     RobustHelix              _helix;       // robust helix created from these hits
     TrkFitFlag               _status;      // status of processes used to create this seed
     HelixRecoDir             _recoDir;     // sign of the longitudinal velocity (z-axis) derived from a T vs Z linear fit
-    HelixRecoDir::PropDir    _propDir = HelixRecoDir::ambiguous; // direction of propagation (upstream, downstream, or ambiguous)
+    FitDir                    _propDir = TrkFitDirection::unknown; // direction of propagation (upstream, downstream, or ambiguous)
     art::Ptr<TimeCluster>    _timeCluster; // associated time cluster
     float                    _eDepAvg =0;  // average energy deposition from helix hits
   };

--- a/RecoDataProducts/inc/TrkFitDirection.hh
+++ b/RecoDataProducts/inc/TrkFitDirection.hh
@@ -5,17 +5,19 @@
 #ifndef TrkFitDirection_HH
 #define TrkFitDirection_HH
 #include <string>
+#include <cmath>
 
 namespace mu2e
 {
   class TrkFitDirection {
     public:
 // define the fit direction as downstream (towards positive Z) or upstream (towards negative Z).
-      enum FitDirection {downstream=0,upstream};
+      enum FitDirection {downstream=0,upstream,unknown};
       TrkFitDirection(FitDirection fdir=downstream);
+      //accessors
       FitDirection fitDirection() const { return _fdir; }
-  // return the SIGN of the z component of velocity (magnitude is not returned)
-      double dzdt() const { return _fdir == downstream ? 1.0 : -1.0; }
+      // return the SIGN of the z component of velocity (magnitude is not returned)
+      double dzdt() const { return _fdir == downstream ? 1.0 : _fdir == upstream ? -1.0 : 0.0; }
       std::string const& name() const;
       bool operator == ( TrkFitDirection const& other) const { return _fdir == other._fdir; }
       bool operator != ( TrkFitDirection const& other) const { return _fdir != other._fdir; }

--- a/RecoDataProducts/inc/TrkFitDirection.hh
+++ b/RecoDataProducts/inc/TrkFitDirection.hh
@@ -5,6 +5,8 @@
 #ifndef TrkFitDirection_HH
 #define TrkFitDirection_HH
 #include <string>
+#include <cctype>
+#include <algorithm>
 #include <cmath>
 
 namespace mu2e
@@ -14,6 +16,7 @@ namespace mu2e
 // define the fit direction as downstream (towards positive Z) or upstream (towards negative Z).
       enum FitDirection {downstream=0,upstream,unknown};
       TrkFitDirection(FitDirection fdir=downstream);
+      TrkFitDirection(std::string name) : TrkFitDirection(fitDirectionFromName(name)) {}
       //accessors
       FitDirection fitDirection() const { return _fdir; }
       // return the SIGN of the z component of velocity (magnitude is not returned)
@@ -21,6 +24,7 @@ namespace mu2e
       std::string const& name() const;
       bool operator == ( TrkFitDirection const& other) const { return _fdir == other._fdir; }
       bool operator != ( TrkFitDirection const& other) const { return _fdir != other._fdir; }
+      static FitDirection fitDirectionFromName(std::string name);
     private:
       FitDirection _fdir;
   };

--- a/RecoDataProducts/inc/TrkFitFlag.hh
+++ b/RecoDataProducts/inc/TrkFitFlag.hh
@@ -15,10 +15,12 @@ namespace mu2e {
   struct TrkFitFlagDetail {
     // I need 32 bits for this class
     typedef unsigned mask_type;
-    enum bit_type {hitsOK=0,circleOK,phizOK,helixOK,seedOK,kalmanOK,circleInit,phizInit,
-    circleConverged,phizConverged,helixConverged,seedConverged,kalmanConverged,
-    MatCorr, BFCorr, FitOK,
-    KSF=16, KFF, TPRHelix, CPRHelix, Straight, KKLoopHelix,KKCentralHelix,KKLine, APRHelix, MPRHelix, MCSeed=31};
+    enum bit_type {hitsOK=0,circleOK,phizOK,helixOK,seedOK,kalmanOK,circleInit,phizInit, //7
+    circleConverged,phizConverged,helixConverged,seedConverged,kalmanConverged, //12
+    MatCorr, BFCorr, FitOK, //15
+    KSF=16, KFF, TPRHelix, CPRHelix, Straight, KKLoopHelix,KKCentralHelix,KKLine, APRHelix, MPRHelix, AmbFitDir, //26
+    MCSeed=31, //31
+    };
 
     // functions needed for the BitMap template
     static std::string const& typeName();

--- a/RecoDataProducts/src/TrkFitDirection.cc
+++ b/RecoDataProducts/src/TrkFitDirection.cc
@@ -28,4 +28,15 @@ namespace mu2e
       }
     }
   }
+
+  TrkFitDirection::FitDirection TrkFitDirection::fitDirectionFromName(std::string name) {
+    TrkFitDirection::FitDirection fdir(TrkFitDirection::FitDirection::unknown);
+    // convert to lowercase to protect against case-based issues
+    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c){ return std::tolower(c); });
+
+    if     (name == "downstream") fdir = TrkFitDirection::FitDirection::downstream;
+    else if(name == "upstream"  ) fdir = TrkFitDirection::FitDirection::upstream;
+    return fdir;
+  }
+
 }

--- a/RecoDataProducts/src/TrkFitFlag.cc
+++ b/RecoDataProducts/src/TrkFitFlag.cc
@@ -47,6 +47,7 @@ namespace mu2e {
       bitnames[std::string("KKCentralHelix")]     = bit_to_mask(KKCentralHelix);
       bitnames[std::string("KKLine")]             = bit_to_mask(KKLine);
       bitnames[std::string("MCSeed")]             = bit_to_mask(MCSeed);
+      bitnames[std::string("AmbiguousFitDir")]    = bit_to_mask(AmbFitDir);
     }
     return bitnames;
   }

--- a/TrkFilters/src/HelixFilter_module.cc
+++ b/TrkFilters/src/HelixFilter_module.cc
@@ -126,13 +126,14 @@ namespace mu2e
         float lambda     = std::fabs(Helix.helix().lambda());
         float nLoops     = helTool.nLoops();
         float hRatio     = helTool.hitRatio();
-        const float slope    = Helix.recoDir().slope();
-        const float slopeErr = std::fabs(Helix.recoDir().slopeErr());
-        const float slopeSig = (slopeErr > 0.f) ? slope/slopeErr : 0.f;
+        const float slope          = Helix.recoDir().slope();
+        const float slopeErr       = std::fabs(Helix.recoDir().slopeErr());
+        const float slopeSignedSig = (slopeErr > 0.f) ? slope/slopeErr : 0.f; //signifance from 0 signed by the slope direction
 
         if(Debug > 2){
-          std::cout << "[HelixFilter] : status = " << Helix.status() << " nhits = " << nstrawhits << " mom = " << hmom << std::endl;
-          std::cout << "[HelixFilter] : chi2XY = " << chi2XY << " chi2ZPHI = " << chi2PhiZ << " d0 = " << d0 << " lambda = "<< lambda << " nLoops = " << nLoops << " hRatio = "<< hRatio << std::endl;
+          std::cout << "[HelixFilter] : status = " << Helix.status() << " nhits = " << nstrawhits << " mom = " << hmom << std::endl
+                    << "[HelixFilter] : chi2XY = " << chi2XY << " chi2ZPHI = " << chi2PhiZ << " d0 = " << d0 << " lambda = "<< lambda
+                    << " nLoops = " << nLoops << " hRatio = "<< hRatio << " slopeSignedSig = " << slopeSignedSig << std::endl;
         }
         if( Helix.status().hasAllProperties(_goodh)      &&
             (!_hascc || Helix.caloCluster().isNonnull()) &&
@@ -148,8 +149,8 @@ namespace mu2e
             nLoops     >= _minnloops     &&
             hmom       >= _minmom        &&
             hmom       <= _maxmom        &&
-            (!_useSlopeSigMin || slopeSig > _slopeSigMin) &&
-            (!_useSlopeSigMax || slopeSig < _slopeSigMax) &&
+            (!_useSlopeSigMin || slopeSignedSig > _slopeSigMin) &&
+            (!_useSlopeSigMax || slopeSignedSig < _slopeSigMax) &&
             hRatio     >= _minHitRatio ) {
           //now check if we want to prescake or not
           if (_prescaleUsingD0Phi) {

--- a/TrkFilters/src/KalSeedFilter_module.cc
+++ b/TrkFilters/src/KalSeedFilter_module.cc
@@ -36,7 +36,7 @@ namespace mu2e
       fhicl::Atom<bool>               doParticleTypeCheck {     Name("doParticleTypeCheck"),     Comment("doParticleTypeCheck")};
       fhicl::Atom<int>                fitparticle         {     Name("fitparticle"),             Comment("fitparticle       ") };
       fhicl::Atom<bool>               doZPropDirCheck     {     Name("doZPropDirCheck"),         Comment("doZPropDirCheck   ") };
-      fhicl::Atom<int>                fitdirection        {     Name("fitdirection"),            Comment("fitdirection      ") };
+      fhicl::Atom<std::string>        fitdirection        {     Name("fitdirection"),            Comment("fitdirection (\"downstream\" or \"upstream\")") };
       fhicl::Atom<double>             minFitCons          {     Name("minFitCons"),              Comment("minFitCons        ") };
       fhicl::Atom<double>             minNHits            {     Name("minNStrawHits"),           Comment("minNStrawHits     ") };
       fhicl::Atom<double>             minMomentum         {     Name("minMomentum"),             Comment("minMomentum       ") };
@@ -55,7 +55,7 @@ namespace mu2e
       KalSeedCutsTool(const KalSeedCutsConfig& config):
         _hascc     (config.requireCaloCluster()),
         _tpart     ((PDGCode::type)config.fitparticle()),
-        _fdir      ((TrkFitDirection::FitDirection)config.fitdirection()),
+        _fdir      (TrkFitDirection::fitDirectionFromName(config.fitdirection())),
         _minfitcons(config.minFitCons()),
         _minnhits  (config.minNHits()),
         _minmom    (config.minMomentum()),

--- a/TrkPatRec/fcl/Particle.fcl
+++ b/TrkPatRec/fcl/Particle.fcl
@@ -2,8 +2,8 @@ BEGIN_PROLOG
 
 # fit directions
 FitDir : {
-  downstream : 0
-  upstream : 1
+  downstream : "downstream"
+  upstream : "upstream"
 }
 
 #NB: fcl doesn't allow underscores in parameter names


### PR DESCRIPTION
This adds the option to use the helix seed slope's significance to decide the fit direction (downstream vs. upstream) to assume in the LoopHelixFit. In the case the slope isn't very significant, both fit directions are fit and the p(chi^2) results are compared. The goal of this option is to fit downstream and upstream tracks in a single LoopHelixFit instance, producing a single output track collection where each helix seed corresponds to at most one track direction hypothesis (there can still be different track mass hypothesis collections).

In the ambiguous fit direction case where a calo-hit is included in one fit result but not the other hypothesis fit result, the fit that included the calo-hit is taken instead. This recovers a significant fraction of incorrectly selected CE- and CE+ direction tracks without additional loss.

I additionally added the option to cut on the helix slope significance when fitting a fixed direction hypothesis, skipping helix seeds with a helix slope that is unlikely to correspond to the fit direction hypothesis. This configuration can then be used in the trigger, to not waste time fitting tracks that are unlikely to match the fit hypothesis.

The current update does not change and default behavior. The next step would be investigating making CPR more fit hypothesis agnostic, which a Yale undergrad will look into, at which point we would be able to use this update to merge the De (Dmu) and Ue (Umu) reconstruction paths into a single Electron (Muon) reconstruction path.

An example fcl file to process events with this configuration is here:
`/exp/mu2e/app/users/mmackenz/Yale/trigger/helix_slope/test.fcl`