### PR TITLE
Add v40 Run 1B config

### DIFF
--- a/Mu2eG4/geom/geom_run1_b_ds_on_v40.txt
+++ b/Mu2eG4/geom/geom_run1_b_ds_on_v40.txt
@@ -1,0 +1,10 @@
+// Run1B v40: 1.75 cm thick mobile target, 1.75 cm thick Al TS5 endcap plate with 135 mm hole added, otherwise a normal Run 1A config
+// Run 1A version with mobile target moved out of the beam for DS-on running
+#include "Offline/Mu2eG4/geom/geom_run1_b_v40.txt"
+
+double degrader.rotation = 120.0; // out of the beam
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_run1_b_v40.txt
+++ b/Mu2eG4/geom/geom_run1_b_v40.txt
@@ -1,0 +1,35 @@
+// Run1B v40: 1.75 cm thick mobile target, 1.75 cm thick Al TS5 endcap plate with 135 mm hole added, otherwise a normal Run 1A config
+#include "Offline/Mu2eG4/geom/geom_run1_a.txt"
+
+// Use the pion degrader as a Run 1B target
+bool   degrader.build               = true;
+double degrader.rotation            = 60.0; // in the beam
+string degrader.filter.materialName = "StoppingTarget_Al"; // stopping target material
+double degrader.filter.halfLength   = 8.75; // 1.75 cm plate
+double degrader.filter.rIn          = 0.0;
+double degrader.filter.rOut         = 150.0; // 150 mm radius disk
+
+// Use the TSdA as an aluminum collimator, helping Run 1B
+bool hasTSdA             = true;
+double tsda.z0           = 4195;
+double tsda.r4           = 600;                 // cover the TS5
+double tsda.rin          = 135.;                // 135 mm hole for normal beam to pass through
+double tsda.halfLength4  = 8.75;                // 1.75 cm plate
+string tsda.materialName = "StoppingTarget_Al"; // stopping target material to capture in the stops finder
+
+// Place tracker in DS2Vacuum (keeps TT_MidInner VD within DS2Vacuum bounds)
+bool tracker.inDS2Vacuum = true;
+
+// Extend DS2Vacuum to contain the tracker at nominal position z=10171 mm.
+// Split lands at 11829 mm, between tracker mother end (11811) and calo face (11842).
+double ds2.halfLength = 3825;
+
+// Disable DS3 service pipes: their upstream face is at z~11480 mm, which falls
+// inside the extended DS2Vacuum (DS3 now starts at 11829 mm), causing extrusion
+// overlaps. geom_run1_b_v01.txt uses the same flag for the same reason.
+bool ds.hasServicePipes = false;
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:


### PR DESCRIPTION
Adding a new Run 1B geometry configuration using:
- A 1.75 cm thick mobile target re-purposing the degrader
- A 1.75 cm thick Al plate at the end of TS5 with a 135 mm hole for normal Run 1A running
- No TSdA poly
- All other Run 1A objects (target, OPA/IPA, etc.) included

The endplate and mobile target are both StoppingTarget_Al, as they're valid aluminum muon stops in Run 1B.