### PR TITLE
Add CRY and CORSIKA to GenId::isCosmic()

### DIFF
--- a/MCDataProducts/inc/GenId.hh
+++ b/MCDataProducts/inc/GenId.hh
@@ -110,7 +110,7 @@ namespace mu2e {
     }
 
     bool isCosmic() const {
-      return (_id == cosmicToy || _id == cosmicDYB || _id == cosmic);
+      return (_id == cosmicToy || _id == cosmicDYB || _id == cosmic || _id == cosmicCRY || _id == cosmicCORSIKA);
     }
 
     bool isConversion() const {


### PR DESCRIPTION
In Mu2e/EventNtuple#247, we were missing the CORSIKA GenId from a check. I noticed that a function ```GenId::isCosmic()``` already exists and so instead of expanding the list in EventNtuple, I have expanded the list here.

A few brief notes:
* I notice that ```isCosmic``` isn't used anywhere in Offline but I have now added a call in RooUtil
* the ```isConversion``` will not work on centrally-produced samples since we now generate conversion from stopped muons
* the the next release of EventNtuple is now tied to a new release of Offline.