### PR TITLE
TZClusterFinder updates for the VST

### DIFF
--- a/CalPatRec/fcl/prolog.fcl
+++ b/CalPatRec/fcl/prolog.fcl
@@ -613,11 +613,11 @@ CalPatRec : { @table::CalPatRec
             useCCs                     : 1
             recoverCCs                 : 1
             chCollLabel                : "flagPH"
-            chCollLabel2               : "makeSH"
             tcCollLabel                : "TimeClusterFinderDe"
             ccCollLabel                : "CaloClusterMaker"
             hitBkgBits                 : ["Noisy","Dead","Background"]
             radSelect                  : 1
+            seedEThresh                : 0.0
             chunkSep                   : 5
             chunkWindow                : 20.0
             chunkThresh                : 3
@@ -631,6 +631,7 @@ CalPatRec : { @table::CalPatRec
             caloDtMax                  : 30.0
             caloTimeOffset             : @local::TrackCaloMatching.DtOffset
             doRefine                   : 0
+            minHitsEThresh             : 0
 
             diagPlugin : { tool_type  : "TZClusterFinderDiag"
                  mcTruth       : 1

--- a/CalPatRec/inc/TZClusterFinder_types.hh
+++ b/CalPatRec/inc/TZClusterFinder_types.hh
@@ -39,6 +39,7 @@ namespace mu2e {
       float  hTime;
       float  hWeight;
       float  hZpos;
+      float  hEdep;
       int    nStrawHits;
       int    hIsUsed;
     };
@@ -67,7 +68,6 @@ namespace mu2e {
       const art::Event*               _event;
       const TimeCluster*              _timeCluster;
       const ComboHitCollection*       _chColl;
-      const ComboHitCollection*       _chColl2; // for tool to get simID info before selection cuts
       const CaloClusterCollection*    _ccColl;
       TimeClusterCollection*          _tcColl; // 'tcColl': time cluster collection
       IntensityInfoTimeCluster*       _iiTC;

--- a/CalPatRec/src/TZClusterFinderDiag_tool.cc
+++ b/CalPatRec/src/TZClusterFinderDiag_tool.cc
@@ -207,9 +207,9 @@ namespace mu2e {
 
     // fill mcSimIDs data members simID, nHits, and pdgID
     if ( _mcTruth != 0 ) {
-      for (size_t i=0; i<_data->_chColl2->size(); ++i){
+      for (size_t i=0; i<_data->_chColl->size(); ++i){
         std::vector<StrawDigiIndex> shids;
-        _data->_chColl2->fillStrawDigiIndices(i,shids);
+        _data->_chColl->fillStrawDigiIndices(i,shids);
         int SimID = _mcUtils->strawHitSimId(_data->_event,shids[0]);
         _simParticle = _mcUtils->getSimParticle(_data->_event,shids[0]);
         int _pdgID = _simParticle->pdgId();
@@ -217,7 +217,7 @@ namespace mu2e {
           mcSimIDs sim_info;
           sim_info.simID = SimID;
           sim_info.pdgID = _pdgID;
-          sim_info.nHits = 1;
+          sim_info.nHits = shids.size();
           _mcHits.push_back(sim_info);
           continue;
         }
@@ -225,7 +225,7 @@ namespace mu2e {
         for (size_t j=0; j<_mcHits.size(); j++) {
           if (_mcHits[j].simID == SimID) {
             alreadyStored = 1;
-            _mcHits[j].nHits++;
+            _mcHits[j].nHits = _mcHits[j].nHits + shids.size();
             break;
           }
         }
@@ -234,7 +234,7 @@ namespace mu2e {
           mcSimIDs sim_info;
           sim_info.simID = SimID;
           sim_info.pdgID = _pdgID;
-          sim_info.nHits = 1;
+          sim_info.nHits = shids.size();
           _mcHits.push_back(sim_info);
         }
       }

--- a/CalPatRec/src/TZClusterFinder_module.cc
+++ b/CalPatRec/src/TZClusterFinder_module.cc
@@ -173,6 +173,7 @@ namespace mu2e {
     _ccLabel                (config().ccCollLabel()                             ),
     _hbkg                   (config().hitBkgBits()                              ),
     _radSelect              (config().radSelect()                               ),
+    _seedEThresh            (config().seedEThresh()                             ),
     _chunkSep               (config().chunkSep()                                ),
     _chunkWindow            (config().chunkWindow()                             ),
     _chunkThresh            (config().chunkThresh()                             ),
@@ -185,7 +186,8 @@ namespace mu2e {
     _minCaloEnergy          (config().minCaloEnergy()                           ),
     _caloDtMax              (config().caloDtMax()                               ),
     _caloTimeOffset         (config().caloTimeOffset()                          ),
-    _doRefine               (config().doRefine()                                )
+    _doRefine               (config().doRefine()                                ),
+    _minHitsEThresh         (config().minHitsEThresh()                          )
     {
 
       consumes<ComboHitCollection>(_chLabel);


### PR DESCRIPTION
The VST is not in a position to label "noisy hits". Pasha requested adding in some logic that will allow us to avoid seeding the cluster search with hits that are likely noise, while also requiring some logic to reject clusters that don't have at least some number of hits above some minimum energy threshold (below which hits are likely noise).

This includes adding two new fcl parameters. By default I am setting them to zero so as not to interfere / be consistent with the Offline before this PR. @pavel1murat can set these values as he pleases in his own area when performing his tests.

Also no longer reading in second combo hit collection in TZ when using the tool. In the past I was reading in a second combo hit collection along with the one used in the producer. This second one was used in the tool. The reason for this was that TZClusterFinder and TimeClusterFinder were using different combo hit collections and I wanted various plots made in the tool to be using the combo hit collection TimeClusterFinder was using for accurate comparisons. These tests are done and the second combo hit collection is unnecessary. Will make a PR in mu2e-trig-config to remove it there as well. 