### PR TITLE
Update accept-reject filter module

### DIFF
--- a/Filters/src/WeightSamplingFilter_module.cc
+++ b/Filters/src/WeightSamplingFilter_module.cc
@@ -9,75 +9,136 @@
 #include "art/Framework/Core/EDFilter.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
-#include "Offline/SeedService/inc/SeedService.hh"
-#include "fhiclcpp/ParameterSet.h"
-
 #include "art/Framework/Principal/Handle.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "fhiclcpp/types/Atom.h"
+#include "art_root_io/TFileService.h"
 
 #include "CLHEP/Random/RandFlat.h"
 
+// ROOT includes
+#include "TFile.h"
+#include "TH1.h"
+
 // Mu2e includes.
+#include "Offline/SeedService/inc/SeedService.hh"
 #include "Offline/MCDataProducts/inc/EventWeight.hh"
-#include "Offline/MCDataProducts/inc/GenId.hh"
-#include "Offline/DataProducts/inc/PDGCode.hh"
-#include "Offline/MCDataProducts/inc/GenParticle.hh"
 
-
-
+// c++ includes
 #include <iostream>
-#include <string>
 
 using namespace std;
 namespace mu2e {
 
   class WeightSamplingFilter : public art::EDFilter {
     public:
-      explicit WeightSamplingFilter(fhicl::ParameterSet const& pset);
+      struct Config {
+        using Name = fhicl::Name;
+        using Comment = fhicl::Comment;
+        fhicl::Atom<art::InputTag> input{Name("EventWeightModule"), Comment("Module tag creating the event weights")};
+        fhicl::Atom<double>        scale{Name("WeightScalingFactor"), Comment("Event weight scale to normalize between 0 and 1"), 1.};
+        fhicl::Atom<int>           debug{Name("debugLevel"), Comment("Debugging level"), 0};
+        fhicl::Atom<bool>          hists{Name("makeHistograms"), Comment("Make debug histograms"), false};
+      };
+      using Parameters = art::EDFilter::Table<Config>;
+      explicit WeightSamplingFilter(const Parameters& conf);
 
     private:
-      bool beginRun(art::Run& run) override;
-      bool endRun(art::Run& run) override;
+      void endJob() override;
       bool filter(art::Event& event) override;
 
       art::InputTag _evtWtModule;
-      art::InputTag _genParticleModule;
-      art::RandomNumberGenerator::base_engine_t& _engine;
-      CLHEP::RandFlat _randflat;
       double _weightScalingFactor; // allows scaling weight to maximize efficiency, want max rescaled weight=>1
       int _debug;
+      bool _hists;
+      art::RandomNumberGenerator::base_engine_t& _engine;
+      CLHEP::RandFlat _randflat;
       unsigned      _nevt, _npass;
+      double        _sumwt;
+
+    struct Hist_t {
+      TH1* hwt_ = nullptr;
+      TH1* hlogwt_ = nullptr;
+      TH1* hpass_ = nullptr;
+    };
+    enum {kHistSets = 3};
+    Hist_t _Hists[kHistSets];
   };
 
-  WeightSamplingFilter::WeightSamplingFilter(fhicl::ParameterSet const& pset):
-    art::EDFilter{pset},
-    _evtWtModule(pset.get<art::InputTag>("EventWeightModule")),
-    _genParticleModule(pset.get<std::string>("genParticleModule","compressDigiMCs")),
+  WeightSamplingFilter::WeightSamplingFilter(const Parameters& config):
+    art::EDFilter{config},
+    _evtWtModule(config().input()),
+    _weightScalingFactor(config().scale()),
+    _debug(config().debug()),
+    _hists(config().hists()),
     _engine(createEngine( art::ServiceHandle<SeedService>()->getSeed())),
     _randflat( _engine ),
-    _weightScalingFactor(pset.get<double>("WeightScalingFactor",1)),
-    _debug        (pset.get<int>          ("debugLevel",0)),
-    _nevt(0), _npass(0){}
-
-  bool WeightSamplingFilter::beginRun(art::Run& run) {
-    return true;
+    _nevt(0), _npass(0), _sumwt(0.) {
+    // Book histograms if requested
+    if(_hists) {
+      art::ServiceHandle<art::TFileService> tfs;
+      {
+        art::TFileDirectory tfdir = tfs->mkdir("all_events");
+        _Hists[0].hwt_    = tfdir.make<TH1F>("hwt", "Event weight", 200,0.,2.);
+        _Hists[0].hlogwt_ = tfdir.make<TH1F>("hlogwt", "log10(Event weight)", 200,-10.,1.);
+        _Hists[0].hpass_  = tfdir.make<TH1D>("hpass", "Filter result", 2,-0.5,1.5);
+      }
+      {
+        art::TFileDirectory tfdir = tfs->mkdir("weighted_events");
+        _Hists[1].hwt_    = tfdir.make<TH1F>("hwt", "Event weight", 200,0.,2.);
+        _Hists[1].hlogwt_ = tfdir.make<TH1F>("hlogwt", "log10(Event weight)", 200,-10.,1.);
+        _Hists[1].hpass_  = tfdir.make<TH1D>("hpass", "Filter result", 2,-0.5,1.5);
+      }
+      {
+        art::TFileDirectory tfdir = tfs->mkdir("accepted_events");
+        _Hists[2].hwt_    = tfdir.make<TH1F>("hwt", "Event weight", 200,0.,2.);
+        _Hists[2].hlogwt_ = tfdir.make<TH1F>("hlogwt", "log10(Event weight)", 200,-10.,1.);
+        _Hists[2].hpass_  = tfdir.make<TH1D>("hpass", "Filter result", 2,-0.5,1.5);
+      }
+    }
   }
-  bool WeightSamplingFilter::endRun(art::Run& run) {
-    return true;
+
+  void WeightSamplingFilter::endJob() {
+    // Report the filtering efficiency unless printout is actively suppressed
+    if(_debug > -1) printf("[WeightSamplingFilter::%s::%s] Saw %u events and accepted %u --> Efficiency = %.3g, sum of weights = %.3g\n",
+                           __func__, moduleDescription().moduleLabel().c_str(), _nevt, _npass, (_nevt > 0) ? _npass*1./_nevt : 0., _sumwt);
+
   }
 
   bool WeightSamplingFilter::filter(art::Event& event) {
     ++_nevt;
-
-    double evtwt = event.getValidHandle<EventWeight>( _evtWtModule )->weight() * _weightScalingFactor;
-    if (_debug > 0 && evtwt > 1){
-      std::cout << moduleDescription().moduleLabel() << " weight scaling too high, probability is " << evtwt << " " << _weightScalingFactor << std::endl;
+    // Retrieve the event weight and scale it by the given factor
+    const double barewt = event.getValidHandle<EventWeight>( _evtWtModule )->weight();
+    const double evtwt =  barewt * _weightScalingFactor;
+    if (_debug > 0 && evtwt > 1.){
+      printf("[WeightSamplingFilter::%s::%s] Event %i:%i:%u: Scaled event weight is greater than 1 (weight = %.3f, base weight = %.3g)\n",
+             __func__, moduleDescription().moduleLabel().c_str(), event.run(), event.subRun(), event.event(), evtwt, barewt);
     }
-    double temp = _randflat.fire();
-    if (temp > evtwt)
-      return false;
+    _sumwt += barewt;
 
-    ++_npass;
-    return true;
+    // Accept/reject algorithm: Fire a uniform random number and accept if weight is greater than the value
+    const double rand = _randflat.fire();
+    const bool pass = evtwt > rand;
+    if(pass) ++_npass;
+    if(_debug > 1) printf("[WeightSamplingFilter::%s::%s] Event %i:%i:%u: Scaled event weight = %.3g, rand = %.3g, pass = %o\n",
+                          __func__, moduleDescription().moduleLabel().c_str(), event.run(), event.subRun(), event.event(), evtwt, rand, pass);
+
+    // Fill histograms if requested
+    if(_hists) {
+      const double logwt = (evtwt > 0.) ? std::log10(evtwt) : -1e10;
+      _Hists[0].hwt_   ->Fill(evtwt);
+      _Hists[0].hlogwt_->Fill(logwt);
+      _Hists[0].hpass_ ->Fill(pass );
+      _Hists[1].hwt_   ->Fill(evtwt, evtwt); //weighted to compare to the accepted shapes
+      _Hists[1].hlogwt_->Fill(logwt, evtwt);
+      _Hists[1].hpass_ ->Fill(pass , evtwt);
+      if(pass) {
+        _Hists[2].hwt_   ->Fill(evtwt);
+        _Hists[2].hlogwt_->Fill(logwt);
+        _Hists[2].hpass_ ->Fill(pass );
+      }
+    }
+    return pass;
   }
 }
 


### PR DESCRIPTION
Update the accept-reject filter module to use validated fcl and include some debug histograms. This is useful in producing physical spectra from weighted events, such as is needed for mock data samples. I will also put in a corresponding PR in Production to add RPC fcls that have the physical pion stop time distribution for use in MDS2.