### PR TITLE
Ovlp fix2

### DIFF
--- a/Mu2eG4/geom/STM_v06.txt
+++ b/Mu2eG4/geom/STM_v06.txt
@@ -90,7 +90,7 @@ string stm.shield.DnStrWall.material   = "StainlessSteel"; //Stainless steel, no
 //Adding hole vd in shield pipe for vd 86
 int stm.verbosityLevel = 0;
 bool vd.STMUpStrHole.build = true;
-bool   vd.STMUpStr.build     = true; //VD86 Rectangle in x-y plane, same size as the CRV (1mm dnStr of CRV)
+bool   vd.STMUpStr.build     = false; //VD86 Rectangle in x-y plane, same size as the CRV (1mm dnStr of CRV)
 bool   vd.STMMagDnStr.build  = true; //VD87 Rectangle in x-y plane, same size as the CRV
 bool   vd.STMSSCollUpStr.build = true; //VD101 Disk upstream of Spot-Size collimator
 double vd.STMSSCollUpStr.r     = 200.0;// r=20cm

--- a/Mu2eG4/geom/geom_SurfaceCheck_run1a.txt
+++ b/Mu2eG4/geom/geom_SurfaceCheck_run1a.txt
@@ -1,0 +1,18 @@
+//
+// Use G4's surface check technology to check for overlaps.
+//
+//
+
+#include "Offline/Mu2eG4/geom/geom_run1_a.txt"
+
+bool g4.doSurfaceCheck    = true;
+
+// number of random points on the volume surface
+int  g4.nSurfaceCheckPointsPercmsq =   1;
+int  g4.minSurfaceCheckPoints      = 100; // per volume
+int  g4.maxSurfaceCheckPoints = 10000000; // per volume
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/tracker_v7.txt
+++ b/Mu2eG4/geom/tracker_v7.txt
@@ -16,7 +16,8 @@ int    tracker.verbosityLevel     =    0;
 // Mother to hold all straws and supports.
 double tracker.mother.rIn         =    376.9; // mm
 double tracker.mother.rOut        =    850.1; // mm
-double tracker.mother.halfLength  =   1635.1; // mm
+double tracker.mother.halfLength  =   1635.5; // mm
+//double tracker.mother.halfLength  =   1635.1; // mm
 double tracker.mother.z0          =  10175.0;  // mm
 double tracker.z0                   = 10171.0; // 10200.0;
 


### PR DESCRIPTION
Fix tracker endcap ring extrusion in tracker mother by extending it by 400 microns in each direction along z.
Disable by default the upstream STM virtual detector waiting to make it compatible with run1a CR geometry.
Add a txt file to be used to check the surfaces with run1a geometry.
