### PR TITLE
minor tweaks for alternate compilers

### DIFF
--- a/CaloMC/inc/CaloWFExtractor.hh
+++ b/CaloMC/inc/CaloWFExtractor.hh
@@ -4,6 +4,7 @@
 // Utility to simulate waveform hit extraction in FPGA
 //
 #include <vector>
+#include <cstddef>
 
 namespace mu2e {
 
@@ -14,7 +15,7 @@ namespace mu2e {
                   bufferDigi_(bufferDigi),nBinsPeak_(nBinsPeak),minPeakADC_(minPeakADC), startOffset_(startOffset)
                {};
 
-               void extract(const std::vector<int>& wf, std::vector<size_t>& starts, std::vector<size_t>& stops) const;
+               void extract(const std::vector<int>& wf, std::vector<std::size_t>& starts, std::vector<std::size_t>& stops) const;
 
            private:
                unsigned  bufferDigi_;

--- a/DAQ/src/StrawDigisFromArtdaqFragments_module.cc
+++ b/DAQ/src/StrawDigisFromArtdaqFragments_module.cc
@@ -32,6 +32,7 @@
 #include <iostream>
 
 #include <string>
+#include <format>
 
 #include <map>
 #include <memory>

--- a/DataProducts/inc/TrkTypes.hh
+++ b/DataProducts/inc/TrkTypes.hh
@@ -6,6 +6,7 @@
 #define TrackerConditions_Types_hh
 #include <array>
 #include <vector>
+#include <cstddef>
 #include <cstdint>
 
 namespace mu2e {

--- a/DbService/src/RunTool.cc
+++ b/DbService/src/RunTool.cc
@@ -3,6 +3,7 @@
 #include "Offline/GeneralUtilities/inc/TimeUtility.hh"
 #include "Offline/GeneralUtilities/inc/splitString.hh"
 #include "cetlib_except/exception.h"
+#include <algorithm>
 
 using namespace mu2e;
 

--- a/Mu2eG4/src/ConstructMaterials.cc
+++ b/Mu2eG4/src/ConstructMaterials.cc
@@ -1901,7 +1901,7 @@ namespace mu2e {
                  << cond
                  << G4endl;
         }
-        if (std::find(conductors.begin(), conductors.end(), theMaterial->GetName())
+        if (std::find(conductors.begin(), conductors.end(), (std::string)(theMaterial->GetName()))
             != conductors.end() ) {
           G4NistManager::Instance()->SetDensityEffectCalculatorFlag(theMaterial, true);
           if (config_.debug().diagLevel() > 0) {

--- a/RecoDataProducts/inc/CaloDigi.hh
+++ b/RecoDataProducts/inc/CaloDigi.hh
@@ -2,6 +2,7 @@
 #define RecoDataProducts_CaloDigi_hh
 
 #include <vector>
+#include <cstddef>
 
 namespace mu2e
 {


### PR DESCRIPTION
I was testing builds with different compilers and ran across these

The code is currently relying on some side-effects of one C++ header including another for you, which the newer compilers are getting better at avoiding.

These are all added standard includes, except for one place where we're replacing size_t with std::size_t, and another place where we're casting to std::string.

