### PR TITLE
STM Upstream Geometry Changes

### DIFF
--- a/GeometryService/inc/STMMaker.hh
+++ b/GeometryService/inc/STMMaker.hh
@@ -196,6 +196,7 @@ namespace mu2e {
     double       _shieldDnStrWallGap;
     double       _shieldUpStrWallGap;
     std::string  _shieldDnStrWallMaterial;
+    bool         _shieldBuildMatingBlock;
 
     bool        _STM_SSCBuild;
     bool        _STM_SSCVDBuild;

--- a/GeometryService/inc/STMMaker.hh
+++ b/GeometryService/inc/STMMaker.hh
@@ -195,6 +195,7 @@ namespace mu2e {
     double       _shieldDnStrWallHalfWidth;
     double       _shieldDnStrWallGap;
     double       _shieldUpStrWallGap;
+    double       _shieldPipeUpStrAirGap;
     std::string  _shieldDnStrWallMaterial;
     bool         _shieldBuildMatingBlock;
 

--- a/GeometryService/src/STMMaker.cc
+++ b/GeometryService/src/STMMaker.cc
@@ -317,6 +317,7 @@ namespace mu2e {
                         _shieldDnStrWallHalfWidth,
                         _shieldDnStrWallGap,
                         _shieldDnStrWallMaterial,
+                        _shieldBuildMatingBlock,
                         _shieldOffsetInMu2e, //This is upstream edge of FOV collimator for now.
                         _shieldRotation
                        ));
@@ -786,6 +787,7 @@ namespace mu2e {
     _shieldDnStrWallGap         = _config.getDouble("stm.shield.DnStrWall.gap", 0.);
     _shieldUpStrWallGap         = _config.getDouble("stm.shield.UpStrWall.gap", 0.); //only if using pipe as origin
     _shieldDnStrWallMaterial    = _config.getString("stm.shield.DnStrWall.material", _shieldMaterial);
+    _shieldBuildMatingBlock     = _config.getBool("stm.shield.matingBlock.build", true); // default to true because that is what older versions did
 
     _stmDnStrEnvBuild       = _config.getBool("stm.downstream.build");
     _stmDnStrEnvHalfLength  = _config.getDouble("stm.downstream.halfLength");

--- a/GeometryService/src/STMMaker.cc
+++ b/GeometryService/src/STMMaker.cc
@@ -161,7 +161,14 @@ namespace mu2e {
     if ( _magnetBuild )        _magnetTableTopHalfLength += _magnetHalfLength;
     if ( _pipeBuild )          _magnetTableTopHalfLength += _pipeDnStrHalfLength;
     if ( _FOVCollimatorBuild ) _magnetTableTopHalfLength += 0.5*_FOVCollimatorUpStrSpace+_FOVCollimatorHalfLength;
-    if ( _shieldBuild )        _magnetTableTopHalfLength += 0.5*_shieldDnStrSpace+_shieldDnStrWallHalfLength;
+    if ( _shieldBuild ) {
+      _magnetTableTopHalfLength += 0.5*_shieldDnStrSpace+_shieldDnStrWallHalfLength;
+      if (!_magnetBuild) {
+        // Previous versions (<STM_v09) didn't need to include the shield pipe length in here.
+        // Now we will include it, otherwise the table is tiny
+        _magnetTableTopHalfLength += _shieldPipeHalfLength;
+      }
+    }
     _magnetTableTopHalfLength += _magnetTableTopExtraLength;
 
     const CLHEP::HepRotation _magnetTableRotation     = CLHEP::HepRotation::IDENTITY;
@@ -169,7 +176,15 @@ namespace mu2e {
     if ( _magnetBuild )        _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,_magnetUpStrSpace+_magnetHalfLength);
     if ( _pipeBuild )          _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,_pipeDnStrHalfLength);
     if ( _FOVCollimatorBuild ) _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,0.5*_FOVCollimatorUpStrSpace+_FOVCollimatorHalfLength);
-    if ( _shieldBuild )        _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,-0.5*_shieldDnStrSpace-_shieldDnStrWallHalfLength);
+    if ( _shieldBuild ) {
+      _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,-0.5*_shieldDnStrSpace-_shieldDnStrWallHalfLength);
+      if (!_magnetBuild) {
+        // Previous versions (<STM_v09) didn't need to include the shield pipe length in here.
+        // Now we will include it, otherwise the table is tiny
+        _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,-0.5*_shieldDnStrSpace-_shieldDnStrWallHalfLength+_shieldPipeHalfLength);
+      }
+    }
+
 
     //if (_magnetTableBuild && (_magnetBuild||_FOVCollimatorBuild) ){
       stm._pSTMMagnetSupportTableParams = std::unique_ptr<SupportTable>

--- a/GeometryService/src/STMMaker.cc
+++ b/GeometryService/src/STMMaker.cc
@@ -340,6 +340,7 @@ namespace mu2e {
                         _shieldDnStrWallGap,
                         _shieldDnStrWallMaterial,
                         _shieldBuildMatingBlock,
+                        _shieldPipeUpStrAirGap,
                         _shieldOffsetInMu2e, //This is upstream edge of FOV collimator for now.
                         _shieldRotation
                        ));
@@ -810,6 +811,7 @@ namespace mu2e {
     _shieldUpStrWallGap         = _config.getDouble("stm.shield.UpStrWall.gap", 0.); //only if using pipe as origin
     _shieldDnStrWallMaterial    = _config.getString("stm.shield.DnStrWall.material", _shieldMaterial);
     _shieldBuildMatingBlock     = _config.getBool("stm.shield.matingBlock.build", true); // default to true because that is what older versions did
+    _shieldPipeUpStrAirGap      = _config.getDouble("stm.shield.pipe.upStrAirGap", 0); // default to 0 for backwards compatibility
 
     _stmDnStrEnvBuild       = _config.getBool("stm.downstream.build");
     _stmDnStrEnvHalfLength  = _config.getDouble("stm.downstream.halfLength");

--- a/GeometryService/src/STMMaker.cc
+++ b/GeometryService/src/STMMaker.cc
@@ -90,7 +90,7 @@ namespace mu2e {
 
 
     const CLHEP::HepRotation _FOVCollimatorRotation     = CLHEP::HepRotation::IDENTITY;
-    CLHEP::Hep3Vector  _FOVCollimatorOffsetInMu2e = _magnetOffsetInMu2e + CLHEP::Hep3Vector(0.0,0.,_magnetHalfLength + _FOVCollimatorUpStrSpace + _FOVCollimatorHalfLength);
+    CLHEP::Hep3Vector  _FOVCollimatorOffsetInMu2e = _magnetOffsetInMu2e + CLHEP::Hep3Vector(0.0,0.,_magnetHalfLength + _FOVCollimatorUpStrSpace + _FOVCollimatorHalfLength + _shieldPipeUpStrAirGap);
     // If we actually don't want to build the magnet, subtract off the offsets related to the magnet.
     // (We can't just set _magnetHalfLength = 0 in config because it is needed in various parts of constructSTM.cc
     // including to make a G4Box, which cannot have length 0...)
@@ -177,11 +177,11 @@ namespace mu2e {
     if ( _pipeBuild )          _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,_pipeDnStrHalfLength);
     if ( _FOVCollimatorBuild ) _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,0.5*_FOVCollimatorUpStrSpace+_FOVCollimatorHalfLength);
     if ( _shieldBuild ) {
-      _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,-0.5*_shieldDnStrSpace-_shieldDnStrWallHalfLength);
+      _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,-0.5*_shieldDnStrSpace-_shieldDnStrWallHalfLength + _shieldPipeUpStrAirGap);
       if (!_magnetBuild) {
         // Previous versions (<STM_v09) didn't need to include the shield pipe length in here.
         // Now we will include it, otherwise the table is tiny
-        _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,-0.5*_shieldDnStrSpace-_shieldDnStrWallHalfLength+_shieldPipeHalfLength);
+        _magnetTableOffsetInMu2e += CLHEP::Hep3Vector(0.0,0.,_shieldPipeHalfLength+0.5*_shieldDnStrSpace+_shieldDnStrWallHalfLength+_shieldPipeUpStrAirGap);
       }
     }
 

--- a/GeometryService/src/STMMaker.cc
+++ b/GeometryService/src/STMMaker.cc
@@ -90,7 +90,14 @@ namespace mu2e {
 
 
     const CLHEP::HepRotation _FOVCollimatorRotation     = CLHEP::HepRotation::IDENTITY;
-    const CLHEP::Hep3Vector  _FOVCollimatorOffsetInMu2e = _magnetOffsetInMu2e + CLHEP::Hep3Vector(0.0,0.,_magnetHalfLength + _FOVCollimatorUpStrSpace + _FOVCollimatorHalfLength);
+    CLHEP::Hep3Vector  _FOVCollimatorOffsetInMu2e = _magnetOffsetInMu2e + CLHEP::Hep3Vector(0.0,0.,_magnetHalfLength + _FOVCollimatorUpStrSpace + _FOVCollimatorHalfLength);
+    // If we actually don't want to build the magnet, subtract off the offsets related to the magnet.
+    // (We can't just set _magnetHalfLength = 0 in config because it is needed in various parts of constructSTM.cc
+    // including to make a G4Box, which cannot have length 0...)
+    if(_config.getBool("stm.magnet.build") == false) {
+      _FOVCollimatorOffsetInMu2e -= CLHEP::Hep3Vector(0.0, 0.0, 2*_magnetHalfLength);
+    }
+
     //if (_FOVCollimatorBuild){
       stm._pSTMFOVCollimatorParams = std::unique_ptr<STMCollimator>
         (new STMCollimator(_FOVCollimatorBuild,

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -200,6 +200,7 @@ double vd.STMSSCollUpStr.r = 2000;
 // changes for STM Upstream infrastructure
 string stm.magnet.stand.material = "StainlessSteel"; // update material of table
 bool   stm.magnet.build = false; // don't build the magnet
+bool stm.shield.matingBlock.build = false; // don't build the mating block since we no longer have a magnet
 // This tells emacs to view this file in c++ mode
 // Local Variables:
 // mode:c++

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -216,6 +216,8 @@ double stm.FOVcollimator.halfLength =   63.5; // fullLength = 127.0 mm (DocDB-49
 
 double stm.FOVcollimator.hole1.radiusUpStr =   70.0; // diameter = 140 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions")
 double stm.FOVcollimator.hole1.radiusDnStr =   70.0; // note: the same underlying class is used for FOV and SSC collimators hence why we see a "hole 1" and "UpStr" and "DnStr" radii. These are used in the SSC collimator
+double stm.FOVcollimator.plug.radius       = 70.0;
+
 
 // This tells emacs to view this file in c++ mode
 // Local Variables:

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -202,6 +202,8 @@ string stm.magnet.stand.material = "StainlessSteel"; // update material of table
 bool   stm.magnet.build = false; // don't build the magnet
 bool stm.shield.matingBlock.build = false; // don't build the mating block since we no longer have a magnet
 double stm.shield.pipe.halfLength      = 888.0; // fullLength = 1776.0 mm, Docdb-49112v2 "STM Aperatures, Positions, and Dimensions"
+double stm.shield.rIn = 139.70; // inner diameter = 11" = 279.4 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") => inner radius = 139.7 mm (note: this is same as previous version)
+double stm.shield.rOut = 177.8; // outer diameter = 14" = 355.6 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") => inner radius = 177.8 mm (note: this is different to previous version)
 // This tells emacs to view this file in c++ mode
 // Local Variables:
 // mode:c++

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -221,7 +221,7 @@ double stm.FOVcollimator.plug.radius       = 70.0;
 double stm.shield.pipe.upStrAirGap = 25.3; // 1" (25.4 mm) gap between ECS and shield pipe (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") but there is a hardcoded 0.1 mm zOffset buffer in constructSTM.cc that we account for here
 double stm.FOVcollimator.UpStrSpace = 11.7; // 0.5" (12.7 mm) gap between shield pipe and FOV collimator (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") but there is a 1 mm offset between where this ends up and that DocDB. Subtract 1 mm here so that FOV sits at z=20419.7 mm
 double stm.shield.DnStrWall.gap  = 0.0;
-
+double stm.magnet.stand.topExtraLength = -200.0; // reduce length of table to avoid overlap with virtual detector
 // This tells emacs to view this file in c++ mode
 // Local Variables:
 // mode:c++

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -197,13 +197,22 @@ double stm.det2VD.rOut = 60;
 double vd.STMCollDnStr.r = 60;
 double vd.STMSSCollUpStr.r = 2000;
 
-// changes for STM Upstream infrastructure
+//
+// Changes for STM Upstream infrastructure
+//
 string stm.magnet.stand.material = "StainlessSteel"; // update material of table
 bool   stm.magnet.build = false; // don't build the magnet
 bool stm.shield.matingBlock.build = false; // don't build the mating block since we no longer have a magnet
+
+// Shield Pipe
 double stm.shield.pipe.halfLength      = 888.0; // fullLength = 1776.0 mm, Docdb-49112v2 "STM Aperatures, Positions, and Dimensions"
 double stm.shield.rIn = 139.70; // inner diameter = 11" = 279.4 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") => inner radius = 139.7 mm (note: this is same as previous version)
 double stm.shield.rOut = 177.8; // outer diameter = 14" = 355.6 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") => inner radius = 177.8 mm (note: this is different to previous version)
+
+// FOV Collimator
+double stm.FOVcollimator.halfWidth  =  198.1; // fullWidth = 396.2 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") => halfWidth = 198.1 mm (note: this is different to previous version)
+double stm.FOVcollimator.halfHeight =  245.1; // fullHeight = 490.2 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") => halfHeight = 245.1 mm (note: this is different to previous version)
+double stm.FOVcollimator.halfLength =   63.5; // fullLength = 127.0 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") => halfLength = 63.5 mm (note: this is same as previous version)
 
 // This tells emacs to view this file in c++ mode
 // Local Variables:

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -218,6 +218,7 @@ double stm.FOVcollimator.hole1.radiusUpStr =   70.0; // diameter = 140 mm (DocDB
 double stm.FOVcollimator.hole1.radiusDnStr =   70.0; // note: the same underlying class is used for FOV and SSC collimators hence why we see a "hole 1" and "UpStr" and "DnStr" radii. These are used in the SSC collimator
 double stm.FOVcollimator.plug.radius       = 70.0;
 
+double stm.shield.pipe.upStrAirGap = 25.3; // 1" gap between ECS and shield pipe (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") but there is a hardcoded 0.1 mm zOffset buffer in constructSTM.cc that we account for here
 
 // This tells emacs to view this file in c++ mode
 // Local Variables:

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -204,7 +204,8 @@ bool stm.shield.matingBlock.build = false; // don't build the mating block since
 double stm.shield.pipe.halfLength      = 888.0; // fullLength = 1776.0 mm, Docdb-49112v2 "STM Aperatures, Positions, and Dimensions"
 double stm.shield.rIn = 139.70; // inner diameter = 11" = 279.4 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") => inner radius = 139.7 mm (note: this is same as previous version)
 double stm.shield.rOut = 177.8; // outer diameter = 14" = 355.6 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") => inner radius = 177.8 mm (note: this is different to previous version)
+
 // This tells emacs to view this file in c++ mode
 // Local Variables:
 // mode:c++
-// End
+// End:

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -197,6 +197,8 @@ double stm.det2VD.rOut = 60;
 double vd.STMCollDnStr.r = 60;
 double vd.STMSSCollUpStr.r = 2000;
 
+// changes for STM Upstream infrastructure
+string stm.magnet.stand.material = "StainlessSteel"; // update material of table
 // This tells emacs to view this file in c++ mode
 // Local Variables:
 // mode:c++

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -199,6 +199,7 @@ double vd.STMSSCollUpStr.r = 2000;
 
 // changes for STM Upstream infrastructure
 string stm.magnet.stand.material = "StainlessSteel"; // update material of table
+bool   stm.magnet.build = false; // don't build the magnet
 // This tells emacs to view this file in c++ mode
 // Local Variables:
 // mode:c++

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -218,7 +218,9 @@ double stm.FOVcollimator.hole1.radiusUpStr =   70.0; // diameter = 140 mm (DocDB
 double stm.FOVcollimator.hole1.radiusDnStr =   70.0; // note: the same underlying class is used for FOV and SSC collimators hence why we see a "hole 1" and "UpStr" and "DnStr" radii. These are used in the SSC collimator
 double stm.FOVcollimator.plug.radius       = 70.0;
 
-double stm.shield.pipe.upStrAirGap = 25.3; // 1" gap between ECS and shield pipe (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") but there is a hardcoded 0.1 mm zOffset buffer in constructSTM.cc that we account for here
+double stm.shield.pipe.upStrAirGap = 25.3; // 1" (25.4 mm) gap between ECS and shield pipe (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") but there is a hardcoded 0.1 mm zOffset buffer in constructSTM.cc that we account for here
+double stm.FOVcollimator.UpStrSpace = 11.7; // 0.5" (12.7 mm) gap between shield pipe and FOV collimator (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") but there is a 1 mm offset between where this ends up and that DocDB. Subtract 1 mm here so that FOV sits at z=20419.7 mm
+double stm.shield.DnStrWall.gap  = 0.0;
 
 // This tells emacs to view this file in c++ mode
 // Local Variables:

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -201,6 +201,7 @@ double vd.STMSSCollUpStr.r = 2000;
 string stm.magnet.stand.material = "StainlessSteel"; // update material of table
 bool   stm.magnet.build = false; // don't build the magnet
 bool stm.shield.matingBlock.build = false; // don't build the mating block since we no longer have a magnet
+double stm.shield.pipe.halfLength      = 888.0; // fullLength = 1776.0 mm, Docdb-49112v2 "STM Aperatures, Positions, and Dimensions"
 // This tells emacs to view this file in c++ mode
 // Local Variables:
 // mode:c++

--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -214,6 +214,9 @@ double stm.FOVcollimator.halfWidth  =  198.1; // fullWidth = 396.2 mm (DocDB-491
 double stm.FOVcollimator.halfHeight =  245.1; // fullHeight = 490.2 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") => halfHeight = 245.1 mm (note: this is different to previous version)
 double stm.FOVcollimator.halfLength =   63.5; // fullLength = 127.0 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions") => halfLength = 63.5 mm (note: this is same as previous version)
 
+double stm.FOVcollimator.hole1.radiusUpStr =   70.0; // diameter = 140 mm (DocDB-49112v2 "STM Apertures, Positions, and Dimensions")
+double stm.FOVcollimator.hole1.radiusDnStr =   70.0; // note: the same underlying class is used for FOV and SSC collimators hence why we see a "hole 1" and "UpStr" and "DnStr" radii. These are used in the SSC collimator
+
 // This tells emacs to view this file in c++ mode
 // Local Variables:
 // mode:c++

--- a/Mu2eG4/src/constructSTM.cc
+++ b/Mu2eG4/src/constructSTM.cc
@@ -3763,6 +3763,7 @@ namespace mu2e {
     const double mstmCRVShieldHalfLength  =  pSTMShieldPipeParams.dnStrWallHalflength();
     double mstmCRVShieldHalfWidth         =  pSTMShieldPipeParams.dnStrWallHalfWidth();
     double mstmCRVShieldHalfHeight        =  pSTMShieldPipeParams.dnStrWallHalfHeight();
+    double shieldPipeUpStrAirGap          =  pSTMShieldPipeParams.upStrAirGap();
 
     //if mating block parameters aren't defined, default to the magnet dimensions for backwards compatibility
     if(mstmCRVShieldHalfWidth < 0.) {
@@ -3805,7 +3806,7 @@ namespace mu2e {
                                       0.0, CLHEP::twopi );
     }
     double zOffsetBuffer = 0.1;
-    double mstmCRVShieldTubeZOffset = -mstmCRVShieldHalfLength-crvShieldTubeHalfLength-zOffsetBuffer;
+    double mstmCRVShieldTubeZOffset = -mstmCRVShieldHalfLength-crvShieldTubeHalfLength-zOffsetBuffer + shieldPipeUpStrAirGap;
     if(pSTMShieldPipeParams.matchPipeBlock()) { //match the pipe to the downstream end of the mating block
       //remove the buffer added in previous versions to prevent overlap as well as mating block half length, then add another half length
       mstmCRVShieldTubeZOffset += zOffsetBuffer + 2.*mstmCRVShieldHalfLength;

--- a/Mu2eG4/src/constructSTM.cc
+++ b/Mu2eG4/src/constructSTM.cc
@@ -3843,18 +3843,20 @@ namespace mu2e {
                                           0.0, CLHEP::twopi );
 
     if (pSTMShieldPipeParams.build()){
-      finishNesting(crvshield,
-                    findMaterialOrThrow(pSTMShieldPipeParams.dnStrWallMaterial()),
-                    0,
-                    mstmCRVShieldPositionInParent,
-                    parentInfo.logical,
-                    0,
-                    STMisVisible,
-                    G4Colour::Magenta(),
-                    STMisSolid,
-                    forceAuxEdgeVisible,
-                    placePV,
-                    doSurfaceCheck);
+      if (pSTMShieldPipeParams.buildMatingBlock()) {
+        finishNesting(crvshield,
+                      findMaterialOrThrow(pSTMShieldPipeParams.dnStrWallMaterial()),
+                      0,
+                      mstmCRVShieldPositionInParent,
+                      parentInfo.logical,
+                      0,
+                      STMisVisible,
+                      G4Colour::Magenta(),
+                      STMisSolid,
+                      forceAuxEdgeVisible,
+                      placePV,
+                      doSurfaceCheck);
+      }
       if(pSTMShieldPipeParams.hasLiner()) {
         finishNesting(crvlinershieldtube,
                       findMaterialOrThrow(pSTMShieldPipeParams.materialLiner()),

--- a/STMGeom/inc/ShieldPipe.hh
+++ b/STMGeom/inc/ShieldPipe.hh
@@ -22,6 +22,7 @@ namespace mu2e {
                double dnStrWallHalflength, double dnStrWallHoleRadius,
                double dnStrWallHalfHeight, double dnStrWallHalfWidth,
                double dnStrWallGap, std::string const& dnStrWallMaterial, bool buildMatingBlock,
+               double upStrAirGap,
                CLHEP::Hep3Vector const& originInMu2e, CLHEP::HepRotation const& rotation
               ) :
       _build( build ),
@@ -42,6 +43,7 @@ namespace mu2e {
       _dnStrWallGap( dnStrWallGap ),
       _dnStrWallMaterial( dnStrWallMaterial ),
       _buildMatingBlock( buildMatingBlock ),
+      _upStrAirGap( upStrAirGap ),
       _originInMu2e( originInMu2e ),
       _rotation    ( rotation     )
     {}
@@ -64,6 +66,7 @@ namespace mu2e {
     double dnStrWallGap()                     const { return _dnStrWallGap; }
     std::string const & dnStrWallMaterial()   const { return _dnStrWallMaterial; }
     bool buildMatingBlock()                   const { return _buildMatingBlock; }
+    double upStrAirGap()                       const { return _upStrAirGap; }
     CLHEP::Hep3Vector const &  originInMu2e() const { return _originInMu2e; }
     CLHEP::HepRotation const & rotation()     const { return _rotation; }
     //double zBegin()          const { return _originInMu2e.z() - zTabletopHalflength(); }
@@ -91,6 +94,7 @@ namespace mu2e {
     double             _dnStrWallGap; //between mating block/shield pipe and magnet
     std::string        _dnStrWallMaterial;
     bool               _buildMatingBlock;
+    double             _upStrAirGap;
     CLHEP::Hep3Vector  _originInMu2e;
     CLHEP::HepRotation _rotation; // wrt to parent volume
 

--- a/STMGeom/inc/ShieldPipe.hh
+++ b/STMGeom/inc/ShieldPipe.hh
@@ -21,7 +21,7 @@ namespace mu2e {
                double upStrSpace, double dnStrSpace,
                double dnStrWallHalflength, double dnStrWallHoleRadius,
                double dnStrWallHalfHeight, double dnStrWallHalfWidth,
-               double dnStrWallGap, std::string const& dnStrWallMaterial,
+               double dnStrWallGap, std::string const& dnStrWallMaterial, bool buildMatingBlock,
                CLHEP::Hep3Vector const& originInMu2e, CLHEP::HepRotation const& rotation
               ) :
       _build( build ),
@@ -41,6 +41,7 @@ namespace mu2e {
       _dnStrWallHalfWidth( dnStrWallHalfWidth ),
       _dnStrWallGap( dnStrWallGap ),
       _dnStrWallMaterial( dnStrWallMaterial ),
+      _buildMatingBlock( buildMatingBlock ),
       _originInMu2e( originInMu2e ),
       _rotation    ( rotation     )
     {}
@@ -62,6 +63,7 @@ namespace mu2e {
     double dnStrWallHalfWidth()               const { return _dnStrWallHalfWidth; }
     double dnStrWallGap()                     const { return _dnStrWallGap; }
     std::string const & dnStrWallMaterial()   const { return _dnStrWallMaterial; }
+    bool buildMatingBlock()                   const { return _buildMatingBlock; }
     CLHEP::Hep3Vector const &  originInMu2e() const { return _originInMu2e; }
     CLHEP::HepRotation const & rotation()     const { return _rotation; }
     //double zBegin()          const { return _originInMu2e.z() - zTabletopHalflength(); }
@@ -88,6 +90,7 @@ namespace mu2e {
     double             _dnStrWallHalfWidth;
     double             _dnStrWallGap; //between mating block/shield pipe and magnet
     std::string        _dnStrWallMaterial;
+    bool               _buildMatingBlock;
     CLHEP::Hep3Vector  _originInMu2e;
     CLHEP::HepRotation _rotation; // wrt to parent volume
 


### PR DESCRIPTION
This PR makes changes to the STM upstream geometry to more closely match what we expect. It:
* removes the magnet geometry (the magnetic field was already turned off)
* makes the shield pipe longer
* adds the air gaps between the shield pipe and the end cap shielding, and the shield pipe and the FOV collimator

It does not:
* replace the table with the trolley

There are before and after pictures in DocDB-53208.

This PR should probably be merged after Haichuan's #1509. We touch some of the same files but I think any merge conflicts would be easy to resolve.