### PR TITLE
Update to MDC20205, add legacy MDC2020 geometry

### DIFF
--- a/Mu2eG4/geom/geom_common.txt
+++ b/Mu2eG4/geom/geom_common.txt
@@ -3,7 +3,7 @@
 // The file that is included will be time dependent.
 //
 
-#include "Offline/Mu2eG4/geom/geom_2021_PhaseI_v03.txt"
+#include "Offline/Mu2eG4/geom/geom_run1_a.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/geom_common_MDC2020.txt
+++ b/Mu2eG4/geom/geom_common_MDC2020.txt
@@ -1,0 +1,4 @@
+//
+// Geometry used for MDC2020 simulations
+//
+#include "Offline/Mu2eG4/geom/geom_2021_PhaseI_v03.txt"

--- a/Mu2eG4/geom/geom_common_current.txt
+++ b/Mu2eG4/geom/geom_common_current.txt
@@ -2,7 +2,7 @@
 // and features that will eventually become default -
 // the latest for testing..
 
-#include "Offline/Mu2eG4/geom/geom_2021_PhaseI_v03.txt"
+#include "Offline/Mu2eG4/geom/geom_common.txt"
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:

--- a/Mu2eG4/geom/geom_common_extracted.txt
+++ b/Mu2eG4/geom/geom_common_extracted.txt
@@ -1,2 +1,2 @@
-//Extracted position for the detector KPP - original/old v01 version
-#include "Offline/Mu2eG4/geom/geom_common_extracted_v01.txt"
+//Extracted position for the detector KPP
+#include "Offline/Mu2eG4/geom/geom_common_extracted_v02.txt"

--- a/Mu2eG4/geom/geom_common_extracted_MDC2020.txt
+++ b/Mu2eG4/geom/geom_common_extracted_MDC2020.txt
@@ -1,0 +1,4 @@
+//
+// Extracted position used for MDC2020 simulations
+//
+#include "Offline/Mu2eG4/geom/geom_common_extracted_v01.txt"


### PR DESCRIPTION
This is a breaking, non-backwards-compatible change advancing the default simulation geometry from that used in MDC2020 datasets to that expected from run1 (run1_a scenario). New geometry configurations corresponding to the MDC2020 configuration are added, and must be used to analyze MDC2020 datasets, or to create new MDC2020 datasets.