### PR TITLE
enable DbTableFactory in swig

### DIFF
--- a/DbTables/src/pywrap.i
+++ b/DbTables/src/pywrap.i
@@ -6,6 +6,7 @@
 
 %include "std_string.i"
 %include "std_vector.i"
+%include "std_shared_ptr.i"
 %include "stdint.i"
 
 %apply const std::string& {std::string* foo};
@@ -17,13 +18,16 @@
 #include "Offline/DbTables/inc/DbTable.hh"
 #include "Offline/DbTables/inc/DbTableCollection.hh"
 #include "Offline/DbTables/inc/DbLiveTable.hh"
+#include "Offline/DbTables/inc/DbTableFactory.hh"
 #include "Offline/DbTables/inc/DbUtil.hh"
 %}
 
 %template(vectordbt) std::vector<mu2e::DbLiveTable>;
+%shared_ptr(mu2e::DbTable)
 
 %include "Offline/DbTables/inc/DbIoV.hh"
 %include "Offline/DbTables/inc/DbTable.hh"
 %include "Offline/DbTables/inc/DbTableCollection.hh"
 %include "Offline/DbTables/inc/DbLiveTable.hh"
+%include "Offline/DbTables/inc/DbTableFactory.hh"
 %include "Offline/DbTables/inc/DbUtil.hh"


### PR DESCRIPTION
This should be a solution to Richie's request this morning (automate table column names) 
```
>>> import DbTables
>>> zz = DbTables.DbTableFactory().newTable("TrkDelayPanel").query()
>>> zz
'index,delay'

```