### PR TITLE
p101 for kinkal 3.6.0

### DIFF
--- a/.muse
+++ b/.muse
@@ -1,5 +1,5 @@
 # prefer to build with this environment
-ENVSET p096
+ENVSET p101
 # add Offline/bin to path
 PATH bin
 # recent commits can take enforce these flags


### PR DESCRIPTION
Update envset pointer to update kinkal dependence to version 3.6.0
We expect this build to fail CI unless built with #1842, kinkal updates
