### PR TITLE
Include calorimeter in digi harvesting

### DIFF
--- a/Blinding/src/DisplaceDigiTimes_module.cc
+++ b/Blinding/src/DisplaceDigiTimes_module.cc
@@ -27,8 +27,10 @@
 #include "fhiclcpp/types/Sequence.h"
 
 // mu2e
+#include "Offline/CaloMC/inc/CaloDigiWrapper.hh"
 #include "Offline/DataProducts/inc/SurfaceId.hh"
 #include "Offline/Mu2eUtilities/inc/BinnedSpectrum.hh"
+#include "Offline/RecoDataProducts/inc/CaloDigi.hh"
 #include "Offline/RecoDataProducts/inc/KalIntersection.hh"
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 #include "Offline/RecoDataProducts/inc/StrawDigi.hh"
@@ -44,6 +46,10 @@ namespace mu2e{
       struct Config{
         fhicl::Atom<art::InputTag> tracker_digi_tag{
           fhicl::Name("StrawDigiCollection"),
+          fhicl::Comment("art::InputTag of digis to displace")
+        };
+        fhicl::Atom<art::InputTag> calo_digi_tag{
+          fhicl::Name("CaloDigiCollection"),
           fhicl::Comment("art::InputTag of digis to displace")
         };
         fhicl::Atom<art::InputTag> kalseed_tag{
@@ -67,6 +73,7 @@ namespace mu2e{
 
     protected:
       art::InputTag _tracker_digi_tag;
+      art::InputTag _calo_digi_tag;
       art::InputTag _kalseed_tag;
       SurfaceIdCollection _surface_ids;
       ProditionsHandle<StrawElectronics> _tracker_conditions_handle;
@@ -82,6 +89,7 @@ namespace mu2e{
   DisplaceDigiTimes::DisplaceDigiTimes(const Parameters& config):
       art::EDProducer(config),
       _tracker_digi_tag(config().tracker_digi_tag()),
+      _calo_digi_tag(config().calo_digi_tag()),
       _kalseed_tag(config().kalseed_tag()),
       _engine{createEngine(art::ServiceHandle<SeedService>()->getSeed())}{
     // initialize target distribution
@@ -106,6 +114,8 @@ namespace mu2e{
     this->produces<StrawDigiADCWaveformCollection>();
 
     // calorimeter...
+    this->consumes<CaloDigiCollection>(_calo_digi_tag);
+    this->produces<CaloDigiCollection>();
   }
 
   void DisplaceDigiTimes::produce(art::Event& event){
@@ -118,6 +128,9 @@ namespace mu2e{
            + " and " + std::to_string(adcs_handle->size());
       throw cet::exception("DisplaceDigiTimes") << msg << std::endl;
     }
+
+    // calorimeter
+    auto cdigi_handle = event.getValidHandle<CaloDigiCollection>(_calo_digi_tag);
 
     // first, check that there is only a single KalSeed associated with
     // these digis
@@ -185,7 +198,27 @@ namespace mu2e{
     event.put(std::move(digis));
     event.put(std::move(adcss));
 
-    // calorimeter...
+    // apply the shift to calorimeter digis
+    // TODO need adc sampling period from fucking conditions!!!
+    double sample_period = 5.0;
+    auto cdigis = std::make_unique<CaloDigiCollection>();
+    if (0 < cdigi_handle->size()){
+      for (const auto& old: *cdigi_handle){
+        auto id = old.SiPMID();
+        auto t0 = old.t0();
+        auto peakpos = old.peakpos();
+        auto& waveform = old.waveform();
+
+        // displace waveform start times
+        auto analog = t0 * sample_period;
+        auto shifted = analog + shift;
+        t0 = static_cast<CaloDigiWrapper::sample_t>(shifted / sample_period);
+
+        // new digi is identical to input digi, with displaced start index
+        cdigis->emplace_back(id, t0, waveform, peakpos);
+      }
+    }
+    event.put(std::move(cdigis));
   }
 
   double DisplaceDigiTimes::sample_target_time(){

--- a/Blinding/src/DisplaceDigiTimes_module.cc
+++ b/Blinding/src/DisplaceDigiTimes_module.cc
@@ -64,6 +64,11 @@ namespace mu2e{
           fhicl::Name("SurfaceIds"),
           fhicl::Comment("Prioritized sequence of mu2e::SurfaceIds at which tracks may be sampled for reference timing")
         };
+        // would be better for the sampling period to come from conditions
+        fhicl::Atom<double> calo_adc_sample_period{
+          fhicl::Name("CaloADCSamplePeriod"),
+          fhicl::Comment("Sample spacing of calorimeter waveforms")
+        };
       };
 
       using Parameters = art::EDProducer::Table<Config>;
@@ -76,6 +81,7 @@ namespace mu2e{
       art::InputTag _calo_digi_tag;
       art::InputTag _kalseed_tag;
       SurfaceIdCollection _surface_ids;
+      double _calo_adc_sample_period;
       ProditionsHandle<StrawElectronics> _tracker_conditions_handle;
       art::RandomNumberGenerator::base_engine_t& _engine;
       BinnedSpectrum _target_distribution;
@@ -91,6 +97,7 @@ namespace mu2e{
       _tracker_digi_tag(config().tracker_digi_tag()),
       _calo_digi_tag(config().calo_digi_tag()),
       _kalseed_tag(config().kalseed_tag()),
+      _calo_adc_sample_period(config().calo_adc_sample_period()),
       _engine{createEngine(art::ServiceHandle<SeedService>()->getSeed())}{
     // initialize target distribution
     const auto pset = config().target_distribution.get<fhicl::ParameterSet>();
@@ -199,8 +206,7 @@ namespace mu2e{
     event.put(std::move(adcss));
 
     // apply the shift to calorimeter digis
-    // TODO need adc sampling period from fucking conditions!!!
-    double sample_period = 5.0;
+    double sample_period = _calo_adc_sample_period;
     auto cdigis = std::make_unique<CaloDigiCollection>();
     if (0 < cdigi_handle->size()){
       for (const auto& old: *cdigi_handle){

--- a/Blinding/src/DisplaceDigiTimes_module.cc
+++ b/Blinding/src/DisplaceDigiTimes_module.cc
@@ -218,7 +218,8 @@ namespace mu2e{
         // displace waveform start times
         auto analog = t0 * sample_period;
         auto shifted = analog + shift;
-        t0 = static_cast<CaloDigiWrapper::sample_t>(shifted / sample_period);
+        auto rounded = std::lround(shifted / sample_period);
+        t0 = static_cast<CaloDigiWrapper::sample_t>(rounded);
 
         // new digi is identical to input digi, with displaced start index
         cdigis->emplace_back(id, t0, waveform, peakpos);

--- a/Blinding/src/TrackDigiExtractor_module.cc
+++ b/Blinding/src/TrackDigiExtractor_module.cc
@@ -43,7 +43,11 @@ namespace mu2e{
           fhicl::Comment("art::InputTag of StrawDigis associated with StrawHits")
         };
 
-        // calorimeter...
+        // calorimeter
+        fhicl::Atom<art::InputTag> calodigi_tag{
+          fhicl::Name("CaloDigiCollection"),
+          fhicl::Comment("art::InputTag of CaloDigis ultimately associated with KalSeed")
+        };
       };
 
       using Parameters = art::EDProducer::Table<Config>;
@@ -53,6 +57,7 @@ namespace mu2e{
       art::InputTag _kalseed_tag;
       art::InputTag _strawhit_tag;
       art::InputTag _strawdigi_tag;
+      art::InputTag _calodigi_tag;
 
     private:
       void produce(art::Event&);
@@ -62,13 +67,16 @@ namespace mu2e{
       art::EDProducer(config),
       _kalseed_tag(config().kalseed_tag()),
       _strawhit_tag(config().strawhit_tag()),
-      _strawdigi_tag(config().strawdigi_tag()){
+      _strawdigi_tag(config().strawdigi_tag()),
+      _calodigi_tag(config().calodigi_tag()){
     this->consumes<KalSeedCollection>(_kalseed_tag);
     this->consumes<StrawHitCollection>(_strawhit_tag);
     this->consumes<StrawDigiCollection>(_strawdigi_tag);
     this->consumes<StrawDigiADCWaveformCollection>(_strawdigi_tag);
+    this->consumes<CaloDigiCollection>(_calodigi_tag);
     this->produces<StrawDigiCollection>();
     this->produces<StrawDigiADCWaveformCollection>();
+    this->produces<CaloDigiCollection>();
   }
 
   void TrackDigiExtractor::produce(art::Event& event){
@@ -77,6 +85,7 @@ namespace mu2e{
     auto strawhits = event.getValidHandle<StrawHitCollection>(_strawhit_tag);
     auto strawdigis = event.getValidHandle<StrawDigiCollection>(_strawdigi_tag);
     auto strawadcss = event.getValidHandle<StrawDigiADCWaveformCollection>(_strawdigi_tag);
+    auto calodigis = event.getValidHandle<CaloDigiCollection>(_calodigi_tag);
 
     // sanity checks
     if (strawhits->size() != strawdigis->size()){
@@ -91,6 +100,7 @@ namespace mu2e{
     // deep-copy digis underlying tracks
     auto ext_strawdigis = std::make_unique<StrawDigiCollection>();
     auto ext_strawadcss = std::make_unique<StrawDigiADCWaveformCollection>();
+    auto ext_calodigis = std::make_unique<CaloDigiCollection>();
     for (const auto& kalseed: *kalseeds){
       // tracker
       auto seeds = kalseed.hits();
@@ -110,12 +120,27 @@ namespace mu2e{
         ext_strawadcss->push_back(adcs);
       }
 
-      // calorimeter...
+      // calorimeter
+      if (kalseed.hasCaloCluster()){
+        const auto& cseed = kalseed.caloHit();
+        const auto& cluster = cseed.caloCluster();
+        const auto& hits = cluster->caloHitsPtrVector();
+        for (const auto& hit: hits){
+          const auto& recos = hit->recoCaloDigis();
+          for (const auto& reco: recos){
+            const auto& ptr = reco->caloDigiPtr();
+            auto digi = CaloDigi(ptr->SiPMID(), ptr->t0(),
+                                 ptr->waveform(), ptr->peakpos());
+            ext_calodigis->push_back(digi);
+          }
+        }
+      }
     }
 
     // place into event
     event.put(std::move(ext_strawdigis));
     event.put(std::move(ext_strawadcss));
+    event.put(std::move(ext_calodigis));
   }
 } // namespace mu2e
 

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -389,7 +389,7 @@ include="Math/Vector3D.h, Math/Vector4D.h, CLHEP/Vector/LorentzVector.h, CLHEP/V
 <!--   ******************Analysis ************************ -->
 <class name="mu2e::MCRelationship"/>
 
-<!-- ejc -->
+<!-- relevant to sampling/ensembling jobs -->
 <class name="art::Sampled<mu2e:ProtonBunchIntensity>"/>
 <class name="art::Wrapper< art::Sampled<mu2e:ProtonBunchIntensity> >"/>
 <class name="std::map<art::SubRunID,mu2e::ProtonBunchIntensity>"/>

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -389,5 +389,17 @@ include="Math/Vector3D.h, Math/Vector4D.h, CLHEP/Vector/LorentzVector.h, CLHEP/V
 <!--   ******************Analysis ************************ -->
 <class name="mu2e::MCRelationship"/>
 
+<!-- ejc -->
+<class name="art::Sampled<mu2e:ProtonBunchIntensity>"/>
+<class name="art::Wrapper< art::Sampled<mu2e:ProtonBunchIntensity> >"/>
+<class name="std::map<art::SubRunID,mu2e::ProtonBunchIntensity>"/>
+<class name="art::Wrapper< std::map<art::SubRunID,mu2e::ProtonBunchIntensity> >"/>
+<class name="std::map< std::string,std::map<art::SubRunID,mu2e::ProtonBunchIntensity> >"/>
+
+<class name="art::Sampled<mu2e:GenEventCount>"/>
+<class name="art::Wrapper< art::Sampled<mu2e:GenEventCount> >"/>
+<class name="std::map<art::SubRunID,mu2e::GenEventCount>"/>
+<class name="art::Wrapper< std::map<art::SubRunID,mu2e::GenEventCount> >"/>
+<class name="std::map< std::string,std::map<art::SubRunID,mu2e::GenEventCount> >"/>
 
 </lcgdict>

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -390,14 +390,14 @@ include="Math/Vector3D.h, Math/Vector4D.h, CLHEP/Vector/LorentzVector.h, CLHEP/V
 <class name="mu2e::MCRelationship"/>
 
 <!-- relevant to sampling/ensembling jobs -->
-<class name="art::Sampled<mu2e:ProtonBunchIntensity>"/>
-<class name="art::Wrapper< art::Sampled<mu2e:ProtonBunchIntensity> >"/>
+<class name="art::Sampled<mu2e::ProtonBunchIntensity>"/>
+<class name="art::Wrapper< art::Sampled<mu2e::ProtonBunchIntensity> >"/>
 <class name="std::map<art::SubRunID,mu2e::ProtonBunchIntensity>"/>
 <class name="art::Wrapper< std::map<art::SubRunID,mu2e::ProtonBunchIntensity> >"/>
 <class name="std::map< std::string,std::map<art::SubRunID,mu2e::ProtonBunchIntensity> >"/>
 
-<class name="art::Sampled<mu2e:GenEventCount>"/>
-<class name="art::Wrapper< art::Sampled<mu2e:GenEventCount> >"/>
+<class name="art::Sampled<mu2e::GenEventCount>"/>
+<class name="art::Wrapper< art::Sampled<mu2e::GenEventCount> >"/>
 <class name="std::map<art::SubRunID,mu2e::GenEventCount>"/>
 <class name="art::Wrapper< std::map<art::SubRunID,mu2e::GenEventCount> >"/>
 <class name="std::map< std::string,std::map<art::SubRunID,mu2e::GenEventCount> >"/>


### PR DESCRIPTION
This PR includes calorimeter digis in the workflow of extracting digis from an event which participate in a reconstructed track and doctoring their timing to change where in the event window they (and, as a consequence, a track reconstructed them) occur in the event window, which is necessary to include the calorimeter in the proposed salt-with-cosmics blinding scheme.

Changes to existing modules:
  - TrackDigiExtractor: Identify all calorimeter digis which ultimately contribute to a calorimeter hit associated with a given fit track, and store them in a dedicated data product, similar to how tracker digis are handled.
  - DisplaceDigiTimes: Deep-copy of all calorimeter digis in a given collection, with the starting timestamp shifted by a predetermined interval (subject to the sample spacing of the waveforms, which are the timestamp units).
 
  One note is that the sample spacing of the calorimeter is not stored condition available via the usual handes, but (where used elsewhere) as a fcl parameter; this implementation thus also supplies this value as a fcl parameter, which may be coordinated as a prolog value when production fcl for this workflow materializes.

This also sneaks in some extra declarations of data products to be serialized to disk, which are necessary when running certain ensembling workflows in the process of testing the blinding mechanics.