### PR TITLE
Fix panels and planes in alignedTracker

### DIFF
--- a/Mu2eKinKal/fcl/prolog.fcl
+++ b/Mu2eKinKal/fcl/prolog.fcl
@@ -39,6 +39,7 @@ Mu2eKinKal : {
     MaxDStraw : 2 # integer (straw)
     MaxStrawDOCA : 5.0 # mm
     MaxStrawDOCAConsistency : 1.0 # units of chi
+    MaxStrawUpos : 1.0 # units of strawlength
   }
 
    CHSEEDFIT: {

--- a/Mu2eKinKal/fcl/prolog.fcl
+++ b/Mu2eKinKal/fcl/prolog.fcl
@@ -39,7 +39,7 @@ Mu2eKinKal : {
     MaxDStraw : 2 # integer (straw)
     MaxStrawDOCA : 5.0 # mm
     MaxStrawDOCAConsistency : 1.0 # units of chi
-    MaxStrawUpos : 1.0 # units of strawlength
+    MaxStrawUposBuffer : 0.0 # units of mm
   }
 
    CHSEEDFIT: {

--- a/Mu2eKinKal/inc/KKFit.hh
+++ b/Mu2eKinKal/inc/KKFit.hh
@@ -128,7 +128,7 @@ namespace mu2e {
       double tprec_; // TPOCA calculation nominal precision
       StrawHitFlag addsel_, addrej_; // selection and rejection flags when adding hits
       // parameters controlling adding hits
-      float maxStrawHitDoca_, maxStrawHitDt_, maxStrawDoca_, maxStrawDocaCon_;
+      float maxStrawHitDoca_, maxStrawHitDt_, maxStrawDoca_, maxStrawDocaCon_, maxStrawUpos_;
       int maxDStraw_; // maximum distance from the track a strawhit can be to consider it for adding.
       // cached info computed from the tracker, used in hit adding; these must be lazy-evaluated as the tracker doesn't exist on construction
       mutable double strawradius_;
@@ -161,7 +161,7 @@ namespace mu2e {
     maxStrawHitDoca_(fitconfig.maxStrawHitDOCA()),
     maxStrawHitDt_(fitconfig.maxStrawHitDt()),
     maxStrawDoca_(fitconfig.maxStrawDOCA()),
-    maxStrawDocaCon_(fitconfig.maxStrawDOCAConsistency()),
+    maxStrawUpos_(fitconfig.maxStrawUpos()),
     maxDStraw_(fitconfig.maxDStraw())
   {
     if (fitconfig.saveTraj() == "T0") {
@@ -336,7 +336,7 @@ namespace mu2e {
             if(istraw >= -maxDStraw_ && istraw < static_cast<int>(panel.nStraws()) + maxDStraw_ ){
               unsigned istrmin = static_cast<unsigned>(std::max(istraw-maxDStraw_,0));
               // largest straw is the innermost; use that to test length
-              if(fabs(pposv.x()) < panel.getStraw(istrmin).halfLength() ) {
+              if(fabs(pposv.x()) < panel.getStraw(istrmin).halfLength() * maxStrawUpos_ ) {
                 unsigned istrmax = static_cast<unsigned>(std::min(istraw+maxDStraw_,static_cast<int>(panel.nStraws())-1));
                 // loop over straws
                 for(unsigned istr = istrmin; istr <= istrmax; ++istr){
@@ -356,7 +356,7 @@ namespace mu2e {
                     double du = (pca.sensorPoca().Vect()-smid).R();
                     double doca = fabs(pca.doca());
                     double dsig = std::max(0.0,doca-strawradius_)/sqrt(pca.docaVar());
-                    if(doca < maxStrawDoca_ && dsig < maxStrawDocaCon_ && du < straw.halfLength()){
+                    if(doca < maxStrawDoca_ && dsig < maxStrawDocaCon_ && du < straw.halfLength() * maxStrawUpos_){
                       addexings.push_back(std::make_shared<KKSTRAWXING>(pca,smat,straw.id()));
                       oldstraws.insert(straw.id());
                     }

--- a/Mu2eKinKal/inc/KKFit.hh
+++ b/Mu2eKinKal/inc/KKFit.hh
@@ -128,7 +128,7 @@ namespace mu2e {
       double tprec_; // TPOCA calculation nominal precision
       StrawHitFlag addsel_, addrej_; // selection and rejection flags when adding hits
       // parameters controlling adding hits
-      float maxStrawHitDoca_, maxStrawHitDt_, maxStrawDoca_, maxStrawDocaCon_, maxStrawUpos_;
+      float maxStrawHitDoca_, maxStrawHitDt_, maxStrawDoca_, maxStrawDocaCon_, maxStrawUposBuff_;
       int maxDStraw_; // maximum distance from the track a strawhit can be to consider it for adding.
       // cached info computed from the tracker, used in hit adding; these must be lazy-evaluated as the tracker doesn't exist on construction
       mutable double strawradius_;
@@ -161,7 +161,7 @@ namespace mu2e {
     maxStrawHitDoca_(fitconfig.maxStrawHitDOCA()),
     maxStrawHitDt_(fitconfig.maxStrawHitDt()),
     maxStrawDoca_(fitconfig.maxStrawDOCA()),
-    maxStrawUpos_(fitconfig.maxStrawUpos()),
+    maxStrawUposBuff_(fitconfig.maxStrawUposBuff()),
     maxDStraw_(fitconfig.maxDStraw())
   {
     if (fitconfig.saveTraj() == "T0") {
@@ -336,7 +336,7 @@ namespace mu2e {
             if(istraw >= -maxDStraw_ && istraw < static_cast<int>(panel.nStraws()) + maxDStraw_ ){
               unsigned istrmin = static_cast<unsigned>(std::max(istraw-maxDStraw_,0));
               // largest straw is the innermost; use that to test length
-              if(fabs(pposv.x()) < panel.getStraw(istrmin).halfLength() * maxStrawUpos_ ) {
+              if(fabs(pposv.x()) < panel.getStraw(istrmin).halfLength() + maxStrawUposBuff_ ) {
                 unsigned istrmax = static_cast<unsigned>(std::min(istraw+maxDStraw_,static_cast<int>(panel.nStraws())-1));
                 // loop over straws
                 for(unsigned istr = istrmin; istr <= istrmax; ++istr){
@@ -356,7 +356,7 @@ namespace mu2e {
                     double du = (pca.sensorPoca().Vect()-smid).R();
                     double doca = fabs(pca.doca());
                     double dsig = std::max(0.0,doca-strawradius_)/sqrt(pca.docaVar());
-                    if(doca < maxStrawDoca_ && dsig < maxStrawDocaCon_ && du < straw.halfLength() * maxStrawUpos_){
+                    if(doca < maxStrawDoca_ && dsig < maxStrawDocaCon_ && du < straw.halfLength() + maxStrawUposBuff_){
                       addexings.push_back(std::make_shared<KKSTRAWXING>(pca,smat,straw.id()));
                       oldstraws.insert(straw.id());
                     }

--- a/Mu2eKinKal/inc/KKFitSettings.hh
+++ b/Mu2eKinKal/inc/KKFitSettings.hh
@@ -85,6 +85,7 @@ namespace mu2e {
       fhicl::Atom<int> maxDStraw { Name("MaxDStraw"), Comment("Maximum (integer) straw separation when adding straw hits") };
       fhicl::Atom<float> maxStrawDOCA { Name("MaxStrawDOCA"), Comment("Max DOCA to add straw material (mm)") };
       fhicl::Atom<float> maxStrawDOCAConsistency { Name("MaxStrawDOCAConsistency"), Comment("Max DOCA chi-consistency to add straw material") };
+      fhicl::Atom<float> maxStrawUpos { Name("MaxStrawUpos"), Comment("Max Upos/strawlength to add straw material (mm)") };
       // extension and sampling
       fhicl::Atom<std::string> saveTraj { Name("SaveTrajectory"), Comment("How to save the trajectory in the KalSeed: None, Full, Detector, or T0 (1 segment containing t0)") };
     };

--- a/Mu2eKinKal/inc/KKFitSettings.hh
+++ b/Mu2eKinKal/inc/KKFitSettings.hh
@@ -85,7 +85,7 @@ namespace mu2e {
       fhicl::Atom<int> maxDStraw { Name("MaxDStraw"), Comment("Maximum (integer) straw separation when adding straw hits") };
       fhicl::Atom<float> maxStrawDOCA { Name("MaxStrawDOCA"), Comment("Max DOCA to add straw material (mm)") };
       fhicl::Atom<float> maxStrawDOCAConsistency { Name("MaxStrawDOCAConsistency"), Comment("Max DOCA chi-consistency to add straw material") };
-      fhicl::Atom<float> maxStrawUpos { Name("MaxStrawUpos"), Comment("Max Upos/strawlength to add straw material (mm)") };
+      fhicl::Atom<float> maxStrawUposBuff { Name("MaxStrawUposBuffer"), Comment("Max Upos beyond strawlength to add straw material (mm)") };
       // extension and sampling
       fhicl::Atom<std::string> saveTraj { Name("SaveTrajectory"), Comment("How to save the trajectory in the KalSeed: None, Full, Detector, or T0 (1 segment containing t0)") };
     };

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -78,8 +78,7 @@ namespace mu2e {
               strawends[StrawEnd::cal], strawends[StrawEnd::hv]);
         } // straw loop
         Panel &newpanel = tracker.getPanel(panel.id());
-        newpanel = Panel(panel.id(),tracker.straws());
-        tracker.getPanel(panel.id()).setPanelToDS(aligned_panel_to_ds);
+        newpanel = Panel(panel.id(),tracker.straws(),aligned_panel_to_ds);
       } // panel loop
       Plane &newplane = tracker.getPlane(plane.id());
       newplane = Plane(plane.id(),tracker.panels());

--- a/TrackerConditions/src/AlignedTrackerMaker.cc
+++ b/TrackerConditions/src/AlignedTrackerMaker.cc
@@ -77,7 +77,13 @@ namespace mu2e {
               wireends[StrawEnd::cal], wireends[StrawEnd::hv],
               strawends[StrawEnd::cal], strawends[StrawEnd::hv]);
         } // straw loop
+        Panel &newpanel = tracker.getPanel(panel.id());
+        newpanel = Panel(panel.id(),tracker.straws());
+        tracker.getPanel(panel.id()).setPanelToDS(aligned_panel_to_ds);
       } // panel loop
+      Plane &newplane = tracker.getPlane(plane.id());
+      newplane = Plane(plane.id(),tracker.panels());
+      newplane.setPlaneToDS(aligned_plane_to_ds);
     } // plane loop
     // should update tracker, plane and panel origins FIXME!
   }

--- a/TrackerGeom/inc/Panel.hh
+++ b/TrackerGeom/inc/Panel.hh
@@ -62,6 +62,13 @@ namespace mu2e {
     auto const& panelToDS() const { return _UVWtoDS; }
     auto dsToPanel() const { return _UVWtoDS.inverse(); }
 
+    void setPanelToDS(HepTransform const& panelToDS) {
+      _UVWtoDS = panelToDS;
+      _udir = panelToDS.rotation()*xyzVec(1.0,0.0,0.0);
+      _vdir = panelToDS.rotation()*xyzVec(0.0,1.0,0.0);
+      _wdir = panelToDS.rotation()*xyzVec(0.0,0.0,1.0);
+    }
+
     // deprecated interface: either use the above local coordinates, or get the straw direction directly
     xyzVec straw0Direction() const { return _straws[0]->wireDirection(); }
     // (The primary straw of each layer is the straw used to establish position.

--- a/TrackerGeom/inc/Panel.hh
+++ b/TrackerGeom/inc/Panel.hh
@@ -25,6 +25,7 @@ namespace mu2e {
     using TrackerStrawCollection = std::array<Straw,StrawId::_nustraws>;
     Panel():_straws(){} // default object non-function but needed for storage classes
     Panel( const StrawId& id, TrackerStrawCollection const& straws ); // construct from the Id and the full set of straws
+    Panel( const StrawId& id, TrackerStrawCollection const& straws, HepTransform const& panelToDS ); // construct with alignment
 
     // Accept the compiler generated destructor, copy constructor and assignment operators
 

--- a/TrackerGeom/inc/Plane.hh
+++ b/TrackerGeom/inc/Plane.hh
@@ -38,6 +38,9 @@ namespace mu2e {
     const StrawId&  id()  const { return _id;}
 
     const xyzVec& origin() const { return _PlanetoDS.displacement(); }
+    xyzVec uDirection() const { return _udir; }
+    xyzVec vDirection() const { return _vdir; }
+    xyzVec wDirection() const { return _wdir; }
 
     PanelCollection const& panels() const { return _panels; }
 
@@ -67,9 +70,17 @@ namespace mu2e {
     auto const& planeToDS() const { return _PlanetoDS; }
     auto dsToPlane() const { return _PlanetoDS.inverse(); }
 
+    void setPlaneToDS(HepTransform const& planeToDS) {
+      _PlanetoDS = planeToDS;
+      _udir = _PlanetoDS.rotation()*xyzVec(1.0,0.0,0.0);
+      _vdir = _PlanetoDS.rotation()*xyzVec(0.0,1.0,0.0);
+      _wdir = _PlanetoDS.rotation()*xyzVec(0.0,0.0,1.0);
+    }
+
     private:
     StrawId             _id;
     HepTransform        _PlanetoDS; // transform from plane coordinates to DS (just a translation)
+    xyzVec _udir, _vdir, _wdir; // direction vectors in DS frame
     PanelCollection     _panels;
     static StrawIdMask  _sidmask; // mask to plane level
   };

--- a/TrackerGeom/inc/Tracker.hh
+++ b/TrackerGeom/inc/Tracker.hh
@@ -75,6 +75,8 @@ namespace mu2e {
     PlaneCollection const& getPlanes() const { return _planes; }
     const Panel& getPanel( const StrawId& id ) const{ return _panels.at(id.uniquePanel()); }
     const Straw& getStraw( const StrawId& id) const{ return _straws[id.uniqueStraw()]; }
+    Plane& getPlane( const StrawId& id) { return _planes.at(id.getPlane()); }
+    Panel& getPanel( const StrawId& id) { return _panels.at(id.uniquePanel()); }
     Straw& getStraw( const StrawId& id) { return _straws[id.uniqueStraw()]; }
     StrawCollection const& getStraws() const{ return _straws; }
     // the following are deprecated: access should be through StrawProperties

--- a/TrackerGeom/src/Panel.cc
+++ b/TrackerGeom/src/Panel.cc
@@ -26,6 +26,16 @@ namespace mu2e {
     return os.str();
   }
 
+  Panel::Panel( const StrawId& id, TrackerStrawCollection const& straws, HepTransform const& panelToDS ) : _id(id) {
+    for(auto const& straw : straws ) {
+      // pick out all the straws belonging to this panel.
+      if(_sidmask.equal(_id,straw.id())){
+        _straws[straw.id().straw()] = &straw;
+      }
+    }
+    setPanelToDS(panelToDS);
+  }
+
   Panel::Panel( const StrawId& id, TrackerStrawCollection const& straws ) : _id(id) {
     for(auto const& straw : straws ) {
       // pick out all the straws belonging to this panel.
@@ -50,13 +60,13 @@ namespace mu2e {
     auto udir = DStoUVW.rotation()*_udir;
     auto vdir = DStoUVW.rotation()*_vdir;
     auto wdir = DStoUVW.rotation()*_wdir;
-//    if( fabs(1.0 - udir.dot(Hep3Vector(1.0,0.0,0.0))) > 1e-6 ||
-//        fabs(1.0 - vdir.dot(Hep3Vector(0.0,1.0,0.0))) > 1e-6 ||
-//        fabs(1.0 - wdir.dot(Hep3Vector(0.0,0.0,1.0))) > 1e-6 )
-//      throw cet::exception("Geom") << "Panel direction error: id " << _id << " udir " << udir << " vdir " << vdir << " wdir " << wdir << std::endl;
-//    auto po = DStoUVW*origin;
-//    if( fabs(po.r()) > 1e-6 )
-//      throw cet::exception("Geom") << "Panel origin error: id " << _id << " po " << po << " transform " << DStoUVW << std::endl;
+    if( fabs(1.0 - udir.dot(Hep3Vector(1.0,0.0,0.0))) > 1e-6 ||
+        fabs(1.0 - vdir.dot(Hep3Vector(0.0,1.0,0.0))) > 1e-6 ||
+        fabs(1.0 - wdir.dot(Hep3Vector(0.0,0.0,1.0))) > 1e-6 )
+      throw cet::exception("Geom") << "Panel direction error: id " << _id << " udir " << udir << " vdir " << vdir << " wdir " << wdir << std::endl;
+    auto po = DStoUVW*origin;
+    if( fabs(po.r()) > 1e-6 )
+      throw cet::exception("Geom") << "Panel origin error: id " << _id << " po " << po << " transform " << DStoUVW << std::endl;
     //
   }
 

--- a/TrackerGeom/src/Panel.cc
+++ b/TrackerGeom/src/Panel.cc
@@ -50,13 +50,13 @@ namespace mu2e {
     auto udir = DStoUVW.rotation()*_udir;
     auto vdir = DStoUVW.rotation()*_vdir;
     auto wdir = DStoUVW.rotation()*_wdir;
-    if( fabs(1.0 - udir.dot(Hep3Vector(1.0,0.0,0.0))) > 1e-6 ||
-        fabs(1.0 - vdir.dot(Hep3Vector(0.0,1.0,0.0))) > 1e-6 ||
-        fabs(1.0 - wdir.dot(Hep3Vector(0.0,0.0,1.0))) > 1e-6 )
-      throw cet::exception("Geom") << "Panel direction error: id " << _id << " udir " << udir << " vdir " << vdir << " wdir " << wdir << std::endl;
-    auto po = DStoUVW*origin;
-    if( fabs(po.r()) > 1e-6 )
-      throw cet::exception("Geom") << "Panel origin error: id " << _id << " po " << po << " transform " << DStoUVW << std::endl;
+//    if( fabs(1.0 - udir.dot(Hep3Vector(1.0,0.0,0.0))) > 1e-6 ||
+//        fabs(1.0 - vdir.dot(Hep3Vector(0.0,1.0,0.0))) > 1e-6 ||
+//        fabs(1.0 - wdir.dot(Hep3Vector(0.0,0.0,1.0))) > 1e-6 )
+//      throw cet::exception("Geom") << "Panel direction error: id " << _id << " udir " << udir << " vdir " << vdir << " wdir " << wdir << std::endl;
+//    auto po = DStoUVW*origin;
+//    if( fabs(po.r()) > 1e-6 )
+//      throw cet::exception("Geom") << "Panel origin error: id " << _id << " po " << po << " transform " << DStoUVW << std::endl;
     //
   }
 

--- a/TrackerGeom/src/Plane.cc
+++ b/TrackerGeom/src/Plane.cc
@@ -41,6 +41,9 @@ namespace mu2e {
     if(wdir.z() < 0.0) // flip about Y
       prot = HepRotation(Hep3Vector(0.0,1.0,0.0),M_PI);
     _PlanetoDS = HepTransform(origin,prot);
+    _udir = _PlanetoDS.rotation()*xyzVec(1.0,0.0,0.0);
+    _vdir = _PlanetoDS.rotation()*xyzVec(0.0,1.0,0.0);
+    _wdir = _PlanetoDS.rotation()*xyzVec(0.0,0.0,1.0);
   }
 
 }

--- a/TrkDiag/src/TrkGeomTest_module.cc
+++ b/TrkDiag/src/TrkGeomTest_module.cc
@@ -33,7 +33,7 @@ namespace mu2e {
       void beginJob ( ) override;
     private:
       ProditionsHandle<Tracker> _alignedTracker_h;
-      TTree* strawtest_, *paneltest_;
+      TTree* strawtest_, *paneltest_, *planetest_;
       int print_, diag_;
       int splane_, spanel_, straw_;
       int pplane_, panel_;
@@ -44,6 +44,8 @@ namespace mu2e {
       bool first_;
       float uphi_, vphi_, wcost_;
       float oz_, or_, ophi_;
+      float puphi_, pvphi_, pwcost_;
+      float poz_, por_, pophi_;
   };
 
   TrkGeomTest::TrkGeomTest(Parameters const& config) :     art::EDAnalyzer(config),
@@ -82,6 +84,15 @@ namespace mu2e {
       paneltest_->Branch("oz",&oz_,"oz/F");
       paneltest_->Branch("or",&or_,"or/F");
       paneltest_->Branch("ophi",&ophi_,"ophi/F");
+      planetest_=tfs->make<TTree>("planetest","planetest");
+      planetest_->Branch("plane",&pplane_,"plane/I");
+      planetest_->Branch("uphi",&puphi_,"uphi/F");
+      planetest_->Branch("vphi",&pvphi_,"vphi/F");
+      planetest_->Branch("wcost",&pwcost_,"wcost/F");
+      planetest_->Branch("oz",&poz_,"oz/F");
+      planetest_->Branch("or",&por_,"or/F");
+      planetest_->Branch("ophi",&pophi_,"ophi/F");
+
     }
   }
 
@@ -128,7 +139,7 @@ namespace mu2e {
         //
         // panel test
         //
-        for(auto const& panel : ntracker.panels()){
+        for(auto const& panel : atracker.panels()){
           pplane_ = panel.id().plane();
           panel_ = panel.id().panel();
           uphi_ = panel.uDirection().phi();
@@ -139,6 +150,17 @@ namespace mu2e {
           ophi_ = panel.origin().phi();
           paneltest_->Fill();
         }
+        for(auto const& plane : atracker.planes()){
+          pplane_ = plane.id().plane();
+          puphi_ = plane.uDirection().phi();
+          pvphi_ = plane.vDirection().phi();
+          pwcost_ = cos(plane.wDirection().theta());
+          poz_ = plane.origin().z();
+          por_ = plane.origin().rho();
+          pophi_ = plane.origin().phi();
+          planetest_->Fill();
+        }
+
       }
       first_ = false;
       std::cout << "Total # Straws " << ntracker.straws().size() << " Sum length = " << totallength


### PR DESCRIPTION
Aligned tracker had an issue where only the straws were updated, but the planes and panels still contained pointers to nominal straws. This impacted straw xing finding in kk fits when misalignments were large. 