### PR TITLE
registered CRV mother volumes

### DIFF
--- a/CRVReco/src/CrvPedestalFinder_module.cc
+++ b/CRVReco/src/CrvPedestalFinder_module.cc
@@ -83,7 +83,7 @@ namespace mu2e
         size_t channelIndex=barIndex*4 + SiPM;
         _pedestalHists.emplace_back(tfs->make<TH1F>(Form("crvPedestalHist_%lu",channelIndex),
                                                     Form("crvPedestalHist_%lu",channelIndex),
-                                                    200,-50,150));   //TODO: needs to be only between -50 and +50, but Offline currently sets the pedestal at +100
+                                                    201,-50.5,150.5));   //TODO: needs to be only between -50 and +50, but Offline currently sets the pedestal at +100
         _timeOffsets[channelIndex]=0;
       }
     }

--- a/Mu2eG4/src/constructCRV.cc
+++ b/Mu2eG4/src/constructCRV.cc
@@ -252,6 +252,12 @@ namespace mu2e
                                                             false);
       if(doSurfaceCheck) checkForOverlaps(motherPhysical, _config, verbosityLevel>0);
 
+      VolumeInfo info(motherSolid->GetName(),motherAirOffset,parent.centerInWorld);
+      info.solid  = motherSolid;
+      info.logical  = motherLogical;
+      info.physical  =  motherPhysical;
+      _helper.addVolInfo(info);
+
       /************************************************************************************/
       /**** mother solid for individual scintillator/aluminum layers of the CRV sector ****/
       /************************************************************************************/


### PR DESCRIPTION
Up until now, we used cut boxes around the CRV modules to create regions where certain cuts are applied. We would like to move away from this approach as it is difficult to maintain for different setups (full geometry, KPP, Wideband). The first step was the Production PR 393 which was just merged. The next step will be to apply smaller minimum range cuts to all CRV sectors. We would like to use the minRangeRegionCuts setting for this purpose. However, this setting requires, that the mother volumes of the CRV sectors are added to the Mu2eG4Helper. This is currently not the case, because the volumes of the CRV were constructed using basic Geant4 functions and not Offline's nestBox, nestTubs, ... functions. These nest functions add the volumes to the Mu2eG4Helper. This PR makes a small change to the construction of the CRV by adding the CRV mother volumes to the Mu2eG4Helper. The result has been tested by applying a much smaller minRangeRegionCuts to the CRV sectors. The picture below shows that the cosmic ray muon has no secondaries outside the CRV, but produces many small tracks inside the CRV (including the scintillator counters, aluminum sheets and strong back). 
![image](https://github.com/user-attachments/assets/6078358e-b3bd-4bab-8fd0-08ffbfd73bfa)
