### PR TITLE
Fix the LumiStreamFilter build under CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,14 @@ endif()
 
 message("WITH_G4 SET TO ${WITH_G4}")
 
+# Create a variable to hold optional Online libraries
+find_package(artdaq)
+if(artdaq_FOUND) # only enable ONLINE_MODE if artdaq is found, so we can use artdaq libraries
+  message("ARTDAQ found, enabling ONLINE_MODE")
+  set(ARTDAQ_DAQDATA_LIB artdaq::DAQdata)
+  add_definitions("-DONLINE_MODE=1")
+endif()
+
 message("Creating link from ${CMAKE_CURRENT_SOURCE_DIR} to ${CMAKE_CURRENT_SOURCE_DIR}/Offline to satisfy includes")
 file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/Offline SYMBOLIC)
  
@@ -63,8 +71,6 @@ if( ${WITH_G4} )
     # TODO: Find or implement FindCRY.cmake
     include_directories($ENV{CRYHOME}/src)
     link_directories($ENV{CRYHOME}/lib)
-else()
-    find_package(artdaq)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,15 +55,16 @@ find_package(Boost COMPONENTS iostreams program_options REQUIRED EXPORT)
 find_package(XercesC REQUIRED EXPORT)
 find_package(BLAS REQUIRED EXPORT)
 find_package(artdaq-core-mu2e REQUIRED EXPORT)
+find_package(TRACE REQUIRED EXPORT)
 if( ${WITH_G4} ) 
     message("--> ADDING G4 LIBS")	
     find_package(Geant4 REQUIRED EXPORT)
 
-# TODO: Find or implement FindCRY.cmake
-include_directories($ENV{CRYHOME}/src)
-link_directories($ENV{CRYHOME}/lib)
+    # TODO: Find or implement FindCRY.cmake
+    include_directories($ENV{CRYHOME}/src)
+    link_directories($ENV{CRYHOME}/lib)
 else()
-    add_definitions("-DONLINE_MODE")
+    find_package(artdaq)
 endif()
 
 

--- a/DAQ/CMakeLists.txt
+++ b/DAQ/CMakeLists.txt
@@ -1,12 +1,4 @@
 
-
-# Create a variable to hold optional Online libraries
-if(artdaq_FOUND)
-  message("ARTDAQ found, enabling ONLINE_MODE for LumiStreamFilter")
-  set(ARTDAQ_DAQDATA_LIB artdaq::DAQdata)
-  add_definitions("-DONLINE_MODE=1")
-endif()
-
 cet_make_library(
     SOURCE
       src/CaloDAQUtilities.cc

--- a/DAQ/CMakeLists.txt
+++ b/DAQ/CMakeLists.txt
@@ -1,10 +1,10 @@
 
 
 # Create a variable to hold optional Online libraries
-if(ONLINE_MODE)
-  set(ARTDAQ_DAQDATA_LIB "artdaq::DAQdata")
-else()
-  set(ARTDAQ_DAQDATA_LIB "")
+if(artdaq_FOUND)
+  message("ARTDAQ found, enabling ONLINE_MODE for LumiStreamFilter")
+  set(ARTDAQ_DAQDATA_LIB artdaq::DAQdata)
+  add_definitions("-DONLINE_MODE=1")
 endif()
 
 cet_make_library(


### PR DESCRIPTION
artdaq-core-mu2e already depends on TRACE, so adding TRACE does not add additional dependencies to the Offline.

find_package(artdaq) does not _require_ the presence of artdaq, and the code in DAQ/CMakeLists.txt enables the ONLINE_MODE flag if artdaq is found.

Without these changes, errors of the form
```
/usr/bin/ld: Offline/DAQ/CMakeFiles/DAQ_LumiStreamFilter_module.dir/src/LumiStreamFilter_module.cc.o: in function `trace_name2TID(char const*)':
/home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:2538: undefined reference to `traceControl_p'
/usr/bin/ld: /home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:3693: undefined reference to `traceNams_p'
/usr/bin/ld: /home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:2572: undefined reference to `traceControl_rwp'
/usr/bin/ld: /home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:1205: undefined reference to `traceInitLck'
/usr/bin/ld: /home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:3692: undefined reference to `traceControl_p'
/usr/bin/ld: Offline/DAQ/CMakeFiles/DAQ_LumiStreamFilter_module.dir/src/LumiStreamFilter_module.cc.o: in function `idx2namsPtr':
/home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:3693: undefined reference to `traceNams_p'
/usr/bin/ld: Offline/DAQ/CMakeFiles/DAQ_LumiStreamFilter_module.dir/src/LumiStreamFilter_module.cc.o: in function `trace_name2TID(char const*)':
/home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:2588: undefined reference to `trace_lvlS'
/usr/bin/ld: /home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:2588: undefined reference to `traceLvls_p'
/usr/bin/ld: /home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:2589: undefined reference to `trace_lvlM'
/usr/bin/ld: /home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:2589: undefined reference to `traceLvls_p'
/usr/bin/ld: /home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:2590: undefined reference to `traceControl_rwp'
/usr/bin/ld: /home/eflumerf/Desktop/mu2e-spack-base/spack/var/spack/environments/tdaq-develop/.spack-env/view/include/TRACE/trace.h:2525: undefined reference to `traceName'
```
occur when trying to build the Offline with the CMake build system (e.g. spack-mpd in the online environment)