### PR TITLE
RPC updates towards the physical pion stop generation

### DIFF
--- a/EventGenerator/src/PionFilter_module.cc
+++ b/EventGenerator/src/PionFilter_module.cc
@@ -7,6 +7,7 @@
 #include "art_root_io/TFileService.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art_root_io/TFileService.h"
+#include "fhiclcpp/types/OptionalAtom.h"
 
 // Mu2e includes.
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
@@ -15,6 +16,7 @@
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+#include "Offline/Mu2eUtilities/inc/SimParticleGetTau.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 #include <iostream>
 #include <string>
@@ -28,11 +30,12 @@ namespace mu2e {
       struct Config {
         using Name=fhicl::Name;
         using Comment=fhicl::Comment;
-        fhicl::Atom<int> diagLevel{Name("diagLevel")};
-        fhicl::Atom<double> tmin{Name("tmin")};
-        fhicl::Atom<double> tmax{Name("tmax")};
-        fhicl::Atom<int> processCode{Name("processCode")};
-        fhicl::Atom<bool> isNull{Name("isNull")};
+        fhicl::Atom<int> diagLevel{Name("diagLevel"), Comment("Diagnostic print level"), 0};
+        fhicl::Atom<double> tmin{Name("tmin"), Comment("Selected pion minimum end time")};
+        fhicl::Atom<double> tmax{Name("tmax"), Comment("Selected pion maximum end time")};
+        fhicl::OptionalAtom<int> maxPions{Name("maxPions"), Comment("Maximum number of pion stops")};
+        fhicl::Atom<int> processCode{Name("processCode"), Comment("Pion end process code to select")};
+        fhicl::Atom<bool> isNull{Name("isNull"), Comment("Skip filtering is turned on"), false};
       };
       explicit PionFilter(const art::EDFilter::Table<Config>& config);
       virtual bool filter(art::Event& event) override;
@@ -44,6 +47,7 @@ namespace mu2e {
       int diagLevel_;
       double tmin_;
       double tmax_;
+      int maxPions_;
       int processCode_;
       bool isNull_;
       float _totalweight = 0;
@@ -60,36 +64,49 @@ namespace mu2e {
     , processCode_{config().processCode()}
     , isNull_{config().isNull()}
   {
+    if(!config().maxPions(maxPions_)) maxPions_ = -1;
   }
 
   void PionFilter::beginJob(){
       art::ServiceHandle<art::TFileService> tfs;
-
-}
+  }
 
   bool PionFilter::filter(art::Event& evt) {
       if(isNull_) return true;
       bool passed = false;
       std::vector<art::Handle<SimParticleCollection>> vah = evt.getMany<SimParticleCollection>();
+      const PhysicsParams& gc = *GlobalConstantsHandle<PhysicsParams>();
+      const std::vector<int> decayOffCodes = {PDGCode::pi_plus, PDGCode::pi_minus};
+      int npions(0);
       for (auto const& ah : vah) { //always one collection
         for(const auto& aParticle : *ah){
           art::Ptr<SimParticle> pp(ah, aParticle.first.asUint());
 
-          float _endglobaltime = pp->endGlobalTime();
+          // check if this is a pion of interest
           if( pp->stoppingCode() == processCode_ and std::abs(pp->pdgId()) == PDGCode::pi_plus){
-            const PhysicsParams& gc = *GlobalConstantsHandle<PhysicsParams>();
-            _totalweight += exp(-1*pp->endProperTime() / gc.getParticleLifetime(pp->pdgId()));
-            _ntot += 1;
-          }
-          if( pp->stoppingCode() == processCode_ and std::abs(pp->pdgId()) == PDGCode::pi_plus and _endglobaltime > tmin_ and _endglobaltime < tmax_ ){
-            passed = true;
-            const PhysicsParams& gc = *GlobalConstantsHandle<PhysicsParams>();
-            _selectedweight += exp(-1*pp->endProperTime() / gc.getParticleLifetime(pp->pdgId()));
-            _nsel += 1;
+            const float globalTime = pp->endGlobalTime();
+            const float weight = SimParticleGetTau::calculate(pp, decayOffCodes, gc);
+
+            // count found pions
+            _totalweight += weight;
+            ++_ntot;
+            ++npions;
+
+            // check additional filters
+            if(globalTime > tmin_ and globalTime < tmax_ ){
+              passed = true;
+              _selectedweight += weight;
+              ++_nsel;
+            }
           }
         }
       }
-    return passed;
+
+      // check global filters
+      passed &= maxPions_ < 0 || npions <= maxPions_;
+
+      // return the result
+      return passed;
   }
 
   void PionFilter::endJob(){

--- a/EventGenerator/src/PionFilter_module.cc
+++ b/EventGenerator/src/PionFilter_module.cc
@@ -31,8 +31,8 @@ namespace mu2e {
         using Name=fhicl::Name;
         using Comment=fhicl::Comment;
         fhicl::Atom<int> diagLevel{Name("diagLevel"), Comment("Diagnostic print level"), 0};
-        fhicl::Atom<double> tmin{Name("tmin"), Comment("Selected pion minimum end time")};
-        fhicl::Atom<double> tmax{Name("tmax"), Comment("Selected pion maximum end time")};
+        fhicl::OptionalAtom<double> tmin{Name("tmin"), Comment("Selected pion minimum end time")};
+        fhicl::OptionalAtom<double> tmax{Name("tmax"), Comment("Selected pion maximum end time")};
         fhicl::OptionalAtom<int> maxPions{Name("maxPions"), Comment("Maximum number of pion stops")};
         fhicl::Atom<int> processCode{Name("processCode"), Comment("Pion end process code to select")};
         fhicl::Atom<bool> isNull{Name("isNull"), Comment("Skip filtering is turned on"), false};
@@ -59,11 +59,11 @@ namespace mu2e {
   PionFilter::PionFilter(const art::EDFilter::Table<Config>& config) :
      EDFilter{config}
     , diagLevel_{config().diagLevel()}
-    , tmin_{config().tmin()}
-    , tmax_{config().tmax()}
     , processCode_{config().processCode()}
     , isNull_{config().isNull()}
   {
+    if(!config().tmin(tmin_)) tmin_ = -1.e10;
+    if(!config().tmax(tmax_)) tmax_ =  1.e10;
     if(!config().maxPions(maxPions_)) maxPions_ = -1;
   }
 

--- a/EventGenerator/src/RPCGun_module.cc
+++ b/EventGenerator/src/RPCGun_module.cc
@@ -55,7 +55,7 @@ namespace mu2e {
     struct Config {
       using Name=fhicl::Name;
       using Comment=fhicl::Comment;
-        fhicl::Atom<art::InputTag> inputSimParticles{Name("inputSimParticles"),Comment("A SimParticleCollection with input stopped muons.")};
+        fhicl::Atom<art::InputTag> inputSimParticles{Name("inputSimParticles"),Comment("A SimParticleCollection with input stopped pions")};
         fhicl::Atom<unsigned> verbosity{Name("verbosity"),Comment("Add additional printout"), 0};
         fhicl::Atom<std::string> RPCType{Name("RPCType"),Comment("a process code, should be either RPCInternal or RPCExternal") };
         fhicl::DelegatedParameter spectrum{Name("spectrum"), Comment("Parameters for BinnedSpectrum")};

--- a/EventGenerator/src/RPCGun_module.cc
+++ b/EventGenerator/src/RPCGun_module.cc
@@ -87,7 +87,8 @@ namespace mu2e {
     ProcessCode process_;
     PionCaptureSpectrum pionCaptureSpectrum_;
 
-    TH1F* _hmomentum;
+    TH1F* _hnstops {nullptr};
+    TH1F* _hmomentum {nullptr};
     TH1F* _hElecMom {nullptr};
     TH1F* _hElecPx {nullptr};
     TH1F* _hElecPy {nullptr};
@@ -136,7 +137,8 @@ namespace mu2e {
         art::ServiceHandle<art::TFileService> tfs;
         art::TFileDirectory tfdir = tfs->mkdir( "RPCGun" );
 
-        _hmomentum     = tfdir.make<TH1F>( "hmomentum", "Produced photon momentum", 100,  40.,  140.  );
+        _hnstops       = tfdir.make<TH1F>("hNStops", "N(pion stops) / event", 10,  -0.5,  9.5);
+        _hmomentum     = tfdir.make<TH1F>("hmomentum", "Produced photon momentum", 100,  40.,  140.  );
         _hTime         = tfdir.make<TH1F>("hTime" , "pion time",100,0,1700);
         _hTimeWt       = tfdir.make<TH1F>("hTimeWt", "pion time, weighted",100,0,1700);
         _hStopXY       = tfdir.make<TH2F>("hStopXY", "Pion stop position;x (mm); y(mm)",100, -200, 200, 100, -200, 200);
@@ -195,6 +197,9 @@ namespace mu2e {
     event.put(std::move(pw));
     addParticles(output.get(), pis[randIn]);
     event.put(std::move(output));
+    if(doHistograms_) {
+      _hnstops->Fill(pis.size());
+    }
   }
 
   void RPCGun::addParticles(StageParticleCollection* output,

--- a/EventGenerator/src/RPCGun_module.cc
+++ b/EventGenerator/src/RPCGun_module.cc
@@ -34,6 +34,7 @@
 #include "Offline/Mu2eUtilities/inc/BinnedSpectrum.hh"
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
 #include "Offline/Mu2eUtilities/inc/PionCaptureSpectrum.hh"
+#include "Offline/Mu2eUtilities/inc/SimParticleGetTau.hh"
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "art_root_io/TFileService.h"
@@ -55,11 +56,11 @@ namespace mu2e {
       using Name=fhicl::Name;
       using Comment=fhicl::Comment;
         fhicl::Atom<art::InputTag> inputSimParticles{Name("inputSimParticles"),Comment("A SimParticleCollection with input stopped muons.")};
-        fhicl::Atom<unsigned> verbosity{Name("verbosity"),0};
+        fhicl::Atom<unsigned> verbosity{Name("verbosity"),Comment("Add additional printout"), 0};
         fhicl::Atom<std::string> RPCType{Name("RPCType"),Comment("a process code, should be either RPCInternal or RPCExternal") };
         fhicl::DelegatedParameter spectrum{Name("spectrum"), Comment("Parameters for BinnedSpectrum")};
-        fhicl::Atom<bool> pionDecayOff{Name("pionDecayOff"),true};
-        fhicl::Atom<bool> doHistograms{Name("doHistograms"),false};
+        fhicl::Atom<bool> pionDecayOff{Name("pionDecayOff"),Comment("Assume pion decay was turned off, produce event weights"), true};
+        fhicl::Atom<bool> doHistograms{Name("doHistograms"),Comment("Produce debug histograms"), false};
     };
 
     using Parameters= art::EDProducer::Table<Config>;
@@ -96,6 +97,10 @@ namespace mu2e {
     TH1F* _hPosiPy {nullptr};
     TH1F* _hPosiPz {nullptr};
     TH1F* _hTime {nullptr};
+    TH1F* _hTimeWt {nullptr};
+    TH2F* _hStopXY {nullptr};
+    TH1F* _hStopZ {nullptr};
+    TH1F* _hWeight {nullptr};
     TH1F* _hMee;
     TH2F* _hMeeVsE;
     TH1F* _hMeeOverE;                   // M(ee)/E(gamma)
@@ -132,16 +137,20 @@ namespace mu2e {
         art::TFileDirectory tfdir = tfs->mkdir( "RPCGun" );
 
         _hmomentum     = tfdir.make<TH1F>( "hmomentum", "Produced photon momentum", 100,  40.,  140.  );
+        _hTime         = tfdir.make<TH1F>("hTime" , "pion time",100,0,1700);
+        _hTimeWt       = tfdir.make<TH1F>("hTimeWt", "pion time, weighted",100,0,1700);
+        _hStopXY       = tfdir.make<TH2F>("hStopXY", "Pion stop position;x (mm); y(mm)",100, -200, 200, 100, -200, 200);
+        _hStopZ        = tfdir.make<TH1F>("hStopZ" , "Pion stop position;z (mm);", 200, 5000, 7000);
+        _hWeight       = tfdir.make<TH1F>("hWeight" , "log10(weight)", 200, -10, 1.);
         if(RPCType_ == "mu2eInternalRPC"){
           _hElecMom  = tfdir.make<TH1F>("hElecMom" , "Produced electron momentum", 140,  0. , 140.);
-          _hElecPx  = tfdir.make<TH1F>("hElecPx" , "Produced electron momentum Px", 140,  -140. , 140.);
-          _hElecPy  = tfdir.make<TH1F>("hElecPy" , "Produced electron momentum Py", 140,  -140. , 140.);
-          _hElecPz  = tfdir.make<TH1F>("hElecPz" , "Produced electron momentum Py", 140,  -140. , 140.);
+          _hElecPx   = tfdir.make<TH1F>("hElecPx" , "Produced electron momentum Px", 140,  -140. , 140.);
+          _hElecPy   = tfdir.make<TH1F>("hElecPy" , "Produced electron momentum Py", 140,  -140. , 140.);
+          _hElecPz   = tfdir.make<TH1F>("hElecPz" , "Produced electron momentum Py", 140,  -140. , 140.);
           _hPosiMom  = tfdir.make<TH1F>("hPosiMom" , "Produced positron momentum", 140,  0. , 140.);
-          _hPosiPx  = tfdir.make<TH1F>("hPosiPx" , "Produced positron momentum Px", 140,  -140. , 140.);
-          _hPosiPy  = tfdir.make<TH1F>("hPosiPy" , "Produced positron momentum Py", 140,  -140. , 140.);
-          _hPosiPz  = tfdir.make<TH1F>("hPosiPz" , "Produced positron momentum Pz", 140,  -140. , 140.);
-          _hTime    = tfdir.make<TH1F>("hTime" , "pion time",100,0,1700);
+          _hPosiPx   = tfdir.make<TH1F>("hPosiPx" , "Produced positron momentum Px", 140,  -140. , 140.);
+          _hPosiPy   = tfdir.make<TH1F>("hPosiPy" , "Produced positron momentum Py", 140,  -140. , 140.);
+          _hPosiPz   = tfdir.make<TH1F>("hPosiPz" , "Produced positron momentum Pz", 140,  -140. , 140.);
           _hMee      = tfdir.make<TH1F>("hMee"     , "M(e+e-) "           , 200,0.,200.);
           _hMeeVsE   = tfdir.make<TH2F>("hMeeVsE"  , "M(e+e-) vs E"       , 200,0.,200.,200,0,200);
           _hMeeOverE = tfdir.make<TH1F>("hMeeOverE", "M(e+e-)/E "         , 200, 0.,1);
@@ -151,16 +160,12 @@ namespace mu2e {
   }
 
   double RPCGun::MakeEventWeight(art::Ptr<SimParticle> part){
-      const PhysicsParams& gc = *GlobalConstantsHandle<PhysicsParams>();
-      double weight = 0.;
-      double tau = part->endProperTime() / gc.getParticleLifetime(part->pdgId());
-      while(part->parent().isNonnull()) { //while particle has a parent which is not null
-        part = part->parent();
-        if ( std::abs(part->pdgId()) == PDGCode::pi_plus ) { //if pion
-            tau += part->endProperTime() / gc.getParticleLifetime(part->pdgId());
-          }
-      }
-    weight = exp(-tau);
+    if(verbosity_ > 1) printf("[RPCGun::%s] Evaluating the event weight from the particle proper time\n", __func__);
+    const PhysicsParams& gc = *GlobalConstantsHandle<PhysicsParams>();
+    const std::vector<int> decayOffCodes = {PDGCode::pi_plus, PDGCode::pi_minus};
+    const double tau = SimParticleGetTau::calculate(part, decayOffCodes, gc);
+    const double weight = exp(-tau);
+    if(verbosity_ > 1) printf(" Tau = %.3f, Weight = %.3g, t(end) = %.3g\n", tau, weight, part->endGlobalTime());
     return weight;
   }
 
@@ -170,6 +175,16 @@ namespace mu2e {
     const auto simh = event.getValidHandle<SimParticleCollection>(simsToken_);
     const auto pis = stoppedPiMinusList(simh);
     if(pis.empty()) {
+      if(verbosity_ > 0) {
+        printf("!!! RPCGun::%s: No pion stops found! Printing the sim collection:\n", __func__);
+        const auto& sims = *simh;
+        for(auto sim = sims.begin(); sim != sims.end(); ++sim) {
+          std::cout << " " << sim->first << ":"
+                    << " pdg = " << sim->second.pdgId()
+                    << " code = " << sim->second.stoppingCode()
+                    << " t = " << sim->second.endGlobalTime() << std::endl;
+        }
+      }
       throw   cet::exception("BADINPUT")
         <<"RPCGun::produce(): no suitable stopped pion in the input SimParticleCollection\n";
     }
@@ -189,6 +204,9 @@ namespace mu2e {
     double energy = spectrum_.sample(randSpectrum_.fire());
     const CLHEP::Hep3Vector p3 = randomUnitSphere_.fire(energy);
     const CLHEP::HepLorentzVector fourmom(p3, energy);
+    if(verbosity_ > 0) printf("[RPCGun::%s] p_gamma = (%7.2f, %7.2f, %7.2f), t_gamma = %6.1f, pos = (%7.1f, %7.1f, %8.1f)\n", __func__,
+                              p3.x(), p3.y(), p3.z(), pistop->endGlobalTime(),
+                              pistop->endPosition().x(), pistop->endPosition().y(), pistop->endPosition().z());
     if(process_ == ProcessCode::mu2eExternalRPC){
      output->emplace_back(pistop,
                          process_,
@@ -227,7 +245,6 @@ namespace mu2e {
           _hPosiPx ->Fill(momp.vect().x());
           _hPosiPy ->Fill(momp.vect().y());
           _hPosiPz ->Fill(momp.vect().z());
-          _hTime->Fill(pistop->endGlobalTime());
           double mee = (mome+momp).m();
           _hMee->Fill(mee);
           _hMeeVsE->Fill(energy,mee);
@@ -242,7 +259,16 @@ namespace mu2e {
           throw   cet::exception("BADINPUT")
           <<"RPCGun::produce(): no suitable process id\n";
       }
-      if(doHistograms_) _hmomentum->Fill(energy);
+      if(doHistograms_) {
+        const float weight = (pionDecayOff_) ? MakeEventWeight(pistop) : 1.;
+        _hmomentum->Fill(energy);
+        _hTime->Fill(pistop->endGlobalTime());
+        _hTimeWt->Fill(pistop->endGlobalTime(), weight);
+        _hStopXY->Fill(pistop->endPosition().x()+3904., pistop->endPosition().y());
+        _hStopZ->Fill(pistop->endPosition().z());
+        _hWeight->Fill((weight > 0.) ? std::log10(weight) : -1.e3);
+      }
+
    }
 
 

--- a/MCDataProducts/inc/SumOfWeights.hh
+++ b/MCDataProducts/inc/SumOfWeights.hh
@@ -1,0 +1,38 @@
+// Michael MacKenzie, 2025
+
+#ifndef MCDataProducts_inc_SumOfWeights_hh
+#define MCDataProducts_inc_SumOfWeights_hh
+
+namespace mu2e {
+
+  class SumOfWeights {
+  public:
+
+    // constructors
+    SumOfWeights() : sum_(0.), count_(0) {}
+    SumOfWeights(double sum, unsigned long count) : sum_(sum), count_(count) {}
+
+    // accessors
+    double sum  () const { return sum_  ; }
+    unsigned long   count() const { return count_; }
+
+    // functions
+    void add(const double weight, const unsigned long count = 1) {
+      sum_ += weight;
+      count_ += count;
+    }
+    void reset() {
+      sum_ = 0.;
+      count_ = 0;
+    }
+    double avg() const {
+      return (count_ > 0) ? sum_ / count_ : 0.;
+    }
+
+  private:
+    double sum_  ; // total sum of weights
+    unsigned long   count_; // N(events) in the sum
+  };
+}
+
+#endif/*MCDataProducts_inc_EventWeight_hh*/

--- a/MCDataProducts/src/classes.h
+++ b/MCDataProducts/src/classes.h
@@ -41,6 +41,7 @@
 #include "Offline/MCDataProducts/inc/ProtonBunchIntensity.hh"
 #include "Offline/MCDataProducts/inc/ProtonBunchIntensitySummary.hh"
 #include "Offline/MCDataProducts/inc/EventWeight.hh"
+#include "Offline/MCDataProducts/inc/SumOfWeights.hh"
 
 // G4
 #include "Offline/MCDataProducts/inc/G4BeamlineInfo.hh"

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -115,6 +115,8 @@ include="Math/Vector3D.h, Math/Vector4D.h, CLHEP/Vector/LorentzVector.h, CLHEP/V
 
 <class name="mu2e::EventWeight"/>
 <class name="art::Wrapper<mu2e::EventWeight>"/>
+<class name="mu2e::SumOfWeights"/>
+<class name="art::Wrapper<mu2e::SumOfWeights>"/>
 
 <class name="mu2e::ProtonBunchTimeMC" />
 <class name="art::Wrapper<mu2e::ProtonBunchTimeMC>"/>

--- a/Mu2eUtilities/inc/SimParticleGetTau.hh
+++ b/Mu2eUtilities/inc/SimParticleGetTau.hh
@@ -39,6 +39,11 @@ namespace mu2e {
                              const VspMC& hitColls,
                              const std::vector<int>& decayOffCodes = std::vector<int>(),
                              const PhysicsParams& gc = *GlobalConstantsHandle<PhysicsParams>());
+
+    // using a sim particle collection from a multi-stage job
+    static double calculate(const art::Ptr<SimParticle>& p,
+                            const std::vector<int>& decayOffCodes = std::vector<int>(),
+                            const PhysicsParams& gc = *GlobalConstantsHandle<PhysicsParams>());
   private:
     static double getMultiStageTau( const art::Ptr<SimParticle>& sp,
                                     const VspMC& hitColls,

--- a/Mu2eUtilities/src/SimParticleGetTau.cc
+++ b/Mu2eUtilities/src/SimParticleGetTau.cc
@@ -36,6 +36,20 @@ namespace mu2e {
   }
 
   //==========================================================================
+  double SimParticleGetTau::calculate( const art::Ptr<SimParticle>& p,
+                                       const std::vector<int>& decayOffCodes,
+                                       const PhysicsParams& gc ){
+    double tau = 0.;
+    const auto pdgId = p->pdgId();
+    // check if this code was turned off
+    if (std::find(decayOffCodes.begin(), decayOffCodes.end(), pdgId) != decayOffCodes.end())
+      tau = p->endProperTime() / gc.getParticleLifetime(pdgId);
+     // continue through the history
+    if(p->parent().isNonnull()) tau += calculate(p->parent(), decayOffCodes, gc);
+    return tau;
+  }
+
+  //==========================================================================
   double SimParticleGetTau::getMultiStageTau( const art::Ptr<SimParticle>& p,
                                               const VspMC& hitColls,
                                               const std::vector<int>& decayOffCodes,

--- a/UtilityModules/CMakeLists.txt
+++ b/UtilityModules/CMakeLists.txt
@@ -22,4 +22,13 @@ cet_build_plugin(RecoNullProducer art::module
       Offline::SeedService
 )
 
+cet_build_plugin(StopSelection art::module
+    REG_SOURCE src/StopSelection_module.cc
+    LIBRARIES REG      
+      Offline::GlobalConstantsService
+      Offline::MCDataProducts
+      Offline::Mu2eUtilities
+      Offline::SeedService
+)
+
 install_source(SUBDIRS src)

--- a/UtilityModules/src/SConscript
+++ b/UtilityModules/src/SConscript
@@ -35,6 +35,9 @@ helper.make_plugin( 'RecoNullProducer_module.cc',  # This build only applies to 
 
 # Build the remaining plugins with the standard link list
 helper.make_plugins( [ 'mu2e_MCDataProducts',
+                       'mu2e_DataProducts',
+                       'mu2e_GlobalConstantsService',
+                       'mu2e_Mu2eUtilities',
                        'mu2e_SeedService',
                        'art_Framework_Core',
                        'art_Framework_IO_Sources',

--- a/UtilityModules/src/StopSelection_module.cc
+++ b/UtilityModules/src/StopSelection_module.cc
@@ -34,6 +34,15 @@ namespace mu2e {
 
   class StopSelection : public art::EDProducer {
   public:
+    // for applying selections to stops
+    struct StopConfig {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      fhicl::OptionalAtom<double> tmin{Name("tmin"), Comment("Minimum stop time")};
+      fhicl::OptionalAtom<double> tmax{Name("tmax"), Comment("Maximum stop time")};
+    };
+
+    // top-level configuration
     struct Config {
       using Name=fhicl::Name;
       using Comment=fhicl::Comment;
@@ -41,8 +50,29 @@ namespace mu2e {
       fhicl::Atom<int> pdgId{Name("pdgId"),Comment("Particle PDG code to select")};
       fhicl::Atom<int> processCode{Name("processCode"), Comment("Particle end process code to select")};
       fhicl::OptionalSequence<int> decayOffPdgs{Name("decayOffPdgs"), Comment("List of PDG IDs that decay was turned off, for event weights")};
+      fhicl::OptionalTable<StopConfig> cuts { Name("cuts"), Comment("Stop selection table") };
       fhicl::Atom<int> diagLevel{Name("diagLevel"), Comment("Diagnostic print level"), 0};
     };
+
+    // Cut selection struct
+    struct StopCuts {
+      using var=std::pair<bool, double>;
+      var tmin_;
+      var tmax_;
+      StopCuts() : tmin_(var(false, 0.)), tmax_(var(false, 0.)) {}
+      StopCuts(StopConfig config) : StopCuts(){
+        tmin_.first = config.tmin(tmin_.second);
+        tmax_.first = config.tmax(tmax_.second);
+      }
+      bool apply_cuts(art::Ptr<SimParticle> sim) {
+        if(sim.isNull()) return false;
+        const double t = sim->endGlobalTime();
+        if(tmin_.first && t < tmin_.second) return false;
+        if(tmax_.first && t > tmax_.second) return false;
+        return true;
+      }
+    };
+
     explicit StopSelection(const art::EDProducer::Table<Config>& config);
     virtual void produce(art::Event& event) override;
     virtual void beginSubRun(art::SubRun& sr) override;
@@ -51,36 +81,55 @@ namespace mu2e {
     virtual void endJob() override;
 
   private:
+    std::vector<art::Ptr<SimParticle>> pruneStops(const std::vector<art::Ptr<SimParticle>>& sims);
+
     art::ProductToken<SimParticleCollection> const simsToken_;
     PDGCode pdgId_;
     ProcessCode::enum_type processCode_;
     std::vector<int> decayOffPdgs_;
     int diagLevel_;
+    StopCuts cuts_;
     SumOfWeights total_;
+    int nempty_;
 
     art::RandomNumberGenerator::base_engine_t& eng_;
     CLHEP::RandFlat randomFlat_;
   };
 
+  //--------------------------------------------------------------------------------------------------------------
   StopSelection::StopSelection(const art::EDProducer::Table<Config>& config) :
     EDProducer{config}
     , simsToken_{consumes<SimParticleCollection>(config().simCollTag())}
     , pdgId_{config().pdgId()}
     , processCode_{static_cast<ProcessCode::enum_type>(config().processCode())}
     , diagLevel_{config().diagLevel()}
+    , nempty_(0)
     , eng_{createEngine(art::ServiceHandle<SeedService>()->getSeed())}
     , randomFlat_{eng_}
   {
     produces<mu2e::SimParticleCollection>();
     if(!config().decayOffPdgs(decayOffPdgs_)) decayOffPdgs_ = {};
+    if(config().cuts()) cuts_ = StopCuts(*config().cuts());
     // if some decays were turned off, produce an event weight
     if(!decayOffPdgs_.empty()) produces<mu2e::EventWeight>();
     produces<SumOfWeights, art::InSubRun>();
   }
 
+  //--------------------------------------------------------------------------------------------------------------
   void StopSelection::beginJob(){
   }
 
+  //--------------------------------------------------------------------------------------------------------------
+  // apply selections to the stop collection
+  std::vector<art::Ptr<SimParticle>> StopSelection::pruneStops(const std::vector<art::Ptr<SimParticle>>& sims) {
+    std::vector<art::Ptr<SimParticle>> outlist;
+    for(auto sim : sims) {
+      if(cuts_.apply_cuts(sim)) outlist.push_back(sim);
+    }
+    return outlist;
+  }
+
+  //--------------------------------------------------------------------------------------------------------------
   void StopSelection::produce(art::Event& event) {
     auto output{std::make_unique<SimParticleCollection>()};
     const bool make_weight = !decayOffPdgs_.empty();
@@ -89,14 +138,15 @@ namespace mu2e {
     // get the sim collection and the corresponding stops
     const auto simh = event.getValidHandle<SimParticleCollection>(simsToken_);
     const auto stops = simParticleList(simh, pdgId_, processCode_);
+    const auto selected = pruneStops(stops);
 
     if(diagLevel_ > 1) {
-      printf("StopSelection::%s:: Printing input sim collections:\n", __func__);
+      printf("StopSelection::%s:: From %zu stops selected %zu candidates\n", __func__, stops.size(), selected.size());
     }
     // select a random stop if available
-    if(!stops.empty()) {
-      const int index = randomFlat_.fireInt(stops.size());
-      art::Ptr<SimParticle> sim = stops[index];
+    if(!selected.empty()) {
+      const int index = randomFlat_.fireInt(selected.size());
+      art::Ptr<SimParticle> sim = selected[index];
 
       // get the selected stop's time weight if requested
       if(make_weight) {
@@ -111,9 +161,11 @@ namespace mu2e {
         output->insert(std::make_pair(sim->id(), *sim));
         sim = sim->parent();
       }
+      total_.add(weight);
+    } else {
+      ++nempty_;
     }
 
-    total_.add(weight);
 
     // produce the data products
     event.put(std::move(output));
@@ -123,17 +175,21 @@ namespace mu2e {
     }
   }
 
+  //--------------------------------------------------------------------------------------------------------------
   void StopSelection::beginSubRun(art::SubRun&) {
     total_.reset();
   }
 
+  //--------------------------------------------------------------------------------------------------------------
   void StopSelection::endSubRun(art::SubRun& sr) {
     sr.put(std::unique_ptr<SumOfWeights>(new SumOfWeights(total_.sum(), total_.count())), art::fullSubRun());
     if(diagLevel_ > 0) {
-      printf("[StopSelection::%s] Selected %lu stops with a sum of weights of %.5g\n", __func__, total_.count(), total_.sum());
+      printf("[StopSelection::%s] Selected %lu stops with a sum of weights of %.5g, %i empty events\n", __func__,
+             total_.count(), total_.sum(), nempty_);
     }
   }
 
+  //--------------------------------------------------------------------------------------------------------------
   void StopSelection::endJob(){
   }
 }

--- a/UtilityModules/src/StopSelection_module.cc
+++ b/UtilityModules/src/StopSelection_module.cc
@@ -1,0 +1,120 @@
+// Select a stopped particle and pass on a slimmed sim particle collection with this stop and its history
+// author: M. MacKenzie  2025
+
+// art includes
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "fhiclcpp/types/OptionalAtom.h"
+#include "fhiclcpp/types/OptionalSequence.h"
+#include "art_root_io/TFileService.h"
+
+// CLHEP
+#include "CLHEP/Random/RandFlat.h"
+
+// Mu2e includes
+#include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+#include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
+#include "Offline/MCDataProducts/inc/EventWeight.hh"
+#include "Offline/MCDataProducts/inc/SimParticle.hh"
+#include "Offline/Mu2eUtilities/inc/SimParticleGetTau.hh"
+#include "Offline/Mu2eUtilities/inc/simParticleList.hh"
+#include "Offline/SeedService/inc/SeedService.hh"
+
+// std includes
+#include <iostream>
+#include <string>
+
+using namespace std;
+namespace mu2e {
+
+  class StopSelection : public art::EDProducer {
+  public:
+    struct Config {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      fhicl::Atom<art::InputTag> simCollTag{Name("simParticles"),Comment("A SimParticleCollection with input stopped particles")};
+      fhicl::Atom<int> pdgId{Name("pdgId"),Comment("Particle PDG code to select")};
+      fhicl::Atom<int> processCode{Name("processCode"), Comment("Particle end process code to select")};
+      fhicl::OptionalSequence<int> decayOffPdgs{Name("decayOffPdgs"), Comment("List of PDG IDs that decay was turned off, for event weights")};
+      fhicl::Atom<int> diagLevel{Name("diagLevel"), Comment("Diagnostic print level"), 0};
+    };
+    explicit StopSelection(const art::EDProducer::Table<Config>& config);
+    virtual void produce(art::Event& event) override;
+    virtual void beginJob() override;
+    virtual void endJob() override;
+
+  private:
+    art::ProductToken<SimParticleCollection> const simsToken_;
+    PDGCode pdgId_;
+    ProcessCode::enum_type processCode_;
+    std::vector<int> decayOffPdgs_;
+    int diagLevel_;
+
+    art::RandomNumberGenerator::base_engine_t& eng_;
+    CLHEP::RandFlat randomFlat_;
+  };
+
+  StopSelection::StopSelection(const art::EDProducer::Table<Config>& config) :
+    EDProducer{config}
+    , simsToken_{consumes<SimParticleCollection>(config().simCollTag())}
+    , pdgId_{config().pdgId()}
+    , processCode_{static_cast<ProcessCode::enum_type>(config().processCode())}
+    , diagLevel_{config().diagLevel()}
+    , eng_{createEngine(art::ServiceHandle<SeedService>()->getSeed())}
+    , randomFlat_{eng_}
+  {
+    produces<mu2e::SimParticleCollection>();
+    if(!config().decayOffPdgs(decayOffPdgs_)) decayOffPdgs_ = {};
+    // if some decays were turned off, produce an event weight
+    if(!decayOffPdgs_.empty()) produces<mu2e::EventWeight>();
+  }
+
+  void StopSelection::beginJob(){
+  }
+
+  void StopSelection::produce(art::Event& event) {
+    auto output{std::make_unique<SimParticleCollection>()};
+    const bool make_weight = !decayOffPdgs_.empty();
+    double weight = 1.;
+
+    // get the sim collection and the corresponding stops
+    const auto simh = event.getValidHandle<SimParticleCollection>(simsToken_);
+    const auto stops = simParticleList(simh, pdgId_, processCode_);
+
+    // select a random stop if available
+    if(!stops.empty()) {
+      const int index = randomFlat_.fireInt(stops.size());
+      art::Ptr<SimParticle> sim = stops[index];
+
+      // get the selected stop's time weight if requested
+      if(make_weight) {
+        const PhysicsParams& gc = *GlobalConstantsHandle<PhysicsParams>();
+        const double tau = SimParticleGetTau::calculate(sim, decayOffPdgs_, gc);
+        weight = std::exp(-tau);
+      }
+
+      // save the entire lineage
+      while(sim.isNonnull()) {
+        output->insert(std::make_pair(sim->id(), *sim));
+        sim = sim->parent();
+      }
+    }
+
+    // produce the data products
+    event.put(std::move(output));
+    if(make_weight) {
+      std::unique_ptr<EventWeight> ew(new EventWeight(weight));
+      event.put(std::move(ew));
+    }
+  }
+
+  void StopSelection::endJob(){
+  }
+}
+
+using mu2e::StopSelection;
+DEFINE_ART_MODULE(StopSelection)

--- a/UtilityModules/src/StopSelection_module.cc
+++ b/UtilityModules/src/StopSelection_module.cc
@@ -2,7 +2,7 @@
 // author: M. MacKenzie  2025
 
 // art includes
-#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/EDFilter.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -33,7 +33,7 @@
 using namespace std;
 namespace mu2e {
 
-  class StopSelection : public art::EDProducer {
+  class StopSelection : public art::EDFilter {
   public:
     // for applying selections to stops
     struct StopConfig {
@@ -51,6 +51,7 @@ namespace mu2e {
       fhicl::Atom<art::InputTag> stepCollTag{Name("stepPointMCs"),Comment("A StepPointMCCollection with input steps")};
       fhicl::Atom<int> pdgId{Name("pdgId"),Comment("Particle PDG code to select")};
       fhicl::Atom<int> processCode{Name("processCode"), Comment("Particle end process code to select")};
+      fhicl::Atom<bool> filter{Name("filter"), Comment("Filter out events with no selected stops")};
       fhicl::OptionalSequence<int> decayOffPdgs{Name("decayOffPdgs"), Comment("List of PDG IDs that decay was turned off, for event weights")};
       fhicl::OptionalTable<StopConfig> cuts { Name("cuts"), Comment("Stop selection table") };
       fhicl::OptionalAtom<double> acceptRejectMax{Name("acceptRejectMax"), Comment("Perform accept/reject with a given maximum weight")};
@@ -76,26 +77,34 @@ namespace mu2e {
       }
     };
 
-    explicit StopSelection(const art::EDProducer::Table<Config>& config);
-    virtual void produce(art::Event& event) override;
-    virtual void beginSubRun(art::SubRun& sr) override;
-    virtual void endSubRun(art::SubRun& sr) override;
+    explicit StopSelection(const art::EDFilter::Table<Config>& config);
+    virtual bool filter(art::Event& event) override;
+    virtual bool beginSubRun(art::SubRun& sr) override;
+    virtual bool endSubRun(art::SubRun& sr) override;
     virtual void beginJob() override;
     virtual void endJob() override;
 
   private:
     std::vector<art::Ptr<SimParticle>> pruneStops(const std::vector<art::Ptr<SimParticle>>& sims);
+    void addSim(art::Ptr<SimParticle> sim, std::unique_ptr<SimParticleCollection>& coll,
+                art::ProductID const& pid, art::EDProductGetter const* getter);
+    void addSteps(const StepPointMCCollection& steps,
+                  std::unique_ptr<SimParticleCollection>& sims,
+                  std::unique_ptr<StepPointMCCollection>& out_steps,
+                  art::ProductID const& pid, art::EDProductGetter const* getter);
 
     art::ProductToken<SimParticleCollection> const simsToken_;
     art::ProductToken<StepPointMCCollection> const stepsToken_;
     PDGCode pdgId_;
     ProcessCode::enum_type processCode_;
+    bool filter_;
     std::vector<int> decayOffPdgs_;
     double maxWeight_;
     bool acceptReject_;
     int diagLevel_;
     StopCuts cuts_;
     SumOfWeights total_;
+    SumOfWeights selected_;
     int nempty_;
 
     art::RandomNumberGenerator::base_engine_t& eng_;
@@ -103,12 +112,13 @@ namespace mu2e {
   };
 
   //--------------------------------------------------------------------------------------------------------------
-  StopSelection::StopSelection(const art::EDProducer::Table<Config>& config) :
-    EDProducer{config}
+  StopSelection::StopSelection(const art::EDFilter::Table<Config>& config) :
+    EDFilter{config}
     , simsToken_{consumes<SimParticleCollection>(config().simCollTag())}
     , stepsToken_{consumes<StepPointMCCollection>(config().stepCollTag())}
     , pdgId_{config().pdgId()}
     , processCode_{static_cast<ProcessCode::enum_type>(config().processCode())}
+    , filter_{config().filter()}
     , acceptReject_{config().acceptRejectMax(maxWeight_)}
     , diagLevel_{config().diagLevel()}
     , nempty_(0)
@@ -142,15 +152,56 @@ namespace mu2e {
   }
 
   //--------------------------------------------------------------------------------------------------------------
-  void StopSelection::produce(art::Event& event) {
-    auto output{std::make_unique<SimParticleCollection>()};
+  // add a particle and its lineage to the collection
+  void StopSelection::addSim(art::Ptr<SimParticle> sim, std::unique_ptr<SimParticleCollection>& coll,
+                             art::ProductID const& pid, art::EDProductGetter const* getter) {
+      while(sim.isNonnull()) {
+        auto sim_id_pair = std::make_pair(sim->id(), *sim);
+        auto& new_sim = sim_id_pair.second;
+        auto parent = sim->parent();
+        new_sim.parent() = art::Ptr<SimParticle>(pid, parent.key(), getter);
+        for (auto& daughter : new_sim.daughters()) {
+          daughter = art::Ptr<SimParticle>(pid,daughter.key(),getter);
+        }
+        sim = parent;
+        coll->insert(sim_id_pair);
+      }
+  }
+
+
+  //--------------------------------------------------------------------------------------------------------------
+  // add relevant step points
+  void StopSelection::addSteps(const StepPointMCCollection& steps,
+                               std::unique_ptr<SimParticleCollection>& sims,
+                               std::unique_ptr<StepPointMCCollection>& out_steps,
+                               art::ProductID const& pid, art::EDProductGetter const* getter) {
+    // for every input step point, add it to the output if relevant, with remapping
+    for(auto& step : steps) {
+      bool found = false;
+      const auto id = step.simParticle()->id();
+      for(auto& sim : *sims) {
+        if(sim.first == id) {
+          found = true;
+          break;
+        }
+      }
+      if(found) { // save the step
+        auto out_step(step);
+        out_step.simParticle() = art::Ptr<SimParticle>(pid, step.simParticle().key(), getter);
+        out_steps->push_back(out_step);
+      }
+    }
+  }
+
+  //--------------------------------------------------------------------------------------------------------------
+  bool StopSelection::filter(art::Event& event) {
+    auto out_sims{std::make_unique<SimParticleCollection>()};
     auto out_steps{std::make_unique<StepPointMCCollection>()};
     const PhysicsParams& gc = *GlobalConstantsHandle<PhysicsParams>();
     const bool make_weight = !decayOffPdgs_.empty();
     double weight = 1.;
 
     // for mapping new sim art Ptrs
-    // auto out_pid = event.getProductID<SimParticleCollection>(moduleDescription().moduleLabel());
     auto out_pid = event.getProductID<SimParticleCollection>("");
     auto out_getter = event.productGetter(out_pid);
 
@@ -161,7 +212,7 @@ namespace mu2e {
     const auto selected = pruneStops(stops); // stopped particles satisfying a given selection
 
     if(diagLevel_ > 1) {
-      printf("StopSelection::%s:: From %zu stops selected %zu candidates\n", __func__, stops.size(), selected.size());
+      printf("[StopSelection::%s] From %zu stops selected %zu candidates\n", __func__, stops.size(), selected.size());
     }
 
     const size_t nstops = selected.size();
@@ -175,6 +226,7 @@ namespace mu2e {
         const double tau = SimParticleGetTau::calculate(sim, decayOffPdgs_, gc);
         weight = std::exp(-tau);
       }
+      total_.add(weight);
 
       // check if doing accept/reject
       if(acceptReject_) {
@@ -183,62 +235,50 @@ namespace mu2e {
       }
 
       // save the entire lineage, updating the pointer mapping
-      while(sim.isNonnull()) {
-        auto sim_id_pair = std::make_pair(sim->id(), *sim);
-        auto& new_sim = sim_id_pair.second;
-        auto parent = sim->parent();
-        new_sim.parent() = art::Ptr<SimParticle>(out_pid, parent.key(), out_getter);
-        for (auto& daughter : new_sim.daughters()) {
-          daughter = art::Ptr<SimParticle>(out_pid,daughter.key(),out_getter);
-        }
-        sim = parent;
-        output->insert(sim_id_pair);
-      }
+      addSim(sim, out_sims, out_pid, out_getter);
 
-      total_.add(weight);
+      selected_.add(weight);
       if(!acceptReject_) break; // no need to check each stop if not doing accept/reject
     }
-    if(output->size() == 0) ++nempty_;
-
+    if(out_sims->size() == 0) ++nempty_;
 
     // for every input step point, add it to the output if relevant, with remapping
-    for(auto& step : *steps) {
-      bool found = false;
-      const auto id = step.simParticle()->id();
-      for(auto& sim : *output) {
-        if(sim.first == id) {
-          found = true;
-          break;
-        }
-      }
-      if(found) { // save the step
-        auto out_step(step);
-        out_step.simParticle() = art::Ptr<SimParticle>(out_pid, step.simParticle().key(), out_getter);
-        out_steps->push_back(out_step);
-      }
+    if(out_sims->size() > 0) {
+      addSteps(*steps, out_sims, out_steps, out_pid, out_getter);
     }
+
+    if(diagLevel_ > 1) {
+      printf("[StopSelection::%s] From %zu candidates accepted %zu stops\n", __func__, selected.size(), out_sims->size());
+    }
+
+    // determine whether or not to accept the event
+    const bool pass = !filter_ || out_sims->size() > 0;
 
     // produce the data products
-    event.put(std::move(output));
+    event.put(std::move(out_sims));
     event.put(std::move(out_steps));
     if(make_weight) {
-      std::unique_ptr<EventWeight> ew(new EventWeight(weight));
-      event.put(std::move(ew));
+      event.put(std::unique_ptr<EventWeight>(new EventWeight(weight)));
     }
+
+    return pass;
   }
 
   //--------------------------------------------------------------------------------------------------------------
-  void StopSelection::beginSubRun(art::SubRun&) {
+  bool StopSelection::beginSubRun(art::SubRun&) {
     total_.reset();
+    selected_.reset();
+    return true;
   }
 
   //--------------------------------------------------------------------------------------------------------------
-  void StopSelection::endSubRun(art::SubRun& sr) {
+  bool StopSelection::endSubRun(art::SubRun& sr) {
     sr.put(std::unique_ptr<SumOfWeights>(new SumOfWeights(total_.sum(), total_.count())), art::fullSubRun());
     if(diagLevel_ > 0) {
-      printf("[StopSelection::%s] Selected %lu stops with a sum of weights of %.5g, %i empty events\n", __func__,
-             total_.count(), total_.sum(), nempty_);
+      printf("[StopSelection::%s] Selected %lu stops with a sum of weights of %.5g, %lu total events with %.5g sum of weights, %i empty events\n", __func__,
+             selected_.count(), selected_.sum(), total_.count(), total_.sum(), nempty_);
     }
+    return true;
   }
 
   //--------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Updating some of the RPC workflow in connection with plans to create a physical pion stop dataset from the infinite lifetime pion stop dataset. Much of this is just minor updates and improvements to the debug printouts/histogramming, where the necessary part is really the addition of the maximum pion count filtering.

We can't accept/reject an event with multiple potential pion stops as the event does not have a well defined global weight. The alternative would be to select a pion and create a collection with only this pion and its predecessors, dropping the input sim particle collection on output. If this latter strategy is preferred, I can add a module to create this slimmed sim particle collection and its associated event weight for the physical stopped pion dataset creation.