### PR TITLE
Fix min cluster check on calo cluster filter

### DIFF
--- a/CaloFilters/src/CaloClusterCounterFilter_module.cc
+++ b/CaloFilters/src/CaloClusterCounterFilter_module.cc
@@ -157,13 +157,24 @@ bool CaloClusterCounter::filter(art::Event& event) {
         (clRadius >= _minClRadius)) {
       size_t index = std::distance(caloClusters->begin(), icl);
       triginfo->_caloClusters.push_back(art::Ptr<CaloCluster>(clH, index));
+      if(_diagLevel > 0) std::cout << "  --> Accepted cluster\n";
 
       ++nClusterAboveThreshold;
-    }
+    } else if(_diagLevel > 1) std::cout << "  --> Rejected cluster\n";
+
   }
 
-  if (nClusterAboveThreshold > _minNCl)
+  if (nClusterAboveThreshold >= _minNCl) {
+    if(_diagLevel > 0) std::cout << "[CaloClusterCounter::filter] Event " << event.id()
+                                 << ": Accepting event, N(accepted clusters) = " << nClusterAboveThreshold
+                                 << " from " << caloClusters->size() << " clusters"
+                                 << std::endl;
     retval = true;
+  } else if(_diagLevel > 1) std::cout << "[CaloClusterCounter::filter] Event " << event.id()
+                                      << ": Rejecting event, N(accepted clusters) = " << nClusterAboveThreshold
+                                      << " from " << caloClusters->size() << " clusters"
+                                      << std::endl;
+
 
   event.put(std::move(triginfo));
   return retval;


### PR DESCRIPTION
Currently, selecting a min clusters of 1 is requiring 2 or more clusters in the cluster filter selection. This fixes this issue and adds more debug printout.