### PR TITLE
Decouple STM VD size from the size of the CRV

### DIFF
--- a/Mu2eG4/geom/STM_v09.txt
+++ b/Mu2eG4/geom/STM_v09.txt
@@ -230,6 +230,10 @@ double stm.magnet.stand.topExtraLength = -200.0; // reduce length of table to av
 
 double stm.shieldingHolePoly.rOut = 127.0; // diameter of ECS hole is 254 mm
 double stm.ifbPoly.rOut = 127.0;
+
+// decouple the VD sizes from the size of the CRS, which is not there for geom_run1_a.txt
+double stm.upstreamVDs.xHalfLength = 2850.;
+
 // This tells emacs to view this file in c++ mode
 // Local Variables:
 // mode:c++

--- a/Mu2eG4/src/constructVirtualDetectors.cc
+++ b/Mu2eG4/src/constructVirtualDetectors.cc
@@ -1359,7 +1359,7 @@ namespace mu2e {
       GeomHandle<CosmicRayShield> CRS;
       //const double y_crv_max       = CRS->getSectorPosition("D").y() + (CRS->getSectorHalfLengths("D"))[1];
       const double yExtentLow      = std::abs(_config.getDouble("yOfFloorSurface.below.mu2eOrigin") );
-      const double x_vd_halflength = (CRS->getSectorHalfLengths("D"))[0];
+      const double x_vd_halflength = _config.getDouble("upstreamVDs.xHalfLength", 2850.); // 2850. is default to use for older version os STM geom before v09;
       //const double y_vd_halflength = (y_crv_max + yExtentLow)/2.0;
       const double y_mother_halflength = yExtentLow;
       const double dimVD[3] = { x_vd_halflength, y_mother_halflength, vdg->getHalfLength() };
@@ -1427,7 +1427,7 @@ namespace mu2e {
       GeomHandle<CosmicRayShield> CRS;
       //const double y_crv_max       = CRS->getSectorPosition("D").y() + (CRS->getSectorHalfLengths("D"))[1];
       const double yExtentLow      = std::abs(_config.getDouble("yOfFloorSurface.below.mu2eOrigin") );
-      const double x_vd_halflength = (CRS->getSectorHalfLengths("D"))[0];
+      const double x_vd_halflength = _config.getDouble("upstreamVDs.xHalfLength", 2850.); // 2850. is default to use for older version os STM geom before v09;
       //const double y_vd_halflength = (y_crv_max + yExtentLow)/2.0;
       const double y_mother_halflength = yExtentLow;
       const double dimVD[3] = { x_vd_halflength, y_mother_halflength, vdg->getHalfLength() };
@@ -1473,7 +1473,7 @@ namespace mu2e {
         x_vd_halflength     = _config.getDouble("stm.magnet.holeHalfWidth");
       } else {
         yExtentLow      = std::abs(_config.getDouble("yOfFloorSurface.below.mu2eOrigin") );
-        x_vd_halflength = (CRS->getSectorHalfLengths("D"))[0];
+        x_vd_halflength = _config.getDouble("upstreamVDs.xHalfLength", 2850.); // 2850. is default to use for older version of STM geom before v09;
       }
       const double y_mother_halflength = yExtentLow;
 


### PR DESCRIPTION
This fixes a crash when running with geom_run1_a.txt. The value 2850 was obtained from geom_common.txt