### PR TITLE
Add lumi stream compression module, add CFO fragment --> event header

### DIFF
--- a/DAQ/CMakeLists.txt
+++ b/DAQ/CMakeLists.txt
@@ -25,8 +25,14 @@ cet_build_plugin(ProcessDTCAndCFOEvents art::module
     REG_SOURCE src/ProcessDTCAndCFOEvents_module.cc
     LIBRARIES REG
       Offline::DAQ
-
 )
+
+cet_build_plugin(EventHeaderFromCFOFragment art::module
+    REG_SOURCE src/EventHeaderFromCFOFragment_module.cc
+    LIBRARIES REG
+      Offline::DAQ
+)
+    
 
 cet_build_plugin(CaloHitsFromDataDecoders art::module
     REG_SOURCE src/CaloHitsFromDataDecoders_module.cc
@@ -81,6 +87,20 @@ cet_build_plugin(DataDecodersAna art::module
       Offline::DAQ
       Offline::DataProducts
       ROOT::Hist
+)
+
+cet_build_plugin(DummyLumiInfoProducer art::module
+    REG_SOURCE src/DummyLumiInfoProducer_module.cc
+    LIBRARIES REG
+      Offline::DAQ
+      Offline::RecoDataProducts
+)
+
+cet_build_plugin(LumiStreamFilter art::module
+    REG_SOURCE src/LumiStreamFilter_module.cc
+    LIBRARIES REG
+      Offline::DAQ
+      Offline::RecoDataProducts
 )
 
 cet_build_plugin(PrefetchDAQData art::module

--- a/DAQ/src/DummyLumiInfoProducer_module.cc
+++ b/DAQ/src/DummyLumiInfoProducer_module.cc
@@ -1,0 +1,82 @@
+// Generate an example lumi stream information for DAQ development
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "fhiclcpp/ParameterSet.h"
+
+#include "Offline/RecoDataProducts/inc/IntensityInfoCalo.hh"
+#include "Offline/RecoDataProducts/inc/IntensityInfoTimeCluster.hh"
+#include "Offline/RecoDataProducts/inc/IntensityInfoTrackerHits.hh"
+
+#include <iostream>
+
+namespace mu2e
+{
+
+  class DummyLumiInfoProducer : public art::EDProducer
+  {
+  public:
+    struct Config
+    {
+      fhicl::Atom<int> diagLevel{fhicl::Name("diagLevel"), fhicl::Comment("diagnostic Level"), 0};
+      fhicl::Atom<int> simMode{fhicl::Name("simMode"), fhicl::Comment("Simulation mode: 0 = all zeros; 1 = non-zero values"), 0};
+    };
+
+    explicit DummyLumiInfoProducer(const art::EDProducer::Table<Config>& config);
+    virtual void produce(art::Event& event) override;
+
+  private:
+    int   _diagLevel;
+    int   _simMode;
+  };
+
+  DummyLumiInfoProducer::DummyLumiInfoProducer(const art::EDProducer::Table<Config>& config) :
+    art::EDProducer{config}
+    , _diagLevel(config().diagLevel())
+    , _simMode(config().simMode())
+  {
+    produces<mu2e::IntensityInfoCalo       >();
+    produces<mu2e::IntensityInfoTimeCluster>();
+    produces<mu2e::IntensityInfoTrackerHits>();
+  }
+
+  void DummyLumiInfoProducer::produce(art::Event& event)
+  {
+    const art::EventNumber_t  eventNumber  = event.event ();
+    const art::SubRunNumber_t subrunNumber = event.subRun();
+    const art::RunNumber_t    runNumber    = event.run   ();
+
+    if(_diagLevel > 1) std::cout << "DummyLumiInfoProducer::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber << std::endl;
+
+    //---------------------------------------
+    // Create example data
+
+    auto caloInfo        = std::unique_ptr<mu2e::IntensityInfoCalo       >(new mu2e::IntensityInfoCalo       );
+    auto timeClusterInfo = std::unique_ptr<mu2e::IntensityInfoTimeCluster>(new mu2e::IntensityInfoTimeCluster);
+    auto trackerInfo     = std::unique_ptr<mu2e::IntensityInfoTrackerHits>(new mu2e::IntensityInfoTrackerHits);
+
+    // Assign non-zero entries for harder compression
+    if(_simMode == 1) {
+      const static int prime_1(17), prime_2(251), prime_3(503), prime_4(1523); //for distributing values somewhat evenly
+      caloInfo->setNCaloHits  ((eventNumber * prime_2) % (prime_3));
+      caloInfo->setCaloEnergy ((eventNumber * prime_1) % (prime_2));
+      caloInfo->setNCaphriHits((eventNumber * prime_3) % (prime_1));
+
+      timeClusterInfo->setNProtonTCs((eventNumber * prime_1) % (prime_2));
+
+      trackerInfo->setNTrackerHits((eventNumber * prime_1) % (prime_4));
+    }
+
+    // Add the intensity info to the event
+    event.put(std::move(caloInfo));
+    event.put(std::move(timeClusterInfo));
+    event.put(std::move(trackerInfo));
+
+  } //produce
+
+} //namespace mu2e
+
+using mu2e::DummyLumiInfoProducer;
+DEFINE_ART_MODULE(DummyLumiInfoProducer)

--- a/DAQ/src/EventHeaderFromCFOFragment_module.cc
+++ b/DAQ/src/EventHeaderFromCFOFragment_module.cc
@@ -1,0 +1,107 @@
+// ======================================================================
+//
+// Add EventHeader to the event from CFO_Events
+//
+// ======================================================================
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "fhiclcpp/ParameterSet.h"
+
+#include "art/Framework/Principal/Handle.h"
+#include <artdaq-core-mu2e/Data/EventHeader.hh>
+#include "artdaq-core-mu2e/Overlays/CFOEventFragment.hh"
+#include "artdaq-core-mu2e/Overlays/FragmentType.hh"
+
+#include <artdaq-core/Data/Fragment.hh>
+
+#include <iostream>
+
+#include <string>
+
+#include <array>
+#include <list>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "trace.h"
+#define TRACE_NAME "Mu2eSubEventReceiver"
+
+namespace art {
+class EventHeaderFromCFOFragment;
+}
+
+// ======================================================================
+
+class art::EventHeaderFromCFOFragment : public EDProducer {
+
+public:
+  struct Config {
+    fhicl::Atom<art::InputTag> cfoTag   {fhicl::Name("cfoTag"),    fhicl::Comment("Input module")};
+    fhicl::Atom<int>           diagLevel{fhicl::Name("diagLevel"), fhicl::Comment("diagnostic level")};
+  };
+
+  // --- C'tor/d'tor:
+  explicit EventHeaderFromCFOFragment(const art::EDProducer::Table<Config>& config);
+  ~EventHeaderFromCFOFragment() override {}
+
+  void beginRun(art::Run&) override;
+
+  // --- Production:
+  void produce(Event&) override;
+
+private:
+  art::InputTag cfoFragmentTag_;
+  int           diagLevel_;
+};
+
+// ======================================================================
+
+void art::EventHeaderFromCFOFragment::beginRun(art::Run& Run) {}
+
+art::EventHeaderFromCFOFragment::EventHeaderFromCFOFragment(
+    const art::EDProducer::Table<Config>& config) :
+    art::EDProducer{config},
+    cfoFragmentTag_(config().cfoTag()),
+    diagLevel_(config().diagLevel()) {
+  produces<mu2e::EventHeader>();
+}
+
+// ----------------------------------------------------------------------
+
+void art::EventHeaderFromCFOFragment::produce(Event& event) {
+
+  // Collection of CaloHits for the event
+  std::unique_ptr<mu2e::EventHeader> evtHdr(new mu2e::EventHeader);
+  art::Handle<artdaq::Fragments>     cfoFragmentHandle;
+
+  if(!event.getByLabel(cfoFragmentTag_, cfoFragmentHandle)) {
+    event.put(std::move(evtHdr));
+    TLOG(TLVL_DEBUG) << "No CFO fragments found";
+    return;
+  }
+
+  const auto *fragments = cfoFragmentHandle.product();
+  if (fragments->size()>0){
+    const auto &frag = fragments->at(0);
+    mu2e::CFOEventFragment   cfoFrag(frag);
+    const CFOLib::CFO_Event  cfo = cfoFrag.getData();
+    //const CFO_EventRecord&   cfoRecord = cfo.GetEventRecord();
+    evtHdr->mode  = 0;//cfo.GetEventMode();
+    evtHdr->ewt   = static_cast<long unsigned int>(cfo.GetEventWindowTag().GetEventWindowTag().to_ullong());
+    evtHdr->flags = cfo.GetEventMode().isOnSpillFlagSet();
+    TLOG(TLVL_DEBUG+20) << "mode = "<< evtHdr->mode <<" ewt  = "<< evtHdr->ewt << " flags = " << evtHdr->flags;
+  }else {
+    TLOG(TLVL_DEBUG) << "No CFO fragments found in the event";
+  }
+
+  event.put(std::move(evtHdr));
+} // produce()
+
+// ======================================================================
+
+DEFINE_ART_MODULE(art::EventHeaderFromCFOFragment)
+
+// ======================================================================

--- a/DAQ/src/LumiStreamFilter_module.cc
+++ b/DAQ/src/LumiStreamFilter_module.cc
@@ -1,0 +1,226 @@
+// Collect lumi stream information and write it out at lower frequency in subruns (and potentially events)
+
+#include "art/Framework/Core/EDFilter.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/OptionalAtom.h"
+#include "fhiclcpp/ParameterSet.h"
+
+#include "Offline/RecoDataProducts/inc/IntensityInfoCalo.hh"
+#include "Offline/RecoDataProducts/inc/IntensityInfoTimeCluster.hh"
+#include "Offline/RecoDataProducts/inc/IntensityInfoTrackerHits.hh"
+
+#include <iostream>
+
+namespace mu2e
+{
+
+  class LumiStreamFilter : public art::EDFilter
+  {
+  public:
+    struct Config
+    {
+      fhicl::Atom<int>                   diagLevel{fhicl::Name("diagLevel"), fhicl::Comment("diagnostic Level"), 0};
+      fhicl::OptionalAtom<art::InputTag> caloTag{fhicl::Name("caloTag"), fhicl::Comment("Calo intensity info Tag")};
+      fhicl::OptionalAtom<art::InputTag> timeClusterTag{fhicl::Name("timeClusterTag"), fhicl::Comment("Time cluster intensity info Tag")};
+      fhicl::OptionalAtom<art::InputTag> trackerTag{fhicl::Name("trackerTag"), fhicl::Comment("Tracker intensity info Tag")};
+      fhicl::OptionalAtom<int>           eventFreq{fhicl::Name("eventFreq"), fhicl::Comment("Frequency of event data product writing, defaulting to sub-runs if not set")};
+    };
+
+    explicit LumiStreamFilter(const art::EDFilter::Table<Config>& config);
+    virtual bool filter(art::Event& event) override;
+    virtual bool endSubRun(art::SubRun& sr ) override;
+
+  private:
+    int                                      _diagLevel;
+    art::InputTag                            _caloTag;
+    bool                                     _useCalo;
+    art::InputTag                            _timeClusterTag;
+    bool                                     _useTimeCluster;
+    art::InputTag                            _trackerTag;
+    bool                                     _useTracker;
+    int                                      _eventFreq;
+    bool                                     _useSubruns;
+    long                                     _eventCount;
+
+    std::unique_ptr<mu2e::IntensityInfosCalo>         _caloInfos;
+    std::unique_ptr<mu2e::IntensityInfosTimeCluster>  _timeClusterInfos;
+    std::unique_ptr<mu2e::IntensityInfosTrackerHits>  _trackerInfos;
+
+  };
+
+  LumiStreamFilter::LumiStreamFilter(const art::EDFilter::Table<Config>& config) :
+    art::EDFilter{config}
+    , _diagLevel(config().diagLevel())
+    , _useCalo(config().caloTag(_caloTag))
+    , _useTimeCluster(config().timeClusterTag(_timeClusterTag))
+    , _useTracker(config().trackerTag(_trackerTag))
+    , _useSubruns(config().eventFreq(_eventFreq))
+    , _eventCount(0)
+    , _caloInfos(nullptr)
+    , _timeClusterInfos(nullptr)
+    , _trackerInfos(nullptr)
+  {
+    if(_diagLevel > 0) {
+      std::cout << "LumiStreamFilter::" << __func__ << ": Configured with:\n eventFreq = " << _eventFreq << std::endl;
+      std::cout << " useCalo = " << _useCalo;
+      if(_useCalo) std::cout << " (" << _caloTag.encode().c_str() << ")";
+      std::cout << std::endl;
+      std::cout << " useTimeCluster = " << _useTimeCluster;
+      if(_useTimeCluster) std::cout << " (" << _timeClusterTag.encode().c_str() << ")";
+      std::cout << std::endl;
+      std::cout << " useTracker = " << _useTracker;
+      if(_useTracker) std::cout << " (" << _trackerTag.encode().c_str() << ")";
+      std::cout << std::endl;
+    }			 
+
+    if(_useCalo) {
+      _caloInfos = std::unique_ptr<mu2e::IntensityInfosCalo>(new mu2e::IntensityInfosCalo);
+      produces<mu2e::IntensityInfosCalo>();
+      produces<mu2e::IntensityInfosCalo, art::InSubRun>();
+    }
+    if(_useTimeCluster) {
+      _timeClusterInfos = std::unique_ptr<mu2e::IntensityInfosTimeCluster>(new mu2e::IntensityInfosTimeCluster);
+      produces<mu2e::IntensityInfosTimeCluster>();
+      produces<mu2e::IntensityInfosTimeCluster, art::InSubRun>();
+    }
+    if(_useTracker) {
+      _trackerInfos = std::unique_ptr<mu2e::IntensityInfosTrackerHits>(new mu2e::IntensityInfosTrackerHits);
+      produces<mu2e::IntensityInfosTrackerHits>();
+      produces<mu2e::IntensityInfosTrackerHits, art::InSubRun>();
+    }
+    if(_useSubruns) _eventFreq = 0;
+    else {
+      if(_caloInfos       ) _caloInfos       ->reserve(_eventFreq);
+      if(_timeClusterInfos) _timeClusterInfos->reserve(_eventFreq);
+      if(_trackerInfos    ) _trackerInfos    ->reserve(_eventFreq);
+    }
+  }
+
+  bool LumiStreamFilter::endSubRun(art::SubRun& sr ) {
+    art::SubRunNumber_t subrunNumber = sr.subRun();
+    art::RunNumber_t    runNumber    = sr.run   ();
+    if(_diagLevel > 0) std::cout << "LumiStreamFilter::" << __func__ << ": Subrun " << runNumber << ":" << subrunNumber
+				  << ": Writing out the accumulated intensity info collections from " << _eventCount << " events\n";
+
+    // Add the data to the subrun
+    if(_caloInfos       ) sr.put(std::move(_caloInfos       ), art::fullSubRun());
+    if(_timeClusterInfos) sr.put(std::move(_timeClusterInfos), art::fullSubRun());
+    if(_trackerInfos    ) sr.put(std::move(_trackerInfos    ), art::fullSubRun());
+
+    // Initialize new collections
+    if(_caloInfos       ) _caloInfos        = std::unique_ptr<mu2e::IntensityInfosCalo       >(new mu2e::IntensityInfosCalo       );
+    if(_timeClusterInfos) _timeClusterInfos = std::unique_ptr<mu2e::IntensityInfosTimeCluster>(new mu2e::IntensityInfosTimeCluster);
+    if(_trackerInfos    ) _trackerInfos     = std::unique_ptr<mu2e::IntensityInfosTrackerHits>(new mu2e::IntensityInfosTrackerHits);
+
+    return true;
+  }
+
+  bool LumiStreamFilter::filter(art::Event& event)
+  {
+    ++_eventCount; // increment the event counter
+
+    // for printout use
+    const art::EventNumber_t  eventNumber  = event.event ();
+    const art::SubRunNumber_t subrunNumber = event.subRun();
+    const art::RunNumber_t    runNumber    = event.run   ();
+
+    if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Begin processing Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+				 << std::endl;
+    //---------------------------------------
+    // Retrieve the data
+
+    if(_useCalo) {
+      art::Handle<mu2e::IntensityInfoCalo> caloH;
+      if(!event.getByLabel(_caloTag, caloH) || !caloH.product()) {
+	std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+		  << ": Calo intensity object not found!\n";
+	_caloInfos->push_back(mu2e::IntensityInfoCalo()); // add an empty one to maintain the list alignment
+      } else {
+	const auto caloInfo = caloH.product();
+	_caloInfos->push_back(mu2e::IntensityInfoCalo(*caloInfo));
+	if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+				     << ": Retrieved calo information\n";
+      }
+    }
+
+    if(_useTimeCluster) {
+      art::Handle<mu2e::IntensityInfoTimeCluster> timeClusterH;
+      if(!event.getByLabel(_timeClusterTag, timeClusterH) || !timeClusterH.product()) {
+	std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+		  << ": Time cluster intensity object not found!\n";
+	_timeClusterInfos->push_back(mu2e::IntensityInfoTimeCluster()); // add an empty one to maintain the list alignment
+      } else {
+	const auto timeClusterInfo = timeClusterH.product();
+	_timeClusterInfos->push_back(mu2e::IntensityInfoTimeCluster(*timeClusterInfo));
+	if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+				     << ": Retrieved time cluster information\n";
+      }
+    }
+
+    if(_useTracker) {
+      art::Handle<mu2e::IntensityInfoTrackerHits> trackerH;
+      if(!event.getByLabel(_trackerTag, trackerH) || !trackerH.product()) {
+	std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+		  << ": Tracker intensity object not found!\n";
+	_trackerInfos->push_back(mu2e::IntensityInfoTrackerHits()); // add an empty one to maintain the list alignment
+      } else {
+	const auto trackerInfo = trackerH.product();
+	_trackerInfos->push_back(mu2e::IntensityInfoTrackerHits(*trackerInfo));
+	if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+				     << ": Retrieved tracker information\n";
+      }
+    }
+
+    //---------------------------------------
+    // Write out the data if requested
+
+    const bool retval = _eventFreq > 0 && (_eventCount % _eventFreq == 0);
+    if(retval) {
+      if(_diagLevel > 0) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+				   << ": Writing out the accumulated intensity info collections from " << _eventCount << " events\n";
+
+      // Add the data to the event
+      if(_useCalo       ) event.put(std::move(_caloInfos       ));
+      if(_useTimeCluster) event.put(std::move(_timeClusterInfos));
+      if(_useTracker    ) event.put(std::move(_trackerInfos    ));
+
+      // Initialize new collections
+      if(_useCalo       ) _caloInfos        = std::unique_ptr<mu2e::IntensityInfosCalo       >(new mu2e::IntensityInfosCalo       );
+      if(_useTimeCluster) _timeClusterInfos = std::unique_ptr<mu2e::IntensityInfosTimeCluster>(new mu2e::IntensityInfosTimeCluster);
+      if(_useTracker    ) _trackerInfos     = std::unique_ptr<mu2e::IntensityInfosTrackerHits>(new mu2e::IntensityInfosTrackerHits);
+      if(!_useSubruns && _useCalo       ) _caloInfos       ->reserve(_eventFreq);
+      if(!_useSubruns && _useTimeCluster) _timeClusterInfos->reserve(_eventFreq);
+      if(!_useSubruns && _useTracker    ) _trackerInfos    ->reserve(_eventFreq);
+
+      // Reset the counter
+      _eventCount = 0;
+    } else { // add empty information in failed events
+      if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+				   << ": Adding empty intensity information to the event\n";
+      if(_useCalo) {
+	auto tmp_info = std::unique_ptr<mu2e::IntensityInfosCalo>(new mu2e::IntensityInfosCalo);
+	event.put(std::move(tmp_info));
+      }
+      if(_useTimeCluster) {
+	auto tmp_info = std::unique_ptr<mu2e::IntensityInfosTimeCluster>(new mu2e::IntensityInfosTimeCluster);
+	event.put(std::move(tmp_info));
+      }
+      if(_useTracker) {
+	auto tmp_info = std::unique_ptr<mu2e::IntensityInfosTrackerHits>(new mu2e::IntensityInfosTrackerHits);
+	event.put(std::move(tmp_info));
+      }
+    }
+
+    if(_diagLevel > 1) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+				 << ": Return value = " << retval << " for event count = " << _eventCount << " events\n";
+    return retval;
+  } //filter
+
+} //namespace mu2e
+
+using mu2e::LumiStreamFilter;
+DEFINE_ART_MODULE(LumiStreamFilter)

--- a/DAQ/src/LumiStreamFilter_module.cc
+++ b/DAQ/src/LumiStreamFilter_module.cc
@@ -91,7 +91,7 @@ namespace mu2e
       if(_useHeader) std::cout << " (" << _headerTag.encode().c_str() << ")";
       std::cout << " passFirst = " << _passFirst << std::endl;
       std::cout << std::endl;
-    }			 
+    }
 
     if(_useCalo) {
       _caloInfos = std::unique_ptr<mu2e::IntensityInfosCalo>(new mu2e::IntensityInfosCalo);
@@ -125,7 +125,7 @@ namespace mu2e
     art::SubRunNumber_t subrunNumber = sr.subRun();
     art::RunNumber_t    runNumber    = sr.run   ();
     if(_diagLevel > 0) std::cout << "LumiStreamFilter::" << __func__ << ": Subrun " << runNumber << ":" << subrunNumber
-				  << ": Writing out the accumulated intensity info collections from " << _eventCount << " events\n";
+                                  << ": Writing out the accumulated intensity info collections from " << _eventCount << " events\n";
 
     // Add the data to the subrun
     if(_useCalo       ) sr.put(std::move(_caloInfos       ), art::fullSubRun());
@@ -153,63 +153,63 @@ namespace mu2e
     const art::RunNumber_t    runNumber    = event.run   ();
 
     if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Begin processing Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-				 << std::endl;
+                                 << std::endl;
     //---------------------------------------
     // Retrieve the data
 
     if(_useCalo) {
       art::Handle<mu2e::IntensityInfoCalo> caloH;
       if(!event.getByLabel(_caloTag, caloH) || !caloH.product()) {
-	std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-		  << ": Calo intensity object not found!\n";
-	_caloInfos->push_back(mu2e::IntensityInfoCalo()); // add an empty one to maintain the list alignment
+        std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+                  << ": Calo intensity object not found!\n";
+        _caloInfos->push_back(mu2e::IntensityInfoCalo()); // add an empty one to maintain the list alignment
       } else {
-	const auto caloInfo = caloH.product();
-	_caloInfos->push_back(mu2e::IntensityInfoCalo(*caloInfo));
-	if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-				     << ": Retrieved calo information\n";
+        const auto caloInfo = caloH.product();
+        _caloInfos->push_back(mu2e::IntensityInfoCalo(*caloInfo));
+        if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+                                     << ": Retrieved calo information\n";
       }
     }
 
     if(_useTimeCluster) {
       art::Handle<mu2e::IntensityInfoTimeCluster> timeClusterH;
       if(!event.getByLabel(_timeClusterTag, timeClusterH) || !timeClusterH.product()) {
-	std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-		  << ": Time cluster intensity object not found!\n";
-	_timeClusterInfos->push_back(mu2e::IntensityInfoTimeCluster()); // add an empty one to maintain the list alignment
+        std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+                  << ": Time cluster intensity object not found!\n";
+        _timeClusterInfos->push_back(mu2e::IntensityInfoTimeCluster()); // add an empty one to maintain the list alignment
       } else {
-	const auto timeClusterInfo = timeClusterH.product();
-	_timeClusterInfos->push_back(mu2e::IntensityInfoTimeCluster(*timeClusterInfo));
-	if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-				     << ": Retrieved time cluster information\n";
+        const auto timeClusterInfo = timeClusterH.product();
+        _timeClusterInfos->push_back(mu2e::IntensityInfoTimeCluster(*timeClusterInfo));
+        if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+                                     << ": Retrieved time cluster information\n";
       }
     }
 
     if(_useTracker) {
       art::Handle<mu2e::IntensityInfoTrackerHits> trackerH;
       if(!event.getByLabel(_trackerTag, trackerH) || !trackerH.product()) {
-	std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-		  << ": Tracker intensity object not found!\n";
-	_trackerInfos->push_back(mu2e::IntensityInfoTrackerHits()); // add an empty one to maintain the list alignment
+        std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+                  << ": Tracker intensity object not found!\n";
+        _trackerInfos->push_back(mu2e::IntensityInfoTrackerHits()); // add an empty one to maintain the list alignment
       } else {
-	const auto trackerInfo = trackerH.product();
-	_trackerInfos->push_back(mu2e::IntensityInfoTrackerHits(*trackerInfo));
-	if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-				     << ": Retrieved tracker information\n";
+        const auto trackerInfo = trackerH.product();
+        _trackerInfos->push_back(mu2e::IntensityInfoTrackerHits(*trackerInfo));
+        if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+                                     << ": Retrieved tracker information\n";
       }
     }
 
     if(_useHeader) {
       art::Handle<mu2e::EventHeader> headerH;
       if(!event.getByLabel(_headerTag, headerH) || !headerH.product()) {
-	std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-		  << ": Event Header not found!\n";
-	_headers->push_back(mu2e::EventHeader()); // add an empty one to maintain the list alignment
+        std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+                  << ": Event Header not found!\n";
+        _headers->push_back(mu2e::EventHeader()); // add an empty one to maintain the list alignment
       } else {
-	const auto header = headerH.product();
-	_headers->push_back(mu2e::EventHeader(*header));
-	if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-				     << ": Retrieved Event Header\n";
+        const auto header = headerH.product();
+        _headers->push_back(mu2e::EventHeader(*header));
+        if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
+                                     << ": Retrieved Event Header\n";
       }
     }
 
@@ -219,7 +219,7 @@ namespace mu2e
     bool retval = _eventFreq > 0 && (_eventCount % _eventFreq == 0);
     if(retval) {
       if(_diagLevel > 0) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-				   << ": Writing out the accumulated intensity info collections from " << _eventCount << " events\n";
+                                   << ": Writing out the accumulated intensity info collections from " << _eventCount << " events\n";
 
       // Add the data to the event
       if(_useCalo       ) event.put(std::move(_caloInfos       ));
@@ -241,22 +241,22 @@ namespace mu2e
       _eventCount = 0;
     } else if(!_useSubruns) { // add empty information in failed events if writing into events
       if(_diagLevel > 2) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-				   << ": Adding empty intensity information to the event\n";
+                                   << ": Adding empty intensity information to the event\n";
       if(_useCalo) {
-	auto tmp_info = std::unique_ptr<mu2e::IntensityInfosCalo>(new mu2e::IntensityInfosCalo);
-	event.put(std::move(tmp_info));
+        auto tmp_info = std::unique_ptr<mu2e::IntensityInfosCalo>(new mu2e::IntensityInfosCalo);
+        event.put(std::move(tmp_info));
       }
       if(_useTimeCluster) {
-	auto tmp_info = std::unique_ptr<mu2e::IntensityInfosTimeCluster>(new mu2e::IntensityInfosTimeCluster);
-	event.put(std::move(tmp_info));
+        auto tmp_info = std::unique_ptr<mu2e::IntensityInfosTimeCluster>(new mu2e::IntensityInfosTimeCluster);
+        event.put(std::move(tmp_info));
       }
       if(_useTracker) {
-	auto tmp_info = std::unique_ptr<mu2e::IntensityInfosTrackerHits>(new mu2e::IntensityInfosTrackerHits);
-	event.put(std::move(tmp_info));
+        auto tmp_info = std::unique_ptr<mu2e::IntensityInfosTrackerHits>(new mu2e::IntensityInfosTrackerHits);
+        event.put(std::move(tmp_info));
       }
       if(_useHeader) {
-	auto tmp_info = std::unique_ptr<mu2e::EventHeaders>(new mu2e::EventHeaders);
-	event.put(std::move(tmp_info));
+        auto tmp_info = std::unique_ptr<mu2e::EventHeaders>(new mu2e::EventHeaders);
+        event.put(std::move(tmp_info));
       }
     }
 
@@ -265,7 +265,7 @@ namespace mu2e
     _firstInSubrun = false;
 
     if(_diagLevel > 1) std::cout << "LumiStreamFilter::" << __func__ << ": Event " << runNumber << ":" << subrunNumber << ":" << eventNumber
-				 << ": Return value = " << retval << " for event count = " << _eventCount << " events and event freq " << _eventFreq << std::endl;
+                                 << ": Return value = " << retval << " for event count = " << _eventCount << " events and event freq " << _eventFreq << std::endl;
     return retval;
   } //filter
 

--- a/DAQ/test/lumi_stream.fcl
+++ b/DAQ/test/lumi_stream.fcl
@@ -21,21 +21,21 @@ source : {
 physics : {
 
     producers : {
-	DummyLumiStream : {
-	    module_type : DummyLumiInfoProducer
-	    simMode     : 1
-	}
+        DummyLumiStream : {
+            module_type : DummyLumiInfoProducer
+            simMode     : 1
+        }
     }
 
     filters : {
-	LumiFilter : {
-	    module_type : LumiStreamFilter
-	    caloTag        : DummyLumiStream
-	    timeClusterTag : DummyLumiStream
-	    trackerTag     : DummyLumiStream
-	    # eventFreq      : 10000
-	    diagLevel      : 1
-	}
+        LumiFilter : {
+            module_type : LumiStreamFilter
+            caloTag        : DummyLumiStream
+            timeClusterTag : DummyLumiStream
+            trackerTag     : DummyLumiStream
+            # eventFreq      : 10000
+            diagLevel      : 1
+        }
     }
 
     t1 : [ DummyLumiStream, LumiFilter  ]
@@ -48,12 +48,12 @@ physics : {
 
 outputs:  {
     outfile :  {
-	module_type   :   RootOutput
-	fileName      :   "lumi_stream.art"
-	SelectEvents  : [ t1 ]
-	outputCommands: [
-			 "drop *_*_*_*",
-			 "keep *_LumiFilter_*_*"
-			]
+        module_type   :   RootOutput
+        fileName      :   "lumi_stream.art"
+        SelectEvents  : [ t1 ]
+        outputCommands: [
+                         "drop *_*_*_*",
+                         "keep *_LumiFilter_*_*"
+                        ]
     }
 }

--- a/DAQ/test/lumi_stream.fcl
+++ b/DAQ/test/lumi_stream.fcl
@@ -1,0 +1,59 @@
+# Test generating dummy lumi info and run it through the lumi stream filter
+# into TRK  collection and analzye it
+# Usage: mu2e -c Offline/DAQ/test/lumi_stream.fcl -n 1000
+#
+#
+# Contact person Michael MacKenzie
+
+#include "Offline/fcl/minimalMessageService.fcl"
+#include "Offline/fcl/standardServices.fcl"
+
+services : @local::Services.Reco
+
+services.scheduler.wantSummary: true
+
+process_name : lumiStream
+
+source : {
+  module_type : EmptyEvent
+}
+
+physics : {
+
+    producers : {
+	DummyLumiStream : {
+	    module_type : DummyLumiInfoProducer
+	    simMode     : 1
+	}
+    }
+
+    filters : {
+	LumiFilter : {
+	    module_type : LumiStreamFilter
+	    caloTag        : DummyLumiStream
+	    timeClusterTag : DummyLumiStream
+	    trackerTag     : DummyLumiStream
+	    # eventFreq      : 10000
+	    diagLevel      : 1
+	}
+    }
+
+    t1 : [ DummyLumiStream, LumiFilter  ]
+    e1 : [ outfile ]
+
+    trigger_paths  : [t1]
+    end_paths      : [e1]
+
+}
+
+outputs:  {
+    outfile :  {
+	module_type   :   RootOutput
+	fileName      :   "lumi_stream.art"
+	SelectEvents  : [ t1 ]
+	outputCommands: [
+			 "drop *_*_*_*",
+			 "keep *_LumiFilter_*_*"
+			]
+    }
+}

--- a/RecoDataProducts/inc/IntensityInfoCalo.hh
+++ b/RecoDataProducts/inc/IntensityInfoCalo.hh
@@ -6,6 +6,7 @@
 
 #ifndef RecoDataProducts_IntensityInfoCalo_hh
 #define RecoDataProducts_IntensityInfoCalo_hh
+#include <vector>
 
 namespace mu2e {
 
@@ -31,6 +32,8 @@ namespace mu2e {
     unsigned short  caloEnergy_   = 0;
     unsigned short  nCaphriHits_  = 0;
   };
+
+  typedef std::vector<mu2e::IntensityInfoCalo> IntensityInfosCalo;
 }
 
 #endif

--- a/RecoDataProducts/inc/IntensityInfoTimeCluster.hh
+++ b/RecoDataProducts/inc/IntensityInfoTimeCluster.hh
@@ -7,6 +7,8 @@
 #ifndef RecoDataProducts_IntensityInfoTimeCluster_hh
 #define RecoDataProducts_IntensityInfoTimeCluster_hh
 
+#include <vector>
+
 namespace mu2e {
 
   class IntensityInfoTimeCluster
@@ -25,6 +27,8 @@ namespace mu2e {
   private:
     unsigned short  nProtonTCs_   = 0;
   };
+
+  typedef std::vector<mu2e::IntensityInfoTimeCluster> IntensityInfosTimeCluster;
 }
 
 #endif

--- a/RecoDataProducts/inc/IntensityInfoTrackerHits.hh
+++ b/RecoDataProducts/inc/IntensityInfoTrackerHits.hh
@@ -7,6 +7,8 @@
 #ifndef RecoDataProducts_IntensityInfoTrackerHits_hh
 #define RecoDataProducts_IntensityInfoTrackerHits_hh
 
+#include <vector>
+
 namespace mu2e {
 
   class IntensityInfoTrackerHits
@@ -25,6 +27,7 @@ namespace mu2e {
   private:
     unsigned short  nTrackerHits_ = 0;
   };
+  typedef std::vector<mu2e::IntensityInfoTrackerHits> IntensityInfosTrackerHits;
 }
 
 #endif

--- a/RecoDataProducts/src/classes_def.xml
+++ b/RecoDataProducts/src/classes_def.xml
@@ -404,10 +404,19 @@
 <!--  ********* POT / stopped muons monitoring  ********* -->
  <class name="mu2e::IntensityInfoCalo"/>
  <class name="art::Wrapper<mu2e::IntensityInfoCalo>"/>
+ <class name="std::vector<mu2e::IntensityInfoCalo>" />
+ <class name="mu2e::IntensityInfosCalo" />
+ <class name="art::Wrapper<mu2e::IntensityInfosCalo>" />
  <class name="mu2e::IntensityInfoTrackerHits"/>
  <class name="art::Wrapper<mu2e::IntensityInfoTrackerHits>"/>
+ <class name="std::vector<mu2e::IntensityInfoTrackerHits>" />
+ <class name="mu2e::IntensityInfosTrackerHits" />
+ <class name="art::Wrapper<mu2e::IntensityInfosTrackerHits>" />
  <class name="mu2e::IntensityInfoTimeCluster"/>
  <class name="art::Wrapper<mu2e::IntensityInfoTimeCluster>"/>
+ <class name="std::vector<mu2e::IntensityInfoTimeCluster>" />
+ <class name="mu2e::IntensityInfosTimeCluster" />
+ <class name="art::Wrapper<mu2e::IntensityInfosTimeCluster>" />
 
 
 <!--  ********* general reco ********* -->


### PR DESCRIPTION
Add a module to produce event headers from the CFO fragment. Also add a module to compress the ~175 kHz lumi stream into either sub-runs or a much lower frequency in events such than we can handle the writing speed (~1-2 kHz). A test module for generating luminosity information during the development stage is added as well. This includes a TRACE message call in the CFO --> event header module as a test of Offline compatibility with TRACE.