### PR TITLE
New tracker conditions tables for TOT and HV trips

### DIFF
--- a/CosmicReco/src/CosmicShowerFilter_module.cc
+++ b/CosmicReco/src/CosmicShowerFilter_module.cc
@@ -145,7 +145,7 @@ namespace mu2e {
                 int gap = 0;
                 for (size_t k=straws[i][j-1]+2;k<straws[i][j];k+=2){
                   StrawId sid(i/6,i%6,k);
-                  if (!trackerStatus.noSignal(sid) && !trackerStatus.suppress(sid)) {
+                  if (!trackerStatus.noSignal(sid,event.event()) && !trackerStatus.suppress(sid)) {
                     gap += 1;
                   }
                 }
@@ -164,7 +164,7 @@ namespace mu2e {
                   int gap = 0;
                   for (size_t k=straws[i][j-1]+1;k<straws[i][j];k++){
                     StrawId sid(i/6,i%6,k);
-                    if (!trackerStatus.noSignal(sid) && !trackerStatus.suppress(sid)) {
+                    if (!trackerStatus.noSignal(sid,event.event()) && !trackerStatus.suppress(sid)) {
                       gap += 1;
                     }
                   }

--- a/DbTables/inc/TrkHVTripStatus.hh
+++ b/DbTables/inc/TrkHVTripStatus.hh
@@ -1,0 +1,86 @@
+#ifndef DbTables_TrkHVTripStatus_hh
+#define DbTables_TrkHVTripStatus_hh
+
+#include "Offline/DataProducts/inc/StrawId.hh"
+#include "Offline/DataProducts/inc/StrawIdMask.hh"
+#include "Offline/DataProducts/inc/StrawStatus.hh"
+#include "Offline/DbTables/inc/DbTable.hh"
+#include "cetlib_except/exception.h"
+#include <iomanip>
+#include <map>
+#include <regex>
+#include <sstream>
+#include <string>
+
+namespace mu2e {
+
+class TrkHVTripStatus : public DbTable {
+ public:
+
+   class Row {
+     public:
+       Row(int index, StrawId sid, uint32_t startevent, uint32_t endevent) :
+         _index(index), _sid(sid), _startevent(startevent), _endevent(endevent) {}
+       int index() const { return _index; }
+       StrawId const& id() const { return _sid; }
+       uint32_t startevent() const { return _startevent; }
+       uint32_t endevent() const { return _endevent; }
+
+     private:
+       int _index;
+       StrawId _sid;
+       uint32_t _startevent;
+       uint32_t _endevent;
+   };
+
+
+
+  typedef std::shared_ptr<TrkHVTripStatus> ptr_t;
+  typedef std::shared_ptr<const TrkHVTripStatus> cptr_t;
+
+  constexpr static const char* cxname = "TrkHVTripStatus";
+
+  TrkHVTripStatus() :
+      DbTable(cxname, "trk.hvtripstatus",
+              "index,strawid,startevent,endevent") {}
+  const Row& rowAt(const std::size_t index) const { return _rows.at(index); }
+  std::vector<Row> const& rows() const { return _rows; }
+  std::size_t nrow() const override { return _rows.size(); };
+  // this is a variable-size table, so don't overrido nrowFix()
+  size_t size() const override { return baseSize() + nrow() * sizeof(Row); };
+  const std::string orderBy() const { return std::string("index"); }
+
+  void addRow(const std::vector<std::string>& columns) override {
+    int index = std::stoi(columns[0]);
+    auto sid = StrawId(columns[1]);
+    uint32_t startevent = std::stoul(columns[2]);
+    uint32_t endevent = std::stoul(columns[3]);
+    // enforce a strict sequential order
+    if (index != int(_rows.size())) {
+      throw cet::exception("TRKHVTRIPSTATUS_BAD_INDEX")
+          << "TrkHVTripStatus::addRow found index out of order: " << index
+          << " != " << _rows.size() << "\n";
+    }
+    _rows.emplace_back(index, sid, startevent, endevent);
+  }
+
+  void rowToCsv(std::ostringstream& sstream, std::size_t irow) const override {
+    Row const& r = _rows.at(irow);
+    sstream << r.index() << ",";
+    sstream << r.id().plane() << "_" << r.id().panel() << "_" << r.id().straw()
+            << ",";
+    sstream << r.startevent() << ",";
+    sstream << r.endevent();
+  }
+
+  virtual void clear() override {
+    baseClear();
+    _rows.clear();
+  }
+
+ private:
+  std::vector<Row> _rows;
+};
+
+}  // namespace mu2e
+#endif

--- a/DbTables/inc/TrkTOTCalib.hh
+++ b/DbTables/inc/TrkTOTCalib.hh
@@ -9,32 +9,37 @@
 
 namespace mu2e {
 
-  class TrkTOTCalibParams : public DbTable {
+  class TrkTOTCalib : public DbTable {
     public:
-      typedef std::shared_ptr<TrkTOTCalibParams> ptr_t;
-      typedef std::shared_ptr<const TrkTOTCalibParams> cptr_t;
+      typedef std::shared_ptr<TrkTOTCalib> ptr_t;
+      typedef std::shared_ptr<const TrkTOTCalib> cptr_t;
 
       class Row {
         public:
-          Row(int totTBins, float totTBinWidth, int totEBins, float totEBinWidth)
+          Row(int totTBins, float totTBinWidth, int totEBins, float totEBinWidth, std::vector<float> driftTimes, std::vector<float> driftErrors)
             : _totTBins(totTBins), _totTBinWidth(totTBinWidth),
-            _totEBins(totEBins), _totEBinWidth(totEBinWidth) {}
+            _totEBins(totEBins), _totEBinWidth(totEBinWidth),
+            _driftTimes(std::move(driftTimes)), _driftErrors(std::move(driftErrors)) {}
           int   totTBins()    const { return _totTBins; }
           float totTBinWidth() const { return _totTBinWidth; }
           int   totEBins()    const { return _totEBins; }
           float totEBinWidth() const { return _totEBinWidth; }
+          std::vector<float> const& driftTimes() const { return _driftTimes; }
+          std::vector<float> const& driftErrors() const { return _driftErrors; }
         private:
           int   _totTBins;
           float _totTBinWidth;
           int   _totEBins;
           float _totEBinWidth;
+          std::vector<float> _driftTimes;
+          std::vector<float> _driftErrors;
       };
 
-      constexpr static const char* cxname = "TrkTOTCalibParams";
+      constexpr static const char* cxname = "TrkTOTCalib";
 
-      TrkTOTCalibParams() :
-        DbTable(cxname, "trk.totcalibparams",
-            "tottbins,tottbinwidth,totebins,totebinwidth") {}
+      TrkTOTCalib() :
+        DbTable(cxname, "trk.totcalib",
+            "tottbins,tottbinwidth,totebins,totebinwidth,drifttimes,drifterrors") {}
       const Row& rowAt(const std::size_t index) const { return _rows.at(index); }
       std::vector<Row> const& rows() const { return _rows; }
       std::size_t nrow() const override { return _rows.size(); };
@@ -44,10 +49,30 @@ namespace mu2e {
 
       void addRow(const std::vector<std::string>& columns) override {
         if (_rows.size() != 0)
-          throw cet::exception("TRKTOTCALIBPARAMS_BAD_INDEX")
-            << "TrkTOTCalibParams::addRow adding more than one row\n";
-        _rows.emplace_back(std::stoi(columns[0]), std::stof(columns[1]),
-            std::stoi(columns[2]), std::stof(columns[3]));
+          throw cet::exception("TRKTOTCALIB_BAD_INDEX")
+            << "TrkTOTCalib::addRow adding more than one row\n";
+        int totTBins = std::stoi(columns[0]);
+        int totEBins = std::stoi(columns[2]);
+        std::istringstream is(columns[4]); // drift times
+        std::vector<float> driftTimes;
+        driftTimes.reserve(totTBins*totEBins);
+        float x;
+        while (is >> x) driftTimes.push_back(x);
+        if (!is.eof()){
+          throw cet::exception("TRKTOTCALIB_BAD_INDEX")
+            << "TrkTOTCalib::addRow bad driftTime\n";
+        }
+        std::istringstream is2(columns[5]); // drift errors
+        std::vector<float> driftErrors;
+        driftErrors.reserve(totTBins*totEBins);
+        while (is2 >> x) driftErrors.push_back(x);
+        if (!is2.eof()){
+          throw cet::exception("TRKTOTCALIB_BAD_INDEX")
+            << "TrkTOTCalib::addRow bad driftError\n";
+        }
+
+        _rows.emplace_back(totTBins, std::stof(columns[1]),
+            totEBins, std::stof(columns[3]), driftTimes, driftErrors);
       }
 
       void rowToCsv(std::ostringstream& sstream, std::size_t irow) const override {
@@ -56,63 +81,16 @@ namespace mu2e {
         sstream << r.totTBins() << ",";
         sstream << r.totTBinWidth() << ",";
         sstream << r.totEBins() << ",";
-        sstream << r.totEBinWidth();
-      }
-
-      virtual void clear() override {
-        baseClear();
-        _rows.clear();
-      }
-
-    private:
-      std::vector<Row> _rows;
-  };
-
-  class TrkTOTCalib : public DbTable {
-    public:
-      typedef std::shared_ptr<TrkTOTCalib> ptr_t;
-      typedef std::shared_ptr<const TrkTOTCalib> cptr_t;
-
-      class Row {
-        public:
-          Row(int index, float driftTime, float driftError)
-            : _index(index), _driftTime(driftTime), _driftError(driftError) {}
-          int   index()      const { return _index; }
-          float driftTime()  const { return _driftTime; }
-          float driftError() const { return _driftError; }
-        private:
-          int   _index;
-          float _driftTime;
-          float _driftError;
-      };
-
-      constexpr static const char* cxname = "TrkTOTCalib";
-
-      TrkTOTCalib() :
-        DbTable(cxname, "trk.totcalib",
-            "index,drifttime,drifterror") {}
-      const Row& rowAt(const std::size_t index) const { return _rows.at(index); }
-      std::vector<Row> const& rows() const { return _rows; }
-      std::size_t nrow() const override { return _rows.size(); };
-      size_t size() const override { return baseSize() + nrow() * sizeof(Row); };
-      const std::string orderBy() const { return std::string("index"); }
-
-      void addRow(const std::vector<std::string>& columns) override {
-        int index = std::stoi(columns[0]);
-        // enforce a strict sequential order
-        if (index != int(_rows.size())) {
-          throw cet::exception("TRKTOTCALIB_BAD_INDEX")
-            << "TrkTOTCalib::addRow found index out of order: " << index
-            << " != " << _rows.size() << "\n";
+        sstream << r.totEBinWidth() << ",";
+        for (size_t k=0;k<r.driftTimes().size();k++){
+          if (k) sstream << " ";
+          sstream << r.driftTimes()[k];
         }
-        _rows.emplace_back(index,std::stof(columns[1]), std::stof(columns[2]));
-      }
-
-      void rowToCsv(std::ostringstream& sstream, std::size_t irow) const override {
-        Row const& r = _rows.at(irow);
-        sstream << std::fixed << std::setprecision(1);
-        sstream << r.driftTime() << ",";
-        sstream << r.driftError();
+        sstream << ",";
+        for (size_t k=0;k<r.driftErrors().size();k++){
+          if (k) sstream << " ";
+          sstream << r.driftErrors()[k];
+        }
       }
 
       virtual void clear() override {
@@ -123,6 +101,5 @@ namespace mu2e {
     private:
       std::vector<Row> _rows;
   };
-
 };  // namespace mu2e
 #endif

--- a/DbTables/inc/TrkTOTCalib.hh
+++ b/DbTables/inc/TrkTOTCalib.hh
@@ -1,0 +1,128 @@
+#ifndef DbTables_TrkTOTCalib_hh
+#define DbTables_TrkTOTCalib_hh
+
+#include "Offline/DbTables/inc/DbTable.hh"
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <string>
+
+namespace mu2e {
+
+  class TrkTOTCalibParams : public DbTable {
+    public:
+      typedef std::shared_ptr<TrkTOTCalibParams> ptr_t;
+      typedef std::shared_ptr<const TrkTOTCalibParams> cptr_t;
+
+      class Row {
+        public:
+          Row(int totTBins, float totTBinWidth, int totEBins, float totEBinWidth)
+            : _totTBins(totTBins), _totTBinWidth(totTBinWidth),
+            _totEBins(totEBins), _totEBinWidth(totEBinWidth) {}
+          int   totTBins()    const { return _totTBins; }
+          float totTBinWidth() const { return _totTBinWidth; }
+          int   totEBins()    const { return _totEBins; }
+          float totEBinWidth() const { return _totEBinWidth; }
+        private:
+          int   _totTBins;
+          float _totTBinWidth;
+          int   _totEBins;
+          float _totEBinWidth;
+      };
+
+      constexpr static const char* cxname = "TrkTOTCalibParams";
+
+      TrkTOTCalibParams() :
+        DbTable(cxname, "trk.totcalibparams",
+            "tottbins,tottbinwidth,totebins,totebinwidth") {}
+      const Row& rowAt(const std::size_t index) const { return _rows.at(index); }
+      std::vector<Row> const& rows() const { return _rows; }
+      std::size_t nrow() const override { return _rows.size(); };
+      virtual std::size_t nrowFix() const override { return 1; }
+      size_t size() const override { return baseSize() + nrow() * sizeof(Row); };
+      const std::string orderBy() const { return std::string("tottbins"); }
+
+      void addRow(const std::vector<std::string>& columns) override {
+        if (_rows.size() != 0)
+          throw cet::exception("TRKTOTCALIBPARAMS_BAD_INDEX")
+            << "TrkTOTCalibParams::addRow adding more than one row\n";
+        _rows.emplace_back(std::stoi(columns[0]), std::stof(columns[1]),
+            std::stoi(columns[2]), std::stof(columns[3]));
+      }
+
+      void rowToCsv(std::ostringstream& sstream, std::size_t irow) const override {
+        Row const& r = _rows.at(irow);
+        sstream << std::fixed << std::setprecision(1);
+        sstream << r.totTBins() << ",";
+        sstream << r.totTBinWidth() << ",";
+        sstream << r.totEBins() << ",";
+        sstream << r.totEBinWidth();
+      }
+
+      virtual void clear() override {
+        baseClear();
+        _rows.clear();
+      }
+
+    private:
+      std::vector<Row> _rows;
+  };
+
+  class TrkTOTCalib : public DbTable {
+    public:
+      typedef std::shared_ptr<TrkTOTCalib> ptr_t;
+      typedef std::shared_ptr<const TrkTOTCalib> cptr_t;
+
+      class Row {
+        public:
+          Row(int index, float driftTime, float driftError)
+            : _index(index), _driftTime(driftTime), _driftError(driftError) {}
+          int   index()      const { return _index; }
+          float driftTime()  const { return _driftTime; }
+          float driftError() const { return _driftError; }
+        private:
+          int   _index;
+          float _driftTime;
+          float _driftError;
+      };
+
+      constexpr static const char* cxname = "TrkTOTCalib";
+
+      TrkTOTCalib() :
+        DbTable(cxname, "trk.totcalib",
+            "index,drifttime,drifterror") {}
+      const Row& rowAt(const std::size_t index) const { return _rows.at(index); }
+      std::vector<Row> const& rows() const { return _rows; }
+      std::size_t nrow() const override { return _rows.size(); };
+      size_t size() const override { return baseSize() + nrow() * sizeof(Row); };
+      const std::string orderBy() const { return std::string("index"); }
+
+      void addRow(const std::vector<std::string>& columns) override {
+        int index = std::stoi(columns[0]);
+        // enforce a strict sequential order
+        if (index != int(_rows.size())) {
+          throw cet::exception("TRKTOTCALIB_BAD_INDEX")
+            << "TrkTOTCalib::addRow found index out of order: " << index
+            << " != " << _rows.size() << "\n";
+        }
+        _rows.emplace_back(index,std::stof(columns[1]), std::stof(columns[2]));
+      }
+
+      void rowToCsv(std::ostringstream& sstream, std::size_t irow) const override {
+        Row const& r = _rows.at(irow);
+        sstream << std::fixed << std::setprecision(1);
+        sstream << r.driftTime() << ",";
+        sstream << r.driftError();
+      }
+
+      virtual void clear() override {
+        baseClear();
+        _rows.clear();
+      }
+
+    private:
+      std::vector<Row> _rows;
+  };
+
+};  // namespace mu2e
+#endif

--- a/DbTables/src/DbTableFactory.cc
+++ b/DbTables/src/DbTableFactory.cc
@@ -33,6 +33,7 @@
 #include "Offline/DbTables/inc/TrkPanelMap.hh"
 #include "Offline/DbTables/inc/TrkPreampStraw.hh"
 #include "Offline/DbTables/inc/TrkTOTCalib.hh"
+#include "Offline/DbTables/inc/TrkHVTripStatus.hh"
 #include "Offline/DbTables/inc/TstCalib1.hh"
 #include "Offline/DbTables/inc/TstCalib2.hh"
 #include "Offline/DbTables/inc/TstCalib3.hh"
@@ -81,6 +82,8 @@ mu2e::DbTable::ptr_t mu2e::DbTableFactory::newTable(std::string const& name) {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkStrawStatusLong());
   } else if (name == "TrkStrawStatusShort") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkStrawStatusShort());
+  } else if (name == "TrkHVTripStatus") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkHVTripStatus());
   } else if (name == "TrkTOTCalib") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkTOTCalib());
   } else if (name == "TrkTOTCalibParams") {

--- a/DbTables/src/DbTableFactory.cc
+++ b/DbTables/src/DbTableFactory.cc
@@ -86,8 +86,6 @@ mu2e::DbTable::ptr_t mu2e::DbTableFactory::newTable(std::string const& name) {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkHVTripStatus());
   } else if (name == "TrkTOTCalib") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkTOTCalib());
-  } else if (name == "TrkTOTCalibParams") {
-    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkTOTCalibParams());
   } else if (name == "AnaTrkQualDb") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::AnaTrkQualDb());
   } else if (name == "SimEfficiencies") {

--- a/DbTables/src/DbTableFactory.cc
+++ b/DbTables/src/DbTableFactory.cc
@@ -32,6 +32,7 @@
 #include "Offline/DbTables/inc/TrkElementStatus.hh"
 #include "Offline/DbTables/inc/TrkPanelMap.hh"
 #include "Offline/DbTables/inc/TrkPreampStraw.hh"
+#include "Offline/DbTables/inc/TrkTOTCalib.hh"
 #include "Offline/DbTables/inc/TstCalib1.hh"
 #include "Offline/DbTables/inc/TstCalib2.hh"
 #include "Offline/DbTables/inc/TstCalib3.hh"
@@ -80,6 +81,10 @@ mu2e::DbTable::ptr_t mu2e::DbTableFactory::newTable(std::string const& name) {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkStrawStatusLong());
   } else if (name == "TrkStrawStatusShort") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkStrawStatusShort());
+  } else if (name == "TrkTOTCalib") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkTOTCalib());
+  } else if (name == "TrkTOTCalibParams") {
+    return std::shared_ptr<mu2e::DbTable>(new mu2e::TrkTOTCalibParams());
   } else if (name == "AnaTrkQualDb") {
     return std::shared_ptr<mu2e::DbTable>(new mu2e::AnaTrkQualDb());
   } else if (name == "SimEfficiencies") {

--- a/Filters/src/StrawGasStepFilter_module.cc
+++ b/Filters/src/StrawGasStepFilter_module.cc
@@ -50,7 +50,7 @@ namespace mu2e{
     auto steps = event.getValidHandle<StrawGasStepCollection>(_stepsTag);
     auto const& stepcol = *steps;
     for (auto const& step : stepcol){
-      if (!trackerStatus->noSignal(step.strawId()))
+      if (!trackerStatus->noSignal(step.strawId(),event.event()))
         count += 1;
     }
     return count >= _minSteps;

--- a/TrackerConditions/fcl/testTrackerAlignment.fcl
+++ b/TrackerConditions/fcl/testTrackerAlignment.fcl
@@ -3,6 +3,7 @@ process_name : TestTrkAlign
 
 source : {
   module_type : EmptyEvent
+  firstRun : 1400
 }
 services : @local::Services.Core
 
@@ -21,8 +22,10 @@ physics : {
 # turn on alignment
 services.ProditionsService.alignedTracker.useDb: true
 services.ProditionsService.alignedTracker.verbose: 2
+services.DbService.purpose : "Sim_best"
+services.DbService.version : "v1_4"
 # select nominal (perfect) alignment or a misaligned file
-services.DbService.textFile : ["Offline/TrackerConditions/data/MisalignTracker.txt"]
+services.DbService.textFile : ["align.txt"]
 # services.DbService.verbose: 2
 
 services.TFileService.fileName: "testAlign.root"

--- a/TrackerConditions/inc/StrawResponse.hh
+++ b/TrackerConditions/inc/StrawResponse.hh
@@ -38,8 +38,8 @@ namespace mu2e {
           double central, std::vector<double> centres,
           std::vector<double> resslope, bool truncateLongitudinal,
           bool rmsLongErrors, int totTBins, double totTBinWidth,
-          int totEBins, double totEBinWidth, std::vector<double> totdtime,
-          std::vector<double> totderror,
+          int totEBins, double totEBinWidth, std::vector<float> totdtime,
+          std::vector<float> totderror,
           std::vector<double> llDriftTimeOffBins, std::vector<double> llDriftTimeOffset,
           std::vector<double> llDriftTimeRMSBins, std::vector<double> llDriftTimeRMS,
           std::vector<double> driftOffBins, std::vector<double> driftOffset,
@@ -108,7 +108,7 @@ namespace mu2e {
         _timeOffsetStrawCal = timeOffsetStrawCal;
       }
       void setTOTCalib(size_t tottbins, double tottbinwidth, size_t totebins, double totebinwidth,
-          std::vector<double> totdtime, std::vector<double> totderror){
+          std::vector<float> totdtime, std::vector<float> totderror){
         _totTBins = tottbins;
         _totTBinWidth = tottbinwidth;
         _totEBins = totebins;
@@ -138,8 +138,9 @@ namespace mu2e {
       double TOTdriftTimeError(Straw const& straw, double tot, double edep) const;
 
       void print(std::ostream& os) const;
+      template<typename T>
       void printVector(std::ostream& os, std::string const& name,
-          std::vector<double> const& a) const;
+          std::vector<T> const& a) const;
 
       template<typename T, size_t SIZE>
         void printArray(std::ostream& os, std::string const& name,
@@ -189,8 +190,8 @@ namespace mu2e {
       double _totTBinWidth;
       size_t _totEBins;
       double _totEBinWidth;
-      std::vector<double> _totdtime;
-      std::vector<double> _totderror;
+      std::vector<float> _totdtime;
+      std::vector<float> _totderror;
       std::vector<double> _llDriftTimeOffBins;
       std::vector<double> _llDriftTimeOffset;
       std::vector<double> _llDriftTimeRMSBins;

--- a/TrackerConditions/inc/StrawResponse.hh
+++ b/TrackerConditions/inc/StrawResponse.hh
@@ -34,7 +34,7 @@ namespace mu2e {
           StrawElectronics::cptr_t strawElectronics,
           StrawPhysics::cptr_t strawPhysics,
           int eBins, double eBinWidth,
-          std::vector<double> edep, std::vector<double> halfvpscale,
+          std::vector<double> edep, std::vector<double> halfpvscale,
           double central, std::vector<double> centres,
           std::vector<double> resslope, bool truncateLongitudinal,
           bool rmsLongErrors, int totTBins, double totTBinWidth,
@@ -59,7 +59,7 @@ namespace mu2e {
         _strawElectronics(strawElectronics),
         _strawPhysics(strawPhysics),
         _eBins(eBins), _eBinWidth(eBinWidth),
-        _edep(edep), _halfvpscale(halfvpscale), _central(central), _centres(centres),
+        _edep(edep), _halfpvscale(halfpvscale), _central(central), _centres(centres),
         _resslope(resslope), _truncateLongitudinal(truncateLongitudinal),
         _rmsLongErrors(rmsLongErrors), _totTBins(totTBins), _totTBinWidth(totTBinWidth),
         _totEBins(totEBins), _totEBinWidth(totEBinWidth),
@@ -101,11 +101,20 @@ namespace mu2e {
 
       // this is used to update values from the database
       void setOffsets( std::array<double, StrawId::_nupanels> timeOffsetPanel,
-          std::array<double, StrawId::_nustraws> timeOffsetStrawHV,
-          std::array<double, StrawId::_nustraws> timeOffsetStrawCal ) {
+          std::array<double, StrawId::_nustraws> const& timeOffsetStrawHV,
+          std::array<double, StrawId::_nustraws> const& timeOffsetStrawCal ) {
         _timeOffsetPanel = timeOffsetPanel;
         _timeOffsetStrawHV = timeOffsetStrawHV;
         _timeOffsetStrawCal = timeOffsetStrawCal;
+      }
+      void setTOTCalib(size_t tottbins, double tottbinwidth, size_t totebins, double totebinwidth,
+          std::vector<double> totdtime, std::vector<double> totderror){
+        _totTBins = tottbins;
+        _totTBinWidth = tottbinwidth;
+        _totEBins = totebins;
+        _totEBinWidth = totebinwidth;
+        _totdtime = std::move(totdtime);
+        _totderror = std::move(totderror);
       }
 
       DriftInfo driftInfo(StrawId strawId, double dtime, double phi) const;
@@ -170,7 +179,7 @@ namespace mu2e {
       int _eBins;
       double _eBinWidth;
       std::vector<double> _edep; // energy deposit boundaries
-      std::vector<double> _halfvpscale; // scaling of effective 1/2 propagation velocity by edep
+      std::vector<double> _halfpvscale; // scaling of effective 1/2 propagation velocity by edep
       double _central; // max wire distance for central wire region
       std::vector<double> _centres; // wire center resolution by edep
       std::vector<double> _resslope; // resolution slope vs position by edep

--- a/TrackerConditions/inc/StrawResponseCache.hh
+++ b/TrackerConditions/inc/StrawResponseCache.hh
@@ -17,6 +17,10 @@ namespace mu2e {
         _strawDrift_p = std::make_unique<ProditionsHandle<StrawDrift> >();
         _strawElectronics_p = std::make_unique<ProditionsHandle<StrawElectronics> >();
         _strawPhysics_p = std::make_unique<ProditionsHandle<StrawPhysics> >();
+        if (_useDb) {
+          _ttc_p = std::make_unique<DbHandle<TrkTOTCalib>>();
+          _ttcp_p = std::make_unique<DbHandle<TrkTOTCalibParams>>();
+        }
       }
       set_t makeSet(art::EventID const& eid) {
         auto sd = _strawDrift_p->get(eid);
@@ -25,6 +29,14 @@ namespace mu2e {
         auto ss = sd.getCids();
         ss.merge(set_t(se.getCids()));
         ss.merge(set_t(sp.getCids()));
+        if (_useDb){
+          // get the tables up to date
+          _ttc_p->get(eid);
+          _ttcp_p->get(eid);
+          // save which data goes into this instance of the service
+          ss.insert(_ttc_p->cid());
+          ss.insert(_ttcp_p->cid());
+        }
         return ss;
       }
       DbIoV makeIov(art::EventID const& eid) {
@@ -34,13 +46,23 @@ namespace mu2e {
         auto iov = _strawDrift_p->iov();
         iov.overlap(_strawElectronics_p->iov());
         iov.overlap(_strawPhysics_p->iov());
+        if(_useDb) {
+          _ttc_p->get(eid);
+          _ttcp_p->get(eid);
+          iov.overlap(_ttc_p->iov());
+          iov.overlap(_ttcp_p->iov());
+        }
         return iov;
       }
       ProditionsEntity::ptr makeEntity(art::EventID const& eid) {
         auto sd = _strawDrift_p->getPtr(eid);
         auto se = _strawElectronics_p->getPtr(eid);
         auto sp = _strawPhysics_p->getPtr(eid);
-        return _maker.fromFcl(sd,se,sp);
+        if (_useDb){
+          return _maker.fromDb(sd,se,sp,_ttc_p->getPtr(eid),_ttcp_p->getPtr(eid));
+        }else{
+          return _maker.fromFcl(sd,se,sp);
+        }
       }
 
     private:
@@ -52,6 +74,8 @@ namespace mu2e {
       std::unique_ptr<ProditionsHandle<StrawDrift> > _strawDrift_p;
       std::unique_ptr<ProditionsHandle<StrawElectronics> > _strawElectronics_p;
       std::unique_ptr<ProditionsHandle<StrawPhysics> > _strawPhysics_p;
+      std::unique_ptr<DbHandle<TrkTOTCalib>> _ttc_p;
+      std::unique_ptr<DbHandle<TrkTOTCalibParams>> _ttcp_p;
   };
 }
 

--- a/TrackerConditions/inc/StrawResponseCache.hh
+++ b/TrackerConditions/inc/StrawResponseCache.hh
@@ -19,7 +19,6 @@ namespace mu2e {
         _strawPhysics_p = std::make_unique<ProditionsHandle<StrawPhysics> >();
         if (_useDb) {
           _ttc_p = std::make_unique<DbHandle<TrkTOTCalib>>();
-          _ttcp_p = std::make_unique<DbHandle<TrkTOTCalibParams>>();
         }
       }
       set_t makeSet(art::EventID const& eid) {
@@ -32,10 +31,8 @@ namespace mu2e {
         if (_useDb){
           // get the tables up to date
           _ttc_p->get(eid);
-          _ttcp_p->get(eid);
           // save which data goes into this instance of the service
           ss.insert(_ttc_p->cid());
-          ss.insert(_ttcp_p->cid());
         }
         return ss;
       }
@@ -48,9 +45,7 @@ namespace mu2e {
         iov.overlap(_strawPhysics_p->iov());
         if(_useDb) {
           _ttc_p->get(eid);
-          _ttcp_p->get(eid);
           iov.overlap(_ttc_p->iov());
-          iov.overlap(_ttcp_p->iov());
         }
         return iov;
       }
@@ -59,7 +54,7 @@ namespace mu2e {
         auto se = _strawElectronics_p->getPtr(eid);
         auto sp = _strawPhysics_p->getPtr(eid);
         if (_useDb){
-          return _maker.fromDb(sd,se,sp,_ttc_p->getPtr(eid),_ttcp_p->getPtr(eid));
+          return _maker.fromDb(sd,se,sp,_ttc_p->getPtr(eid));
         }else{
           return _maker.fromFcl(sd,se,sp);
         }
@@ -75,7 +70,6 @@ namespace mu2e {
       std::unique_ptr<ProditionsHandle<StrawElectronics> > _strawElectronics_p;
       std::unique_ptr<ProditionsHandle<StrawPhysics> > _strawPhysics_p;
       std::unique_ptr<DbHandle<TrkTOTCalib>> _ttc_p;
-      std::unique_ptr<DbHandle<TrkTOTCalibParams>> _ttcp_p;
   };
 }
 

--- a/TrackerConditions/inc/StrawResponseMaker.hh
+++ b/TrackerConditions/inc/StrawResponseMaker.hh
@@ -21,7 +21,7 @@ namespace mu2e {
       StrawResponse::ptr_t fromDb(StrawDrift::cptr_t strawDrift,
           StrawElectronics::cptr_t strawElectronics,
           StrawPhysics::cptr_t strawPhysics,
-          TrkTOTCalib::cptr_t ttc, TrkTOTCalibParams::cptr_t ttcp);
+          TrkTOTCalib::cptr_t ttc);
 
     private:
 

--- a/TrackerConditions/inc/StrawResponseMaker.hh
+++ b/TrackerConditions/inc/StrawResponseMaker.hh
@@ -8,7 +8,7 @@
 
 #include "Offline/TrackerConditions/inc/StrawResponse.hh"
 #include "Offline/TrackerConfig/inc/StrawResponseConfig.hh"
-
+#include "Offline/DbTables/inc/TrkTOTCalib.hh"
 
 namespace mu2e {
 
@@ -18,7 +18,10 @@ namespace mu2e {
       StrawResponse::ptr_t fromFcl(StrawDrift::cptr_t strawDrift,
           StrawElectronics::cptr_t strawElectronics,
           StrawPhysics::cptr_t strawPhysics);
-      StrawResponse::ptr_t fromDb( /* db tables will go here*/ );
+      StrawResponse::ptr_t fromDb(StrawDrift::cptr_t strawDrift,
+          StrawElectronics::cptr_t strawElectronics,
+          StrawPhysics::cptr_t strawPhysics,
+          TrkTOTCalib::cptr_t ttc, TrkTOTCalibParams::cptr_t ttcp);
 
     private:
 

--- a/TrackerConditions/inc/TrackerStatus.hh
+++ b/TrackerConditions/inc/TrackerStatus.hh
@@ -32,23 +32,28 @@ namespace mu2e {
 
       // add status for an element.  This is cumulative
       void addStatus(StrawId const& sid, StrawIdMask const& mask, StrawStatus const& status);
+      void addTrip(StrawId const&sid, uint32_t startevent, uint32_t endevent);
 
       void print( std::ostream& ) const override;
       // convenience operators for some common situations
-      bool noSignal(StrawId const& sid) const;    // return 'true' if we expect no signal from this straw
+      bool hvTripped(StrawId const& sid, uint32_t event) const;
+      bool noSignal(StrawId const& sid, uint32_t event) const;    // return 'true' if we expect no signal from this straw
       bool noisy(StrawId const& sid) const;  // This straw sometimes produces a valid signal, but not always
       bool suppress(StrawId const& sid) const;  // This straw may produce a signal, but it should be suppressed as it is inaccurate
       bool noMaterial(StrawId const& sid) const;  // straw doesn't contribute to scattering or energy loss
 
       // Net status of an individual Straw.  If the straw is in a plane or panel with status, that will be aggregated
       StrawStatus strawStatus(StrawId const& sid) const;
+      StrawStatus strawStatus(StrawId const& sid, uint32_t event) const; // including HV trips
       // same for panel, plane.  Note; these will return only status that applies to the ENTIRE PANEL (or plane)
       // It will NOT detect (say) a panel where every straw has had the same status individually set (that's not a good configuration)
       StrawStatus panelStatus(StrawId const& sid) const;
+      StrawStatus panelStatus(StrawId const& sid, uint32_t event) const; // including HV trips
       StrawStatus planeStatus(StrawId const& sid) const;
     private:
       std::array<StrawStatus,StrawId::_nustraws> _fullstatus;
       estat_t _status;
+      std::map<uint16_t,std::vector<std::pair<uint32_t, uint32_t>>> _trips;
   };
 
 } // namespace mu2e

--- a/TrackerConditions/inc/TrackerStatusCache.hh
+++ b/TrackerConditions/inc/TrackerStatusCache.hh
@@ -4,6 +4,7 @@
 #include "Offline/Mu2eInterfaces/inc/ProditionsCache.hh"
 #include "Offline/DbService/inc/DbHandle.hh"
 #include "Offline/DbTables/inc/TrkElementStatus.hh"
+#include "Offline/DbTables/inc/TrkHVTripStatus.hh"
 #include "Offline/TrackerConditions/inc/TrackerStatusMaker.hh"
 
 
@@ -21,6 +22,7 @@ namespace mu2e {
           _tpas_p = std::make_unique<DbHandle<TrkPanelStatus>>();
           _tssl_p = std::make_unique<DbHandle<TrkStrawStatusLong>>();
           _tsss_p = std::make_unique<DbHandle<TrkStrawStatusShort>>();
+          _thvs_p = std::make_unique<DbHandle<TrkHVTripStatus>>();
         }
       }
 
@@ -32,10 +34,12 @@ namespace mu2e {
           _tpas_p->get(eid);
           _tssl_p->get(eid);
           _tsss_p->get(eid);
+          _thvs_p->get(eid);
           cids.insert(_tpls_p->cid());
           cids.insert(_tpas_p->cid());
           cids.insert(_tssl_p->cid());
           cids.insert(_tsss_p->cid());
+          cids.insert(_thvs_p->cid());
         }
         return cids;
       }
@@ -48,6 +52,7 @@ namespace mu2e {
           iov.overlap(_tpas_p->iov());
           iov.overlap(_tssl_p->iov());
           iov.overlap(_tsss_p->iov());
+          iov.overlap(_thvs_p->iov());
         }
         return iov;
       }
@@ -57,7 +62,8 @@ namespace mu2e {
           return _maker.fromDb( _tpls_p->getPtr(eid),
               _tpas_p->getPtr(eid),
               _tssl_p->getPtr(eid),
-              _tsss_p->getPtr(eid) );
+              _tsss_p->getPtr(eid),
+              _thvs_p->getPtr(eid));
         } else {
           return _maker.fromFcl();
         }
@@ -72,6 +78,7 @@ namespace mu2e {
       std::unique_ptr<DbHandle<TrkPanelStatus>>       _tpas_p;
       std::unique_ptr<DbHandle<TrkStrawStatusLong>>   _tssl_p;
       std::unique_ptr<DbHandle<TrkStrawStatusShort>>  _tsss_p;
+      std::unique_ptr<DbHandle<TrkHVTripStatus>>      _thvs_p;
   };
 }
 

--- a/TrackerConditions/inc/TrackerStatusMaker.hh
+++ b/TrackerConditions/inc/TrackerStatusMaker.hh
@@ -9,6 +9,7 @@
 #include "Offline/TrackerConditions/inc/TrackerStatus.hh"
 #include "Offline/TrackerConfig/inc/TrackerStatusConfig.hh"
 #include "Offline/DbTables/inc/TrkElementStatus.hh"
+#include "Offline/DbTables/inc/TrkHVTripStatus.hh"
 
 // C++ includes
 #include <set>
@@ -25,7 +26,8 @@ namespace mu2e {
           TrkPlaneStatus::cptr_t tpls_p,
           TrkPanelStatus::cptr_t   tpas_p,
           TrkStrawStatusLong::cptr_t   tssl_p,
-          TrkStrawStatusShort::cptr_t   tsss_p ); // construct from plane, panel, long-term straw and short-term straw status tables
+          TrkStrawStatusShort::cptr_t   tsss_p,
+          TrkHVTripStatus::cptr_t thvs_p ); // construct from plane, panel, long-term straw and short-term straw status tables
     private:
       // this object needs to be thread safe, config_ should only be initialized once
       const TrackerStatusConfig config_;

--- a/TrackerConditions/src/StrawResponse.cc
+++ b/TrackerConditions/src/StrawResponse.cc
@@ -145,7 +145,7 @@ namespace mu2e {
 
   double StrawResponse::halfPropV(StrawId strawId, double kedep) const {
     double mean_prop_v = _strawHalfvp[strawId.uniqueStraw()];
-    return PieceLine(_edep,_halfvpscale,kedep)*mean_prop_v;
+    return PieceLine(_edep,_halfpvscale,kedep)*mean_prop_v;
   }
 
   double StrawResponse::wpRes(double kedep,double wlen) const {
@@ -205,9 +205,9 @@ namespace mu2e {
     os << endl << "StrawResponse parameters: "  << std::endl;
 
     printVector(os,"edep",_edep);
-    printVector(os,"ehalfvpscale",_halfvpscale);
+    printVector(os,"ehalfpvscale",_halfpvscale);
     os << "central = " << _central << endl;
-    printArray(os,"halfvp",_strawHalfvp);
+    printArray(os,"halfpv",_strawHalfvp);
     printVector(os,"centres",_centres);
     printVector(os,"resslope",_resslope);
     printVector(os,"totdtime",_totdtime);

--- a/TrackerConditions/src/StrawResponse.cc
+++ b/TrackerConditions/src/StrawResponse.cc
@@ -238,8 +238,9 @@ namespace mu2e {
 
   }
 
+  template<typename T>
   void StrawResponse::printVector(std::ostream& os, std::string const& name,
-      std::vector<double> const& a) const {
+      std::vector<T> const& a) const {
     size_t n = a.size();
     if(n<=4) {
       os << name << " ("<<n<<") = ";

--- a/TrackerConditions/src/StrawResponseMaker.cc
+++ b/TrackerConditions/src/StrawResponseMaker.cc
@@ -144,4 +144,28 @@ namespace mu2e {
     return ptr;
   }
 
+  StrawResponse::ptr_t StrawResponseMaker::fromDb(
+      StrawDrift::cptr_t strawDrift,
+      StrawElectronics::cptr_t strawElectronics,
+      StrawPhysics::cptr_t strawPhysics,
+      TrkTOTCalib::cptr_t ttc,
+      TrkTOTCalibParams::cptr_t ttcp) {
+    // initially fill from fcl to get all the constants
+    auto ptr = fromFcl(strawDrift, strawElectronics, strawPhysics);
+
+    size_t tottbins = (size_t) ttcp->rowAt(0).totTBins();
+    size_t totebins = (size_t) ttcp->rowAt(0).totEBins();
+    double tottbinwidth = ttcp->rowAt(0).totTBinWidth();
+    double totebinwidth = ttcp->rowAt(0).totEBinWidth();
+    std::vector<double> totdtime;
+    std::vector<double> totderror;
+    for (size_t i=0;i<tottbins*totebins;i++){
+      totdtime.push_back(ttc->rowAt(i).driftTime());
+      totderror.push_back(ttc->rowAt(i).driftError());
+    }
+
+    ptr->setTOTCalib(tottbins, tottbinwidth, totebins, totebinwidth, totdtime, totderror);
+
+    return ptr;
+  }
 }

--- a/TrackerConditions/src/StrawResponseMaker.cc
+++ b/TrackerConditions/src/StrawResponseMaker.cc
@@ -148,21 +148,16 @@ namespace mu2e {
       StrawDrift::cptr_t strawDrift,
       StrawElectronics::cptr_t strawElectronics,
       StrawPhysics::cptr_t strawPhysics,
-      TrkTOTCalib::cptr_t ttc,
-      TrkTOTCalibParams::cptr_t ttcp) {
+      TrkTOTCalib::cptr_t ttc) {
     // initially fill from fcl to get all the constants
     auto ptr = fromFcl(strawDrift, strawElectronics, strawPhysics);
 
-    size_t tottbins = (size_t) ttcp->rowAt(0).totTBins();
-    size_t totebins = (size_t) ttcp->rowAt(0).totEBins();
-    double tottbinwidth = ttcp->rowAt(0).totTBinWidth();
-    double totebinwidth = ttcp->rowAt(0).totEBinWidth();
-    std::vector<double> totdtime;
-    std::vector<double> totderror;
-    for (size_t i=0;i<tottbins*totebins;i++){
-      totdtime.push_back(ttc->rowAt(i).driftTime());
-      totderror.push_back(ttc->rowAt(i).driftError());
-    }
+    size_t tottbins = (size_t) ttc->rowAt(0).totTBins();
+    size_t totebins = (size_t) ttc->rowAt(0).totEBins();
+    double tottbinwidth = ttc->rowAt(0).totTBinWidth();
+    double totebinwidth = ttc->rowAt(0).totEBinWidth();
+    auto const& totdtime = ttc->rowAt(0).driftTimes();
+    auto const& totderror = ttc->rowAt(0).driftErrors();
 
     ptr->setTOTCalib(tottbins, tottbinwidth, totebins, totebinwidth, totdtime, totderror);
 

--- a/TrackerConditions/src/TrackerStatus.cc
+++ b/TrackerConditions/src/TrackerStatus.cc
@@ -68,6 +68,11 @@ namespace mu2e {
     }
   }
 
+  void TrackerStatus::addTrip(StrawId const& sid, uint32_t startevent, uint32_t endevent) {
+    _trips[sid.uniquePanel()].emplace_back(startevent, endevent);
+  }
+
+
   void TrackerStatus::print( ostream& out) const{
     for( auto ielem = _status.begin(); ielem != _status.end(); ++ielem) {
       auto const& mask = ielem->first;
@@ -84,6 +89,13 @@ namespace mu2e {
     return _fullstatus[sid.uniqueStraw()];
   }
 
+  StrawStatus TrackerStatus::strawStatus(StrawId const& sid, uint32_t event) const {
+    StrawStatus sstat = strawStatus(sid);
+    if (hvTripped(sid,event))
+      sstat.merge(StrawStatus::noHV);
+    return sstat;
+  }
+
   StrawStatus TrackerStatus::panelStatus(StrawId const& sid) const {
     StrawStatus sstat;
     for( auto ielem = _status.begin(); ielem != _status.end(); ++ielem) {
@@ -97,6 +109,13 @@ namespace mu2e {
         }
       }
     }
+    return sstat;
+  }
+
+  StrawStatus TrackerStatus::panelStatus(StrawId const& sid, uint32_t event) const {
+    StrawStatus sstat = panelStatus(sid);
+    if (hvTripped(sid,event))
+      sstat.merge(StrawStatus::noHV);
     return sstat;
   }
 
@@ -116,8 +135,22 @@ namespace mu2e {
     return sstat;
   }
 
+  bool TrackerStatus::hvTripped(StrawId const& sid, uint32_t event) const {
+    auto ifnd = _trips.find(sid.uniquePanel());
+    if(ifnd != _trips.end()){
+      for ( auto ielem = ifnd->second.begin(); ielem != ifnd->second.end(); ++ielem) {
+        if (ielem->second < event)
+          continue;
+        else if (ielem->first <= event){
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   // no signal expected from this straw
-  bool TrackerStatus::noSignal(StrawId const& sid) const {
+  bool TrackerStatus::noSignal(StrawId const& sid, uint32_t event) const {
     static StrawStatus mask = StrawStatus(StrawStatus::absent) |
       StrawStatus(StrawStatus::nowire) |
       StrawStatus(StrawStatus::noHV) |
@@ -127,7 +160,7 @@ namespace mu2e {
       StrawStatus(StrawStatus::noHVPreamp) |
       StrawStatus(StrawStatus::noCalPreamp) |
       StrawStatus(StrawStatus::disabled);
-    StrawStatus status = strawStatus(sid);
+    StrawStatus status = strawStatus(sid, event);
     return status.hasAnyProperty(mask);
   }
 

--- a/TrackerConditions/src/TrackerStatusMaker.cc
+++ b/TrackerConditions/src/TrackerStatusMaker.cc
@@ -38,7 +38,8 @@ namespace mu2e {
       TrkPlaneStatus::cptr_t tpls_p,
       TrkPanelStatus::cptr_t   tpas_p,
       TrkStrawStatusLong::cptr_t   tssl_p,
-      TrkStrawStatusShort::cptr_t   tsss_p ) {
+      TrkStrawStatusShort::cptr_t   tsss_p,
+      TrkHVTripStatus::cptr_t thvs_p) {
     // create return object
     auto trkstatptr = std::make_shared<TrackerStatus>();
     auto const& settings = config_.settings();
@@ -48,12 +49,14 @@ namespace mu2e {
       cout << "Panel table has " << tpas_p->rows().size() << " rows " << endl;
       cout << "Long-term Straw table has " << tssl_p->rows().size() << " rows " << endl;
       cout << "Short-term Straw table has " << tsss_p->rows().size() << " rows " << endl;
+      cout << "HV trip table has " << thvs_p->rows().size() << " rows " << endl;
     }
 
     for (auto const& row : tpls_p->rows()) trkstatptr->addStatus(row.id(),tpls_p->sidMask(),row.status());
     for (auto const& row : tpas_p->rows()) trkstatptr->addStatus(row.id(),tpas_p->sidMask(),row.status());
     for (auto const& row : tssl_p->rows()) trkstatptr->addStatus(row.id(),tssl_p->sidMask(),row.status());
     for (auto const& row : tsss_p->rows()) trkstatptr->addStatus(row.id(),tsss_p->sidMask(),row.status());
+    for (auto const& row : thvs_p->rows()) trkstatptr->addTrip(row.id(), row.startevent(), row.endevent());
 
     if ( settings.verbose() > 1 ) trkstatptr->print(cout);
     return trkstatptr;

--- a/TrackerConfig/inc/StrawResponseConfig.hh
+++ b/TrackerConfig/inc/StrawResponseConfig.hh
@@ -45,9 +45,9 @@ namespace mu2e {
       Name("totEBins"), Comment("TOT drift time e bins")};
     fhicl::Atom<double> totEBinWidth {
       Name("totEBinWidth"), Comment("TOT drift time e bin width")};
-    fhicl::Sequence<double>  totDriftTime {
+    fhicl::Sequence<float>  totDriftTime {
       Name("totDriftTime"), Comment(" totDriftTime ")};
-    fhicl::Sequence<double>  totDriftError {
+    fhicl::Sequence<float>  totDriftError {
       Name("totDriftError"), Comment(" totDriftError ")};
     fhicl::Sequence<double> llDriftTimeOffBins {
       Name("llDriftTimeOffBins"), Comment("Drift time Offset Bin edges for likelihood fit (mm)")};

--- a/TrackerMC/src/StationStepSelector_module.cc
+++ b/TrackerMC/src/StationStepSelector_module.cc
@@ -56,7 +56,7 @@ namespace mu2e{
     auto steps = event.getValidHandle<StrawGasStepCollection>(_stepsTag);
     auto const& stepcol = *steps;
     for (auto const& step: stepcol){
-      if (!trackerStatus->noSignal(step.strawId()))
+      if (!trackerStatus->noSignal(step.strawId(),event.event()))
         counts[step.strawId().station()]++;
     }
     std::vector<size_t> goodstations;

--- a/TrackerMC/src/StrawDigisFromStrawGasSteps_module.cc
+++ b/TrackerMC/src/StrawDigisFromStrawGasSteps_module.cc
@@ -625,7 +625,7 @@ namespace mu2e {
           auto const& sgs = steps[isgs];
           // lookup straw here, to avoid having to find the tracker for every step
           StrawId const & sid = sgs.strawId();
-          if ( ((!_usestatus) || (!trackerStatus->noSignal(sid))) && sgs.ionizingEdep() > _minstepE){
+          if ( ((!_usestatus) || (!trackerStatus->noSignal(sid,event.event()))) && sgs.ionizingEdep() > _minstepE){
             Straw const& straw = _tracker->getStraw(sid);
             auto sgsptr = SGSPtr(sgsch,isgs);
             // create a clust from this step, and add it to the clust map

--- a/TrkHitReco/inc/StrawHitRecoUtils.hh
+++ b/TrkHitReco/inc/StrawHitRecoUtils.hh
@@ -29,7 +29,7 @@ namespace mu2e {
       void flagCrossTalk(std::unique_ptr<StrawHitCollection> const& shCol,
           std::unique_ptr<ComboHitCollection> const& chCol) const;
 
-      bool createComboHit(EventWindowMarker const& ewm, size_t isd, std::unique_ptr<ComboHitCollection> const& chCol,
+      bool createComboHit(uint32_t event, EventWindowMarker const& ewm, size_t isd, std::unique_ptr<ComboHitCollection> const& chCol,
           std::unique_ptr<StrawHitCollection> const& shCol,
           const CaloClusterCollection *caloClusters,
           double pbtOffset,

--- a/TrkHitReco/src/StrawHitRecoUtils.cc
+++ b/TrkHitReco/src/StrawHitRecoUtils.cc
@@ -77,7 +77,7 @@ namespace mu2e {
     return (peak-pedestal);
   }
 
-  bool StrawHitRecoUtils::createComboHit(EventWindowMarker const& ewm, size_t isd, std::unique_ptr<ComboHitCollection> const& chCol,
+  bool StrawHitRecoUtils::createComboHit(uint32_t event, EventWindowMarker const& ewm, size_t isd, std::unique_ptr<ComboHitCollection> const& chCol,
       std::unique_ptr<StrawHitCollection> const& shCol, const CaloClusterCollection* caloClusters,
       double pbtOffset,
       StrawId const& sid, TrkTypes::TDCValues const& tdc, TrkTypes::TOTValues const& tot,
@@ -93,7 +93,7 @@ namespace mu2e {
 
     // flag digis that shouldn't be here or we don't want; true for both On and OffSpill
     StrawHitFlag flag;
-    if (trackerStatus.noSignal(sid) || trackerStatus.suppress(sid)) {
+    if (trackerStatus.noSignal(sid,event) || trackerStatus.suppress(sid)) {
       if(_filter)
         return false;
       else

--- a/TrkHitReco/src/StrawHitReco_module.cc
+++ b/TrkHitReco/src/StrawHitReco_module.cc
@@ -210,7 +210,7 @@ namespace mu2e {
         pmp = _shrUtils.peakMinusPedWF(adcwf,srep,maxiter);
         if(_diagLevel > 0)_maxiter->Fill( std::distance(adcwf.begin(),maxiter));
       }
-      _shrUtils.createComboHit(ewm, isd, chCol, shCol, caloClusters, pbtOffset,
+      _shrUtils.createComboHit(event.event(), ewm, isd, chCol, shCol, caloClusters, pbtOffset,
           digi.strawId(), digi.TDC(), digi.TOT(), pmp,
           trackerStatus,  srep, tt);
       //flag straw and electronic cross-talk


### PR DESCRIPTION
Adds three new database tables. Two tables implementing the TOT=>drift time calibration, and one table to hold a list of HV trips. Since trips are expected to be within a run/subrun, they are stored as a list of panels + start and end event id