### PR TITLE
Filter to select events with the primary + pileup are above a threshold

### DIFF
--- a/Filters/CMakeLists.txt
+++ b/Filters/CMakeLists.txt
@@ -17,7 +17,7 @@ cet_build_plugin(CaloPileupDtsFilter art::module
       Offline::MCDataProducts
 )
 
-cet_build_plugin(CaloPileupDtsFilter art::module
+cet_build_plugin(CaloDtsClusterFilter art::module
     REG_SOURCE src/CaloDtsClusterFilter_module.cc
     LIBRARIES REG
       Offline::CalorimeterGeom
@@ -44,7 +44,7 @@ cet_build_plugin(CompressPhysicalVolumes art::module
 
 cet_build_plugin(CompressStepPointMCs art::module
     REG_SOURCE src/CompressStepPointMCs_module.cc
-    LIBRARIES REG      
+    LIBRARIES REG
       Offline::MCDataProducts
       Offline::Mu2eUtilities
 )

--- a/Filters/src/CaloPileupDtsFilter_module.cc
+++ b/Filters/src/CaloPileupDtsFilter_module.cc
@@ -211,6 +211,7 @@ namespace mu2e {
     double pileup_edep = 0.;
 
     for(const auto& tag : caloStepsTags_) {
+      if(primary_edep + pileup_edep > maxTotalEnergy_) break; // early exit
       const auto handle = event.getValidHandle<CaloShowerStepCollection>(tag);
       for(const auto& css : *handle) {
         const auto sim_step = css.simParticle();


### PR DESCRIPTION
This is motivated by Run 1B studies, to select DIO primary events that either are high energy calo deposits on their own or through the addition of pileup. This is run before digi-making, which takes a significant amount of time and we therefore want to cut down on this time.