### PR TITLE
Update TrkPID's use of KalSegment to avoid rare crash in Production

### DIFF
--- a/TrkDiag/src/TrackPID_module.cc
+++ b/TrkDiag/src/TrackPID_module.cc
@@ -102,13 +102,7 @@ namespace mu2e {
         if(kalSeed.hasCaloCluster() && kalSeed.caloHit()._flag.hasAllProperties(StrawHitFlag::active)){
           auto const& tchs = kalSeed.caloHit();
           auto const& cc = tchs.caloCluster();
-          XYZVectorF trkmom;
-          auto ikseg = kalSeed.nearestSegment(tchs._rptoca);
-          if(ikseg != kalSeed.segments().end())
-            ikseg->mom(ikseg->localFlt(tchs.trkLen()),trkmom);
-          else
-            throw cet::exception("RECO")<<"mu2e::TrackPID: KalSeed segment missing" << endl;
-          // compute the energy difference, assuming an electron mass
+          XYZVectorD trkmom = kalSeed.nearestSegment(tchs._rptoca)->momentum3();
           features[0] = cc->energyDep() - sqrt(trkmom.Mag2());
           // move into detector coordinates.  Yikes!!
           XYZVectorF cpos = XYZVectorF(calo->geomUtil().mu2eToTracker(calo->geomUtil().diskFFToMu2e( cc->diskID(), cc->cog3Vector())));


### PR DESCRIPTION
There was a rare crash in Production when creating EventNtuples for cosmic datasets (e.g. cs.mu2e.CosmicSignalOnSpillTriggered.MDC2025ae_best_v1_3.001430_00000177.art event 1430:25324:288337). This is because the TrackPID module hadn't been updated to use safer KalSegment methods, which avoid a LoopHelix to CentralHelix conversion, which is not guaranteed.

I've tested that this PR avoids the crash in the above event. I also see that there are small changes in the output values of trkpid, which I think are negligible:

```
**************************************************
*    Row   * Instance * trkpid before * trkpid after *
***************************************************
*        0 *        0 * 0.9993190 * 0.9993316 *
*        0 *        1 * 0.9989910 * 0.9989038 *
*        0 *        2 *        -1 *         -1 *
*        0 *        3 *        -1 *        -1 *
*        1 *        0 * 0.9998521 * 0.9998775 *
*        1 *        1 *        -1 *        -1 *
*        1 *        2 * 0.9998736 * 0.9998475 *
*        1 *        3 *        -1 *        -1 *
*        1 *        4 * 0.9999800 * 0.9999810 *
*        1 *        5 * 0.9998608 * 0.9998847 *
*        1 *        6 *        -1 *        -1 *
*        2 *        0 * 0.6418564 * 0.6384652 *
*        2 *        1 *        -1 *        -1 *
*        2 *        2 * 0.6571090 * 0.6546272 *
*        2 *        3 *        -1 *        -1 *
*        3 *        0 * 0.9996761 * 0.9996979 *
*        3 *        1 *        -1 *        -1 *
*        3 *        2 *        -1 *        -1 *
*        3 *        3 *        -1 *        -1 *
*        4 *        0 * 0.2899154 * 0.3079537 *
*        4 *        1 *        -1 *        -1 *
*        4 *        2 *        -1 *        -1 *
*        4 *        3 *        -1 *        -1 *
*        5 *        0 * 0.9994995 * 0.9995087 *
*        5 *        1 *        -1 *        -1 *
```