### PR TITLE
Added diagnostic kinkal strawhitupdater

### DIFF
--- a/Mu2eKinKal/CMakeLists.txt
+++ b/Mu2eKinKal/CMakeLists.txt
@@ -3,6 +3,7 @@ cet_make_library(
       src/BkgANNSHU.cc
       src/CADSHU.cc
       src/Chi2SHU.cc
+      src/PanelDiagSHU.cc
       src/DriftANNSHU.cc
       src/KKBField.cc
       src/KKConstantBField.cc

--- a/Mu2eKinKal/inc/KKFitSettings.hh
+++ b/Mu2eKinKal/inc/KKFitSettings.hh
@@ -16,6 +16,7 @@
 #include "Offline/Mu2eKinKal/inc/DriftANNSHU.hh"
 #include "Offline/Mu2eKinKal/inc/BkgANNSHU.hh"
 #include "Offline/Mu2eKinKal/inc/Chi2SHU.hh"
+#include "Offline/Mu2eKinKal/inc/PanelDiagSHU.hh"
 #include "Offline/Mu2eKinKal/inc/StrawXingUpdater.hh"
 namespace mu2e {
   namespace Mu2eKinKal{
@@ -45,6 +46,8 @@ namespace mu2e {
       BkgANNSHUSettings bkgshuConfig{ Name("BkgANNSHUSettings"), Comment(BkgANNSHU::configDescription()) };
       using Chi2SHUSettings = fhicl::OptionalSequence<fhicl::Tuple<unsigned,float,float,float,std::string,std::string,std::string,std::string,int>>;
       Chi2SHUSettings combishuConfig{ Name("Chi2SHUSettings"), Comment(Chi2SHU::configDescription()) };
+      using PanelDiagSHUSettings = fhicl::OptionalSequence<fhicl::Tuple<std::string,std::string,int>>;
+      PanelDiagSHUSettings paneldiagshuConfig{ Name("PanelDiagSHUSettings"), Comment(PanelDiagSHU::configDescription()) };
       using StrawXingUpdaterSettings = fhicl::Sequence<fhicl::Tuple<float,float,bool,int>>;
       StrawXingUpdaterSettings sxuConfig{ Name("StrawXingUpdaterSettings"), Comment(StrawXingUpdater::configDescription()) };
     };

--- a/Mu2eKinKal/inc/KKStrawHit.hh
+++ b/Mu2eKinKal/inc/KKStrawHit.hh
@@ -23,6 +23,7 @@
 #include "Offline/Mu2eKinKal/inc/DriftANNSHU.hh"
 #include "Offline/Mu2eKinKal/inc/BkgANNSHU.hh"
 #include "Offline/Mu2eKinKal/inc/Chi2SHU.hh"
+#include "Offline/Mu2eKinKal/inc/PanelDiagSHU.hh"
 #include "Offline/Mu2eKinKal/inc/StrawHitUpdaters.hh"
 #include "Offline/Mu2eKinKal/inc/KKFitUtilities.hh"
 // Other
@@ -178,10 +179,12 @@ namespace mu2e {
     auto cashu = miconfig.findUpdater<CADSHU>();
     auto driftshu = miconfig.findUpdater<DriftANNSHU>();
     auto bkgshu = miconfig.findUpdater<BkgANNSHU>();
+    auto diagshu = miconfig.findUpdater<PanelDiagSHU>();
     CA ca = unbiasedClosestApproach();
     if(ca.usable()){
       auto dinfo = fillDriftInfo(ca);
       // there can be multiple updaters: apply them all
+      if(diagshu)whstate_ = diagshu->wireHitState(whstate_,straw_.id());
       if(cashu)whstate_ = cashu->wireHitState(whstate_,ca.tpData(),dinfo);
       if(bkgshu)whstate_ = bkgshu->wireHitState(whstate_,ca.tpData(),dinfo,chit_);
       if(driftshu)whstate_ = driftshu->wireHitState(whstate_,ca.tpData(),dinfo,chit_);

--- a/Mu2eKinKal/inc/PanelDiagSHU.hh
+++ b/Mu2eKinKal/inc/PanelDiagSHU.hh
@@ -1,0 +1,30 @@
+#ifndef Mu2eKinKal_PanelDiagSHU_hh
+#define Mu2eKinKal_PanelDiagSHU_hh
+//
+// Diagnostic updater of StrawHits that can force panels to be inactive
+//
+#include "Offline/Mu2eKinKal/inc/WireHitState.hh"
+#include "Offline/Mu2eKinKal/inc/WHSMask.hh"
+#include "Offline/Mu2eKinKal/inc/StrawHitUpdaters.hh"
+#include "Offline/DataProducts/inc/StrawIdMask.hh"
+#include "Offline/DataProducts/inc/StrawId.hh"
+#include <tuple>
+#include <string>
+#include <iostream>
+
+namespace mu2e {
+  // Update based just on PTCA to the wire
+  class PanelDiagSHU {
+    public:
+      using Config = std::tuple<std::string,std::string,int>;
+      PanelDiagSHU(Config const& config);
+      static std::string const& configDescription(); // description of the variables
+      // set the state based on the current PTCA value
+      WireHitState wireHitState(WireHitState const& input, StrawId const& id) const;
+    private:
+      StrawIdMask mask_;
+      StrawId sid_;
+      int diag_ =0; // diag print level
+  };
+}
+#endif

--- a/Mu2eKinKal/inc/StrawHitUpdaters.hh
+++ b/Mu2eKinKal/inc/StrawHitUpdaters.hh
@@ -9,7 +9,7 @@
 namespace mu2e {
   // straw hit updater algorithms: this needs to be extended if new updaters are defined
   struct StrawHitUpdaters {
-    enum algorithm: int {unknown=-1,none=0, CAD=1, DriftANN=2, BkgANN=3, Chi2=10, nalgos };
+    enum algorithm: int {unknown=-1,none=0, CAD=1, DriftANN=2, BkgANN=3, PanelDiag=9, Chi2=10, nalgos };
     // translate from algo to name
     static std::string const& name(algorithm alg);
     static algorithm algo(std::string const& name);

--- a/Mu2eKinKal/src/KKFitSettings.cc
+++ b/Mu2eKinKal/src/KKFitSettings.cc
@@ -26,16 +26,18 @@ namespace mu2e {
       std::vector<CADSHU::Config> cadshusettings;
       std::vector<DriftANNSHU::Config> driftannshusettings;
       std::vector<BkgANNSHU::Config> bkgannshusettings;
+      std::vector<PanelDiagSHU::Config> paneldiagshusettings;
       std::vector<Chi2SHU::Config> chi2shusettings;
       // specific updaters can be empty, so fetch config data with a default empty vector
       cadshusettings = fitconfig.cadshuConfig().value_or(cadshusettings);
       driftannshusettings = fitconfig.annshuConfig().value_or(driftannshusettings);
       bkgannshusettings = fitconfig.bkgshuConfig().value_or(bkgannshusettings);
+      paneldiagshusettings = fitconfig.paneldiagshuConfig().value_or(paneldiagshusettings);
       chi2shusettings = fitconfig.combishuConfig().value_or(chi2shusettings);
       // straw material updater must always be here
       auto const& sxusettings = fitconfig.sxuConfig();
       // set the schedule for the meta-iterations
-      unsigned ncadshu(0), nann(0), nbkg(0), ncomb(0), nnone(0), nsxu(0);
+      unsigned ncadshu(0), nann(0), nbkg(0), ncomb(0), nnone(0), nsxu(0), npdiag(0);
       for(auto const& misetting : fitconfig.miConfig()) {
         MetaIterConfig miconfig(std::get<0>(misetting));
         // parse StrawHit updaters, and add to the config of this meta-iteraion
@@ -49,6 +51,9 @@ namespace mu2e {
             miconfig.addUpdater(std::any(DriftANNSHU(driftannshusettings.at(nann++))));
           } else if(alg == StrawHitUpdaters::BkgANN) {
             miconfig.addUpdater(std::any(BkgANNSHU(bkgannshusettings.at(nbkg++))));
+          } else if(alg == StrawHitUpdaters::PanelDiag) {
+            miconfig.addUpdater(std::any(PanelDiagSHU(paneldiagshusettings.at(npdiag))));
+            if (paneldiagshusettings.size()>npdiag+1)npdiag++;
           } else if(alg == StrawHitUpdaters::Chi2) {
             miconfig.addUpdater(std::any(Chi2SHU(chi2shusettings.at(ncomb++))));
           } else if(alg == StrawHitUpdaters::none) {

--- a/Mu2eKinKal/src/PanelDiagSHU.cc
+++ b/Mu2eKinKal/src/PanelDiagSHU.cc
@@ -1,0 +1,30 @@
+#include "Offline/Mu2eKinKal/inc/PanelDiagSHU.hh"
+#include <cmath>
+
+namespace mu2e {
+  PanelDiagSHU::PanelDiagSHU(Config const& config) {
+    mask_ = StrawIdMask(std::get<0>(config));
+    sid_ = StrawId(std::get<1>(config));
+    diag_ = std::get<2>(config);
+    if(diag_ > 0)std::cout << "PanelDiagSHU " << mask_.levelName() << " " << sid_ << std::endl;
+  }
+
+  WireHitState PanelDiagSHU::wireHitState(WireHitState const& input, StrawId const& id) const {
+    WireHitState whstate = input;
+    if(input.updateable(StrawHitUpdaters::PanelDiag)){
+      if (mask_.equal(id,sid_)){
+        whstate.state_ = WireHitState::inactive;
+        whstate.algo_ = StrawHitUpdaters::PanelDiag;
+        whstate.frozen_ = true;
+        if (diag_ > 1)std::cout << "PanelDiagSHU set hit " << id << " inactive" << std::endl;
+      }
+    }
+    return whstate;
+  }
+
+  std::string const& PanelDiagSHU::configDescription() {
+    static std::string descrip( "StrawId mask, StrawId to set inactive, diag level");
+    return descrip;
+  }
+
+}

--- a/Mu2eKinKal/src/StrawHitUpdaters.cc
+++ b/Mu2eKinKal/src/StrawHitUpdaters.cc
@@ -1,6 +1,6 @@
 #include "Offline/Mu2eKinKal/inc/StrawHitUpdaters.hh"
 namespace mu2e {
-  std::vector<std::string> StrawHitUpdaters::names_{"None","CADSHU","DriftANNSHU","BkgANNSHU","","","","","","","Chi2SHU"};
+  std::vector<std::string> StrawHitUpdaters::names_{"None","CADSHU","DriftANNSHU","BkgANNSHU","","","","","","PanelDiagSHU","Chi2SHU"};
   std::string const& StrawHitUpdaters::name(algorithm alg) {
     return names_[static_cast<size_t>(alg)];
   }


### PR DESCRIPTION
Simple SHU that allows you to force all hits from a single panel or plane to be inactive in the kinkal fits. If done by panel status instead no hits would be created, this allows information from that panel to still make it into EventNtuple for alignment diagnostics etc.