### PR TITLE
Rename timeout watchdog so file name/module name/cmake name all agree

### DIFF
--- a/CalPatRec/src/AgnosticHelixFinder_module.cc
+++ b/CalPatRec/src/AgnosticHelixFinder_module.cc
@@ -114,8 +114,8 @@ namespace mu2e {
     int _diagLevel;
     int _doTiming;
     std::unique_ptr<StopWatch> _watch;
-    std::optional<art::ServiceHandle<TimeoutWatchdogService>> _timeoutService;
-    std::optional<TimeoutWatchdogService::ModuleGuard> _timeoutGuard;
+    std::optional<art::ServiceHandle<TimeoutWatchdog>> _timeoutService;
+    std::optional<TimeoutWatchdog::ModuleGuard> _timeoutGuard;
 
     //-----------------------------------------------------------------------------
     // event object labels

--- a/CalPatRec/src/TZClusterFinder_module.cc
+++ b/CalPatRec/src/TZClusterFinder_module.cc
@@ -85,8 +85,8 @@ namespace mu2e {
     int              _runDisplay;
     int              _useCaloClusters;
     int              _recoverCaloClusters;
-    std::optional<art::ServiceHandle<TimeoutWatchdogService>> _timeoutService;
-    std::optional<TimeoutWatchdogService::ModuleGuard> _timeoutGuard;
+    std::optional<art::ServiceHandle<TimeoutWatchdog>> _timeoutService;
+    std::optional<TimeoutWatchdog::ModuleGuard> _timeoutGuard;
 
     //-----------------------------------------------------------------------------
     // event object labels

--- a/TimeoutService/CMakeLists.txt
+++ b/TimeoutService/CMakeLists.txt
@@ -8,7 +8,7 @@ cet_make_library(
       fhiclcpp::types
 )
 
-cet_build_plugin(TimeoutWatchdogService art::service
+cet_build_plugin(TimeoutWatchdog art::service
     REG_SOURCE src/TimeoutWatchdog_service.cc
     LIBRARIES REG
       Offline::TimeoutService

--- a/TimeoutService/inc/TimeoutWatchdog.hh
+++ b/TimeoutService/inc/TimeoutWatchdog.hh
@@ -21,7 +21,7 @@ namespace art {
 
 namespace mu2e {
 
-class TimeoutWatchdogService {
+class TimeoutWatchdog {
 public:
   struct Config {
     using Name = fhicl::Name;
@@ -49,11 +49,11 @@ public:
 
   using Parameters = art::ServiceTable<Config>;
 
-  TimeoutWatchdogService(Parameters const& config, art::ActivityRegistry&);
-  TimeoutWatchdogService(TimeoutWatchdogService const&) = delete;
-  TimeoutWatchdogService& operator=(TimeoutWatchdogService const&) = delete;
-  TimeoutWatchdogService(TimeoutWatchdogService&&) = delete;
-  TimeoutWatchdogService& operator=(TimeoutWatchdogService&&) = delete;
+  TimeoutWatchdog(Parameters const& config, art::ActivityRegistry&);
+  TimeoutWatchdog(TimeoutWatchdog const&) = delete;
+  TimeoutWatchdog& operator=(TimeoutWatchdog const&) = delete;
+  TimeoutWatchdog(TimeoutWatchdog&&) = delete;
+  TimeoutWatchdog& operator=(TimeoutWatchdog&&) = delete;
 
   // --- called by modules (cooperative) ---
   void startEvent(art::Event const& e);
@@ -110,9 +110,9 @@ private:
   int debugLevel_;
 };
 
-class TimeoutWatchdogService::ModuleGuard {
+class TimeoutWatchdog::ModuleGuard {
 public:
-  ModuleGuard(TimeoutWatchdogService& svc,
+  ModuleGuard(TimeoutWatchdog& svc,
               art::Event const& e,
               std::string const& moduleLabel,
               std::optional<double> allowedTimeMs = std::nullopt)
@@ -132,11 +132,11 @@ public:
   std::stop_token stopToken() const { return svc_.stopToken(); }
 
 private:
-  TimeoutWatchdogService& svc_;
+  TimeoutWatchdog& svc_;
 };
 
 } // namespace mu2e
 
-DECLARE_ART_SERVICE(mu2e::TimeoutWatchdogService, SHARED)
+DECLARE_ART_SERVICE(mu2e::TimeoutWatchdog, SHARED)
 
 #endif /* TimeoutService_TimeoutWatchdog_hh */

--- a/TimeoutService/src/TimeoutWatchdog.cc
+++ b/TimeoutService/src/TimeoutWatchdog.cc
@@ -7,149 +7,149 @@
 
 namespace mu2e {
 
-TimeoutWatchdog::TimeoutWatchdog(Parameters const& config,
-                                               art::ActivityRegistry& registry)
-  : eventTimeoutMs_(config().eventTimeoutMs())
-  , moduleTimeoutMs_(config().moduleTimeoutMs())
-  , debugLevel_(config().debugLevel())
-{
-  if(config().registerPreEventCallback()) {
-    registry.sPreProcessEvent.watch([this](art::Event const& e, art::ScheduleContext) {
-      this->startEvent(e);
-    });
+  TimeoutWatchdog::TimeoutWatchdog(Parameters const& config,
+                                   art::ActivityRegistry& registry)
+    : eventTimeoutMs_(config().eventTimeoutMs())
+    , moduleTimeoutMs_(config().moduleTimeoutMs())
+    , debugLevel_(config().debugLevel())
+  {
+    if(config().registerPreEventCallback()) {
+      registry.sPreProcessEvent.watch([this](art::Event const& e, art::ScheduleContext) {
+        this->startEvent(e);
+      });
+    }
   }
-}
 
-void TimeoutWatchdog::startEvent(art::Event const& e) {
-  if (tls_.event != e.event() || tls_.subRun != e.subRun() || tls_.run != e.run()) {
-    // New event: reset cancellation state and apply event-level deadline.
-    tls_.run = e.run();
-    tls_.subRun = e.subRun();
-    tls_.event = e.event();
-    tls_.moduleLabel.clear();
-    tls_.stopSource = std::stop_source{};
-    tls_.stopToken = tls_.stopSource.get_token();
+  void TimeoutWatchdog::startEvent(art::Event const& e) {
+    if (tls_.event != e.event() || tls_.subRun != e.subRun() || tls_.run != e.run()) {
+      // New event: reset cancellation state and apply event-level deadline.
+      tls_.run = e.run();
+      tls_.subRun = e.subRun();
+      tls_.event = e.event();
+      tls_.moduleLabel.clear();
+      tls_.stopSource = std::stop_source{};
+      tls_.stopToken = tls_.stopSource.get_token();
 
-    if (eventTimeoutMs_ > 0.0) {
-      Clock::time_point const now = Clock::now();
-      tls_.eventDeadline = now + std::chrono::duration_cast<Clock::duration>(
-        std::chrono::duration<double, std::milli>(eventTimeoutMs_));
-    } else {
-      tls_.eventDeadline.reset();
+      if (eventTimeoutMs_ > 0.0) {
+        Clock::time_point const now = Clock::now();
+        tls_.eventDeadline = now + std::chrono::duration_cast<Clock::duration>(
+                                                                               std::chrono::duration<double, std::milli>(eventTimeoutMs_));
+      } else {
+        tls_.eventDeadline.reset();
+      }
+
+      tls_.moduleDeadline.reset();
+
+      if (debugLevel_ > 1) {
+        std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u eventTimeoutMs=%.3f\n",
+                    __func__,
+                    tls_.run,
+                    tls_.subRun,
+                    tls_.event,
+                    eventTimeoutMs_);
+      }
+    }
+  }
+
+  double TimeoutWatchdog::moduleBudgetFor_(std::optional<double> allowedTimeMs) const {
+    // Module-provided budget takes precedence over service default.
+    if (allowedTimeMs) return *allowedTimeMs;
+    return moduleTimeoutMs_;
+  }
+
+  void TimeoutWatchdog::startModule(std::string const& moduleLabel,
+                                    std::optional<double> allowedTimeMs) {
+    // Module scope starts a fresh stop token so checks are local to this invocation.
+    tls_.moduleLabel = moduleLabel;
+    if (tls_.stopToken.stop_requested()) { //FIXME: Need to decide if a previous module was timed out but the event wasn't, do we allow next modules to continue anyway
+      if (debugLevel_ > 0) {
+        std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u stop already requested when starting module=%s\n",
+                    __func__,
+                    tls_.run,
+                    tls_.subRun,
+                    tls_.event,
+                    tls_.moduleLabel.c_str());
+      }
+      // add source reset here if we want to ignore previous module's stop
     }
 
-    tls_.moduleDeadline.reset();
+    double const budget = moduleBudgetFor_(allowedTimeMs);
+    if (budget > 0.0) {
+      Clock::time_point const now = Clock::now();
+      tls_.moduleDeadline = now + std::chrono::duration_cast<Clock::duration>(
+                                                                              std::chrono::duration<double, std::milli>(budget));
+    } else {
+      tls_.moduleDeadline.reset();
+    }
 
     if (debugLevel_ > 1) {
-      std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u eventTimeoutMs=%.3f\n",
+      std::printf("[TimeoutWatchdog::%s] module=%s moduleTimeoutMs=%.3f\n",
                   __func__,
-                  tls_.run,
-                  tls_.subRun,
-                  tls_.event,
-                  eventTimeoutMs_);
+                  tls_.moduleLabel.c_str(),
+                  budget);
     }
   }
-}
 
-double TimeoutWatchdog::moduleBudgetFor_(std::optional<double> allowedTimeMs) const {
-  // Module-provided budget takes precedence over service default.
-  if (allowedTimeMs) return *allowedTimeMs;
-  return moduleTimeoutMs_;
-}
-
-void TimeoutWatchdog::startModule(std::string const& moduleLabel,
-                                         std::optional<double> allowedTimeMs) {
-  // Module scope starts a fresh stop token so checks are local to this invocation.
-  tls_.moduleLabel = moduleLabel;
-  if (tls_.stopToken.stop_requested()) { //FIXME: Need to decide if a previous module was timed out but the event wasn't, do we allow next modules to continue anyway
-    if (debugLevel_ > 0) {
-      std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u stop already requested when starting module=%s\n",
+  void TimeoutWatchdog::endModule() {
+    if (debugLevel_ > 1 && !tls_.moduleLabel.empty()) {
+      std::printf("[TimeoutWatchdog::%s] module=%s\n",
                   __func__,
-                  tls_.run,
-                  tls_.subRun,
-                  tls_.event,
                   tls_.moduleLabel.c_str());
     }
-    // add source reset here if we want to ignore previous module's stop
-  }
 
-  double const budget = moduleBudgetFor_(allowedTimeMs);
-  if (budget > 0.0) {
-    Clock::time_point const now = Clock::now();
-    tls_.moduleDeadline = now + std::chrono::duration_cast<Clock::duration>(
-      std::chrono::duration<double, std::milli>(budget));
-  } else {
+    // Clear module-only state; event-level deadline remains active.
     tls_.moduleDeadline.reset();
+    tls_.moduleLabel.clear();
   }
 
-  if (debugLevel_ > 1) {
-    std::printf("[TimeoutWatchdog::%s] module=%s moduleTimeoutMs=%.3f\n",
-                __func__,
-                tls_.moduleLabel.c_str(),
-                budget);
-  }
-}
+  std::optional<TimeoutWatchdog::Clock::time_point>
+  TimeoutWatchdog::eventDeadline() const { return tls_.eventDeadline; }
 
-void TimeoutWatchdog::endModule() {
-  if (debugLevel_ > 1 && !tls_.moduleLabel.empty()) {
-    std::printf("[TimeoutWatchdog::%s] module=%s\n",
-                __func__,
-                tls_.moduleLabel.c_str());
-  }
+  std::optional<TimeoutWatchdog::Clock::time_point>
+  TimeoutWatchdog::moduleDeadline() const { return tls_.moduleDeadline; }
 
-  // Clear module-only state; event-level deadline remains active.
-  tls_.moduleDeadline.reset();
-  tls_.moduleLabel.clear();
-}
+  bool TimeoutWatchdog::check() {
+    // Once cancellation is requested, preserve sticky behavior for callers.
+    if (tls_.stopToken.stop_requested()) {
+      if (debugLevel_ > 0) {
+        std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u stop already requested module=%s\n",
+                    __func__,
+                    tls_.run,
+                    tls_.subRun,
+                    tls_.event,
+                    tls_.moduleLabel.c_str());
+      }
+      return true;
+    }
 
-std::optional<TimeoutWatchdog::Clock::time_point>
-TimeoutWatchdog::eventDeadline() const { return tls_.eventDeadline; }
+    Clock::time_point const now = Clock::now();
 
-std::optional<TimeoutWatchdog::Clock::time_point>
-TimeoutWatchdog::moduleDeadline() const { return tls_.moduleDeadline; }
+    bool const timedOutEvent = tls_.eventDeadline && (now > *tls_.eventDeadline);
+    bool const timedOutModule = tls_.moduleDeadline && (now > *tls_.moduleDeadline);
 
-bool TimeoutWatchdog::check() {
-  // Once cancellation is requested, preserve sticky behavior for callers.
-  if (tls_.stopToken.stop_requested()) {
+    if (!timedOutEvent && !timedOutModule) {
+      return false;
+    }
+
+    // Transition to cancelled state so subsequent checks can short-circuit quickly.
+    tls_.stopSource.request_stop();
+
     if (debugLevel_ > 0) {
-      std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u stop already requested module=%s\n",
+      std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u timeout module=%s eventExceeded=%d moduleExceeded=%d\n",
                   __func__,
                   tls_.run,
                   tls_.subRun,
                   tls_.event,
-                  tls_.moduleLabel.c_str());
+                  tls_.moduleLabel.c_str(),
+                  timedOutEvent ? 1 : 0,
+                  timedOutModule ? 1 : 0);
     }
+
     return true;
   }
 
-  Clock::time_point const now = Clock::now();
-
-  bool const timedOutEvent = tls_.eventDeadline && (now > *tls_.eventDeadline);
-  bool const timedOutModule = tls_.moduleDeadline && (now > *tls_.moduleDeadline);
-
-  if (!timedOutEvent && !timedOutModule) {
-    return false;
+  std::stop_token TimeoutWatchdog::stopToken() const {
+    return tls_.stopToken;
   }
-
-  // Transition to cancelled state so subsequent checks can short-circuit quickly.
-  tls_.stopSource.request_stop();
-
-  if (debugLevel_ > 0) {
-    std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u timeout module=%s eventExceeded=%d moduleExceeded=%d\n",
-                __func__,
-                tls_.run,
-                tls_.subRun,
-                tls_.event,
-                tls_.moduleLabel.c_str(),
-                timedOutEvent ? 1 : 0,
-                timedOutModule ? 1 : 0);
-  }
-
-  return true;
-}
-
-std::stop_token TimeoutWatchdog::stopToken() const {
-  return tls_.stopToken;
-}
 
 } // namespace mu2e

--- a/TimeoutService/src/TimeoutWatchdog.cc
+++ b/TimeoutService/src/TimeoutWatchdog.cc
@@ -7,7 +7,7 @@
 
 namespace mu2e {
 
-TimeoutWatchdogService::TimeoutWatchdogService(Parameters const& config,
+TimeoutWatchdog::TimeoutWatchdog(Parameters const& config,
                                                art::ActivityRegistry& registry)
   : eventTimeoutMs_(config().eventTimeoutMs())
   , moduleTimeoutMs_(config().moduleTimeoutMs())
@@ -20,7 +20,7 @@ TimeoutWatchdogService::TimeoutWatchdogService(Parameters const& config,
   }
 }
 
-void TimeoutWatchdogService::startEvent(art::Event const& e) {
+void TimeoutWatchdog::startEvent(art::Event const& e) {
   if (tls_.event != e.event() || tls_.subRun != e.subRun() || tls_.run != e.run()) {
     // New event: reset cancellation state and apply event-level deadline.
     tls_.run = e.run();
@@ -41,7 +41,7 @@ void TimeoutWatchdogService::startEvent(art::Event const& e) {
     tls_.moduleDeadline.reset();
 
     if (debugLevel_ > 1) {
-      std::printf("[TimeoutWatchdogService::%s] Event %u:%u:%u eventTimeoutMs=%.3f\n",
+      std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u eventTimeoutMs=%.3f\n",
                   __func__,
                   tls_.run,
                   tls_.subRun,
@@ -51,19 +51,19 @@ void TimeoutWatchdogService::startEvent(art::Event const& e) {
   }
 }
 
-double TimeoutWatchdogService::moduleBudgetFor_(std::optional<double> allowedTimeMs) const {
+double TimeoutWatchdog::moduleBudgetFor_(std::optional<double> allowedTimeMs) const {
   // Module-provided budget takes precedence over service default.
   if (allowedTimeMs) return *allowedTimeMs;
   return moduleTimeoutMs_;
 }
 
-void TimeoutWatchdogService::startModule(std::string const& moduleLabel,
+void TimeoutWatchdog::startModule(std::string const& moduleLabel,
                                          std::optional<double> allowedTimeMs) {
   // Module scope starts a fresh stop token so checks are local to this invocation.
   tls_.moduleLabel = moduleLabel;
   if (tls_.stopToken.stop_requested()) { //FIXME: Need to decide if a previous module was timed out but the event wasn't, do we allow next modules to continue anyway
     if (debugLevel_ > 0) {
-      std::printf("[TimeoutWatchdogService::%s] Event %u:%u:%u stop already requested when starting module=%s\n",
+      std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u stop already requested when starting module=%s\n",
                   __func__,
                   tls_.run,
                   tls_.subRun,
@@ -83,16 +83,16 @@ void TimeoutWatchdogService::startModule(std::string const& moduleLabel,
   }
 
   if (debugLevel_ > 1) {
-    std::printf("[TimeoutWatchdogService::%s] module=%s moduleTimeoutMs=%.3f\n",
+    std::printf("[TimeoutWatchdog::%s] module=%s moduleTimeoutMs=%.3f\n",
                 __func__,
                 tls_.moduleLabel.c_str(),
                 budget);
   }
 }
 
-void TimeoutWatchdogService::endModule() {
+void TimeoutWatchdog::endModule() {
   if (debugLevel_ > 1 && !tls_.moduleLabel.empty()) {
-    std::printf("[TimeoutWatchdogService::%s] module=%s\n",
+    std::printf("[TimeoutWatchdog::%s] module=%s\n",
                 __func__,
                 tls_.moduleLabel.c_str());
   }
@@ -102,17 +102,17 @@ void TimeoutWatchdogService::endModule() {
   tls_.moduleLabel.clear();
 }
 
-std::optional<TimeoutWatchdogService::Clock::time_point>
-TimeoutWatchdogService::eventDeadline() const { return tls_.eventDeadline; }
+std::optional<TimeoutWatchdog::Clock::time_point>
+TimeoutWatchdog::eventDeadline() const { return tls_.eventDeadline; }
 
-std::optional<TimeoutWatchdogService::Clock::time_point>
-TimeoutWatchdogService::moduleDeadline() const { return tls_.moduleDeadline; }
+std::optional<TimeoutWatchdog::Clock::time_point>
+TimeoutWatchdog::moduleDeadline() const { return tls_.moduleDeadline; }
 
-bool TimeoutWatchdogService::check() {
+bool TimeoutWatchdog::check() {
   // Once cancellation is requested, preserve sticky behavior for callers.
   if (tls_.stopToken.stop_requested()) {
     if (debugLevel_ > 0) {
-      std::printf("[TimeoutWatchdogService::%s] Event %u:%u:%u stop already requested module=%s\n",
+      std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u stop already requested module=%s\n",
                   __func__,
                   tls_.run,
                   tls_.subRun,
@@ -135,7 +135,7 @@ bool TimeoutWatchdogService::check() {
   tls_.stopSource.request_stop();
 
   if (debugLevel_ > 0) {
-    std::printf("[TimeoutWatchdogService::%s] Event %u:%u:%u timeout module=%s eventExceeded=%d moduleExceeded=%d\n",
+    std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u timeout module=%s eventExceeded=%d moduleExceeded=%d\n",
                 __func__,
                 tls_.run,
                 tls_.subRun,
@@ -148,7 +148,7 @@ bool TimeoutWatchdogService::check() {
   return true;
 }
 
-std::stop_token TimeoutWatchdogService::stopToken() const {
+std::stop_token TimeoutWatchdog::stopToken() const {
   return tls_.stopToken;
 }
 

--- a/TimeoutService/src/TimeoutWatchdog_service.cc
+++ b/TimeoutService/src/TimeoutWatchdog_service.cc
@@ -5,4 +5,4 @@
 #include "art/Framework/Services/Registry/ServiceDefinitionMacros.h"
 #include "Offline/TimeoutService/inc/TimeoutWatchdog.hh"
 
-DEFINE_ART_SERVICE(mu2e::TimeoutWatchdogService)
+DEFINE_ART_SERVICE(mu2e::TimeoutWatchdog)

--- a/TimeoutService/src/TimeoutWatchdog_service.cc
+++ b/TimeoutService/src/TimeoutWatchdog_service.cc
@@ -1,5 +1,5 @@
 //
-// TimeoutWatchdogService plugin
+// TimeoutWatchdog service plugin
 //
 
 #include "art/Framework/Services/Registry/ServiceDefinitionMacros.h"


### PR DESCRIPTION
There were errors in the spack build test, where hopefully this renaming solves these errors.