### PR TITLE
Optionally produce the EWM as well as the event header

### DIFF
--- a/DAQ/src/EventHeaderFromCFOFragment_module.cc
+++ b/DAQ/src/EventHeaderFromCFOFragment_module.cc
@@ -117,9 +117,9 @@ void art::EventHeaderFromCFOFragment::produce(Event& event) {
   }
 
   if(ewm_) {
-    constexpr double tick = 5.; // clock ticks -> ns
+    constexpr double tick = 25.; // clock ticks -> ns
     ewm->_spillType   = (evtHdr->isOnSpill()) ? mu2e::EventWindowMarker::SpillType::onspill : mu2e::EventWindowMarker::SpillType::offspill;
-    ewm->_eventLength = tick*evtHdr->eventDuration;
+    ewm->_eventLength = tick * evtHdr->eventDuration;
   }
 
   event.put(std::move(evtHdr));


### PR DESCRIPTION
This allows for the creation of the `EventWindowMarker` when creating the `EventHeader` object Online. There are also a few minor edits to the `EventHeader` creation logic. The `EventHeader` definition should be reviewed in a future discussion, to ensure we have the necessary data in it without unnecessarily increasing its size (which directly impacts the data volume of the luminosity stream).