### PR TITLE
Improvements to the PhiClusterFinder

### DIFF
--- a/CalPatRec/fcl/prolog.fcl
+++ b/CalPatRec/fcl/prolog.fcl
@@ -692,7 +692,7 @@ CalPatRec : { @table::CalPatRec
              #TimeClusterCollection  : "TimeClusterFinderDmu"
              diag                   : 0
              debug                  : 0
-             minNSH                 : 5
+             minNSH                 : 10
              threshold              : 1 # 4
              nPhiClusters           : 40
              phiMin                 : 0.0


### PR DESCRIPTION
1. Added a provision to use the input time cluster itself if the PhiClusterFinder fails to find any or less time clusters than the input time cluster collection.
2. Improved the function which checks the delta phi between the phi clusters. In the previous iteration, it was only checking delta phi in the events where there were specifically just two phi clusters. 
3. Sometimes, hits of a single track form two phi clusters with a separation of < 1.5 rad (threshold delta phi, at the moment) and neither of the clusters have enough hits to form a good time cluster. In these cases, we merge the two phi clusters.

Note: I think I'm the sole user of this algorithm at the moment. I made these improvements as the algorithm is still a relevant part of my thesis. Also, we (Pasha and I) have more PRs coming up. So, this serves as a good test PR.