### PR TITLE
skip collimator at PS entrance

### DIFF
--- a/Mu2eG4/geom/reduced_ExtShieldUpstream_v06.txt
+++ b/Mu2eG4/geom/reduced_ExtShieldUpstream_v06.txt
@@ -17,7 +17,7 @@ int ExtShieldUpstream.nBoxType5 = 1;   // Block label  BRN-264
 int ExtShieldUpstream.nBoxType6 = 8;   // Block label  BRW-175
 int ExtShieldUpstream.nBoxType7 = 2;   // Block label  CRN-262
 int ExtShieldUpstream.nBoxType8 = 2;   // Block label  CRW-262
-int ExtShieldUpstream.nBoxType9 = 1;   // Protection Collimator
+int ExtShieldUpstream.nBoxType9 = 0;   // Protection Collimator
 int ExtShieldUpstream.nBoxType10 = 1;  // Block label  BRP-152
 int ExtShieldUpstream.nBoxType11 = 2;  // Block label  BRP-152
 


### PR DESCRIPTION
Disable collimator at PS entrance to avoid conflicts with MARS geometry