### PR TITLE
move to p071 for KinKal@3.1.6

### DIFF
--- a/.muse
+++ b/.muse
@@ -1,5 +1,5 @@
 # prefer to build with this environment
-ENVSET p068
+ENVSET p071
 # add Offline/bin to path
 PATH bin
 # recent commits can take enforce these flags


### PR DESCRIPTION
Compared to the current head (p068), this envset (p071) adds artdaq-core-mu2e@v3_05_00 and KinKal@3.1.6.
The PR for p070 can be closed.
This envset has been minimally tested locally against heads plus #1429 and appears OK.
