### PR TITLE
Add CAPHRI digi count to lumi stream output

### DIFF
--- a/CaloReco/src/CaloHitMakerFast_module.cc
+++ b/CaloReco/src/CaloHitMakerFast_module.cc
@@ -151,6 +151,7 @@ namespace mu2e {
 
        intInfo.setCaloEnergy(evtEnergy);
        intInfo.setNCaloHits(pulseMap.size());
+       intInfo.setNCaphriHits(caphriHitsColl.size());
 
        if ( diagLevel_ > 0 ) std::cout<<"[CaloHitMakerFast] extracted "<<caloHitsColl.size()<<" CaloDigis"<<std::endl;
        if ( diagLevel_ > 0 ) std::cout<<"[CaloHitMakerFast] extracted "<<caphriHitsColl.size()<<" CapriDigis"<<std::endl;

--- a/DAQ/src/CaloHitsFromDataDecoders_module.cc
+++ b/DAQ/src/CaloHitsFromDataDecoders_module.cc
@@ -237,6 +237,7 @@ void art::CaloHitsFromDataDecoders::produce(Event& event) {
 
   int_info->setCaloEnergy(evtEnergy);
   int_info->setNCaloHits(calo_hits->size());
+  int_info->setNCaphriHits(caphri_hits->size());
   event.put(std::move(int_info));
 
   // Store the calo hits in the event

--- a/RecoDataProducts/inc/IntensityInfoCalo.hh
+++ b/RecoDataProducts/inc/IntensityInfoCalo.hh
@@ -13,20 +13,23 @@ namespace mu2e {
   {
   public:
     IntensityInfoCalo() {}
-    IntensityInfoCalo( unsigned short nCaloHits, unsigned short caloEnergy):
-      nCaloHits_(nCaloHits),caloEnergy_(caloEnergy)
+    IntensityInfoCalo( unsigned short nCaloHits, unsigned short caloEnergy, unsigned short nCaphriHits):
+      nCaloHits_(nCaloHits),caloEnergy_(caloEnergy),nCaphriHits_(nCaphriHits)
     {}
 
 
     void setNCaloHits      (unsigned short tmp) {nCaloHits_    = tmp;}
     void setCaloEnergy     (unsigned short tmp) {caloEnergy_   = tmp;}
+    void setNCaphriHits    (unsigned short tmp) {nCaphriHits_  = tmp;}
 
     unsigned short nCaloHits    () const { return nCaloHits_   ; }
     unsigned short caloEnergy   () const { return caloEnergy_  ; }
+    unsigned short nCaphriHits  () const { return nCaphriHits_ ; }
 
   private:
     unsigned short  nCaloHits_    = 0;
     unsigned short  caloEnergy_   = 0;
+    unsigned short  nCaphriHits_  = 0;
   };
 }
 


### PR DESCRIPTION
Add the CAPHRI digi count to the calorimeter intensity info object for the luminosity stream output.