### PR TITLE
mark event as const in utility function

### DIFF
--- a/DAQ/inc/CaloDAQUtilities.hh
+++ b/DAQ/inc/CaloDAQUtilities.hh
@@ -137,7 +137,7 @@ public:
 
 
   // Function to get art fragments from event
-  artdaq::Fragments getFragments(art::Event& event) {
+  artdaq::Fragments getFragments(art::Event const& event) {
 
     artdaq::Fragments fragments;
     artdaq::FragmentPtrs containerFragments;


### PR DESCRIPTION
Minor edit in order to be able to use the function in all modules with no "const" qualification drop:
```
void analyze(art::Event const& event){
  caloDAQUtil_.getFragments(event);
}
```