### PR TITLE
remove deprecated clang-tidy option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,performance-*,readability-misleading-indentation,readability-non-const-parameter,cppcoreguidelines-*,-bugprone-narrowing-conversions,-bugprone-easily-swappable-parameters'
 WarningsAsErrors: ''
 HeaderFilterRegex: 'Offline/.*'
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 User:            roneil
 CheckOptions:    


### PR DESCRIPTION
gen2 smack scripts enabled llvm@19 (used to be @14), need to remove deprecated option