### PR TITLE
p074 envset

### DIFF
--- a/.muse
+++ b/.muse
@@ -1,5 +1,5 @@
 # prefer to build with this environment
-ENVSET p074
+ENVSET p076
 # add Offline/bin to path
 PATH bin
 # recent commits can take enforce these flags

--- a/.muse
+++ b/.muse
@@ -1,5 +1,5 @@
 # prefer to build with this environment
-ENVSET p075
+ENVSET p074
 # add Offline/bin to path
 PATH bin
 # recent commits can take enforce these flags


### PR DESCRIPTION
This will change the envset to p074, which points to art 3.1.5.  This should fix the problem with xrootd not accepting tokens.
A validation test with 2k reco events shows no difference. A test with 1k ceSimReco shows compatible but not identical results, and is shown [here](https://mu2e.fnal.gov/atwork/computing/ops/val/plots/temp/ce/result.html)