### PR TITLE
HelloWorld .fcl tutorial typo: Change "process :" to "process_name :"

### DIFF
--- a/HelloWorld/test/erase.fcl
+++ b/HelloWorld/test/erase.fcl
@@ -1,4 +1,4 @@
-process : HelloWorld
+process_name : HelloWorld
 
 source : {
   module_type : EmptyEvent

--- a/HelloWorld/test/hello.fcl
+++ b/HelloWorld/test/hello.fcl
@@ -4,7 +4,7 @@
 #include "Offline/fcl/minimalMessageService.fcl"
 
 # Give this job a name.
-process : HelloWorld
+process_name : HelloWorld
 
 # Start form an empty source
 source : {

--- a/HelloWorld/test/tableExample.fcl
+++ b/HelloWorld/test/tableExample.fcl
@@ -1,6 +1,6 @@
 #include "Offline/HelloWorld/test/prolog.fcl"
 
-process : HelloWorld
+process_name : HelloWorld
 
 source : {
   module_type : EmptyEvent


### PR DESCRIPTION
The .fcl files in the HelloWorld tutorial currently all start with `process : HelloWorld`. The correct keyword is `process_name`.

This is a typo and results in the following being printed upon running of the .fcl file:

> INFO: using default process_name of "DUMMY".

This commit fixes the three instances of "process" to "process_name".