### PR TITLE
Making the root based overlap check more stringent

### DIFF
--- a/bin/overlapCheck.C
+++ b/bin/overlapCheck.C
@@ -1,5 +1,5 @@
 void overlapCheck(TString const fname="mu2e.gdml",
-                  Double_t res=0.001)
+                  Double_t res=1.e-12)
 {
   TGeoManager::Import(fname);
   gGeoManager->CheckOverlaps(res);


### PR DESCRIPTION
This PR makes the root based overlap check more stringent without noticeably increasing the check time.
The checker should not detect any overlaps at this time, but should prevent very small overlaps/extrusions in future.