### PR TITLE
Add process dependence to lognormal PBI simulation

### DIFF
--- a/EventMixing/src/ProtonBunchIntensityLogNormal_module.cc
+++ b/EventMixing/src/ProtonBunchIntensityLogNormal_module.cc
@@ -121,17 +121,24 @@ namespace mu2e {
     auto pph = event.getValidHandle<PrimaryParticle>(pp_);
     auto const& pp = *pph;
     double res=cutMax_; // force to enter the loop
+    unsigned ntries(0);
     if(ProcessCode::isFromProtonBeam(pp.primaryProcess())){
+      if(debug_ > 1)std::cout << "Beam-based primary: sampling x lognormal(x)" << std::endl;
       // these primaries are biased in that their production is proporitional to the PBI. In this case, sample X * lognormal(X)
       while( (res < cutMin_) || (cutMax_ <= res) ) {
+        ++ntries;
         res = xLogNormalCDFInverse(unitflatd_(urbg_));
       }
+
     } else {
+      if(debug_ > 1)std::cout << "Non-beam-based primary: lognormal(x)" << std::endl;
       // primaries unrelated to beam protons scale as lognormal(X)
       while( (res < cutMin_) || (cutMax_ <= res) ) {
+        ++ntries;
         res = lognd_(urbg_);
       }
     }
+    if(debug_ > 1)std::cout << "PBI = " << res << " required " << ntries << " tries"  << std::endl;
 
     // convert to nearest ingeger and write out
     event.put(std::make_unique<ProtonBunchIntensity>(static_cast<unsigned long long>(llrint(res))));

--- a/MCDataProducts/inc/ProcessCode.hh
+++ b/MCDataProducts/inc/ProcessCode.hh
@@ -39,6 +39,7 @@ namespace mu2e {
     // Need to keep the enum and the _name member in sync.
     // Add new elements just before lastEnum; do not insert new elements
     // prior to this - it will break backwards compatibility.
+    // if you add a new beam process (from stopped muons or pions) please update the isFromProtonBeam function
     enum enum_type {
       unknown,                AlphaInelastic,          annihil,             AntiLambdaInelastic, // 3
       AntiNeutronInelastic,   AntiOmegaMinusInelastic, AntiProtonInelastic, AntiSigmaMinusInelastic, // 7
@@ -231,6 +232,9 @@ namespace mu2e {
     bool isValid() const{
       return isValid(_id);
     }
+
+    // return true if this process originated with a beam proton
+    static bool isFromProtonBeam(const ProcessCode& pcode);
 
 #ifndef SWIG
     // List of names corresponding to the enum.

--- a/MCDataProducts/src/ProcessCode.cc
+++ b/MCDataProducts/src/ProcessCode.cc
@@ -56,5 +56,34 @@ namespace mu2e {
     return codes;
   }
 
+  bool ProcessCode::isFromProtonBeam(const ProcessCode& pcode) {
+    static std::vector<ProcessCode::enum_type> pbeamcodes = {
+      ProcessCode::mu2eMuonCaptureAtRest,
+      ProcessCode::mu2eMuonCaptureAtRest,
+      ProcessCode::mu2eMuonDecayAtRest,
+      ProcessCode::mu2eCeMinusEndpoint,
+      ProcessCode::mu2eCeMinusLeadingLog,
+      ProcessCode::mu2eCePlusEndpoint,
+      ProcessCode::mu2eDIOLeadingLog,
+      ProcessCode::mu2eInternalRMC,
+      ProcessCode::mu2eExternalRMC,
+      ProcessCode::mu2eFlateMinus,
+      ProcessCode::mu2eFlatePlus,
+      ProcessCode::mu2eFlatPhoton,
+      ProcessCode::mu2eCePlusLeadingLog,
+      ProcessCode::mu2ePionCaptureAtRest,
+      ProcessCode::mu2eExternalRPC,
+      ProcessCode::mu2eInternalRPC,
+      ProcessCode::mu2eCaloCalib,
+      ProcessCode::mu2ePienu,
+      ProcessCode::mu2eGammaConversion,
+      ProcessCode::mu2eAntiproton };
+    for(auto pbeamcode : pbeamcodes){
+      if(pcode._id == pbeamcode) return true;
+    }
+    return false;
+  }
+
+
 
 }


### PR DESCRIPTION
Use the correct PBI distribution depending on whether the primary particle came from a beam proton or not.