### PR TITLE
Use CMake Target notation for KinKal (depends on KFTrack/KinKal#212)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,8 @@ find_package(XercesC REQUIRED EXPORT)
 find_package(BLAS REQUIRED EXPORT)
 find_package(artdaq-core-mu2e REQUIRED EXPORT)
 find_package(TRACE REQUIRED EXPORT)
+find_package(KinKal REQUIRED EXPORT)
+
 if( ${WITH_G4} )
     message("--> ADDING G4 LIBS")
     find_package(Geant4 REQUIRED EXPORT)
@@ -76,9 +78,10 @@ endif()
 
 
 # BTrk and KinKal have non-standard Find*.cmake...
-include_directories($ENV{KINKAL_INC})
+if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/../KinKal/KinKalTargets.cmake)
+  include(${CMAKE_CURRENT_BINARY_DIR}/../KinKal/KinKalTargets.cmake)
+endif()
 include_directories($ENV{BTRK_INC})
-link_directories($ENV{KINKAL_LIB})
 link_directories($ENV{BTRK_LIB})
 
 include(ArtDictionary)

--- a/KinKalGeom/CMakeLists.txt
+++ b/KinKalGeom/CMakeLists.txt
@@ -7,7 +7,7 @@ cet_make_library(
       src/TestCRV.cc
       src/Tracker.cc
     LIBRARIES PUBLIC
-      KinKal_Geometry
+      KinKal::Geometry
       Offline::GeneralUtilities
 )
 

--- a/Mu2eKinKal/CMakeLists.txt
+++ b/Mu2eKinKal/CMakeLists.txt
@@ -18,12 +18,12 @@ cet_make_library(
       src/WireHitState.cc
     LIBRARIES PUBLIC
       BLAS::BLAS
-      KinKal_General
-      KinKal_MatEnv
-      KinKal_Geometry
-      KinKal_Detector
-      KinKal_Trajectory
-      KinKal_Fit
+      KinKal::General
+      KinKal::MatEnv
+      KinKal::Geometry
+      KinKal::Detector
+      KinKal::Trajectory
+      KinKal::Fit
       Offline::BFieldGeom
       Offline::CalorimeterGeom
       Offline::ConfigTools

--- a/Print/CMakeLists.txt
+++ b/Print/CMakeLists.txt
@@ -47,7 +47,7 @@ cet_make_library(
       src/TriggerResultsPrinter.cc
       src/TrkCaloIntersectPrinter.cc
     LIBRARIES PUBLIC
-      KinKal_General
+      KinKal::General
       Offline::ConditionsService
       Offline::DataProducts
       Offline::GeometryService

--- a/RecoDataProducts/CMakeLists.txt
+++ b/RecoDataProducts/CMakeLists.txt
@@ -39,7 +39,7 @@ cet_make_library(
       BTrk_BbrGeom
       BTrk_KalmanTrack
       BTrk_ProbTools
-      KinKal_Trajectory
+      KinKal::Trajectory
 
       Offline::DataProducts
       Offline::GeneralUtilities

--- a/Trigger/CMakeLists.txt
+++ b/Trigger/CMakeLists.txt
@@ -36,7 +36,7 @@ cet_build_plugin(ReadTriggerInfo art::module
       Offline::Mu2eUtilities
       Offline::RecoDataProducts
       Offline::TrackerGeom
-      KinKal_Trajectory
+      KinKal::Trajectory
 
 )
 


### PR DESCRIPTION
While these changes only affect CMake, they do rely on a new build of KinKal, so should not be merged until the referenced KinKal PR is merged and a new version distributed.