### PR TITLE
nPOT Reconstruction from Observables Work

### DIFF
--- a/Analyses/fcl/prolog.fcl
+++ b/Analyses/fcl/prolog.fcl
@@ -10,7 +10,6 @@ NPOTAnalysis : {
     hsCollTag: "TTAprHelixFinder"
     prontonBunchIntensity: "PBISim"
     processName: "S5Stn"
-    ##changed to lumiStream from RecoNPOTFilter
     filterName: "lumiStream"
 }
 

--- a/Analyses/fcl/prolog.fcl
+++ b/Analyses/fcl/prolog.fcl
@@ -1,6 +1,18 @@
+
+
 # -*- mode: tcl -*-
 BEGIN_PROLOG
 
+NPOTAnalysis : {
+    module_type           : NPOTAnalysis
+    chCollTag: "TTmakePH"
+    tcCollTag: "TTTZClusterFinder"
+    hsCollTag: "TTAprHelixFinder"
+    prontonBunchIntensity: "PBISim"
+    processName: "S5Stn"
+    ##changed to lumiStream from RecoNPOTFilter
+    filterName: "lumiStream"
+}
 
 CosmicFilter: {
     module_type           : CosmicFilter

--- a/Analyses/src/NPOTAnalysis_module.cc
+++ b/Analyses/src/NPOTAnalysis_module.cc
@@ -102,29 +102,31 @@ namespace mu2e {
     };
 
     struct EventHists {
+      //-------------1D Histograms of all the Observables-------------
       TH1D* nTimeClusters;
-      TH1D* nCaloHits; //initialize my new histograms that are filled per event here
+      TH1D* nCaloHits;
       TH1D* caloEnergy;
       TH1D* nCaphriHits;
       TH1D* nProtonTCs;
       TH1D* nTrackerHits;
+      TH1D* nProtonsDeltaFinder; //Number of Protons from DeltaFinder module
 
-      TH1D* nPOT;
-      TH1D* nProtonsDeltaFinder; //Number of POT from deltafinder module
+      TH1D* nPOT; //MC Truth  nPOT
 
-      TH1D* recoNPOT_caloE; //1d RecoNPOT from RecoNPOTMaker_module.cc in CalPatRec
+      TH1D* recoNPOT_caloE; //Produced in RecoNPOTMaker_module.cc in CalPatRec
 
-      TH1D* filteredRecoNPOT; //protons that passed the filter
-      //2d hists! with nPOT
+      TH1D* filteredRecoNPOT; //Passed RecoNPOTFilter_module.cc
+
+      //-------------Observable v. NPOT-------------
       TH2D* nTimeClusters2d;
       TH2D* nCaloHits2d;
       TH2D* caloEnergy2d;
       TH2D* nCaphriHits2d;
       TH2D* nProtonTCs2d;
       TH2D* nTrackerHits2d;
+      TH2D* nPOTvnProtonTracks; //nPOT v nProtonsDeltaFinder
 
-      //2d hists! wiht nProtonsDeltaFinder
-
+      //-------------Observable v. nProtons from Delta Finder Module-------------
       TH2D* nTimeClusters2df;
       TH2D* nCaloHits2df;
       TH2D* caloEnergy2df;
@@ -132,32 +134,32 @@ namespace mu2e {
       TH2D* nProtonTCs2df;
       TH2D* nTrackerHits2df;
 
-      //2d hists! variable v variable
-      TH2D* nPOTvnProtonTracks; //nPOT v nProtonsDeltaFinder
+      //-------------Observable v Observable-------------
       TH2D* caloEH; //caloEnergy v nCaloHits
-      TH2D* cTCs; //nTimeClusters v nProtonTCs (time clusters vrs from intensitycalo time clusters)
+      TH2D* cTCs; //nTimeClusters v nProtonTCs (from IntensityCalo Time Clusters)
       TH2D* hitsTC; //nTrackerHits v nCaloHits
       TH2D* hitsCAPHRIvCal; //nCaphriHits v nCalHits
       TH2D* hitsCAPHRIvTrker; //nCaphriHits v nTrackerHits
 
-      // Residual histograms:
+      //--------------Residual histograms: (nPOT predicted from Observable-nPOT)/(nPOT)--------------
+      //naming scheme: resid_Observable
       //TH1D* resid_nTimeClusters;
       // TH1D* resid_nCaloHits;
-      TH1D* resid_caloE_reco; //residual histogram for nPOT predicted from CaloEnergy - nPOT from MCDataProducts divided by nPOT from MC
-      //TH1D* extended_resid_caloE_reco;
+      TH1D* resid_caloE_reco;
       // TH1D* resid_nCaphriHits;
       // TH1D* resid_nProtonTCs;
       // TH1D* resid_nTrackerHits;
 
-      //nPOT v residual histograms:
+      //--------------nPOT v residual histograms:--------------
       // TH2D* resid_nTimeClusters2d;
       // TH2D* resid_nCaloHits2d;
       TH2D* resid_caloE_reco2d; //nPOT versus resid_caloEnergy normalized
-      TH2D* resid_caloE_reco_v_caloE2d; // resid_caloEnergy versus caloE
-      // TH2D* extended_resid_caloE_reco2d;
       // TH2D* resid_nCaphriHits2d;
       // TH2D* resid_nProtonTCs2d;
       // TH2D* resid_nTrackerHits2d;
+
+      //-------------Observable v Residual-------------
+      TH2D* resid_caloE_reco_v_caloE2d; // resid_caloEnergy versus caloE
 
     };
 
@@ -171,7 +173,7 @@ namespace mu2e {
     };
 
     struct Hists {
-      EventHists* _EventHists[kNEventHistsSets]; //create an arry of  pointers of type EventHists called  _EventHists of size kNeventHistsSets (which here is 1)
+      EventHists* _EventHists[kNEventHistsSets];
       TimeClusterHists* _TimeClusterHists[kNTimeClusterHistsSets];
       HelixSeedHists* _HelixSeedHists[kNHelixSeedHistsSets];
     };
@@ -183,17 +185,18 @@ namespace mu2e {
 
     struct eventData {
       int nPOT_;
-      int nProtonsDeltaFinder_; //number of protons from deltafinder module
+      //-------------Observables-------------
+      int nProtonsDeltaFinder_;
       int nClusters;
-      int nCaloHits_; //added bc given in IntensityInfoCalo.hh
+      int nCaloHits_;
       int caloEnergy_;
       int nCaphriHits_;
-      int nProtonTCs_; //add in from intensityinfotimecluster.hh
-      int nTrackerHits_; //from intensityinfotrackerhits.hh
+      int nProtonTCs_;
+      int nTrackerHits_;
+      //-------------Made in RecoNPOTMaker_module.cc as <ProtonBunchIntensity>
+      int recoNPOT_caloE_;
 
-      int recoNPOT_caloE_; //from RecoNPOTMaker_module.cc ProtonBunchIntensity.hh
-
-      // Add residuals here:
+      //-------------Residuals-------------
       // double resid_nTimeClusters_;
       // double resid_nCaloHits_;
       double resid_caloE_reco_;
@@ -201,7 +204,8 @@ namespace mu2e {
       // double resid_nProtonTCs_;
       // double resid_nTrackerHits_;
 
-      bool passed; //for my filter
+      //-------------Passed RecoNPOTFilter_module.cc-------------
+      bool passed;
     };
 
     struct hsData{
@@ -215,7 +219,6 @@ namespace mu2e {
     virtual void endJob();
     virtual void endSubRun(const art::SubRun& sr);
 
-    // This is called for each event.
     virtual void analyze(const art::Event& e);
     virtual void beginRun(const art::Run & run);
 
@@ -238,7 +241,6 @@ namespace mu2e {
 
   private:
 
-    // parameter set stuff
     std::string                        _chCollTag;
     std::string                        _tcCollTag;
     std::string                        _hsCollTag;
@@ -250,12 +252,11 @@ namespace mu2e {
     const mu2e::TimeClusterCollection* _tcColl;
     const mu2e::ComboHit*              _ch;
     const art::Event*                  _event;
-    const mu2e::HelixSeedCollection*   _hsColl; //this is initializing a pointer _hsColl of type constant HelixSeedCollection (from mu2e library)
+    const mu2e::HelixSeedCollection*   _hsColl;
 
     std::vector<tcData>                _tcData;
-    std::vector<hsData>                _hsData; //makes a vector with each entry of type hsData and calls it _hsData
+    std::vector<hsData>                _hsData;
 
-    //for filter
     std::string _processName;
     std::string _filterName;
 
@@ -271,8 +272,8 @@ namespace mu2e {
     _tcCollTag      (pset.get<string>("tcCollTag", "TTTZClusterFinder")),
     _hsCollTag      (pset.get<string>("hsCollTag", "TTAprHelixFinder")),
     _evtWeightTag   (pset.get<art::InputTag>("protonBunchIntensity" , "PBISim")),
-    _processName    (pset.get<std::string>("processName", " S5Stn")), //idk if i did this correct at all, lumiStream is the name of the sequence my filter is in in CalPatTrkReco 's prolog.fcl
-    _filterName     (pset.get<std::string>("filterName", "lumiStream"))  //changed RecoNPOTFilter to lumiStream
+    _processName    (pset.get<std::string>("processName", " S5Stn")),
+    _filterName     (pset.get<std::string>("filterName", "lumiStream"))
   {
 
   }
@@ -320,66 +321,68 @@ namespace mu2e {
   //-----------------------------------------------------------------------------
   void NPOTAnalysis::bookEventHistograms(EventHists* Hist, art::TFileDirectory* Dir) {
 
-    //1D histograms!!!
-    Hist->nTimeClusters = Dir->make<TH1D>("nTimeClusters" , "Number of Time Clusters; nTC ", 100, 0.0, 30.0 );
-    Hist->nCaloHits     = Dir->make<TH1D>("nCaloHits", "Number of Calorimeter Hits; nCaloHits", 100, 0.0, 1300);
-    Hist->caloEnergy    = Dir->make<TH1D>("caloEnergy", "Calorimeter Energy; E[MeV]", 100, 0.0, 7500);
-    Hist->nCaphriHits   = Dir->make<TH1D>("nCAPHRIHits", "Number of CAPHRI Hits; nCAPHRIHits", 100, 0.0, 20);
-    Hist->nProtonTCs    = Dir->make<TH1D>("nProtonTCs", "Number of Proton Time Clusters from Intensity Information; nProtonTC from Int", 100, 0.0, 100);
-    Hist->nTrackerHits  = Dir->make<TH1D>("nTrackerHits", "Number of Tracker Hits from Intensity Information; nTrkHits from Int", 100, 0.0, 7500);
+    //-------------1D Observables-------------
+    Hist->nTimeClusters          = Dir->make<TH1D>("nTimeClusters" , "Number of Time Clusters; nTC ", 100, 0.0, 30.0 );
+    Hist->nCaloHits              = Dir->make<TH1D>("nCaloHits", "Number of Calorimeter Hits; nCaloHits", 100, 0.0, 1300);
+    Hist->caloEnergy             = Dir->make<TH1D>("caloEnergy", "Calorimeter Energy; E[MeV]", 100, 0.0, 7500);
+    Hist->nCaphriHits            = Dir->make<TH1D>("nCAPHRIHits", "Number of CAPHRI Hits; nCAPHRIHits", 100, 0.0, 20);
+    Hist->nProtonTCs             = Dir->make<TH1D>("nProtonTCs", "Number of Proton Time Clusters from Intensity Information; nProtonTC from Int", 100, 0.0, 100);
+    Hist->nTrackerHits           = Dir->make<TH1D>("nTrackerHits", "Number of Tracker Hits from Intensity Information; nTrkHits from Int", 100, 0.0, 7500);
+    Hist->nProtonsDeltaFinder    = Dir->make<TH1D>("nProtonsDeltaFinder", "Number of Proton tracks from DeltaFinder Module; nProtons ", 100, 0.0, 100);
 
-    Hist->nPOT          = Dir->make<TH1D>("nPOT", "Number of Protons on Target; nPOT", 100, 0.0, 1e8);
-    Hist->nProtonsDeltaFinder        = Dir->make<TH1D>("nProtonsDeltaFinder", "Number of Proton tracks from DeltaFinder Module; nProtons ", 100, 0.0, 100);
+    //-------------MC Truth nPOT-------------
+    Hist->nPOT                   = Dir->make<TH1D>("nPOT", "Number of Protons on Target; nPOT", 100, 0.0, 1e8);
 
-    Hist->recoNPOT_caloE = Dir->make<TH1D>("recoNPOT_caloE", "Reconstructed nPOT from Calorimeter Energy; RecoNPOT from CaloE", 100, 0.0, 1e8);
+    //-------------Reconstructed nPOT from Observable-------------
+    Hist->recoNPOT_caloE         = Dir->make<TH1D>("recoNPOT_caloE", "Reconstructed nPOT from Calorimeter Energy; RecoNPOT from CaloE", 100, 0.0, 1e8);
 
-    //filtered
-    Hist->filteredRecoNPOT = Dir->make<TH1D>("filteredRecoNPOT", "Reconstructed nPOT that passed Filter; Filtered ReconPOT", 100, 0.0, 1e8);
-    //2d histograms!!! nPOT
-    Hist->nTimeClusters2d = Dir->make<TH2D>("nTimeClusters2d" , "Number of Protons on Target v Number of Time Clusters; nTC; nPOT ", 100, 0.0, 100.0, 100, 0.0, 1e8);
-    Hist->nCaloHits2d     = Dir->make<TH2D>("nCaloHits2d", "Number of Protons on Target v Number of Calorimeter Hits; nCaloHits; nPOT", 100, 0.0, 1300, 100, 0.0, 1e8);
-    Hist->caloEnergy2d    = Dir->make<TH2D>("caloEnergy2d", "Number of Protons on Target v Calorimeter Energy; E[MeV]; nPOT", 100, 0.0, 7500, 100, 0.0, 1e8);
-    Hist->nCaphriHits2d   = Dir->make<TH2D>("nCAPHRIHits2d", "Number of Protons on Target v Number of CAPHRI Hits; nCAPHRIHits; nPOT", 100, 0.0, 100, 100, 0.0, 1e8);
-    Hist->nProtonTCs2d    = Dir->make<TH2D>("nProtonTCs2d", "Number of Protons on Target v Number of Proton Time Clusters from Intensity Information; nProtonTC from Int; nPOT", 100, 0.0, 100, 100, 0.0, 1e8);
-    Hist->nTrackerHits2d  = Dir->make<TH2D>("nTrackerHits2d", "Number of Protons on Target v Number of Tracker Hits from Intensity Information; nTrkHits from Int; nPOT", 100, 0.0, 7500, 100, 0.0, 1e8);
+    //-------------Filtered-------------
+    Hist->filteredRecoNPOT       = Dir->make<TH1D>("filteredRecoNPOT", "Reconstructed nPOT that passed Filter; Filtered ReconPOT", 100, 0.0, 1e8);
 
-    //2d histograms!!!! nProtonsDeltaFinder
-    Hist->nTimeClusters2df = Dir->make<TH2D>("nTimeClusters2df" , "Number of Protons from Delta Finder v Number of Time Clusters; nTC; nProtons from DeltaFinder ", 100, 0.0, 100.0, 100, 0.0, 100);
-    Hist->nCaloHits2df     = Dir->make<TH2D>("nCaloHits2df", "Number of Protons from Delta Finder v Number of Calorimeter Hits; nCaloHits; nProtons from DeltaFinder", 100, 0.0, 1300, 100, 0.0, 100);
-    Hist->caloEnergy2df    = Dir->make<TH2D>("caloEnergy2df", "Number of Protons from Delta Finder v Calorimeter Energy; E[MeV]; nProtons from DeltaFinder", 100, 0.0, 7500, 100, 0.0, 100);
-    Hist->nCaphriHits2df   = Dir->make<TH2D>("nCAPHRIHits2df", "Number of Protons from Delta Finder v Number of CAPHRI Hits; nCAPHRIHits; nProtons from DeltaFinder", 100, 0.0, 100, 100, 0.0, 100);
-    Hist->nProtonTCs2df    = Dir->make<TH2D>("nProtonTCs2df", "Number of Protons from Delta Finder v Number of Proton Time Clusters from Intensity Information; nProtonTC from Int; nProtons from DeltaFinder", 100, 0.0, 100, 100, 0.0, 100);
-    Hist->nTrackerHits2df  = Dir->make<TH2D>("nTrackerHits2df", "Number of Protons from Delta Finder v Number of Tracker Hits from Intensity Information; nTrkHits from Int; nProtons from DeltaFinder", 100, 0.0, 7500, 100, 0.0, 100);
+    //-------------Observable v nPOT-------------
+    Hist->nTimeClusters2d        = Dir->make<TH2D>("nTimeClusters2d" , "Number of Protons on Target v Number of Time Clusters; nTC; nPOT ", 100, 0.0, 100.0, 100, 0.0, 1e8);
+    Hist->nCaloHits2d            = Dir->make<TH2D>("nCaloHits2d", "Number of Protons on Target v Number of Calorimeter Hits; nCaloHits; nPOT", 100, 0.0, 1300, 100, 0.0, 1e8);
+    Hist->caloEnergy2d           = Dir->make<TH2D>("caloEnergy2d", "Number of Protons on Target v Calorimeter Energy; E[MeV]; nPOT", 100, 0.0, 7500, 100, 0.0, 1e8);
+    Hist->nCaphriHits2d          = Dir->make<TH2D>("nCAPHRIHits2d", "Number of Protons on Target v Number of CAPHRI Hits; nCAPHRIHits; nPOT", 100, 0.0, 100, 100, 0.0, 1e8);
+    Hist->nProtonTCs2d           = Dir->make<TH2D>("nProtonTCs2d", "Number of Protons on Target v Number of Proton Time Clusters from Intensity Information; nProtonTC from Int; nPOT", 100, 0.0, 100, 100, 0.0, 1e8);
+    Hist->nTrackerHits2d         = Dir->make<TH2D>("nTrackerHits2d", "Number of Protons on Target v Number of Tracker Hits from Intensity Information; nTrkHits from Int; nPOT", 100, 0.0, 7500, 100, 0.0, 1e8);
+    Hist->nPOTvnProtonTracks     = Dir->make<TH2D>("nPOTvnProtonTracks", "Number of Protons v Number of Protons from Delta Finder; nProtons from DF; nPOT", 100, 0.0, 100, 100, 0.0, 1e8);
 
-    //2d Hists!! variable v variable
-    Hist->nPOTvnProtonTracks            = Dir->make<TH2D>("nPOTvnProtonTracks", "Number of Protons v Number of Protons from Delta Finder; nProtons from DF; nPOT", 100, 0.0, 100, 100, 0.0, 1e8);
-    Hist->caloEH           = Dir->make<TH2D>("caloEH", "Calorimeter Energy vs the number of Calorimeter Hits; nCaloHits; E[MeV]", 100, 0.0, 1300, 100, 0.0, 7500);
-    Hist->cTCs             = Dir->make<TH2D>("cTCs", "Number of Time Clusters vs Number of Time Clusters from Intensity Information; nProtonTCs from IntensityInfo; nTCs", 100, 0.0, 100, 100, 0.0, 100);
-    Hist->hitsTC           = Dir->make<TH2D>("hitsTC", "Number of Tracker Hits v number of Calorimeter Hits; nCaloHits; nTrackerHits", 100.0, 0.0, 1300, 20, 0.0, 7500);
-    Hist->hitsCAPHRIvCal   = Dir->make<TH2D>("hitsCAPHRIvCal", "Number of CAPHRI Hits v Number of Calorimeter Hits; nCaloHits; nCAPHRIHits", 100, 0.0, 1300, 100, 0.0, 100);
-    Hist->hitsCAPHRIvTrker = Dir->make<TH2D>("hitsCAPHRIvTrker", "Number of CAPHRI Hits v Number of Tracker Hits; nTrackerHits; nCAPHRIHits", 100, 0.0, 7500, 100, 0.0, 100);
+    //-------------Observable v nProtons from DeltaFinder-------------
+    Hist->nTimeClusters2df       = Dir->make<TH2D>("nTimeClusters2df" , "Number of Protons from Delta Finder v Number of Time Clusters; nTC; nProtons from DeltaFinder ", 100, 0.0, 100.0, 100, 0.0, 100);
+    Hist->nCaloHits2df           = Dir->make<TH2D>("nCaloHits2df", "Number of Protons from Delta Finder v Number of Calorimeter Hits; nCaloHits; nProtons from DeltaFinder", 100, 0.0, 1300, 100, 0.0, 100);
+    Hist->caloEnergy2df          = Dir->make<TH2D>("caloEnergy2df", "Number of Protons from Delta Finder v Calorimeter Energy; E[MeV]; nProtons from DeltaFinder", 100, 0.0, 7500, 100, 0.0, 100);
+    Hist->nCaphriHits2df         = Dir->make<TH2D>("nCAPHRIHits2df", "Number of Protons from Delta Finder v Number of CAPHRI Hits; nCAPHRIHits; nProtons from DeltaFinder", 100, 0.0, 100, 100, 0.0, 100);
+    Hist->nProtonTCs2df          = Dir->make<TH2D>("nProtonTCs2df", "Number of Protons from Delta Finder v Number of Proton Time Clusters from Intensity Information; nProtonTC from Int; nProtons from DeltaFinder", 100, 0.0, 100, 100, 0.0, 100);
+    Hist->nTrackerHits2df        = Dir->make<TH2D>("nTrackerHits2df", "Number of Protons from Delta Finder v Number of Tracker Hits from Intensity Information; nTrkHits from Int; nProtons from DeltaFinder", 100, 0.0, 7500, 100, 0.0, 100);
 
-    // Residual histograms:1D
-    // Hist->resid_nTimeClusters = Dir->make<TH1D>("resid_nTimeClusters", "Residual between nPOT and predicted nPOT using the nTimeClusters; nPOT-PredictednPOT", 100, -1e6, 1e6);
-    //Hist->resid_nCaloHits     = Dir->make<TH1D>("resid_nCaloHits", "Residual between nPOT and predicted nPOT using the nCaloHits;  nPOT-PredictednPOT", 100, -1e7, 1e7);
-    Hist->resid_caloE_reco    = Dir->make<TH1D>("resid_caloE_reco", "Normalized Residual:  nPOT - reconstucted  nPOT from Calorimeter Energy; ( nPOT-recoNPOT)/nPOT", 100, -0.600, 0.600); //eventually -.5,5 i hope
-    //Hist->extended_resid_caloE_reco = Dir->make<TH1D>("extended_resid_caloE_reco", "Normalized Residual:  nPOT - reconstucted  nPOT from Calorimeter Energy; ( nPOT-recoNPOT)/nPOT", 100, -1.40, 0.40); //same but x-axis expanded to the left so no underflow
-    // Hist->extended_resid_caloE_reco = Dir->make<TH1D>("extended_resid_caloE_reco", "Normalized Residual:  nPOT - reconstucted  nPOT from Calorimeter Energy; ( nPOT-recoNPOT)/nPOT", 100, -2.00, 2.00); //shouldnt need now that fixed!
-    // Hist->resid_nCaphriHits   = Dir->make<TH1D>("resid_nCAPHRIHits", "Residual between nPOT and predicted nPOT using the nCAPHRIHits;  nPOT-PredictednPOT", 100, -1e7, 1e7);
-    // Hist->resid_nProtonTCs    = Dir->make<TH1D>("resid_nProtonTCs", "Residual between nPOT and predicted nPOT using the nProtonTCs;  nPOT-PredictednPOT", 100, -1e8, 1e8);
-    // Hist->resid_nTrackerHits  = Dir->make<TH1D>("resid_nTrackerHits", "Residual between nPOT and predicted nPOT using the nTrackerHits;  nPOT-PredictednPOT", 100, -1e7, 1e7);
+    //-------------Observable v Observable-------------
+
+    Hist->caloEH                 = Dir->make<TH2D>("caloEH", "Calorimeter Energy vs the number of Calorimeter Hits; nCaloHits; E[MeV]", 100, 0.0, 1300, 100, 0.0, 7500);
+    Hist->cTCs                   = Dir->make<TH2D>("cTCs", "Number of Time Clusters vs Number of Time Clusters from Intensity Information; nProtonTCs from IntensityInfo; nTCs", 100, 0.0, 100, 100, 0.0, 100);
+    Hist->hitsTC                 = Dir->make<TH2D>("hitsTC", "Number of Tracker Hits v number of Calorimeter Hits; nCaloHits; nTrackerHits", 100.0, 0.0, 1300, 20, 0.0, 7500);
+    Hist->hitsCAPHRIvCal         = Dir->make<TH2D>("hitsCAPHRIvCal", "Number of CAPHRI Hits v Number of Calorimeter Hits; nCaloHits; nCAPHRIHits", 100, 0.0, 1300, 100, 0.0, 100);
+    Hist->hitsCAPHRIvTrker       = Dir->make<TH2D>("hitsCAPHRIvTrker", "Number of CAPHRI Hits v Number of Tracker Hits; nTrackerHits; nCAPHRIHits", 100, 0.0, 7500, 100, 0.0, 100);
+
+    //-------------1D Residuals-------------
+    //Hist->resid_nTimeClusters  = Dir->make<TH1D>("resid_nTimeClusters", "Residual between nPOT and predicted nPOT using the nTimeClusters; nPOT-PredictednPOT", 100, -1e6, 1e6);
+    //Hist->resid_nCaloHits      = Dir->make<TH1D>("resid_nCaloHits", "Residual between nPOT and predicted nPOT using the nCaloHits;  nPOT-PredictednPOT", 100, -1e7, 1e7);
+    Hist->resid_caloE_reco       = Dir->make<TH1D>("resid_caloE_reco", "Normalized Residual:  nPOT - reconstucted  nPOT from Calorimeter Energy; ( nPOT-recoNPOT)/nPOT", 100, -0.600, 0.600); //eventually -.5,5 i hope
+    //Hist->resid_nCaphriHits    = Dir->make<TH1D>("resid_nCAPHRIHits", "Residual between nPOT and predicted nPOT using the nCAPHRIHits;  nPOT-PredictednPOT", 100, -1e7, 1e7);
+    //Hist->resid_nProtonTCs     = Dir->make<TH1D>("resid_nProtonTCs", "Residual between nPOT and predicted nPOT using the nProtonTCs;  nPOT-PredictednPOT", 100, -1e8, 1e8);
+    //Hist->resid_nTrackerHits   = Dir->make<TH1D>("resid_nTrackerHits", "Residual between nPOT and predicted nPOT using the nTrackerHits;  nPOT-PredictednPOT", 100, -1e7, 1e7);
 
 
-    //nPOT v residual :2d ( nPOT v actualPOT-predictedPOT)
+    //------------Residual v nPOT-------------
     // Hist->resid_nTimeClusters2d = Dir->make<TH2D>("resid_nTimeClusters2d", "nPOT v Residual of nPOT from nTimeClusters; nPOT-PredictednPOT; nPOT", 100, -1e6, 1e6, 100, 0.0, 1e8);
     // Hist->resid_nCaloHits2d     = Dir->make<TH2D>("resid_nCaloHits2d", "nPOT v Residual of nPOT from nCaloHits; nPOT-PredictednPOT; ", 100, -1e7, 1e7, 100, 0.0, 1e8);
-    Hist->resid_caloE_reco2d    = Dir->make<TH2D>("resid_caloE_reco2d", "Normalized Residual of nPOT from Calorimeter Energy v nPOT;nPOT; (nPOT-recoNPOT)/nPOT", 100, 0.0, 1e8, 100, -0.600, 0.600);
-    Hist->resid_caloE_reco_v_caloE2d = Dir->make<TH2D>("resid_caloE_reco_v_caloE2d", "Normalized Residual of nPOT from Calorimeter Energy v Calorimeter Energy; CaloE [MeV]; (nPOT-recoNPOT)/nPOT", 100, 0.0, 1e4, 100, -0.600, 0.600); //try 1e4 instead of 7500? so see where fit fails bc only should work for 7500 really idk just try
-    // Hist->extended_resid_caloE_reco2d = Dir->make<TH2D>("extended_resid_caloE_reco2d", "nPOT v Normalized Residual of nPOT from Calorimeter Energy; (nPOT-recoNPOT)/nPOT; nPOT", 100, -1.40, 0.40, 100, 0.0, 1e8); //before giani recommendations
-    // Hist->extended_resid_caloE_reco2d = Dir->make<TH2D>("extended_resid_caloE_reco2d", "Normalized Residual of nPOT from Calorimeter Energy vnPOT; nPOT; (nPOT-recoNPOT)/nPOT", 100, 0.0, 1e8, 100, -2.00, 2.00); //shouldnt need now that fixed
-    //Hist->resid_nCaphriHits2d   = Dir->make<TH2D>("resid_nCAPHRIHits2d", "nPT v Residual of nPOT from nCAPHRIHits; nPOT-PredictednPOT; nPOT", 100, -1e7, 1e7, 100, 0.0, 1e8);
+    Hist->resid_caloE_reco2d       = Dir->make<TH2D>("resid_caloE_reco2d", "Normalized Residual of nPOT from Calorimeter Energy v nPOT;nPOT; (nPOT-recoNPOT)/nPOT", 100, 0.0, 1e8, 100, -0.600, 0.600);
+    //Hist->resid_nCaphriHits2d    = Dir->make<TH2D>("resid_nCAPHRIHits2d", "nPT v Residual of nPOT from nCAPHRIHits; nPOT-PredictednPOT; nPOT", 100, -1e7, 1e7, 100, 0.0, 1e8);
     // Hist->resid_nProtonTCs2d    = Dir->make<TH2D>("resid_nProtonTCs2d", "nPOT v Residual of nPOT from nProtonTCs; nPOT-PredictednPOT; nPOT", 100, -1e8, 1e8, 100, 0.0, 1e8);
     // Hist->resid_nTrackerHits2d  = Dir->make<TH2D>("resid_nTrackerHits2d", "nPOT v Residual of nPOT from nTrackerHits; nPOT-PredictednPOT; nPOT", 100, -1e7, 1e7, 100, 0.0, 1e8);
+
+    //-------------Residual v Observable------------
+    Hist->resid_caloE_reco_v_caloE2d = Dir->make<TH2D>("resid_caloE_reco_v_caloE2d", "Normalized Residual of nPOT from Calorimeter Energy v Calorimeter Energy; CaloE [MeV]; (nPOT-recoNPOT)/nPOT", 100, 0.0, 1e4, 100, -0.600, 0.600);
   }
 
 
@@ -442,31 +445,34 @@ namespace mu2e {
   //-----------------------------------------------------------------------------
   void NPOTAnalysis::fillEventHistograms(EventHists* Hist) {
 
-    //1D histograms!!
+    //----------------1D Observables----------------
     Hist->nTimeClusters->Fill(_eventData.nClusters);
     Hist->nCaloHits->Fill(_eventData.nCaloHits_);
     Hist->caloEnergy->Fill(_eventData.caloEnergy_);
     Hist->nCaphriHits->Fill(_eventData.nCaphriHits_);
     Hist->nProtonTCs->Fill(_eventData.nProtonTCs_);
     Hist->nTrackerHits->Fill(_eventData.nTrackerHits_);
-
-    Hist->nPOT->Fill(_eventData.nPOT_);
     Hist->nProtonsDeltaFinder->Fill(_eventData.nProtonsDeltaFinder_);
 
-    //reconstructed npot
+    //----------------MC Truth nPOT----------------
+    Hist->nPOT->Fill(_eventData.nPOT_);
+
+    //----------------Reconstructed nPOT----------------
     Hist->recoNPOT_caloE->Fill(_eventData.recoNPOT_caloE_);
 
-    //filtered
-    if (_eventData.passed) {Hist->filteredRecoNPOT->Fill(_eventData.recoNPOT_caloE_); } //if the event passed the filter, then add it to the histogram
-    //2d histograms!!! y is nPOT
+    //----------------Passed Filter----------------
+    if (_eventData.passed) {Hist->filteredRecoNPOT->Fill(_eventData.recoNPOT_caloE_); }
+
+    //----------------nPOT v Observable----------------
     Hist->nTimeClusters2d->Fill(_eventData.nClusters, _eventData.nPOT_);
     Hist->nCaloHits2d->Fill(_eventData.nCaloHits_, _eventData.nPOT_);
     Hist->caloEnergy2d->Fill(_eventData.caloEnergy_, _eventData.nPOT_);
     Hist->nCaphriHits2d->Fill(_eventData.nCaphriHits_, _eventData.nPOT_);
     Hist->nProtonTCs2d->Fill(_eventData.nProtonTCs_, _eventData.nPOT_);
     Hist->nTrackerHits2d->Fill(_eventData.nTrackerHits_, _eventData.nPOT_);
+    Hist->nPOTvnProtonTracks->Fill(_eventData.nProtonsDeltaFinder_, _eventData.nPOT_);
 
-    //2d histograms!!! y is nProtonsDeltaFinder
+    //---------------- nProtonsDeltaFinder v Observable----------------
     Hist->nTimeClusters2df->Fill(_eventData.nClusters, _eventData.nProtonsDeltaFinder_);
     Hist->nCaloHits2df->Fill(_eventData.nCaloHits_, _eventData.nProtonsDeltaFinder_);
     Hist->caloEnergy2df->Fill(_eventData.caloEnergy_, _eventData.nProtonsDeltaFinder_);
@@ -474,8 +480,7 @@ namespace mu2e {
     Hist->nProtonTCs2df->Fill(_eventData.nProtonTCs_, _eventData.nProtonsDeltaFinder_);
     Hist->nTrackerHits2df->Fill(_eventData.nTrackerHits_, _eventData.nProtonsDeltaFinder_);
 
-    //2d Hists variable v variable
-    Hist->nPOTvnProtonTracks->Fill(_eventData.nProtonsDeltaFinder_, _eventData.nPOT_);
+    //----------------Observable v Observable----------------
     Hist->caloEH->Fill(_eventData.nCaloHits_, _eventData.caloEnergy_);
     Hist->cTCs->Fill(_eventData.nProtonTCs_, _eventData.nClusters);
     Hist->hitsTC->Fill(_eventData.nCaloHits_, _eventData.nTrackerHits_);
@@ -483,28 +488,24 @@ namespace mu2e {
     Hist->hitsCAPHRIvTrker->Fill(_eventData.nTrackerHits_, _eventData.nCaphriHits_);
 
 
-    // fill residual histograms
+    //----------------1D Residual----------------
     // Hist->resid_nTimeClusters->Fill(_eventData.resid_nTimeClusters_);
     //Hist->resid_nCaloHits->Fill(_eventData.resid_nCaloHits_);
     Hist->resid_caloE_reco->Fill(_eventData.resid_caloE_reco_);
-    // Hist->extended_resid_caloE_reco->Fill(_eventData.resid_caloE_reco_);
     //Hist->resid_nCaphriHits->Fill(_eventData.resid_nCaphriHits_);
     // Hist->resid_nProtonTCs->Fill(_eventData.resid_nProtonTCs_);
     // Hist->resid_nTrackerHits->Fill(_eventData.resid_nTrackerHits_);
 
-    //fill the 2d nPOT v residual histograms
+    //----------------Residual v nPOT----------------
     // Hist->resid_nTimeClusters->Fill(_eventData.resid_nTimeClusters_, _eventData.nPOT_);
     //Hist->resid_nCaloHits->Fill(_eventData.resid_nCaloHits_, _eventData.nPOT_);
     Hist->resid_caloE_reco2d->Fill( _eventData.nPOT_, _eventData.resid_caloE_reco_); //residuals on y-axis
-    Hist->resid_caloE_reco_v_caloE2d->Fill(_eventData.caloEnergy_, _eventData.resid_caloE_reco_);
-    //Hist->extended_resid_caloE_reco2d->Fill(_eventData.resid_caloE_reco_, _eventData.nPOT_);
-    // Hist->extended_resid_caloE_reco2d->Fill(_eventData.nPOT_, _eventData.resid_caloE_reco_); //residual v nPOT ask giani advised.
-
     //Hist->resid_nCaphriHits->Fill(_eventData.resid_nCaphriHits_, _eventData.nPOT_);
     //Hist->resid_nProtonTCs->Fill(_eventData.resid_nProtonTCs_, _eventData.nPOT_);
     //Hist->resid_nTrackerHits->Fill(_eventData.resid_nTrackerHits_, _eventData.nPOT_);
 
-
+    //----------------Residual v Observable----------------
+    Hist->resid_caloE_reco_v_caloE2d->Fill(_eventData.caloEnergy_, _eventData.resid_caloE_reco_);
   }
 
   //-----------------------------------------------------------------------------
@@ -536,24 +537,6 @@ namespace mu2e {
     // compute event level stuff
     _eventData.nClusters = (int)_tcColl->size();
 
-    //find the residual btw the predicted nPOT( from observed _eventData.observable plugged into  fit function defined) and the actual nPOT. residual = actual-pred
-    /* if (_eventData.nClusters > 0) {
-       double pred = nTimeClusters2d(static_cast<double>(_eventData.nClusters));
-       _eventData.resid_nTimeClusters_ = static_cast<double>(_eventData.nPOT_) - pred;
-       } else {
-       _eventData.resid_nTimeClusters_ = 0.0;
-       }
-
-       if (_eventData.nCaloHits_ > 0) {
-       double pred = nCaloHits2d(static_cast<double>(_eventData.nCaloHits_));
-       _eventData.resid_nCaloHits_ = static_cast<double>(_eventData.nPOT_) - pred;
-       } else {
-       _eventData.resid_nCaloHits_ = 0.0;
-       }
-    */
-
-
-
     if (_eventData.nPOT_ > 0 && _eventData.recoNPOT_caloE_ > 0) {
       double residual = _eventData.nPOT_ - _eventData.recoNPOT_caloE_;
       _eventData.resid_caloE_reco_ = residual / _eventData.nPOT_;
@@ -564,41 +547,9 @@ namespace mu2e {
     }
 
   }
-  /*
-    if (_eventData.nCaphriHits_ > 0) {
-    double pred = nCaphriHits2d(static_cast<double>(_eventData.nCaphriHits_));
-    _eventData.resid_nCaphriHits_ = static_cast<double>(_eventData.nPOT_) - pred;
-    } else {
-    _eventData.resid_nCaphriHits_ = 0.0;
-    }
 
-    if (_eventData.nProtonTCs_ > 0) {
-    double pred = nProtonTCs2d(static_cast<double>(_eventData.nProtonTCs_));
-    _eventData.resid_nProtonTCs_ = static_cast<double>(_eventData.nPOT_) - pred;
-    } else {
-    _eventData.resid_nProtonTCs_ = 0.0;
-    }
-
-    if (_eventData.nTrackerHits_ > 0) {
-    double pred = nTrackerHits2d(static_cast<double>(_eventData.nTrackerHits_));
-    _eventData.resid_nTrackerHits_ = static_cast<double>(_eventData.nPOT_) - pred;
-    } else {
-    _eventData.resid_nTrackerHits_ = 0.0;
-
-    }
-    }
-
-  */
   //--------------------------------------------------------------------------------
   void NPOTAnalysis::computeTimeClusterData() {
-
-
-
-
-    // Get the TimeClusterCollection
-    //auto tcCollHandle = _event->getValidHandle<TimeClusterCollection>(_chCollTag);
-    //_tcColl = const_cast<TimeClusterCollection*>(tcCollHandle.product());
-
 
     // compute dT for each cluster
     for (size_t i=0; i<_tcColl->size(); i++) {
@@ -642,38 +593,18 @@ namespace mu2e {
     _event = &event;
 
 
-    //LOAD IN WHETHER PASSED FILTER OR NOT from RecoNPOTFilter_module.cc
+    //--------------Get if passed RecoNPOTFilter_module.cc--------------
     std::ostringstream oss;
-    oss << "TriggerResults::" << _processName; //fcl parameter
+    oss << "TriggerResults::" << _processName;
     art::InputTag const tag{oss.str()};
 
-    /*DEBUGGING TO MAKE SURE PROCESS AND FILTER NAME ARE VALID
-    std::cout << "[DEBUG] Looking for TriggerResults with tag: '" << tag.encode() << "'" << std::endl;
-    std::cout << "[DEBUG] Process name: '" << _processName << "'" << std::endl;
-    std::cout << "[DEBUG] Filter name: '" << _filterName << "'" << std::endl;
-    */
     try {
       auto const trigResultsH = event.getValidHandle<art::TriggerResults>(tag);
       if (trigResultsH.isValid()) {
-        // std::cout << "[DEBUG] TriggerResults handle IS VALID" << std::endl;
         const art::TriggerResults* trigResults = trigResultsH.product();
         TriggerResultsNavigator trigNavig(trigResults);
-        /*DEBUGGING TO SEE AVALIBLE PATH NAMES-----------------
-
-        std::cout << "[DEBUG] Paths and acceptance from TriggerResultsNavigator:" << std::endl;
-        for (size_t i = 0; i < trigResults->size(); ++i) {
-          std::string const& pathName = trigNavig.getTrigPathName(i);
-          bool accepted = trigNavig.accepted(pathName);
-          std::cout << "  [" << i << "] Path: " << pathName << std::endl;
-        }
-        //---------------------------------------------------*/
+        //If passed, set boolean "passed" to TRUE for this event
         _eventData.passed = trigNavig.accepted(_filterName);
-
-        /*DEBUGGING TO SEE IF PASSED FILTER
-        std::cout << "[NPOTAnalysis] Filter check successful. Event " << event.id()
-                  << " passed filter '" << _filterName << "': "
-                  << (_eventData.passed ? "YES" : "NO") << std::endl;
-        */
       } else {
         std::cout << "[NPOTAnalysis] TriggerResults handle is not valid!" << std::endl;
         _eventData.passed = false;
@@ -684,28 +615,20 @@ namespace mu2e {
       _eventData.passed = false;
     }
 
-
-
-
-    //RECONSTRUCTED NPOT FOR ANALYSIS ON FIT AND FOR RecoNPOTMaker_module.cc
+    //--------------Get Reconstructed nPOT from RecoNPOTMaker_module.cc--------------
     art::Handle<ProtonBunchIntensity> recoNPOTH;
     _event->getByLabel("RecoNPOTMaker",recoNPOTH);
     if(recoNPOTH.isValid()) {
       _eventData.recoNPOT_caloE_ = recoNPOTH->intensity();
-      // std::cout << "Event ID: " << event.id()
-      //<< "  recoNPOT_caloE_ = " << _eventData.recoNPOT_caloE_ << std::endl;
-
     }
     else { std::cout << "[NPOTAnalysis] Could not retrieve RecoNPOT from RecoNPOTMaker!" << std::endl; }
 
-
-
-    //get the EventData from ProtonBunchIntensity
+    //--------------Get the EventData from ProtonBunchIntensity--------------
     art::Handle<ProtonBunchIntensity> evtWeightH;
     _event->getByLabel(_evtWeightTag, evtWeightH);
     if (evtWeightH.isValid()) {_eventData.nPOT_  = evtWeightH->intensity();}
 
-    //get the EventData from IntensityInfoCalo
+    //--------------Get the EventData from IntensityInfoCalo--------------
     art::Handle<IntensityInfoCalo> caloInt;
     _event->getByLabel("CaloHitMakerFast", caloInt);
     if (caloInt.isValid()){
@@ -714,25 +637,23 @@ namespace mu2e {
       _eventData.nCaphriHits_ = caloInt->nCaphriHits();
     }
 
+    //--------------Get the EventData from IntensityInfoTimeCluster--------------
+    //Use TTTZClusterFinder
     art::Handle<IntensityInfoTimeCluster> tcInt;
     _event->getByLabel("TTTZClusterFinder", tcInt);
     if (tcInt.isValid()) { _eventData.nProtonTCs_  = tcInt->nProtonTCs();}
-
-    //Get the nProtonsDeltaFinder from IntensityInfoTimeCluster
+    //Use DeltaFinder Module
     art::Handle<IntensityInfoTimeCluster> tcIntph;
     _event->getByLabel("TTflagPH", tcIntph);
     if (tcIntph.isValid()) { _eventData.nProtonsDeltaFinder_ = tcIntph->nProtonTCs();}
     else { std::cout << "tcIntph is not valid, not filling nProtonsDeltaFinder_" << std::endl;}
 
+    //--------------Get the EventData from IntensityInfoTrackerHits--------------
     art::Handle<IntensityInfoTrackerHits> thInt;
     _event->getByLabel("TTmakeSH", thInt);
     if (thInt.isValid()) { _eventData.nTrackerHits_ = thInt->nTrackerHits();}
 
-
-
-
-
-    // get the ComboHitCollection
+    //--------------Get the ComboHitCollection--------------
     art::Handle<mu2e::ComboHitCollection> chCollHandle;
     _event->getByLabel(_chCollTag, chCollHandle);
     if (chCollHandle.isValid())
@@ -742,13 +663,13 @@ namespace mu2e {
     else {_chColl = NULL;}
 
 
-    //get the TimeClusterCollection
+    //--------------Get the TimeClusterCollection--------------
     art::Handle<mu2e::TimeClusterCollection> tcCollHandle;
     _event->getByLabel(_tcCollTag, tcCollHandle);
     if (tcCollHandle.isValid()) {_tcColl = tcCollHandle.product();}
     else {_tcColl = NULL;}
 
-    //get the HelixSeedCollection
+    //--------------Get the HelixSeedCollection--------------
     art::Handle<mu2e::HelixSeedCollection> hsCollHandle;
     _event->getByLabel(_hsCollTag, hsCollHandle);
     if (hsCollHandle.isValid()) {_hsColl = hsCollHandle.product();}
@@ -758,9 +679,7 @@ namespace mu2e {
     computeEventData();
     // compute data that will be plotted
     if(_tcColl != NULL){ computeTimeClusterData();}
-    //radius idk man
     if(_hsColl != NULL){ computeHelixSeedData();}
-
 
 
     // fill histograms
@@ -770,7 +689,5 @@ namespace mu2e {
     _hsData.clear();
 
   }
-
-
 }
 DEFINE_ART_MODULE(mu2e::NPOTAnalysis)

--- a/Analyses/src/NPOTAnalysis_module.cc
+++ b/Analyses/src/NPOTAnalysis_module.cc
@@ -1,0 +1,776 @@
+
+//
+//
+//
+//
+
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "art_root_io/TFileService.h"
+#include "art_root_io/TFileDirectory.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Selector.h"
+#include "art/Framework/Principal/Provenance.h"
+#include "art/Utilities/make_tool.h"
+#include "canvas/Persistency/Common/TriggerResults.h"
+#include "art/Framework/Services/System/TriggerNamesService.h"
+#include "cetlib_except/exception.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "fhiclcpp/ParameterSetRegistry.h"
+
+#include "messagefacility/MessageLogger/MessageLogger.h"
+// #include "canvas/Utilities/InputTag.h"
+#include "Offline/BFieldGeom/inc/BFieldManager.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
+#include "Offline/GeometryService/inc/DetectorSystem.hh"
+#include "Offline/TrackerGeom/inc/Tracker.hh"
+
+//Conditions
+// #include "Offline/ConditionsService/inc/AcceleratorParams.hh"
+// #include "Offline/ConditionsService/inc/ConditionsHandle.hh"
+
+//Dataproducts
+#include "Offline/RecoDataProducts/inc/CaloCluster.hh"
+#include "Offline/RecoDataProducts/inc/CaloTrigSeed.hh"
+#include "Offline/RecoDataProducts/inc/HelixSeed.hh"
+#include "Offline/RecoDataProducts/inc/KalSeed.hh"
+#include "Offline/RecoDataProducts/inc/TrkQual.hh"
+#include "Offline/RecoDataProducts/inc/TriggerInfo.hh"
+#include "Offline/RecoDataProducts/inc/ComboHit.hh"
+#include "Offline/RecoDataProducts/inc/StrawDigi.hh"
+#include "Offline/RecoDataProducts/inc/StrawHitFlag.hh"
+#include "Offline/RecoDataProducts/inc/CaloDigi.hh"
+#include "Offline/RecoDataProducts/inc/IntensityInfoTimeCluster.hh"
+#include "Offline/RecoDataProducts/inc/IntensityInfoCalo.hh" //added
+#include "Offline/RecoDataProducts/inc/IntensityInfoTrackerHits.hh" //added
+#include "Offline/DataProducts/inc/GenVector.hh"
+#include "Offline/RecoDataProducts/inc/TriggerInfo.hh"
+
+
+//MC dataproducts
+#include "Offline/MCDataProducts/inc/SimParticle.hh"
+#include "Offline/MCDataProducts/inc/StrawDigiMC.hh"
+#include "Offline/MCDataProducts/inc/StepPointMC.hh"
+#include "Offline/MCDataProducts/inc/ProtonBunchIntensity.hh"
+#include "Offline/DataProducts/inc/PDGCode.hh"
+
+#include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
+#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
+
+//Utilities
+#include "Offline/Mu2eUtilities/inc/TriggerResultsNavigator.hh"
+#include "Offline/Mu2eUtilities/inc/HelixTool.hh"
+#include "Offline/Mu2eUtilities/inc/McUtilsToolBase.hh"
+#include "Offline/Mu2eUtilities/inc/ModuleHistToolBase.hh"
+#include "Offline/Mu2eUtilities/inc/LsqSums2.hh"
+#include "Offline/Mu2eUtilities/inc/LsqSums4.hh"
+#include "Offline/Mu2eUtilities/inc/TriggerResultsNavigator.hh"
+
+
+//ROOT
+#include "TH1F.h"
+#include "TH2D.h"
+#include "TProfile.h"
+#include "TEfficiency.h"
+#include "TMath.h"
+#include "TCanvas.h"
+#include "TMultiGraph.h"
+#include "TGraph.h"
+#include <TROOT.h>
+#include "TLine.h"
+#include "TEllipse.h"
+
+#include <cmath>
+#include <string>
+#include <cstring>
+#include <sstream>
+#include <vector>
+#include <iostream>
+
+namespace mu2e {
+
+  class NPOTAnalysis : public art::EDAnalyzer {
+
+  public:
+
+    enum {
+      kNEventHistsSets = 1,
+      kNTimeClusterHistsSets = 1,
+      kNHelixSeedHistsSets = 1
+    };
+
+    struct EventHists {
+      TH1D* nTimeClusters;
+      TH1D* nCaloHits; //initialize my new histograms that are filled per event here
+      TH1D* caloEnergy;
+      TH1D* nCaphriHits;
+      TH1D* nProtonTCs;
+      TH1D* nTrackerHits;
+
+      TH1D* nPOT;
+      TH1D* nProtonsDeltaFinder; //Number of POT from deltafinder module
+
+      TH1D* recoNPOT_caloE; //1d RecoNPOT from RecoNPOTMaker_module.cc in CalPatRec
+
+      TH1D* filteredRecoNPOT; //protons that passed the filter
+      //2d hists! with nPOT
+      TH2D* nTimeClusters2d;
+      TH2D* nCaloHits2d;
+      TH2D* caloEnergy2d;
+      TH2D* nCaphriHits2d;
+      TH2D* nProtonTCs2d;
+      TH2D* nTrackerHits2d;
+
+      //2d hists! wiht nProtonsDeltaFinder
+
+      TH2D* nTimeClusters2df;
+      TH2D* nCaloHits2df;
+      TH2D* caloEnergy2df;
+      TH2D* nCaphriHits2df;
+      TH2D* nProtonTCs2df;
+      TH2D* nTrackerHits2df;
+
+      //2d hists! variable v variable
+      TH2D* nPOTvnProtonTracks; //nPOT v nProtonsDeltaFinder
+      TH2D* caloEH; //caloEnergy v nCaloHits
+      TH2D* cTCs; //nTimeClusters v nProtonTCs (time clusters vrs from intensitycalo time clusters)
+      TH2D* hitsTC; //nTrackerHits v nCaloHits
+      TH2D* hitsCAPHRIvCal; //nCaphriHits v nCalHits
+      TH2D* hitsCAPHRIvTrker; //nCaphriHits v nTrackerHits
+
+      // Residual histograms:
+      //TH1D* resid_nTimeClusters;
+      // TH1D* resid_nCaloHits;
+      TH1D* resid_caloE_reco; //residual histogram for nPOT predicted from CaloEnergy - nPOT from MCDataProducts divided by nPOT from MC
+      //TH1D* extended_resid_caloE_reco;
+      // TH1D* resid_nCaphriHits;
+      // TH1D* resid_nProtonTCs;
+      // TH1D* resid_nTrackerHits;
+
+      //nPOT v residual histograms:
+      // TH2D* resid_nTimeClusters2d;
+      // TH2D* resid_nCaloHits2d;
+      TH2D* resid_caloE_reco2d; //nPOT versus resid_caloEnergy normalized
+      TH2D* resid_caloE_reco_v_caloE2d; // resid_caloEnergy versus caloE
+      // TH2D* extended_resid_caloE_reco2d;
+      // TH2D* resid_nCaphriHits2d;
+      // TH2D* resid_nProtonTCs2d;
+      // TH2D* resid_nTrackerHits2d;
+
+    };
+
+    struct TimeClusterHists {
+      TH1D* dT;
+      TH1D* t0;
+    };
+
+    struct HelixSeedHists{
+      TH1D* radius;
+    };
+
+    struct Hists {
+      EventHists* _EventHists[kNEventHistsSets]; //create an arry of  pointers of type EventHists called  _EventHists of size kNeventHistsSets (which here is 1)
+      TimeClusterHists* _TimeClusterHists[kNTimeClusterHistsSets];
+      HelixSeedHists* _HelixSeedHists[kNHelixSeedHistsSets];
+    };
+
+    struct tcData {
+      double dT;
+      double t0;
+    };
+
+    struct eventData {
+      int nPOT_;
+      int nProtonsDeltaFinder_; //number of protons from deltafinder module
+      int nClusters;
+      int nCaloHits_; //added bc given in IntensityInfoCalo.hh
+      int caloEnergy_;
+      int nCaphriHits_;
+      int nProtonTCs_; //add in from intensityinfotimecluster.hh
+      int nTrackerHits_; //from intensityinfotrackerhits.hh
+
+      int recoNPOT_caloE_; //from RecoNPOTMaker_module.cc ProtonBunchIntensity.hh
+
+      // Add residuals here:
+      // double resid_nTimeClusters_;
+      // double resid_nCaloHits_;
+      double resid_caloE_reco_;
+      // double resid_nCaphriHits_;
+      // double resid_nProtonTCs_;
+      // double resid_nTrackerHits_;
+
+      bool passed; //for my filter
+    };
+
+    struct hsData{
+      double radius;
+    };
+
+    explicit NPOTAnalysis(fhicl::ParameterSet const& pset);
+    virtual ~NPOTAnalysis();
+
+    virtual void beginJob();
+    virtual void endJob();
+    virtual void endSubRun(const art::SubRun& sr);
+
+    // This is called for each event.
+    virtual void analyze(const art::Event& e);
+    virtual void beginRun(const art::Run & run);
+
+    void bookEventHistograms(EventHists* Hist, art::TFileDirectory* Dir);
+    void bookTimeClusterHistograms(TimeClusterHists* Hist, art::TFileDirectory* Dir);
+    void bookHelixSeedHistograms(HelixSeedHists* Hist, art::TFileDirectory* Dir);
+
+    void fillEventHistograms(EventHists* Hist);
+    void fillTimeClusterHistograms(TimeClusterHists* Hist, size_t loopIndex);
+    void fillHelixSeedHistograms(HelixSeedHists* Hist, size_t loopIndex);
+
+    void bookHistograms(art::ServiceHandle<art::TFileService>& Tfs);
+    void fillHistograms();
+
+    void computeTimeClusterData();
+    void computeEventData();
+    void computeHelixSeedData();
+
+
+
+  private:
+
+    // parameter set stuff
+    std::string                        _chCollTag;
+    std::string                        _tcCollTag;
+    std::string                        _hsCollTag;
+    art::InputTag                      _evtWeightTag;
+
+
+    Hists                              _hist;
+    const mu2e::ComboHitCollection*    _chColl;
+    const mu2e::TimeClusterCollection* _tcColl;
+    const mu2e::ComboHit*              _ch;
+    const art::Event*                  _event;
+    const mu2e::HelixSeedCollection*   _hsColl; //this is initializing a pointer _hsColl of type constant HelixSeedCollection (from mu2e library)
+
+    std::vector<tcData>                _tcData;
+    std::vector<hsData>                _hsData; //makes a vector with each entry of type hsData and calls it _hsData
+
+    //for filter
+    std::string _processName;
+    std::string _filterName;
+
+    eventData                          _eventData;
+
+  };
+
+
+
+  NPOTAnalysis::NPOTAnalysis(fhicl::ParameterSet const& pset) :
+    art::EDAnalyzer(pset),
+    _chCollTag      (pset.get<string>("chCollTag", "TTmakePH")),
+    _tcCollTag      (pset.get<string>("tcCollTag", "TTTZClusterFinder")),
+    _hsCollTag      (pset.get<string>("hsCollTag", "TTAprHelixFinder")),
+    _evtWeightTag   (pset.get<art::InputTag>("protonBunchIntensity" , "PBISim")),
+    _processName    (pset.get<std::string>("processName", " S5Stn")), //idk if i did this correct at all, lumiStream is the name of the sequence my filter is in in CalPatTrkReco 's prolog.fcl
+    _filterName     (pset.get<std::string>("filterName", "lumiStream"))  //changed RecoNPOTFilter to lumiStream
+  {
+
+  }
+  //-----------------------------------------------------------------------------
+  NPOTAnalysis::~NPOTAnalysis() {}
+
+  //-----------------------------------------------------------------------------
+  void NPOTAnalysis::bookHistograms(art::ServiceHandle<art::TFileService>& Tfs) {
+
+    char folder_name[20];
+    TH1::AddDirectory(0);
+
+    //-----------------------------------------------------------------------------
+    // book event histograms
+    //-----------------------------------------------------------------------------
+    for (int i=0; i<kNEventHistsSets; i++) {
+      sprintf(folder_name,"evt_%i",i);
+      art::TFileDirectory tfdir = Tfs->mkdir(folder_name);
+      _hist._EventHists[i] = new EventHists;
+      bookEventHistograms(_hist._EventHists[i],&tfdir);
+    }
+
+    //-----------------------------------------------------------------------------
+    // book time cluster histograms
+    //-----------------------------------------------------------------------------
+    for (int i=0; i<kNTimeClusterHistsSets; i++) {
+      sprintf(folder_name,"tcl_%i",i);
+      art::TFileDirectory tfdir = Tfs->mkdir(folder_name);
+      _hist._TimeClusterHists[i] = new TimeClusterHists;
+      bookTimeClusterHistograms(_hist._TimeClusterHists[i],&tfdir);
+    }
+
+
+    //-----------------------------------------------------------------------------
+    // book helix seed histograms
+    //-----------------------------------------------------------------------------
+
+    for (int i=0; i<kNHelixSeedHistsSets; i++) {
+      sprintf(folder_name, "hsc_%i",i);
+      art::TFileDirectory tfdir = Tfs->mkdir(folder_name);
+      _hist._HelixSeedHists[i] = new HelixSeedHists;
+      bookHelixSeedHistograms(_hist._HelixSeedHists[i],&tfdir);
+    }
+  }
+  //-----------------------------------------------------------------------------
+  void NPOTAnalysis::bookEventHistograms(EventHists* Hist, art::TFileDirectory* Dir) {
+
+    //1D histograms!!!
+    Hist->nTimeClusters = Dir->make<TH1D>("nTimeClusters" , "Number of Time Clusters; nTC ", 100, 0.0, 30.0 );
+    Hist->nCaloHits     = Dir->make<TH1D>("nCaloHits", "Number of Calorimeter Hits; nCaloHits", 100, 0.0, 1300);
+    Hist->caloEnergy    = Dir->make<TH1D>("caloEnergy", "Calorimeter Energy; E[MeV]", 100, 0.0, 7500);
+    Hist->nCaphriHits   = Dir->make<TH1D>("nCAPHRIHits", "Number of CAPHRI Hits; nCAPHRIHits", 100, 0.0, 20);
+    Hist->nProtonTCs    = Dir->make<TH1D>("nProtonTCs", "Number of Proton Time Clusters from Intensity Information; nProtonTC from Int", 100, 0.0, 100);
+    Hist->nTrackerHits  = Dir->make<TH1D>("nTrackerHits", "Number of Tracker Hits from Intensity Information; nTrkHits from Int", 100, 0.0, 7500);
+
+    Hist->nPOT          = Dir->make<TH1D>("nPOT", "Number of Protons on Target; nPOT", 100, 0.0, 1e8);
+    Hist->nProtonsDeltaFinder        = Dir->make<TH1D>("nProtonsDeltaFinder", "Number of Proton tracks from DeltaFinder Module; nProtons ", 100, 0.0, 100);
+
+    Hist->recoNPOT_caloE = Dir->make<TH1D>("recoNPOT_caloE", "Reconstructed nPOT from Calorimeter Energy; RecoNPOT from CaloE", 100, 0.0, 1e8);
+
+    //filtered
+    Hist->filteredRecoNPOT = Dir->make<TH1D>("filteredRecoNPOT", "Reconstructed nPOT that passed Filter; Filtered ReconPOT", 100, 0.0, 1e8);
+    //2d histograms!!! nPOT
+    Hist->nTimeClusters2d = Dir->make<TH2D>("nTimeClusters2d" , "Number of Protons on Target v Number of Time Clusters; nTC; nPOT ", 100, 0.0, 100.0, 100, 0.0, 1e8);
+    Hist->nCaloHits2d     = Dir->make<TH2D>("nCaloHits2d", "Number of Protons on Target v Number of Calorimeter Hits; nCaloHits; nPOT", 100, 0.0, 1300, 100, 0.0, 1e8);
+    Hist->caloEnergy2d    = Dir->make<TH2D>("caloEnergy2d", "Number of Protons on Target v Calorimeter Energy; E[MeV]; nPOT", 100, 0.0, 7500, 100, 0.0, 1e8);
+    Hist->nCaphriHits2d   = Dir->make<TH2D>("nCAPHRIHits2d", "Number of Protons on Target v Number of CAPHRI Hits; nCAPHRIHits; nPOT", 100, 0.0, 100, 100, 0.0, 1e8);
+    Hist->nProtonTCs2d    = Dir->make<TH2D>("nProtonTCs2d", "Number of Protons on Target v Number of Proton Time Clusters from Intensity Information; nProtonTC from Int; nPOT", 100, 0.0, 100, 100, 0.0, 1e8);
+    Hist->nTrackerHits2d  = Dir->make<TH2D>("nTrackerHits2d", "Number of Protons on Target v Number of Tracker Hits from Intensity Information; nTrkHits from Int; nPOT", 100, 0.0, 7500, 100, 0.0, 1e8);
+
+    //2d histograms!!!! nProtonsDeltaFinder
+    Hist->nTimeClusters2df = Dir->make<TH2D>("nTimeClusters2df" , "Number of Protons from Delta Finder v Number of Time Clusters; nTC; nProtons from DeltaFinder ", 100, 0.0, 100.0, 100, 0.0, 100);
+    Hist->nCaloHits2df     = Dir->make<TH2D>("nCaloHits2df", "Number of Protons from Delta Finder v Number of Calorimeter Hits; nCaloHits; nProtons from DeltaFinder", 100, 0.0, 1300, 100, 0.0, 100);
+    Hist->caloEnergy2df    = Dir->make<TH2D>("caloEnergy2df", "Number of Protons from Delta Finder v Calorimeter Energy; E[MeV]; nProtons from DeltaFinder", 100, 0.0, 7500, 100, 0.0, 100);
+    Hist->nCaphriHits2df   = Dir->make<TH2D>("nCAPHRIHits2df", "Number of Protons from Delta Finder v Number of CAPHRI Hits; nCAPHRIHits; nProtons from DeltaFinder", 100, 0.0, 100, 100, 0.0, 100);
+    Hist->nProtonTCs2df    = Dir->make<TH2D>("nProtonTCs2df", "Number of Protons from Delta Finder v Number of Proton Time Clusters from Intensity Information; nProtonTC from Int; nProtons from DeltaFinder", 100, 0.0, 100, 100, 0.0, 100);
+    Hist->nTrackerHits2df  = Dir->make<TH2D>("nTrackerHits2df", "Number of Protons from Delta Finder v Number of Tracker Hits from Intensity Information; nTrkHits from Int; nProtons from DeltaFinder", 100, 0.0, 7500, 100, 0.0, 100);
+
+    //2d Hists!! variable v variable
+    Hist->nPOTvnProtonTracks            = Dir->make<TH2D>("nPOTvnProtonTracks", "Number of Protons v Number of Protons from Delta Finder; nProtons from DF; nPOT", 100, 0.0, 100, 100, 0.0, 1e8);
+    Hist->caloEH           = Dir->make<TH2D>("caloEH", "Calorimeter Energy vs the number of Calorimeter Hits; nCaloHits; E[MeV]", 100, 0.0, 1300, 100, 0.0, 7500);
+    Hist->cTCs             = Dir->make<TH2D>("cTCs", "Number of Time Clusters vs Number of Time Clusters from Intensity Information; nProtonTCs from IntensityInfo; nTCs", 100, 0.0, 100, 100, 0.0, 100);
+    Hist->hitsTC           = Dir->make<TH2D>("hitsTC", "Number of Tracker Hits v number of Calorimeter Hits; nCaloHits; nTrackerHits", 100.0, 0.0, 1300, 20, 0.0, 7500);
+    Hist->hitsCAPHRIvCal   = Dir->make<TH2D>("hitsCAPHRIvCal", "Number of CAPHRI Hits v Number of Calorimeter Hits; nCaloHits; nCAPHRIHits", 100, 0.0, 1300, 100, 0.0, 100);
+    Hist->hitsCAPHRIvTrker = Dir->make<TH2D>("hitsCAPHRIvTrker", "Number of CAPHRI Hits v Number of Tracker Hits; nTrackerHits; nCAPHRIHits", 100, 0.0, 7500, 100, 0.0, 100);
+
+    // Residual histograms:1D
+    // Hist->resid_nTimeClusters = Dir->make<TH1D>("resid_nTimeClusters", "Residual between nPOT and predicted nPOT using the nTimeClusters; nPOT-PredictednPOT", 100, -1e6, 1e6);
+    //Hist->resid_nCaloHits     = Dir->make<TH1D>("resid_nCaloHits", "Residual between nPOT and predicted nPOT using the nCaloHits;  nPOT-PredictednPOT", 100, -1e7, 1e7);
+    Hist->resid_caloE_reco    = Dir->make<TH1D>("resid_caloE_reco", "Normalized Residual:  nPOT - reconstucted  nPOT from Calorimeter Energy; ( nPOT-recoNPOT)/nPOT", 100, -0.600, 0.600); //eventually -.5,5 i hope
+    //Hist->extended_resid_caloE_reco = Dir->make<TH1D>("extended_resid_caloE_reco", "Normalized Residual:  nPOT - reconstucted  nPOT from Calorimeter Energy; ( nPOT-recoNPOT)/nPOT", 100, -1.40, 0.40); //same but x-axis expanded to the left so no underflow
+    // Hist->extended_resid_caloE_reco = Dir->make<TH1D>("extended_resid_caloE_reco", "Normalized Residual:  nPOT - reconstucted  nPOT from Calorimeter Energy; ( nPOT-recoNPOT)/nPOT", 100, -2.00, 2.00); //shouldnt need now that fixed!
+    // Hist->resid_nCaphriHits   = Dir->make<TH1D>("resid_nCAPHRIHits", "Residual between nPOT and predicted nPOT using the nCAPHRIHits;  nPOT-PredictednPOT", 100, -1e7, 1e7);
+    // Hist->resid_nProtonTCs    = Dir->make<TH1D>("resid_nProtonTCs", "Residual between nPOT and predicted nPOT using the nProtonTCs;  nPOT-PredictednPOT", 100, -1e8, 1e8);
+    // Hist->resid_nTrackerHits  = Dir->make<TH1D>("resid_nTrackerHits", "Residual between nPOT and predicted nPOT using the nTrackerHits;  nPOT-PredictednPOT", 100, -1e7, 1e7);
+
+
+    //nPOT v residual :2d ( nPOT v actualPOT-predictedPOT)
+    // Hist->resid_nTimeClusters2d = Dir->make<TH2D>("resid_nTimeClusters2d", "nPOT v Residual of nPOT from nTimeClusters; nPOT-PredictednPOT; nPOT", 100, -1e6, 1e6, 100, 0.0, 1e8);
+    // Hist->resid_nCaloHits2d     = Dir->make<TH2D>("resid_nCaloHits2d", "nPOT v Residual of nPOT from nCaloHits; nPOT-PredictednPOT; ", 100, -1e7, 1e7, 100, 0.0, 1e8);
+    Hist->resid_caloE_reco2d    = Dir->make<TH2D>("resid_caloE_reco2d", "Normalized Residual of nPOT from Calorimeter Energy v nPOT;nPOT; (nPOT-recoNPOT)/nPOT", 100, 0.0, 1e8, 100, -0.600, 0.600);
+    Hist->resid_caloE_reco_v_caloE2d = Dir->make<TH2D>("resid_caloE_reco_v_caloE2d", "Normalized Residual of nPOT from Calorimeter Energy v Calorimeter Energy; CaloE [MeV]; (nPOT-recoNPOT)/nPOT", 100, 0.0, 1e4, 100, -0.600, 0.600); //try 1e4 instead of 7500? so see where fit fails bc only should work for 7500 really idk just try
+    // Hist->extended_resid_caloE_reco2d = Dir->make<TH2D>("extended_resid_caloE_reco2d", "nPOT v Normalized Residual of nPOT from Calorimeter Energy; (nPOT-recoNPOT)/nPOT; nPOT", 100, -1.40, 0.40, 100, 0.0, 1e8); //before giani recommendations
+    // Hist->extended_resid_caloE_reco2d = Dir->make<TH2D>("extended_resid_caloE_reco2d", "Normalized Residual of nPOT from Calorimeter Energy vnPOT; nPOT; (nPOT-recoNPOT)/nPOT", 100, 0.0, 1e8, 100, -2.00, 2.00); //shouldnt need now that fixed
+    //Hist->resid_nCaphriHits2d   = Dir->make<TH2D>("resid_nCAPHRIHits2d", "nPT v Residual of nPOT from nCAPHRIHits; nPOT-PredictednPOT; nPOT", 100, -1e7, 1e7, 100, 0.0, 1e8);
+    // Hist->resid_nProtonTCs2d    = Dir->make<TH2D>("resid_nProtonTCs2d", "nPOT v Residual of nPOT from nProtonTCs; nPOT-PredictednPOT; nPOT", 100, -1e8, 1e8, 100, 0.0, 1e8);
+    // Hist->resid_nTrackerHits2d  = Dir->make<TH2D>("resid_nTrackerHits2d", "nPOT v Residual of nPOT from nTrackerHits; nPOT-PredictednPOT; nPOT", 100, -1e7, 1e7, 100, 0.0, 1e8);
+  }
+
+
+  //-----------------------------------------------------------------------------
+  void NPOTAnalysis::bookTimeClusterHistograms(TimeClusterHists* Hist, art::TFileDirectory* Dir) {
+
+    Hist->dT = Dir->make<TH1D>("dT" , "width of time clusters", 40, 0.0, 500.0 );
+    Hist->t0 = Dir->make<TH1D>("t0" , "time of cluster", 200, 0.0, 1800.0 );
+
+  }
+
+  //The one im adding
+  //-----------------------------------------------------------------------------
+  void NPOTAnalysis::bookHelixSeedHistograms(HelixSeedHists* Hist, art::TFileDirectory* Dir) {
+    Hist->radius = Dir->make<TH1D>("radius", "radius of Helix", 50, 0.0, 500);
+  }
+
+  //--------------------------------------------------------------------------------//
+  void NPOTAnalysis::beginJob(){
+    art::ServiceHandle<art::TFileService> tfs;
+    bookHistograms(tfs);
+  }
+
+  //--------------------------------------------------------------------------------//
+  void NPOTAnalysis::endJob(){}
+
+  //--------------------------------------------------------------------------------//
+  void NPOTAnalysis::beginRun(const art::Run & run){}
+
+  //--------------------------------------------------------------------------------//
+  void NPOTAnalysis::endSubRun(const art::SubRun& sr){}
+
+  //--------------------------------------------------------------------------------//
+  void NPOTAnalysis::fillHistograms() {
+
+    //-----------------------------------------------------------------------------
+    // fill event histograms
+    //-----------------------------------------------------------------------------
+
+    fillEventHistograms(_hist._EventHists[0]);
+
+
+
+    //-----------------------------------------------------------------------------
+    // fill time cluster histograms
+    //-----------------------------------------------------------------------------
+    for (size_t i=0; i<_tcData.size(); i++) {
+      fillTimeClusterHistograms(_hist._TimeClusterHists[0], i);
+    }
+
+    //-----------------------------------------------------------------------------
+    // fill helix seed histograms
+    //-----------------------------------------------------------------------------
+
+    for (size_t i=0; i<_hsData.size(); i++) {
+      fillHelixSeedHistograms(_hist._HelixSeedHists[0], i);
+    }
+  }
+
+  //-----------------------------------------------------------------------------
+  void NPOTAnalysis::fillEventHistograms(EventHists* Hist) {
+
+    //1D histograms!!
+    Hist->nTimeClusters->Fill(_eventData.nClusters);
+    Hist->nCaloHits->Fill(_eventData.nCaloHits_);
+    Hist->caloEnergy->Fill(_eventData.caloEnergy_);
+    Hist->nCaphriHits->Fill(_eventData.nCaphriHits_);
+    Hist->nProtonTCs->Fill(_eventData.nProtonTCs_);
+    Hist->nTrackerHits->Fill(_eventData.nTrackerHits_);
+
+    Hist->nPOT->Fill(_eventData.nPOT_);
+    Hist->nProtonsDeltaFinder->Fill(_eventData.nProtonsDeltaFinder_);
+
+    //reconstructed npot
+    Hist->recoNPOT_caloE->Fill(_eventData.recoNPOT_caloE_);
+
+    //filtered
+    if (_eventData.passed) {Hist->filteredRecoNPOT->Fill(_eventData.recoNPOT_caloE_); } //if the event passed the filter, then add it to the histogram
+    //2d histograms!!! y is nPOT
+    Hist->nTimeClusters2d->Fill(_eventData.nClusters, _eventData.nPOT_);
+    Hist->nCaloHits2d->Fill(_eventData.nCaloHits_, _eventData.nPOT_);
+    Hist->caloEnergy2d->Fill(_eventData.caloEnergy_, _eventData.nPOT_);
+    Hist->nCaphriHits2d->Fill(_eventData.nCaphriHits_, _eventData.nPOT_);
+    Hist->nProtonTCs2d->Fill(_eventData.nProtonTCs_, _eventData.nPOT_);
+    Hist->nTrackerHits2d->Fill(_eventData.nTrackerHits_, _eventData.nPOT_);
+
+    //2d histograms!!! y is nProtonsDeltaFinder
+    Hist->nTimeClusters2df->Fill(_eventData.nClusters, _eventData.nProtonsDeltaFinder_);
+    Hist->nCaloHits2df->Fill(_eventData.nCaloHits_, _eventData.nProtonsDeltaFinder_);
+    Hist->caloEnergy2df->Fill(_eventData.caloEnergy_, _eventData.nProtonsDeltaFinder_);
+    Hist->nCaphriHits2df->Fill(_eventData.nCaphriHits_, _eventData.nProtonsDeltaFinder_);
+    Hist->nProtonTCs2df->Fill(_eventData.nProtonTCs_, _eventData.nProtonsDeltaFinder_);
+    Hist->nTrackerHits2df->Fill(_eventData.nTrackerHits_, _eventData.nProtonsDeltaFinder_);
+
+    //2d Hists variable v variable
+    Hist->nPOTvnProtonTracks->Fill(_eventData.nProtonsDeltaFinder_, _eventData.nPOT_);
+    Hist->caloEH->Fill(_eventData.nCaloHits_, _eventData.caloEnergy_);
+    Hist->cTCs->Fill(_eventData.nProtonTCs_, _eventData.nClusters);
+    Hist->hitsTC->Fill(_eventData.nCaloHits_, _eventData.nTrackerHits_);
+    Hist->hitsCAPHRIvCal->Fill(_eventData.nCaloHits_, _eventData.nCaphriHits_);
+    Hist->hitsCAPHRIvTrker->Fill(_eventData.nTrackerHits_, _eventData.nCaphriHits_);
+
+
+    // fill residual histograms
+    // Hist->resid_nTimeClusters->Fill(_eventData.resid_nTimeClusters_);
+    //Hist->resid_nCaloHits->Fill(_eventData.resid_nCaloHits_);
+    Hist->resid_caloE_reco->Fill(_eventData.resid_caloE_reco_);
+    // Hist->extended_resid_caloE_reco->Fill(_eventData.resid_caloE_reco_);
+    //Hist->resid_nCaphriHits->Fill(_eventData.resid_nCaphriHits_);
+    // Hist->resid_nProtonTCs->Fill(_eventData.resid_nProtonTCs_);
+    // Hist->resid_nTrackerHits->Fill(_eventData.resid_nTrackerHits_);
+
+    //fill the 2d nPOT v residual histograms
+    // Hist->resid_nTimeClusters->Fill(_eventData.resid_nTimeClusters_, _eventData.nPOT_);
+    //Hist->resid_nCaloHits->Fill(_eventData.resid_nCaloHits_, _eventData.nPOT_);
+    Hist->resid_caloE_reco2d->Fill( _eventData.nPOT_, _eventData.resid_caloE_reco_); //residuals on y-axis
+    Hist->resid_caloE_reco_v_caloE2d->Fill(_eventData.caloEnergy_, _eventData.resid_caloE_reco_);
+    //Hist->extended_resid_caloE_reco2d->Fill(_eventData.resid_caloE_reco_, _eventData.nPOT_);
+    // Hist->extended_resid_caloE_reco2d->Fill(_eventData.nPOT_, _eventData.resid_caloE_reco_); //residual v nPOT ask giani advised.
+
+    //Hist->resid_nCaphriHits->Fill(_eventData.resid_nCaphriHits_, _eventData.nPOT_);
+    //Hist->resid_nProtonTCs->Fill(_eventData.resid_nProtonTCs_, _eventData.nPOT_);
+    //Hist->resid_nTrackerHits->Fill(_eventData.resid_nTrackerHits_, _eventData.nPOT_);
+
+
+  }
+
+  //-----------------------------------------------------------------------------
+  void NPOTAnalysis::fillTimeClusterHistograms(TimeClusterHists* Hist, size_t loopIndex) {
+
+    // fill dT plot
+    double deltaTime = _tcData.at(loopIndex).dT;
+    Hist->dT->Fill(deltaTime);
+    // fill t0 plot
+    double timeZero = _tcData.at(loopIndex).t0;
+    Hist->t0->Fill(timeZero);
+
+  }
+
+
+  //-----------------------------------------------------------------------------
+  void NPOTAnalysis::fillHelixSeedHistograms(HelixSeedHists* Hist, size_t loopIndex) {
+    //fill radius plot
+    double radiusdata = _hsData.at(loopIndex).radius;
+    Hist->radius->Fill(radiusdata);
+  }
+  //--------------------------------------------------------------------------------
+  void NPOTAnalysis::computeEventData() {
+
+    // for (size_t i=0; i<_chCollph->size(); i++) {
+
+
+
+    // compute event level stuff
+    _eventData.nClusters = (int)_tcColl->size();
+
+    //find the residual btw the predicted nPOT( from observed _eventData.observable plugged into  fit function defined) and the actual nPOT. residual = actual-pred
+    /* if (_eventData.nClusters > 0) {
+       double pred = nTimeClusters2d(static_cast<double>(_eventData.nClusters));
+       _eventData.resid_nTimeClusters_ = static_cast<double>(_eventData.nPOT_) - pred;
+       } else {
+       _eventData.resid_nTimeClusters_ = 0.0;
+       }
+
+       if (_eventData.nCaloHits_ > 0) {
+       double pred = nCaloHits2d(static_cast<double>(_eventData.nCaloHits_));
+       _eventData.resid_nCaloHits_ = static_cast<double>(_eventData.nPOT_) - pred;
+       } else {
+       _eventData.resid_nCaloHits_ = 0.0;
+       }
+    */
+
+
+
+    if (_eventData.nPOT_ > 0 && _eventData.recoNPOT_caloE_ > 0) {
+      double residual = _eventData.nPOT_ - _eventData.recoNPOT_caloE_;
+      _eventData.resid_caloE_reco_ = residual / _eventData.nPOT_;
+    } else {
+      _eventData.resid_caloE_reco_ = 0.0;
+      std::cout << "Failed to calculate normalized residual: nPOT = "
+                << _eventData.nPOT_ << ", recoNPOT = " << _eventData.recoNPOT_caloE_ << std::endl;
+    }
+
+  }
+  /*
+    if (_eventData.nCaphriHits_ > 0) {
+    double pred = nCaphriHits2d(static_cast<double>(_eventData.nCaphriHits_));
+    _eventData.resid_nCaphriHits_ = static_cast<double>(_eventData.nPOT_) - pred;
+    } else {
+    _eventData.resid_nCaphriHits_ = 0.0;
+    }
+
+    if (_eventData.nProtonTCs_ > 0) {
+    double pred = nProtonTCs2d(static_cast<double>(_eventData.nProtonTCs_));
+    _eventData.resid_nProtonTCs_ = static_cast<double>(_eventData.nPOT_) - pred;
+    } else {
+    _eventData.resid_nProtonTCs_ = 0.0;
+    }
+
+    if (_eventData.nTrackerHits_ > 0) {
+    double pred = nTrackerHits2d(static_cast<double>(_eventData.nTrackerHits_));
+    _eventData.resid_nTrackerHits_ = static_cast<double>(_eventData.nPOT_) - pred;
+    } else {
+    _eventData.resid_nTrackerHits_ = 0.0;
+
+    }
+    }
+
+  */
+  //--------------------------------------------------------------------------------
+  void NPOTAnalysis::computeTimeClusterData() {
+
+
+
+
+    // Get the TimeClusterCollection
+    //auto tcCollHandle = _event->getValidHandle<TimeClusterCollection>(_chCollTag);
+    //_tcColl = const_cast<TimeClusterCollection*>(tcCollHandle.product());
+
+
+    // compute dT for each cluster
+    for (size_t i=0; i<_tcColl->size(); i++) {
+      tcData clusterData;
+      clusterData.t0 = _tcColl->at(i)._t0._t0;
+      double minT = 0.0;
+      double maxT = 0.0;
+      for (size_t j=0; j<_tcColl->at(i)._strawHitIdxs.size(); j++) {
+        int chIndex = _tcColl->at(i)._strawHitIdxs[j];
+        double chTime = _chColl->at(chIndex).correctedTime();
+        if (j==0) {
+          minT = chTime;
+          maxT = chTime;
+        }
+        if (chTime<minT) {minT = chTime;}
+        if (chTime>maxT) {maxT = chTime;}
+      }
+      clusterData.dT = maxT - minT;
+      _tcData.push_back(clusterData);
+    }
+
+  }
+
+  //--------------------------------------------------------------------------------
+  void NPOTAnalysis::computeHelixSeedData() {
+
+
+    //loop through all of the helices and grab the data members of interest
+    for (size_t i=0; i<_hsColl->size(); i++) {
+      hsData radiusData;
+      radiusData.radius = _hsColl->at(i).helix().radius();
+      _hsData.push_back(radiusData);
+    }
+
+  }
+
+  //--------------------------------------------------------------------------------
+  void NPOTAnalysis::analyze(const art::Event& event) {
+
+    // get event
+    _event = &event;
+
+
+    //LOAD IN WHETHER PASSED FILTER OR NOT from RecoNPOTFilter_module.cc
+    std::ostringstream oss;
+    oss << "TriggerResults::" << _processName; //fcl parameter
+    art::InputTag const tag{oss.str()};
+
+    /*DEBUGGING TO MAKE SURE PROCESS AND FILTER NAME ARE VALID
+    std::cout << "[DEBUG] Looking for TriggerResults with tag: '" << tag.encode() << "'" << std::endl;
+    std::cout << "[DEBUG] Process name: '" << _processName << "'" << std::endl;
+    std::cout << "[DEBUG] Filter name: '" << _filterName << "'" << std::endl;
+    */
+    try {
+      auto const trigResultsH = event.getValidHandle<art::TriggerResults>(tag);
+      if (trigResultsH.isValid()) {
+        // std::cout << "[DEBUG] TriggerResults handle IS VALID" << std::endl;
+        const art::TriggerResults* trigResults = trigResultsH.product();
+        TriggerResultsNavigator trigNavig(trigResults);
+        /*DEBUGGING TO SEE AVALIBLE PATH NAMES-----------------
+
+        std::cout << "[DEBUG] Paths and acceptance from TriggerResultsNavigator:" << std::endl;
+        for (size_t i = 0; i < trigResults->size(); ++i) {
+          std::string const& pathName = trigNavig.getTrigPathName(i);
+          bool accepted = trigNavig.accepted(pathName);
+          std::cout << "  [" << i << "] Path: " << pathName << std::endl;
+        }
+        //---------------------------------------------------*/
+        _eventData.passed = trigNavig.accepted(_filterName);
+
+        /*DEBUGGING TO SEE IF PASSED FILTER
+        std::cout << "[NPOTAnalysis] Filter check successful. Event " << event.id()
+                  << " passed filter '" << _filterName << "': "
+                  << (_eventData.passed ? "YES" : "NO") << std::endl;
+        */
+      } else {
+        std::cout << "[NPOTAnalysis] TriggerResults handle is not valid!" << std::endl;
+        _eventData.passed = false;
+      }
+    } catch (const std::exception& e) {
+      std::cout << "[NPOTAnalysis] Could not retrieve TriggerResults with tag '"
+                << tag.encode() << "'. Error: " << e.what() << std::endl;
+      _eventData.passed = false;
+    }
+
+
+
+
+    //RECONSTRUCTED NPOT FOR ANALYSIS ON FIT AND FOR RecoNPOTMaker_module.cc
+    art::Handle<ProtonBunchIntensity> recoNPOTH;
+    _event->getByLabel("RecoNPOTMaker",recoNPOTH);
+    if(recoNPOTH.isValid()) {
+      _eventData.recoNPOT_caloE_ = recoNPOTH->intensity();
+      // std::cout << "Event ID: " << event.id()
+      //<< "  recoNPOT_caloE_ = " << _eventData.recoNPOT_caloE_ << std::endl;
+
+    }
+    else { std::cout << "[NPOTAnalysis] Could not retrieve RecoNPOT from RecoNPOTMaker!" << std::endl; }
+
+
+
+    //get the EventData from ProtonBunchIntensity
+    art::Handle<ProtonBunchIntensity> evtWeightH;
+    _event->getByLabel(_evtWeightTag, evtWeightH);
+    if (evtWeightH.isValid()) {_eventData.nPOT_  = evtWeightH->intensity();}
+
+    //get the EventData from IntensityInfoCalo
+    art::Handle<IntensityInfoCalo> caloInt;
+    _event->getByLabel("CaloHitMakerFast", caloInt);
+    if (caloInt.isValid()){
+      _eventData.nCaloHits_   = caloInt->nCaloHits();
+      _eventData.caloEnergy_  = caloInt->caloEnergy();
+      _eventData.nCaphriHits_ = caloInt->nCaphriHits();
+    }
+
+    art::Handle<IntensityInfoTimeCluster> tcInt;
+    _event->getByLabel("TTTZClusterFinder", tcInt);
+    if (tcInt.isValid()) { _eventData.nProtonTCs_  = tcInt->nProtonTCs();}
+
+    //Get the nProtonsDeltaFinder from IntensityInfoTimeCluster
+    art::Handle<IntensityInfoTimeCluster> tcIntph;
+    _event->getByLabel("TTflagPH", tcIntph);
+    if (tcIntph.isValid()) { _eventData.nProtonsDeltaFinder_ = tcIntph->nProtonTCs();}
+    else { std::cout << "tcIntph is not valid, not filling nProtonsDeltaFinder_" << std::endl;}
+
+    art::Handle<IntensityInfoTrackerHits> thInt;
+    _event->getByLabel("TTmakeSH", thInt);
+    if (thInt.isValid()) { _eventData.nTrackerHits_ = thInt->nTrackerHits();}
+
+
+
+
+
+    // get the ComboHitCollection
+    art::Handle<mu2e::ComboHitCollection> chCollHandle;
+    _event->getByLabel(_chCollTag, chCollHandle);
+    if (chCollHandle.isValid())
+      {
+        _chColl = chCollHandle.product();
+      }
+    else {_chColl = NULL;}
+
+
+    //get the TimeClusterCollection
+    art::Handle<mu2e::TimeClusterCollection> tcCollHandle;
+    _event->getByLabel(_tcCollTag, tcCollHandle);
+    if (tcCollHandle.isValid()) {_tcColl = tcCollHandle.product();}
+    else {_tcColl = NULL;}
+
+    //get the HelixSeedCollection
+    art::Handle<mu2e::HelixSeedCollection> hsCollHandle;
+    _event->getByLabel(_hsCollTag, hsCollHandle);
+    if (hsCollHandle.isValid()) {_hsColl = hsCollHandle.product();}
+    else {_hsColl = NULL;}
+
+
+    computeEventData();
+    // compute data that will be plotted
+    if(_tcColl != NULL){ computeTimeClusterData();}
+    //radius idk man
+    if(_hsColl != NULL){ computeHelixSeedData();}
+
+
+
+    // fill histograms
+    fillHistograms();
+
+    _tcData.clear();
+    _hsData.clear();
+
+  }
+
+
+}
+DEFINE_ART_MODULE(mu2e::NPOTAnalysis)

--- a/CalPatRec/fcl/prolog.fcl
+++ b/CalPatRec/fcl/prolog.fcl
@@ -630,6 +630,8 @@ CalPatRec : { @table::CalPatRec
             caloDtMax                  : 30.0
             caloTimeOffset             : @local::TrackCaloMatching.DtOffset
             doRefine                   : 0
+            MinimumEnergy              : 0.0001
+            MaximumEnergy              : 0.005
 
             diagPlugin : { tool_type  : "TZClusterFinderDiag"
                  mcTruth       : 1
@@ -637,6 +639,22 @@ CalPatRec : { @table::CalPatRec
                  mcUtils       : { @table::TrkReco.McUtils }
             }
         }
+
+        ##------------------------MY NEW MODULE-----------------------------
+        RecoNPOTMaker : {
+            module_type         : RecoNPOTMaker
+            debugLevel          : 0
+            evtWeightTag        : "PBISim"
+           ## chCollTag           : "TTmakePH"
+           ## tcCollTag           : "TTTZClusterFinder"
+           ## hsCollTag           : "TTAprHelixFinder"
+            caloIntInfoTag      : "CaloHitMakerFast"
+           ## tcIntInfoTZTag      : "TTTZClusterFinder"
+            ## tcIntInfoFlagTag    : "TTflagPH"
+            ## trkHitIntInfoTag    : "TTmakeSH"
+        }
+
+        ##-----------------------------------------------------------------
 
         AgnosticHelixFinder : {
             module_type : AgnosticHelixFinder
@@ -719,6 +737,15 @@ CalPatRec : { @table::CalPatRec
     }
 
     filters : {
+
+        RecoNPOTFilter: {
+            module_type         : RecoNPOTFilter
+            recoNPOTTag         : "RecoNPOTMaker"
+            minWeight           : 1e-2
+        }
+
+
+
 #------------------------------------------------------------------------------
 # new modules
 #------------------------------------------------------------------------------

--- a/CalPatRec/src/RecoNPOTFilter_module.cc
+++ b/CalPatRec/src/RecoNPOTFilter_module.cc
@@ -1,0 +1,169 @@
+
+// Purpose: Filter events based on RecoNPOT to create a flat distribution for even statistics per bin when sampling
+// author: H Applegate 2025
+
+//For use getting results:    processName: "S5Stn"      filterName: "lumiStream"
+//Filter fcl parameters must be updated in proloc.fcl<CalPatRec> and /mu2e-trig-config/core/filters/trigSupFilters.fcl
+#include "art/Framework/Core/EDFilter.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art/Framework/Services/Optional/RandomNumberGenerator.h"
+
+#include "fhiclcpp/ParameterSet.h"
+#include "art_root_io/TFileService.h"
+
+#include "CLHEP/Random/RandGeneral.h"
+#include "CLHEP/Random/RandFlat.h"
+
+// Mu2e includes.
+
+#include "Offline/SeedService/inc/SeedService.hh"
+
+//MC DataProduct
+#include "Offline/MCDataProducts/inc/ProtonBunchIntensity.hh" // recoNPOT
+
+
+#include <iostream>
+#include <string>
+
+//using namespace std;
+namespace mu2e {
+
+  class RecoNPOTFilter : public art::EDFilter {
+  public:
+    struct Config {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+      fhicl::Atom<art::InputTag>           recoNPOTTag      {Name("recoNPOTTag"         ) ,Comment("for recoNPOT")};
+      fhicl::Atom<double>            minWeight        {Name("minWeight"           ) ,Comment("the largest weight we want to have a 100% sampling probability for")};
+    };
+    explicit RecoNPOTFilter(const art::EDFilter::Table<Config>& config);
+    virtual bool filter(art::Event& event) override;
+
+
+    //-----------------------------------------------------------------------------
+    // helper functions
+    //-----------------------------------------------------------------------------
+    bool findData                                        (const art::Event& evt);
+
+
+
+
+  private:
+
+    art::RandomNumberGenerator::base_engine_t& eng_;
+    CLHEP::RandFlat randomFlat_;
+
+    //-----------------------------------------------------------------------------
+    // event object labels
+    //-----------------------------------------------------------------------------
+
+    art::InputTag   _recoNPOTTag ;
+    double        _minWeight;
+    float      _largestInverseWeight;
+
+
+    const art::Event*                  _event;
+    //-----------------------------------------------------------------------------
+    // collections
+    //-----------------------------------------------------------------------------
+    const ProtonBunchIntensity*      _recoNPOT;
+
+    //-----------------------------------------------------------------------------
+    // Data Members
+    //-----------------------------------------------------------------------------
+    std::array<float, 100> _weights={1e-7, 1e-7, 0.004985, 0.019526, 0.068550, 0.154549, 0.230577, 0.341089, 0.472372, 0.530120, 0.665559, 0.755713, 0.787287, 0.863731, 0.892813, 0.929788, 0.979227, 1.000000, 0.944329, 0.985875, 0.942252, 0.959701, 0.985044, 0.970503, 0.949314, 0.891151, 0.883673, 0.847113, 0.833818, 0.840050, 0.798089, 0.753220, 0.728292, 0.704612, 0.655588, 0.688409 , 0.640216, 0.615289, 0.574574, 0.570004, 0.543831, 0.525135, 0.498961, 0.468218, 0.488990, 0.465310, 0.446199, 0.412962, 0.387619, 0.389281, 0.363939, 0.347736, 0.336934, 0.342750, 0.325717, 0.299958, 0.302036, 0.272954, 0.293311, 0.287910, 0.247611, 0.242210, 0.230162, 0.206897, 0.211467, 0.216452, 0.207312, 0.199834, 0.174491, 0.171998, 0.177815, 0.171998, 0.162027, 0.136269, 0.141670, 0.154549, 0.119651, 0.120482, 0.130868, 0.119236, 0.116743, 0.110926, 0.114250, 0.105526, 0.106356, 0.105110, 0.086415, 0.094308, 0.081429, 0.081429, 0.079767, 0.068135, 0.081014, 0.068135, 0.075613, 0.068966, 0.067304, 0.081014, 0.068135, 0.059826}; //weights of 0 are manually reset to 1e-7
+
+
+    //min and max values on x-axis from nPOT histogram
+    const double _minNPOT = 0;
+    //nPOT value of the maxBin / number of bins
+    const double _binWidth= 1000000.0; // 100e6/100  = 1e6
+
+  };
+
+
+
+
+
+
+
+
+
+  RecoNPOTFilter::RecoNPOTFilter(const art::EDFilter::Table<Config>& config) :
+    EDFilter{config}                                                                       ,
+    eng_                   {createEngine(art::ServiceHandle<SeedService>()->getSeed())}    ,
+    randomFlat_            {eng_}                                                          ,
+    _recoNPOTTag           {config().recoNPOTTag()}                                        ,
+    _minWeight                    {config().minWeight()}
+
+
+  {
+    _largestInverseWeight = 1./_minWeight;
+  }
+
+
+  //-----------------------------------------------------------------------------
+  // find input things
+  //-----------------------------------------------------------------------------
+  bool RecoNPOTFilter::findData(const art::Event& evt) {
+
+
+    //recoNPOT
+    auto recoNPOTH = evt.getValidHandle<ProtonBunchIntensity>(_recoNPOTTag);
+    if (recoNPOTH.product() != 0){_recoNPOT = recoNPOTH.product(); }
+    else {
+      _recoNPOT = 0;
+      std::cout << ">>> ERROR in RecoNPOTFilter::findata: ProtonBunchIntensity, recoNPOT,  not found." << std::endl;
+      return false;
+    }
+
+    return true;
+  }
+
+  //-----------------------------------------------------------------------------
+  // MAIN FILTER FUNCTION
+  //-----------------------------------------------------------------------------
+  bool RecoNPOTFilter::filter(art::Event& event) {
+    bool dataexist = findData(event);
+    if (dataexist) {
+      if (_recoNPOT !=nullptr){
+        unsigned long long npotreco = _recoNPOT->intensity();
+         //if the event's recoNPOT exceeds the size of our weights array, its  bin index in this arry will default to last index
+        unsigned long long  binIndex =std::min((_weights.size() - 1), static_cast<size_t>((npotreco - _minNPOT) / (_binWidth))   );
+
+         //If a bin's weight is less than the minimum bin weight we defined, the code will assume it has the minWeight (this means all weights smaller than our minWeight will have the same 100% sampling probability, therefore our efficiency increases because higher weighted bins are not given too small of sampling probabilities to make this code useful on a resasonable number of entries)
+        float weight =std::max(static_cast<float>(_minWeight), static_cast<float>(_weights[binIndex]));
+
+        float inverseWeight = 1.0/weight; //higher weight means we want a lower sampling probability
+
+        float inverseWeightScaled = inverseWeight/_largestInverseWeight; //ensures the limit is between 0 and 1
+        float randomVal = randomFlat_.fire(); //random integer between 0 and 1
+
+        //FOR DEBUGGING, uncomment if needed
+        //std::cout << "inverseWeightScaled = " << inverseWeightScaled << std::endl;
+        // std::cout << "randomVal = " << randomVal << std::endl;
+
+        //Filtering Step
+        if(randomVal < inverseWeightScaled) {
+          return true;
+        }
+        else { return false;}
+      }
+      else {
+        //DEBUGGING
+        std::cout << "[RecoNPOTFilter] recoNPOT not found, returning false" << std::endl;
+        return false;
+      }
+    }
+    else{
+      std::cout << "[RecoNPOTFilter::filter] Data does not exist, returning false" << std::endl;
+      return false;
+    }
+    return false;
+  }
+}
+
+using mu2e::RecoNPOTFilter;
+DEFINE_ART_MODULE(RecoNPOTFilter)

--- a/CalPatRec/src/RecoNPOTFilter_module.cc
+++ b/CalPatRec/src/RecoNPOTFilter_module.cc
@@ -17,11 +17,10 @@
 #include "CLHEP/Random/RandFlat.h"
 
 // Mu2e includes.
-
 #include "Offline/SeedService/inc/SeedService.hh"
 
 //MC DataProduct
-#include "Offline/MCDataProducts/inc/ProtonBunchIntensity.hh" // recoNPOT
+#include "Offline/MCDataProducts/inc/ProtonBunchIntensity.hh"
 
 
 #include <iostream>
@@ -35,7 +34,7 @@ namespace mu2e {
     struct Config {
       using Name=fhicl::Name;
       using Comment=fhicl::Comment;
-      fhicl::Atom<art::InputTag>           recoNPOTTag      {Name("recoNPOTTag"         ) ,Comment("for recoNPOT")};
+      fhicl::Atom<art::InputTag>     recoNPOTTag      {Name("recoNPOTTag"         ) ,Comment("for recoNPOT")};
       fhicl::Atom<double>            minWeight        {Name("minWeight"           ) ,Comment("the largest weight we want to have a 100% sampling probability for")};
     };
     explicit RecoNPOTFilter(const art::EDFilter::Table<Config>& config);
@@ -60,8 +59,8 @@ namespace mu2e {
     //-----------------------------------------------------------------------------
 
     art::InputTag   _recoNPOTTag ;
-    double        _minWeight;
-    float      _largestInverseWeight;
+    double          _minWeight;
+    float           _largestInverseWeight;
 
 
     const art::Event*                  _event;
@@ -73,10 +72,12 @@ namespace mu2e {
     //-----------------------------------------------------------------------------
     // Data Members
     //-----------------------------------------------------------------------------
-    std::array<float, 100> _weights={1e-7, 1e-7, 0.004985, 0.019526, 0.068550, 0.154549, 0.230577, 0.341089, 0.472372, 0.530120, 0.665559, 0.755713, 0.787287, 0.863731, 0.892813, 0.929788, 0.979227, 1.000000, 0.944329, 0.985875, 0.942252, 0.959701, 0.985044, 0.970503, 0.949314, 0.891151, 0.883673, 0.847113, 0.833818, 0.840050, 0.798089, 0.753220, 0.728292, 0.704612, 0.655588, 0.688409 , 0.640216, 0.615289, 0.574574, 0.570004, 0.543831, 0.525135, 0.498961, 0.468218, 0.488990, 0.465310, 0.446199, 0.412962, 0.387619, 0.389281, 0.363939, 0.347736, 0.336934, 0.342750, 0.325717, 0.299958, 0.302036, 0.272954, 0.293311, 0.287910, 0.247611, 0.242210, 0.230162, 0.206897, 0.211467, 0.216452, 0.207312, 0.199834, 0.174491, 0.171998, 0.177815, 0.171998, 0.162027, 0.136269, 0.141670, 0.154549, 0.119651, 0.120482, 0.130868, 0.119236, 0.116743, 0.110926, 0.114250, 0.105526, 0.106356, 0.105110, 0.086415, 0.094308, 0.081429, 0.081429, 0.079767, 0.068135, 0.081014, 0.068135, 0.075613, 0.068966, 0.067304, 0.081014, 0.068135, 0.059826}; //weights of 0 are manually reset to 1e-7
+
+    //Hardcoded from a Histogram of nPOT with 100 bins run on mnbs2 dataset
+    std::array<float, 100> _weights={1e-7, 1e-7, 0.004985, 0.019526, 0.068550, 0.154549, 0.230577, 0.341089, 0.472372, 0.530120, 0.665559, 0.755713, 0.787287, 0.863731, 0.892813, 0.929788, 0.979227, 1.000000, 0.944329, 0.985875, 0.942252, 0.959701, 0.985044, 0.970503, 0.949314, 0.891151, 0.883673, 0.847113, 0.833818, 0.840050, 0.798089, 0.753220, 0.728292, 0.704612, 0.655588, 0.688409 , 0.640216, 0.615289, 0.574574, 0.570004, 0.543831, 0.525135, 0.498961, 0.468218, 0.488990, 0.465310, 0.446199, 0.412962, 0.387619, 0.389281, 0.363939, 0.347736, 0.336934, 0.342750, 0.325717, 0.299958, 0.302036, 0.272954, 0.293311, 0.287910, 0.247611, 0.242210, 0.230162, 0.206897, 0.211467, 0.216452, 0.207312, 0.199834, 0.174491, 0.171998, 0.177815, 0.171998, 0.162027, 0.136269, 0.141670, 0.154549, 0.119651, 0.120482, 0.130868, 0.119236, 0.116743, 0.110926, 0.114250, 0.105526, 0.106356, 0.105110, 0.086415, 0.094308, 0.081429, 0.081429, 0.079767, 0.068135, 0.081014, 0.068135, 0.075613, 0.068966, 0.067304, 0.081014, 0.068135, 0.059826}; //weights of 0 are manually written as  1e-7
 
 
-    //min and max values on x-axis from nPOT histogram
+    //min value on x-axis from nPOT histogram
     const double _minNPOT = 0;
     //nPOT value of the maxBin / number of bins
     const double _binWidth= 1000000.0; // 100e6/100  = 1e6
@@ -96,7 +97,7 @@ namespace mu2e {
     eng_                   {createEngine(art::ServiceHandle<SeedService>()->getSeed())}    ,
     randomFlat_            {eng_}                                                          ,
     _recoNPOTTag           {config().recoNPOTTag()}                                        ,
-    _minWeight                    {config().minWeight()}
+    _minWeight             {config().minWeight()}
 
 
   {
@@ -105,7 +106,7 @@ namespace mu2e {
 
 
   //-----------------------------------------------------------------------------
-  // find input things
+  // find data
   //-----------------------------------------------------------------------------
   bool RecoNPOTFilter::findData(const art::Event& evt) {
 
@@ -130,20 +131,15 @@ namespace mu2e {
     if (dataexist) {
       if (_recoNPOT !=nullptr){
         unsigned long long npotreco = _recoNPOT->intensity();
-         //if the event's recoNPOT exceeds the size of our weights array, its  bin index in this arry will default to last index
-        unsigned long long  binIndex =std::min((_weights.size() - 1), static_cast<size_t>((npotreco - _minNPOT) / (_binWidth))   );
-
-         //If a bin's weight is less than the minimum bin weight we defined, the code will assume it has the minWeight (this means all weights smaller than our minWeight will have the same 100% sampling probability, therefore our efficiency increases because higher weighted bins are not given too small of sampling probabilities to make this code useful on a resasonable number of entries)
-        float weight =std::max(static_cast<float>(_minWeight), static_cast<float>(_weights[binIndex]));
+        //if recoNPOT exceeds our weights array, default its bin index to the last index
+        unsigned long long  binIndex =std::min( (_weights.size() - 1), static_cast<size_t>((npotreco - _minNPOT) / (_binWidth)) );
+        //If a bin's weight < minimum binWeight, assume it has the minWeight (and therefore 100% sampling probability)
+        float weight =std::max( static_cast<float>(_minWeight), static_cast<float>(_weights[binIndex]) );
 
         float inverseWeight = 1.0/weight; //higher weight means we want a lower sampling probability
 
-        float inverseWeightScaled = inverseWeight/_largestInverseWeight; //ensures the limit is between 0 and 1
+        float inverseWeightScaled = inverseWeight/_largestInverseWeight; //ensure between 0 and 1
         float randomVal = randomFlat_.fire(); //random integer between 0 and 1
-
-        //FOR DEBUGGING, uncomment if needed
-        //std::cout << "inverseWeightScaled = " << inverseWeightScaled << std::endl;
-        // std::cout << "randomVal = " << randomVal << std::endl;
 
         //Filtering Step
         if(randomVal < inverseWeightScaled) {
@@ -152,7 +148,6 @@ namespace mu2e {
         else { return false;}
       }
       else {
-        //DEBUGGING
         std::cout << "[RecoNPOTFilter] recoNPOT not found, returning false" << std::endl;
         return false;
       }

--- a/CalPatRec/src/RecoNPOTMaker_module.cc
+++ b/CalPatRec/src/RecoNPOTMaker_module.cc
@@ -1,0 +1,410 @@
+///////////////////////////////////////////////////////////////////////////////
+// RecoNPOTMaker
+// H. Applegate
+///////////////////////////////////////////////////////////////////////////////
+
+
+#include "fhiclcpp/ParameterSet.h"
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art_root_io/TFileService.h"
+#include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
+
+
+//MC DataProducts
+#include "Offline/MCDataProducts/inc/ProtonBunchIntensity.hh"
+
+//Reco DataProducts
+#include "Offline/RecoDataProducts/inc/TimeCluster.hh"
+#include "Offline/RecoDataProducts/inc/ComboHit.hh"
+#include "Offline/RecoDataProducts/inc/HelixSeed.hh"
+#include "Offline/RecoDataProducts/inc/IntensityInfoTimeCluster.hh"
+#include "Offline/RecoDataProducts/inc/IntensityInfoTrackerHits.hh"
+#include "Offline/RecoDataProducts/inc/IntensityInfoCalo.hh"
+
+
+//math stupp
+#include <cmath>
+
+
+
+//try to get debugging statements to print
+#include <iostream>
+
+namespace mu2e {
+
+  class RecoNPOTMaker: public art::EDProducer {
+
+  public:
+
+    struct Config {
+      using Name    = fhicl::Name;
+      using Comment = fhicl::Comment;
+      fhicl::Atom<int>               debugLevel       {Name("debugLevel"       ), Comment("turn on/off debug"           ) };
+      // fhicl::Atom<art::InputTag>     chCollTag        {Name("chCollTag"         ), Comment("ComboHitCollection"         ) };
+      // fhicl::Atom<art::InputTag>     tcCollTag        {Name("tcCollTag"         ), Comment("TimeClusterCollection"      ) };
+      // fhicl::Atom<art::InputTag>     hsCollTag        {Name("hsCollTag"         ), Comment("HelixSeedCollection"        ) };
+      fhicl::Atom<art::InputTag>     caloIntInfoTag   {Name("caloIntInfoTag"    ), Comment("IntensityInfoCalo"          ) };
+      // fhicl::Atom<art::InputTag>     tcIntInfoTZTag   {Name("tcIntInfoTZTag"    ), Comment("IntensityInfoTimeCluster"   ) };
+      // fhicl::Atom<art::InputTag>     tcIntInfoFlagTag {Name("tcIntInfoFlagTag"  ), Comment("IntensityInfoTimeCluster"   ) };
+      // fhicl::Atom<art::InputTag>     trkHitIntInfoTag {Name("trkHitIntInfoTag"  ), Comment("IntensityInfoTrackerHits"   ) };
+      fhicl::Atom<art::InputTag>     evtWeightTag     {Name("evtWeightTag"      ), Comment("ProtonBunchIntensity"       ) };
+
+    };
+
+    //-----------------------------------------------------------------------------
+    // how im storing my data within this module
+    //-----------------------------------------------------------------------------
+    struct Data {
+      const art::Event* _event;
+      unsigned long long actualNPOT = 0; //nPOT from ProtonBunchIntensity MC
+
+      struct PredictionResult {
+        std::string observable; //which observable gave this prediction
+        double  observableValue = 0.0; //the value of the observable
+        unsigned long long predictedNPOT = 0; //nPOT observable predicted
+      };
+
+      std::vector<PredictionResult> predictions;
+
+    };
+
+
+
+
+
+  private:
+
+    //-----------------------------------------------------------------------------
+    // data members
+    //-----------------------------------------------------------------------------
+    int              _debugLevel;
+
+    //-----------------------------------------------------------------------------
+    // event object labels
+    //-----------------------------------------------------------------------------
+    // art::InputTag   _chCollTag ;
+    // art::InputTag   _tcCollTag ;
+    // art::InputTag   _hsCollTag ;
+    art::InputTag   _caloIntInfoTag ;
+    //  art::InputTag   _tcIntInfoTZTag ;
+    // art::InputTag   _tcIntInfoFlagTag ;
+    // art::InputTag   _trkHitIntInfoTag ;
+    art::InputTag   _evtWeightTag ;
+
+    const art::Event*                  _event;
+    Data                               _Data;
+
+
+
+    //-----------------------------------------------------------------------------
+    // collections
+    //-----------------------------------------------------------------------------
+    const ProtonBunchIntensity*      _evtWeight;
+    const IntensityInfoCalo*         _caloIntInfo;
+    // const IntensityInfoTimeCluster*  _tcIntInfoTZ;
+    // const IntensityInfoTimeCluster*  _tcIntInfoFlag;
+    //const IntensityInfoTrackerHits*  _trkHitIntInfo;
+    //const TimeClusterCollection*     _tcColl;
+    // const HelixSeedCollection*       _hsColl;
+    //const ComboHitCollection*        _chColl;
+
+
+    ProtonBunchIntensity*            recoPBI; //pointer to what  i am producing
+
+    //-----------------------------------------------------------------------------
+    // functions
+    //-----------------------------------------------------------------------------
+
+  public:
+
+    explicit RecoNPOTMaker(const art::EDProducer::Table<Config>& config);
+    virtual ~RecoNPOTMaker();
+
+    virtual void beginJob ();
+    virtual void beginRun (art::Run&);
+    virtual void produce  (art::Event& e);
+    virtual void endJob   ();
+
+    //-----------------------------------------------------------------------------
+    // helper functions
+    //-----------------------------------------------------------------------------
+    bool findData                                        (const art::Event& evt);
+
+
+    //store the predicted nPOT for each event and observable
+    void addPrediction                                   (Data& data, const std::string& obsName, double& obsVal, unsigned long long& predicted);
+
+
+    unsigned long long predictnPOTfromCaloEnergy         (const art::Event& evt, double& caloEnergy);
+
+  };
+
+
+  //-----------------------------------------------------------------------------
+  // module constructor
+  //-----------------------------------------------------------------------------
+  RecoNPOTMaker::RecoNPOTMaker(const art::EDProducer::Table<Config>& config) :
+    art::EDProducer{config},
+    _debugLevel               (config().debugLevel()                                  ),
+    // _chCollTag                (config().chCollTag()                                   ),
+    // _tcCollTag                (config().tcCollTag()                                   ),
+    //  _hsCollTag                (config().hsCollTag()                                   ),
+    _caloIntInfoTag           (config().caloIntInfoTag()                              ),
+    // _tcIntInfoTZTag           (config().tcIntInfoTZTag()                              ),
+    // _tcIntInfoFlagTag         (config().tcIntInfoFlagTag()                            ),
+    // _trkHitIntInfoTag         (config().trkHitIntInfoTag()                            ),
+    _evtWeightTag             (config().evtWeightTag()                                )
+  {
+
+    consumes<ProtonBunchIntensity>(_evtWeightTag);
+    // consumes<ComboHitCollection>(_chCollTag);
+    // consumes<TimeClusterCollection>(_tcCollTag);
+    // consumes<HelixSeedCollection>(_hsCollTag);
+    // consumes<IntensityInfoTrackerHits>(_trkHitIntInfoTag);
+    consumes<IntensityInfoCalo>(_caloIntInfoTag);
+    // consumes<IntensityInfoTimeCluster>(_tcIntInfoTZTag);
+    // consumes<IntensityInfoTimeCluster>(_tcIntInfoFlagTag);
+
+    produces<ProtonBunchIntensity>();
+
+  }
+
+  //-----------------------------------------------------------------------------
+  // destructor
+  //-----------------------------------------------------------------------------
+  RecoNPOTMaker::~RecoNPOTMaker() {}
+
+  //-----------------------------------------------------------------------------
+  // beginJob
+  //-----------------------------------------------------------------------------
+  void RecoNPOTMaker::beginJob(){}
+
+  //-----------------------------------------------------------------------------
+  // beginRun
+  //-----------------------------------------------------------------------------
+  void RecoNPOTMaker::beginRun(art::Run& ) {}
+
+  //-----------------------------------------------------------------------------
+  // find input things
+  //-----------------------------------------------------------------------------
+  bool RecoNPOTMaker::findData(const art::Event& evt) {
+
+    //ProtonBunchIntensity
+    auto evtWeightH = evt.getValidHandle<ProtonBunchIntensity>(_evtWeightTag);
+    if (evtWeightH.product() != 0){_evtWeight = evtWeightH.product(); }
+    else {
+      _evtWeight = 0;
+      std::cout << ">>> ERROR in RecoNPOTMaker::findData: ProtonBunchIntensity not found." << std::endl;
+      return false;
+    }
+
+    //IntensityInfoCalo
+    auto caloIntInfoH = evt.getValidHandle<IntensityInfoCalo>(_caloIntInfoTag);
+    if (caloIntInfoH.product() != 0){_caloIntInfo = caloIntInfoH.product(); }
+    else {
+      _caloIntInfo = 0;
+      std::cout << ">>> ERROR in RecoNPOTMaker::findData: IntensityInfoCalo not found." << std::endl;
+      return false;
+    }
+
+    /* //IntensityInfoTimeCluster, TTTZClusterFinder
+       auto tcIntInfoTZH = evt.getValidHandle<IntensityInfoTimeCluster>(_tcIntInfoTZTag);
+       if (tcIntInfoTZH.product() != 0){_tcIntInfoTZ = tcIntInfoTZH.product(); }
+       else {
+       _tcIntInfoTZ = 0;
+       std::cout << ">>> ERROR in RecoNPOTMaker::findData: IntensityInfoTimeCluster with TTTZClusterFinder not found." << std::endl;
+       return false;
+       }
+
+       //IntensityInfoTimeCluster, TTflagPH
+       auto tcIntInfoFlagH = evt.getValidHandle<IntensityInfoTimeCluster>(_tcIntInfoFlagTag);
+       if (tcIntInfoFlagH.product() != 0){_tcIntInfoFlag = tcIntInfoFlagH.product(); }
+       else {
+       _tcIntInfoFlag = 0;
+       std::cout << ">>> ERROR in RecoNPOTMaker::findData: IntensityInfoTimeCluster with TTflagPH not found." << std::endl;
+       return false;
+       }
+
+       //IntensityInfoTrackerHits
+       auto trkHitIntInfoH = evt.getValidHandle<IntensityInfoTrackerHits>(_trkHitIntInfoTag);
+       if (trkHitIntInfoH.product() != 0){_trkHitIntInfo = trkHitIntInfoH.product(); }
+       else {
+       _trkHitIntInfo = 0;
+       std::cout << ">>> ERROR in RecoNPOTMaker::findData: IntensityInfoTrackerHits not found." << std::endl;
+       return false;
+       }
+
+       //ComboHitCollection
+       auto chCollH = evt.getValidHandle<ComboHitCollection>(_chCollTag);
+       if (chCollH.product() != 0){ _chColl = chCollH.product(); }
+       else{
+       _chColl = 0;
+       std::cout << ">>> ERROR in RecoNPOTMaker::findData: ComboHitCollection not found." << std::endl;
+       return false;
+       }
+
+       //TimeClusterCollection
+       auto tcCollH = evt.getValidHandle<TimeClusterCollection>(_tcCollTag);
+       if (tcCollH.product() != 0){ _tcColl = tcCollH.product(); }
+       else{
+       _tcColl = 0;
+       std::cout << ">>> ERROR in RecoNPOTMaker::findData: TimeClusterCollection not found." << std::endl;
+       return false;
+       }
+
+       //HelixSeedCollection
+       auto hsCollH = evt.getValidHandle<HelixSeedCollection>(_hsCollTag);
+       if (hsCollH.product() != 0) {_hsColl = hsCollH.product(); }
+
+    */
+    return true;
+  }
+  //-----------------------------------------------------------------------------
+  // event entry point
+  //-----------------------------------------------------------------------------
+  void RecoNPOTMaker::produce(art::Event& event) {
+
+    unsigned long long caloPredicted(0.0);
+
+    bool dataexist = findData(event);
+    if (dataexist) {
+      //ProtonBunchIntensity
+      if(_evtWeight != nullptr){
+        unsigned long long npot = _evtWeight->intensity();
+        _Data.actualNPOT = npot;
+        //std::cout << "[RecoNPOTMaker::produce] >> nPOT = " << npot << std::endl;
+      }
+      else {std::cout << "[RecoNPOTMaker::produce] Did Not find Proton Bunch Intensity data" << std::endl;}
+
+      //IntensityInfoCalo
+      if(_caloIntInfo != nullptr){
+        //std::cout << "[RecoNPOTMaker::produce] >> nCaloHits = " << _caloIntInfo->nCaloHits() << std::endl;
+        double caloEnergy = _caloIntInfo->caloEnergy();
+        // int nCalo = _caloIntInfo->nCaloHits();
+        // int nCaphri = _caloIntInfo->nCaphriHits();
+
+
+        Data::PredictionResult caloPred;
+        caloPred.observable = "caloEnergy";
+        caloPred.observableValue = caloEnergy;
+        caloPredicted = predictnPOTfromCaloEnergy(event, caloEnergy);
+        addPrediction(_Data, "caloEnergy", caloEnergy, caloPredicted);
+
+        //nCaloHits()
+        //nCaphriHits()
+      }
+      else {std:: cout <<"[RecoNPOTMaker::produce] Did Not find IntensityInfoCalo data" << std::endl;}
+      /*
+      //IntensityInfoTimeCluster, TTTZClusterFinder
+      if(_tcIntInfoTZ != nullptr){std::cout << "[RecoNPOTMaker::produce] >> nProtonTCs = " <<  _tcIntInfoTZ->nProtonTCs() << std::endl; }
+      else {std:: cout <<"[RecoNPOTMaker::produce] Did Not find IntensityInfoTimeCluster with TTTZClusterFinder data" << std::endl;}
+
+      //IntensityInfoTimeCluster,TTflagPH
+      if(_tcIntInfoFlag != nullptr){std::cout << "[RecoNPOTMaker::produce] >> nProtonTCs = " <<  _tcIntInfoFlag->nProtonTCs() << std::endl; }
+      else {std:: cout <<"[RecoNPOTMaker::produce] Did Not find IntensityInfoTimeCluster with TTflagPH data" << std::endl;}
+
+
+      //IntensityInfoTrackerHits
+      if(_trkHitIntInfo != nullptr){std::cout << "[RecoNPOTMaker::produce] >> nTrackerHits = " <<  _trkHitIntInfo->nTrackerHits() << std::endl; }
+      else {std:: cout <<"[RecoNPOTMaker::produce] Did Not find IntensityInfoTrackerHits data" << std::endl;}
+
+
+      //ComboHitCollection
+      if (_chColl != nullptr){ std::cout << "[RecoNPOTMaker::produce] >> total nStrawHits = " << _chColl->nStrawHits() << std::endl; }
+      else {std::cout << "[RecoNPOTMaker::produce] Did Not find ComboHitCollection data" << std::endl;}
+
+
+      //TimeClusterCollection
+      if(_tcColl != nullptr) {
+      size_t totalHits = 0;
+      for (const auto& cluster : *_tcColl) { totalHits += cluster.nhits(); }
+      std::cout << "[RecoNPOTMaker::produce] >> Total nhits = " << totalHits << std::endl;
+      }
+      else {std::cout << "[RecoNPOTMaker::produce] Did Not find TimeClusterCollection data" << std::endl;}
+
+
+
+      //HelixSeedCollection
+      if(_hsColl != nullptr){
+      size_t i = 0;
+      for (const auto& helixSeed : *_hsColl) {
+      double radius = helixSeed.helix().radius();
+      std::cout << "[RecoNPOTMaker::produce] >> Helix[" << i++ << "] Radius = " << radius << std::endl;
+      }
+      }
+      else {std::cout << "[RecoNPOTMaker::produce] Did Not find HelixSeedCollection data" << std::endl;}
+      */
+    }
+
+    else {std::cout << "[RecoNPOTMaker::produce] Data does not Exist" << std::endl; }
+
+
+
+    std::unique_ptr<ProtonBunchIntensity> recoPBI (new ProtonBunchIntensity);
+    recoPBI->set(caloPredicted);
+
+
+    event.put(std::move(recoPBI));
+
+  }
+
+  //-----------------------------------------------------------------------------
+  // endJob
+  //-----------------------------------------------------------------------------
+  void RecoNPOTMaker::endJob(){}
+
+
+  //------------------------ My Helper Functions---------------------------------
+
+  //-----------------------------------------------------------------------------
+  // predict nPOT from CaloEnergy Observable (from FittedPlots_2batchjuly10th2025)
+  //-----------------------------------------------------------------------------
+
+  unsigned long long RecoNPOTMaker:: predictnPOTfromCaloEnergy(const art::Event& evt, double& caloEnergy){
+    unsigned long long predictednPOT;
+
+    if (caloEnergy >= 0.000000 && caloEnergy <= 3750.000000) {
+      predictednPOT = 700948 + 12627.9*pow(caloEnergy,1) + 0.293111*pow(caloEnergy,2);
+    }
+    else if (caloEnergy >= 3750.000000 && caloEnergy <= 6300.000000) { //try changing 5625 to 6300
+      predictednPOT = 3.25191e+06 + 11524*pow(caloEnergy,1) + 0.403671*pow(caloEnergy,2);
+    }
+    //else if (caloEnergy >= 5625.000000 && caloEnergy <= 6300.000000) {//changed  6300 bc then stats drop off
+      //predictednPOT = -2.47431e+08 + 94480*pow(caloEnergy,1) + -6.45608*pow(caloEnergy,2); //fit from histogramfitting.c
+    // predictednPOT = -5.36566e+06 + 15314.2*pow(caloEnergy,1); //fit i did dynamically from 5250 to 6500, linear fit chi2rd 15.3631/15
+    else {
+      //predictednPOT = 0;
+      //predictednPOT =409009+13038.4*pow(caloEnergy,1); // july18th2batch100000weridbump.root
+      predictednPOT = -5.36566e+06 + 15314.2*pow(caloEnergy,1); //july18thlowstatstotrynewfitbutnotsatisfied.root
+      //predictednPOT = -1.86775e+08 +  74433.2*pow(caloEnergy,1) + -4.80806*pow(caloEnergy,2); //really bad residuals, over estimates the tail
+    }
+
+    return predictednPOT;
+  }
+  //-----------------------------------------------------------------------------
+  //add predicted nPOT to my vector of predictions of type PredictionResult in my Data Struct
+  //-----------------------------------------------------------------------------
+
+  void RecoNPOTMaker::addPrediction(Data& data, const std::string& obsName,  double& obsVal, unsigned long long& predicted) {
+    Data::PredictionResult pred;
+    pred.observable = obsName;
+    pred.observableValue = obsVal;
+    pred.predictedNPOT = predicted;
+    /*
+    //TO CHECK IT IS WORKING
+    std::cout << "\n[addPrediction] Final PredictionResult Summary:" << std::endl;
+    std::cout << "  Observable            : " << pred.observable << std::endl;
+    std::cout << "  Observable Value      : " << pred.observableValue << std::endl;
+    std::cout << "  Predicted nPOT        : " << pred.predictedNPOT << std::endl;
+    std::cout << "  Actual nPOT           : " << data.actualNPOT << std::endl;
+    //can delete btw comments once satisfied
+    */
+    data.predictions.push_back(pred);
+  }
+
+}
+using mu2e::RecoNPOTMaker;
+DEFINE_ART_MODULE(RecoNPOTMaker)

--- a/CalPatRec/src/RecoNPOTMaker_module.cc
+++ b/CalPatRec/src/RecoNPOTMaker_module.cc
@@ -12,7 +12,6 @@
 #include "art_root_io/TFileService.h"
 #include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
 
-
 //MC DataProducts
 #include "Offline/MCDataProducts/inc/ProtonBunchIntensity.hh"
 
@@ -24,13 +23,7 @@
 #include "Offline/RecoDataProducts/inc/IntensityInfoTrackerHits.hh"
 #include "Offline/RecoDataProducts/inc/IntensityInfoCalo.hh"
 
-
-//math stupp
 #include <cmath>
-
-
-
-//try to get debugging statements to print
 #include <iostream>
 
 namespace mu2e {
@@ -55,7 +48,7 @@ namespace mu2e {
     };
 
     //-----------------------------------------------------------------------------
-    // how im storing my data within this module
+    // Data Storage SetUp
     //-----------------------------------------------------------------------------
     struct Data {
       const art::Event* _event;
@@ -78,12 +71,12 @@ namespace mu2e {
   private:
 
     //-----------------------------------------------------------------------------
-    // data members
+    // Data Members
     //-----------------------------------------------------------------------------
     int              _debugLevel;
 
     //-----------------------------------------------------------------------------
-    // event object labels
+    // Event Object Labels
     //-----------------------------------------------------------------------------
     // art::InputTag   _chCollTag ;
     // art::InputTag   _tcCollTag ;
@@ -104,15 +97,15 @@ namespace mu2e {
     //-----------------------------------------------------------------------------
     const ProtonBunchIntensity*      _evtWeight;
     const IntensityInfoCalo*         _caloIntInfo;
-    // const IntensityInfoTimeCluster*  _tcIntInfoTZ;
-    // const IntensityInfoTimeCluster*  _tcIntInfoFlag;
+    //const IntensityInfoTimeCluster*  _tcIntInfoTZ;
+    //const IntensityInfoTimeCluster*  _tcIntInfoFlag;
     //const IntensityInfoTrackerHits*  _trkHitIntInfo;
     //const TimeClusterCollection*     _tcColl;
-    // const HelixSeedCollection*       _hsColl;
+    //const HelixSeedCollection*       _hsColl;
     //const ComboHitCollection*        _chColl;
 
 
-    ProtonBunchIntensity*            recoPBI; //pointer to what  i am producing
+    ProtonBunchIntensity*            recoPBI; //Pointer to Collection Module Produces
 
     //-----------------------------------------------------------------------------
     // functions
@@ -134,10 +127,9 @@ namespace mu2e {
     bool findData                                        (const art::Event& evt);
 
 
-    //store the predicted nPOT for each event and observable
+    //Add Prediction to Data Storage
     void addPrediction                                   (Data& data, const std::string& obsName, double& obsVal, unsigned long long& predicted);
-
-
+    //Functions to Reconstruct nPOT from Observable
     unsigned long long predictnPOTfromCaloEnergy         (const art::Event& evt, double& caloEnergy);
 
   };
@@ -151,7 +143,7 @@ namespace mu2e {
     _debugLevel               (config().debugLevel()                                  ),
     // _chCollTag                (config().chCollTag()                                   ),
     // _tcCollTag                (config().tcCollTag()                                   ),
-    //  _hsCollTag                (config().hsCollTag()                                   ),
+    // _hsCollTag                (config().hsCollTag()                                   ),
     _caloIntInfoTag           (config().caloIntInfoTag()                              ),
     // _tcIntInfoTZTag           (config().tcIntInfoTZTag()                              ),
     // _tcIntInfoFlagTag         (config().tcIntInfoFlagTag()                            ),
@@ -258,7 +250,6 @@ namespace mu2e {
        //HelixSeedCollection
        auto hsCollH = evt.getValidHandle<HelixSeedCollection>(_hsCollTag);
        if (hsCollH.product() != 0) {_hsColl = hsCollH.product(); }
-
     */
     return true;
   }
@@ -281,7 +272,6 @@ namespace mu2e {
 
       //IntensityInfoCalo
       if(_caloIntInfo != nullptr){
-        //std::cout << "[RecoNPOTMaker::produce] >> nCaloHits = " << _caloIntInfo->nCaloHits() << std::endl;
         double caloEnergy = _caloIntInfo->caloEnergy();
         // int nCalo = _caloIntInfo->nCaloHits();
         // int nCaphri = _caloIntInfo->nCaphriHits();
@@ -292,11 +282,9 @@ namespace mu2e {
         caloPred.observableValue = caloEnergy;
         caloPredicted = predictnPOTfromCaloEnergy(event, caloEnergy);
         addPrediction(_Data, "caloEnergy", caloEnergy, caloPredicted);
-
-        //nCaloHits()
-        //nCaphriHits()
       }
       else {std:: cout <<"[RecoNPOTMaker::produce] Did Not find IntensityInfoCalo data" << std::endl;}
+
       /*
       //IntensityInfoTimeCluster, TTTZClusterFinder
       if(_tcIntInfoTZ != nullptr){std::cout << "[RecoNPOTMaker::produce] >> nProtonTCs = " <<  _tcIntInfoTZ->nProtonTCs() << std::endl; }
@@ -360,7 +348,7 @@ namespace mu2e {
   //------------------------ My Helper Functions---------------------------------
 
   //-----------------------------------------------------------------------------
-  // predict nPOT from CaloEnergy Observable (from FittedPlots_2batchjuly10th2025)
+  // predict nPOT from CaloEnergy Observable
   //-----------------------------------------------------------------------------
 
   unsigned long long RecoNPOTMaker:: predictnPOTfromCaloEnergy(const art::Event& evt, double& caloEnergy){
@@ -369,17 +357,11 @@ namespace mu2e {
     if (caloEnergy >= 0.000000 && caloEnergy <= 3750.000000) {
       predictednPOT = 700948 + 12627.9*pow(caloEnergy,1) + 0.293111*pow(caloEnergy,2);
     }
-    else if (caloEnergy >= 3750.000000 && caloEnergy <= 6300.000000) { //try changing 5625 to 6300
+    else if (caloEnergy >= 3750.000000 && caloEnergy <= 6300.000000) {
       predictednPOT = 3.25191e+06 + 11524*pow(caloEnergy,1) + 0.403671*pow(caloEnergy,2);
     }
-    //else if (caloEnergy >= 5625.000000 && caloEnergy <= 6300.000000) {//changed  6300 bc then stats drop off
-      //predictednPOT = -2.47431e+08 + 94480*pow(caloEnergy,1) + -6.45608*pow(caloEnergy,2); //fit from histogramfitting.c
-    // predictednPOT = -5.36566e+06 + 15314.2*pow(caloEnergy,1); //fit i did dynamically from 5250 to 6500, linear fit chi2rd 15.3631/15
     else {
-      //predictednPOT = 0;
-      //predictednPOT =409009+13038.4*pow(caloEnergy,1); // july18th2batch100000weridbump.root
-      predictednPOT = -5.36566e+06 + 15314.2*pow(caloEnergy,1); //july18thlowstatstotrynewfitbutnotsatisfied.root
-      //predictednPOT = -1.86775e+08 +  74433.2*pow(caloEnergy,1) + -4.80806*pow(caloEnergy,2); //really bad residuals, over estimates the tail
+      predictednPOT = -5.36566e+06 + 15314.2*pow(caloEnergy,1);
     }
 
     return predictednPOT;
@@ -393,15 +375,6 @@ namespace mu2e {
     pred.observable = obsName;
     pred.observableValue = obsVal;
     pred.predictedNPOT = predicted;
-    /*
-    //TO CHECK IT IS WORKING
-    std::cout << "\n[addPrediction] Final PredictionResult Summary:" << std::endl;
-    std::cout << "  Observable            : " << pred.observable << std::endl;
-    std::cout << "  Observable Value      : " << pred.observableValue << std::endl;
-    std::cout << "  Predicted nPOT        : " << pred.predictedNPOT << std::endl;
-    std::cout << "  Actual nPOT           : " << data.actualNPOT << std::endl;
-    //can delete btw comments once satisfied
-    */
     data.predictions.push_back(pred);
   }
 

--- a/CalPatRec/src/SConscript
+++ b/CalPatRec/src/SConscript
@@ -15,7 +15,8 @@ extrarootlibs = ['TMVA' , 'Minuit' , 'XMLIO' ]
 
 helper=mu2e_helper(env);
 
-mainlib = helper.make_mainlib( [ 'mu2e_CalPatRec_dict',
+mainlib = helper.make_mainlib( [ 'mu2e_SeedService', #added
+                                 'mu2e_CalPatRec_dict',
                                  'mu2e_CaloCluster',
                                  'mu2e_TrkReco',
                                  'mu2e_BTrkData',
@@ -55,6 +56,7 @@ mainlib = helper.make_mainlib( [ 'mu2e_CalPatRec_dict',
                                  ] )
 
 helper.make_plugins( [ mainlib,
+                       'mu2e_SeedService', #added
                        'mu2e_TrkReco',
                        'mu2e_BTrkData',
                        'mu2e_Mu2eBTrk',
@@ -96,6 +98,7 @@ helper.make_plugins( [ mainlib,
 
 
 helper.make_dict_and_map( [ # mainlib,
+    'mu2e_SeedService', #added
   'mu2e_GeomPrimitives',
   'mu2e_GeneralUtilities',
   'mu2e_TrackerGeom',

--- a/CalPatRec/src/SConscript
+++ b/CalPatRec/src/SConscript
@@ -15,7 +15,7 @@ extrarootlibs = ['TMVA' , 'Minuit' , 'XMLIO' ]
 
 helper=mu2e_helper(env);
 
-mainlib = helper.make_mainlib( [ 'mu2e_SeedService', #added
+mainlib = helper.make_mainlib( [ 'mu2e_SeedService',
                                  'mu2e_CalPatRec_dict',
                                  'mu2e_CaloCluster',
                                  'mu2e_TrkReco',
@@ -56,7 +56,7 @@ mainlib = helper.make_mainlib( [ 'mu2e_SeedService', #added
                                  ] )
 
 helper.make_plugins( [ mainlib,
-                       'mu2e_SeedService', #added
+                       'mu2e_SeedService',
                        'mu2e_TrkReco',
                        'mu2e_BTrkData',
                        'mu2e_Mu2eBTrk',
@@ -98,7 +98,7 @@ helper.make_plugins( [ mainlib,
 
 
 helper.make_dict_and_map( [ # mainlib,
-    'mu2e_SeedService', #added
+  'mu2e_SeedService',
   'mu2e_GeomPrimitives',
   'mu2e_GeneralUtilities',
   'mu2e_TrackerGeom',

--- a/CalPatRec/src/TZClusterFinder_module.cc
+++ b/CalPatRec/src/TZClusterFinder_module.cc
@@ -64,6 +64,10 @@ namespace mu2e {
       fhicl::Atom<float>             caloDtMax        {Name("caloDtMax"        ), Comment("search time window (ns)"     ) };
       fhicl::Atom<float>             caloTimeOffset   {Name("caloTimeOffset"   ), Comment("in ns"                       ) };
       fhicl::Atom<int>               doRefine         {Name("doRefine"         ), Comment("filter out bad TCs at end"   ) };
+      //----------ADDING MIN AND MAX E------------
+      fhicl::Atom<float>            minE    { Name("MinimumEnergy"),         Comment("Minimum straw energy deposit (MeV)")};
+      fhicl::Atom<float>            maxE    { Name("MaximumEnergy"),         Comment("Maximum straw energy deposit (MeV)")};
+
 
       fhicl::Table<TZClusterFinderTypes::Config> diagPlugin{Name("diagPlugin"      ), Comment("Diag plugin") };
     };
@@ -107,7 +111,8 @@ namespace mu2e {
     float    _caloDtMax; // max time from time cluster for calo cluster to be associated with time cluster
     float    _caloTimeOffset; // time offset for calo clusters
     int      _doRefine; // if set to 1 then some pattern recogntion is used to filter out bad TC candidates
-
+    //ADDING MIN AND MAX E
+    float         _minE, _maxE;
     //-----------------------------------------------------------------------------
     // diagnostics
     //-----------------------------------------------------------------------------
@@ -181,7 +186,10 @@ namespace mu2e {
     _minCaloEnergy          (config().minCaloEnergy()                           ),
     _caloDtMax              (config().caloDtMax()                               ),
     _caloTimeOffset         (config().caloTimeOffset()                          ),
-    _doRefine               (config().doRefine()                                )
+    _doRefine               (config().doRefine()                                ),
+    //adding min and max e
+    _minE(      config().minE()                                                 ),
+    _maxE(      config().maxE()                                                 )
     {
 
       consumes<ComboHitCollection>(_chLabel);
@@ -623,8 +631,9 @@ namespace mu2e {
         _f.testWeight = _f.cHits[i].plnHits[j].hWeight;
         _f.testZpos = _f.cHits[i].plnHits[j].hZpos;
         _f.testIndice = _f.cHits[i].plnHits[j].hIndex;
-        const StrawHitFlag flag = _data._chColl->at(_f.testIndice).flag();
-        if (flag.hasAnyProperty(StrawHitFlag::energysel)) { _f.testNRGselection = 1; }
+        //const StrawHitFlag flag = _data._chColl->at(_f.testIndice).flag();
+        auto energy = _data._chColl->at(_f.testIndice).energyDep(); //newline
+        if ((energy < _maxE) && (energy >  _minE) ) { _f.testNRGselection = 1; } //replacedline
         else { _f.testNRGselection = 0; }
         validLinesFound = 0;
         minValidDtFound = 0.0;

--- a/CalPatRec/src/TZClusterFinder_module.cc
+++ b/CalPatRec/src/TZClusterFinder_module.cc
@@ -64,7 +64,6 @@ namespace mu2e {
       fhicl::Atom<float>             caloDtMax        {Name("caloDtMax"        ), Comment("search time window (ns)"     ) };
       fhicl::Atom<float>             caloTimeOffset   {Name("caloTimeOffset"   ), Comment("in ns"                       ) };
       fhicl::Atom<int>               doRefine         {Name("doRefine"         ), Comment("filter out bad TCs at end"   ) };
-      //----------ADDING MIN AND MAX E------------
       fhicl::Atom<float>            minE    { Name("MinimumEnergy"),         Comment("Minimum straw energy deposit (MeV)")};
       fhicl::Atom<float>            maxE    { Name("MaximumEnergy"),         Comment("Maximum straw energy deposit (MeV)")};
 
@@ -111,7 +110,6 @@ namespace mu2e {
     float    _caloDtMax; // max time from time cluster for calo cluster to be associated with time cluster
     float    _caloTimeOffset; // time offset for calo clusters
     int      _doRefine; // if set to 1 then some pattern recogntion is used to filter out bad TC candidates
-    //ADDING MIN AND MAX E
     float         _minE, _maxE;
     //-----------------------------------------------------------------------------
     // diagnostics
@@ -187,25 +185,24 @@ namespace mu2e {
     _caloDtMax              (config().caloDtMax()                               ),
     _caloTimeOffset         (config().caloTimeOffset()                          ),
     _doRefine               (config().doRefine()                                ),
-    //adding min and max e
     _minE(      config().minE()                                                 ),
     _maxE(      config().maxE()                                                 )
-    {
+  {
 
-      consumes<ComboHitCollection>(_chLabel);
-      consumes<CaloClusterCollection>(_ccLabel);
-      produces<TimeClusterCollection>();
-      produces<IntensityInfoTimeCluster>();
+    consumes<ComboHitCollection>(_chLabel);
+    consumes<CaloClusterCollection>(_ccLabel);
+    produces<TimeClusterCollection>();
+    produces<IntensityInfoTimeCluster>();
 
 
-      if (_runDisplay == 1) { _c1 = new TCanvas("_c1", "t vs. z", 900, 900); }
+    if (_runDisplay == 1) { _c1 = new TCanvas("_c1", "t vs. z", 900, 900); }
 
-      if (_debugLevel != 0) _printfreq = 1;
+    if (_debugLevel != 0) _printfreq = 1;
 
-      if (_diagLevel  != 0) _hmanager = art::make_tool<ModuleHistToolBase>(config().diagPlugin, "diagPlugin");
-      else                  _hmanager = std::make_unique<ModuleHistToolBase>();
+    if (_diagLevel  != 0) _hmanager = art::make_tool<ModuleHistToolBase>(config().diagPlugin, "diagPlugin");
+    else                  _hmanager = std::make_unique<ModuleHistToolBase>();
 
-    }
+  }
 
   //-----------------------------------------------------------------------------
   // destructor
@@ -631,9 +628,8 @@ namespace mu2e {
         _f.testWeight = _f.cHits[i].plnHits[j].hWeight;
         _f.testZpos = _f.cHits[i].plnHits[j].hZpos;
         _f.testIndice = _f.cHits[i].plnHits[j].hIndex;
-        //const StrawHitFlag flag = _data._chColl->at(_f.testIndice).flag();
-        auto energy = _data._chColl->at(_f.testIndice).energyDep(); //newline
-        if ((energy < _maxE) && (energy >  _minE) ) { _f.testNRGselection = 1; } //replacedline
+        auto energy = _data._chColl->at(_f.testIndice).energyDep();
+        if ((energy < _maxE) && (energy >  _minE) ) { _f.testNRGselection = 1; }
         else { _f.testNRGselection = 0; }
         validLinesFound = 0;
         minValidDtFound = 0.0;

--- a/MCDataProducts/inc/ProtonBunchIntensity.hh
+++ b/MCDataProducts/inc/ProtonBunchIntensity.hh
@@ -15,6 +15,7 @@ namespace mu2e {
         return _intensity == other.intensity(); }
       bool operator != (ProtonBunchIntensity const& other ) const { return !(operator ==(other)); }
       void add(ProtonBunchIntensity const& other) { _intensity += other.intensity(); }
+    void set(unsigned long long intensity){ _intensity = intensity;}
     private:
       unsigned long long _intensity; // this has units # of protons/microbunch
   };


### PR DESCRIPTION

-RecoNPOTMaker  producer module to reconstruct nPOT from Observables. Currently only reconstructing from Calorimeter Energy. 

-RecoNPOTFilter filter module to sample even counts from all intensities of the nPOT range. Around 3% of events pass currently.

-NPOTAnalysis plots histograms of Luminosity Stream Observables (1D, nPOTvObservable,nProtonsvObservable).  NPOTAnalysis plots recoNPOT, calculates and plots normalized residual ((npot-reconstructed)/npot), plots residuals v NPOT and vObservable. NPOTAnalysis also plots the recoNPOT that passed the filter.

-Remove flag from TZClusterFinder and replace with energy selection.
