### PR TITLE
Preparation for using Geant4 11.3.p02

### DIFF
--- a/Mu2eG4/fcl/prolog.fcl
+++ b/Mu2eG4/fcl/prolog.fcl
@@ -29,6 +29,8 @@ mu2eg4DefaultPhysics: {
     // or any of the _HP ones
     turnOnThermalNeutronPhysics: false
 
+    // setBertiniAs11_2: false  // For Geant4 11.3.p02 and above uncommenting turns on the new behavior which as of 11.3.p02 may be not good for Mu2e; more validation/work needed in future
+
     setMuHadLateralDisplacement: true // improves accuracy of boundary
                                       // crossing for muons and common charged hadrons
 

--- a/Mu2eG4/inc/Mu2eG4Config.hh
+++ b/Mu2eG4/inc/Mu2eG4Config.hh
@@ -152,6 +152,11 @@ namespace mu2e {
       fhicl::OptionalAtom<double> muonMaxPreAssignedDecayProperTime {Name("muonMaxPreAssignedDecayProperTime")};
       fhicl::OptionalAtom<double> muonMinPreAssignedDecayProperTime {Name("muonMinPreAssignedDecayProperTime")};
 
+#if G4VERSION>4112
+      // works for Geant4 11.3.p02
+      fhicl::OptionalAtom<bool> setBertiniAs11_2 {Name("setBertiniAs11_2")};
+#endif
+
       OptionalDelegatedParameter BirksConsts {Name("BirksConsts")};
       OptionalDelegatedParameter minRangeRegionCuts {Name("minRangeRegionCuts")};
 

--- a/Mu2eG4/src/physicsListDecider.cc
+++ b/Mu2eG4/src/physicsListDecider.cc
@@ -52,6 +52,10 @@
 #include "Geant4/G4EmParameters.hh"
 #endif
 
+#if G4VERSION>4106
+#include "Geant4/G4HadronicParameters.hh"
+#endif
+
 using namespace std;
 
 namespace mu2e{
@@ -84,6 +88,22 @@ namespace mu2e{
 
     // General case
     else {
+
+    // the Hadronic params have to be set before defining the list
+
+#if G4VERSION>4112
+    { bool BertiniAs11_2 = true; // restores 11.2 behavior in Geant4 11.3.p02
+      phys.setBertiniAs11_2(BertiniAs11_2);
+      if (BertiniAs11_2) {
+        if (debug.diagLevel()>0) {
+          G4cout << __func__
+                 << " Setting Bertini model behavior to one of 11.2 "
+                 << G4endl;
+        }
+        G4HadronicParameters::Instance()->SetBertiniAs11_2(BertiniAs11_2);
+      }
+    }
+#endif
 
       G4PhysListFactory physListFactory;
       physListFactory.SetVerbose(debug.diagLevel());


### PR DESCRIPTION
This pull request enables the use of Geant4 11.3.p02
It should not affect the current use as the mods are guarded by ifdefs which require a higher version of Geant4