### PR TITLE
Add protection for poor maximum weight configuration

### DIFF
--- a/Filters/src/WeightSamplingFilter_module.cc
+++ b/Filters/src/WeightSamplingFilter_module.cc
@@ -35,8 +35,8 @@ namespace mu2e {
       struct Config {
         using Name = fhicl::Name;
         using Comment = fhicl::Comment;
-        fhicl::Atom<art::InputTag> input{Name("EventWeightModule"), Comment("Module tag creating the event weights")};
-        fhicl::Atom<double>        scale{Name("WeightScalingFactor"), Comment("Event weight scale to normalize between 0 and 1"), 1.};
+        fhicl::Atom<art::InputTag> input{Name("inputTag"), Comment("Module tag creating the event weights")};
+        fhicl::Atom<double>        maxWeight{Name("maximumWeight"), Comment("Maximum weight value assumed in accept/reject algorithm"), 1.};
         fhicl::Atom<int>           debug{Name("debugLevel"), Comment("Debugging level"), 0};
         fhicl::Atom<bool>          hists{Name("makeHistograms"), Comment("Make debug histograms"), false};
       };
@@ -48,7 +48,7 @@ namespace mu2e {
       bool filter(art::Event& event) override;
 
       art::InputTag _evtWtModule;
-      double _weightScalingFactor; // allows scaling weight to maximize efficiency, want max rescaled weight=>1
+      double _maxWeight; //accept/reject algorithm needs to know the maximum weight in the input data when sampling
       int _debug;
       bool _hists;
       art::RandomNumberGenerator::base_engine_t& _engine;
@@ -68,30 +68,34 @@ namespace mu2e {
   WeightSamplingFilter::WeightSamplingFilter(const Parameters& config):
     art::EDFilter{config},
     _evtWtModule(config().input()),
-    _weightScalingFactor(config().scale()),
+    _maxWeight(config().maxWeight()),
     _debug(config().debug()),
     _hists(config().hists()),
     _engine(createEngine( art::ServiceHandle<SeedService>()->getSeed())),
     _randflat( _engine ),
     _nevt(0), _npass(0), _sumwt(0.) {
+
+    // Produces event weights to potentially correct the accept/reject algorithm in cases where the maximum weight is wrong
+    produces<mu2e::EventWeight>();
+
     // Book histograms if requested
     if(_hists) {
       art::ServiceHandle<art::TFileService> tfs;
       {
         art::TFileDirectory tfdir = tfs->mkdir("all_events");
-        _Hists[0].hwt_    = tfdir.make<TH1F>("hwt", "Event weight", 200,0.,2.);
+        _Hists[0].hwt_    = tfdir.make<TH1F>("hwt", "Event weight", 200,0.,(_maxWeight > 0.) ? 2.*_maxWeight : 2.);
         _Hists[0].hlogwt_ = tfdir.make<TH1F>("hlogwt", "log10(Event weight)", 200,-10.,1.);
         _Hists[0].hpass_  = tfdir.make<TH1D>("hpass", "Filter result", 2,-0.5,1.5);
       }
       {
         art::TFileDirectory tfdir = tfs->mkdir("weighted_events");
-        _Hists[1].hwt_    = tfdir.make<TH1F>("hwt", "Event weight", 200,0.,2.);
+        _Hists[1].hwt_    = tfdir.make<TH1F>("hwt", "Event weight", 200,0.,(_maxWeight > 0.) ? 2.*_maxWeight : 2.);
         _Hists[1].hlogwt_ = tfdir.make<TH1F>("hlogwt", "log10(Event weight)", 200,-10.,1.);
         _Hists[1].hpass_  = tfdir.make<TH1D>("hpass", "Filter result", 2,-0.5,1.5);
       }
       {
         art::TFileDirectory tfdir = tfs->mkdir("accepted_events");
-        _Hists[2].hwt_    = tfdir.make<TH1F>("hwt", "Event weight", 200,0.,2.);
+        _Hists[2].hwt_    = tfdir.make<TH1F>("hwt", "Event weight", 200,0.,(_maxWeight > 0.) ? 2.*_maxWeight : 2.);
         _Hists[2].hlogwt_ = tfdir.make<TH1F>("hlogwt", "log10(Event weight)", 200,-10.,1.);
         _Hists[2].hpass_  = tfdir.make<TH1D>("hpass", "Filter result", 2,-0.5,1.5);
       }
@@ -107,21 +111,25 @@ namespace mu2e {
 
   bool WeightSamplingFilter::filter(art::Event& event) {
     ++_nevt;
-    // Retrieve the event weight and scale it by the given factor
-    const double barewt = event.getValidHandle<EventWeight>( _evtWtModule )->weight();
-    const double evtwt =  barewt * _weightScalingFactor;
-    if (_debug > 0 && evtwt > 1.){
-      printf("[WeightSamplingFilter::%s::%s] Event %i:%i:%u: Scaled event weight is greater than 1 (weight = %.3f, base weight = %.3g)\n",
-             __func__, moduleDescription().moduleLabel().c_str(), event.run(), event.subRun(), event.event(), evtwt, barewt);
+    // Retrieve the event weight
+    const double evtwt = event.getValidHandle<EventWeight>( _evtWtModule )->weight();
+    if (_debug > 0 && evtwt > _maxWeight){
+      printf("[WeightSamplingFilter::%s::%s] Event %i:%i:%u: Event weight is greater than maximum weight (weight = %.3g, max weight = %.3g)\n",
+             __func__, moduleDescription().moduleLabel().c_str(), event.run(), event.subRun(), event.event(), evtwt, _maxWeight);
     }
-    _sumwt += barewt;
+    _sumwt += evtwt;
 
     // Accept/reject algorithm: Fire a uniform random number and accept if weight is greater than the value
-    const double rand = _randflat.fire();
+    const double rand = _maxWeight*_randflat.fire();
     const bool pass = evtwt > rand;
     if(pass) ++_npass;
     if(_debug > 1) printf("[WeightSamplingFilter::%s::%s] Event %i:%i:%u: Scaled event weight = %.3g, rand = %.3g, pass = %o\n",
                           __func__, moduleDescription().moduleLabel().c_str(), event.run(), event.subRun(), event.event(), evtwt, rand, pass);
+
+    // Add the output event weight
+    const double out_weight = std::max(_maxWeight, evtwt); // if event weight exceeds this maximum, need weights to account for it
+    std::unique_ptr<EventWeight> pw(new EventWeight(out_weight));
+    event.put(std::move(pw));
 
     // Fill histograms if requested
     if(_hists) {
@@ -133,9 +141,9 @@ namespace mu2e {
       _Hists[1].hlogwt_->Fill(logwt, evtwt);
       _Hists[1].hpass_ ->Fill(pass , evtwt);
       if(pass) {
-        _Hists[2].hwt_   ->Fill(evtwt);
-        _Hists[2].hlogwt_->Fill(logwt);
-        _Hists[2].hpass_ ->Fill(pass );
+        _Hists[2].hwt_   ->Fill(evtwt, out_weight);
+        _Hists[2].hlogwt_->Fill(logwt, out_weight);
+        _Hists[2].hpass_ ->Fill(pass , out_weight);
       }
     }
     return pass;


### PR DESCRIPTION
Add an event weight output from the accept/reject filter module. This will be a flat weight in the normal operating mode, but if the maximum event weight is set too low, it will correct the output spectrum shape.