### PR TITLE
Optional skip of DTC-level headers in tracker fragments

### DIFF
--- a/DAQ/fcl/prolog.fcl
+++ b/DAQ/fcl/prolog.fcl
@@ -6,7 +6,7 @@ DAQ: {
             module_type: StrawDigisFromArtdaqFragments
             diagLevel: 0
             saveWaveforms: false
-            containsDTCHeaders: true
+            missingDTCHeaders: false
         }
     }
 }

--- a/DAQ/fcl/prolog.fcl
+++ b/DAQ/fcl/prolog.fcl
@@ -1,10 +1,12 @@
 # -*- mode:tcl -*-
 BEGIN_PROLOG
-DAQ : {
-    producers : {
-        StrawDigisFromArtdaqFragments: { module_type: StrawDigisFromArtdaqFragments
-            saveWaveforms : 0
-            diagLevel     : 0  # not used yet
+DAQ: {
+    producers: {
+        StrawDigisFromArtdaqFragments: {
+            module_type: StrawDigisFromArtdaqFragments
+            diagLevel: 0
+            saveWaveforms: false
+            containsDTCHeaders: true
         }
     }
 }

--- a/DAQ/src/StrawDigisFromArtdaqFragments_module.cc
+++ b/DAQ/src/StrawDigisFromArtdaqFragments_module.cc
@@ -56,9 +56,9 @@ public:
     fhicl::Atom<int> debugLevel   {fhicl::Name("debugLevel"   ), fhicl::Comment("debug level, default = 0"               ), 0};
     fhicl::Atom<bool> saveWaveforms{fhicl::Name("saveWaveforms"), fhicl::Comment("save StrawDigiADCWaveforms, default = true"), true};
 
-    fhicl::Atom<bool> containsDTCHeaders{
-      fhicl::Name("containsDTCHeaders"),
-      fhicl::Comment("Whether data was produced in DTC_Events; set to false to disable skipping DTC-level header in deserialization sequence.")
+    fhicl::Atom<bool> missingDTCHeaders{
+      fhicl::Name("missingDTCHeaders"),
+      fhicl::Comment("Whether data was (not) produced using DTC_Events; set to true to disable skipping DTC-level header in deserialization sequence.")
     };
 
     // individual tuple specifying a minnesota label, e.g. MN123,
@@ -158,7 +158,7 @@ art::StrawDigisFromArtdaqFragments::StrawDigisFromArtdaqFragments(const art::EDP
 
   // if data is properly embedded in DTC_Events, then skip DTC-level header
   // when deserializing
-  if (config().containsDTCHeaders()){
+  if (!config().missingDTCHeaders()){
     roc_payload_offset_ = static_cast<uint8_t>(sizeof(DTCLib::DTC_EventHeader));
   }
 


### PR DESCRIPTION
  PR #1402 implemented efficiency deserialization of artdaq fragments for the tracker. It has since been realized that the data produced by the current tracker daq does not include a DTC-level header which should be present to maintain alignment of the data structure whether produced using hardware- or software-event-building. The data produced by the tracker daq will soon transition to including this header. This PR introduces a configuration flag for the absence of the header, which defaults to false; future data will decode properly by default, and previous datasets may be processed by manually overriding the flag as true, indicating that the relevant headers are not present.