### PR TITLE
move lone dict to DataProducts

### DIFF
--- a/CRVReco/src/SConscript
+++ b/CRVReco/src/SConscript
@@ -28,14 +28,6 @@ mainlib = helper.make_mainlib ( [ 'CLHEP',
                                   rootlibs]
                               )
 
-helper.make_dict_and_map( [ mainlib,
-                       'art_root_io_tfile_support',
-                       'art_root_io_TFileService',
-                       'canvas',
-                       'libSpectrum',
-                       rootlibs,
-                       ] )
-
 helper.make_plugins( [ mainlib,
                        'mu2e_SeedService',
                        'mu2e_Mu2eUtilities',

--- a/CRVReco/src/classes.h
+++ b/CRVReco/src/classes.h
@@ -1,6 +1,0 @@
-#define ENABLE_MU2E_GENREFLEX_HACKS
-
-#include <utility>
-#include <TString.h>
-
-#undef ENABLE_MU2E_GENREFLEX_HACKS

--- a/CRVReco/src/classes_def.xml
+++ b/CRVReco/src/classes_def.xml
@@ -1,6 +1,0 @@
-<lcgdict>
-
- <class name="std::pair<TString,int>"/>
-
-</lcgdict>
-

--- a/DataProducts/src/classes.h
+++ b/DataProducts/src/classes.h
@@ -7,6 +7,8 @@
 #include "cetlib/map_vector.h"
 #include "boost/array.hpp"
 #include <vector>
+#include <utility>
+#include <TString.h>
 
 // PDG
 #include "Offline/DataProducts/inc/PDGCode.hh"

--- a/DataProducts/src/classes_def.xml
+++ b/DataProducts/src/classes_def.xml
@@ -8,6 +8,7 @@
 
  <class name="std::vector<cet::map_vector_key>"/>
  <class name="boost::array<double,5>"/>
+ <class name="std::pair<TString,int>"/>
 
 <!--  ********* PDG  ********* -->
   <class name="mu2e::PDGCodeDetail"/>


### PR DESCRIPTION
This dict was not being built correctly in cmake, and shouldn't be in the CRV directory anyway, so this is a cleanup.  Ralf has already checked.