### PR TITLE
Overlap fixes

### DIFF
--- a/Mu2eG4/geom/geom_run1_b_v40.txt
+++ b/Mu2eG4/geom/geom_run1_b_v40.txt
@@ -8,6 +8,8 @@ string degrader.filter.materialName = "StoppingTarget_Al"; // stopping target ma
 double degrader.filter.halfLength   = 8.75; // 1.75 cm plate
 double degrader.filter.rIn          = 0.0;
 double degrader.filter.rOut         = 150.0; // 150 mm radius disk
+double degrader.supportArm.offsetz  = 245.0;
+double degrader.supportArm.dz       = 186.0;
 
 // Use the TSdA as an aluminum collimator, helping Run 1B
 bool hasTSdA             = true;

--- a/Mu2eG4/src/constructProtonAbsorber.cc
+++ b/Mu2eG4/src/constructProtonAbsorber.cc
@@ -1373,10 +1373,9 @@ namespace mu2e {
                                                       *CLHEP::degree);
         double yLocMoBox = pivotPos.at(1) + dptoc*sin(pabs->degraderRotation()
                                                       *CLHEP::degree);
-        CLHEP::Hep3Vector locationInMu2e (xLocMoBox, yLocMoBox,
-                                          pabs->degraderZ0()
-                                          + 2.0*filterDims.at(2)
-                                          + frameDims.at(2) );
+        const float dgr_z0 = pabs->degraderZ0(); // front face of the degrader
+        const double mother_half_width = filterDims.at(2) + frameDims.at(2) + 0.1; // contain both the frame and the filter
+        CLHEP::Hep3Vector locationInMu2e (xLocMoBox, yLocMoBox, dgr_z0 + mother_half_width);
 
         // Make mother volume for degrader
         std::string motherName("Degrader");
@@ -1387,8 +1386,7 @@ namespace mu2e {
         G4Box* motherBox = new G4Box ( "degraderOutline",
                                        lengthPDMoBox/2.0,
                                        frameDims.at(1),
-                                       2.0*filterDims.at(2) + frameDims.at(2)
-                                       + 1 );
+                                       mother_half_width);
         degraderMother.solid = motherBox;
 
         // Now put degraderMother in DS2Vacuum
@@ -1401,15 +1399,28 @@ namespace mu2e {
                         placePV,
                         doSurfaceCheck );
 
-        // Start cobbling pieces together by putting frame in mother
-        CLHEP::Hep3Vector trans1( frameDims.at(1) - lengthPDMoBox/2.0,
-                                  0,0);
+        // First put the filter in the mother
+        CLHEP::Hep3Vector trans_filter(frameDims.at(1) - lengthPDMoBox/2.0,0,
+                                       filterDims.at(2) - mother_half_width); // upstream edge of the mother box
+        nestTubs("degraderFilter",
+                 TubsParams(filterDims.at(0),filterDims.at(1),filterDims.at(2)),
+                 findMaterialOrThrow(pabs->degraderFilterMaterial()),
+                 0, trans_filter, degraderMother,
+                 0, pabsIsVisible, G4Color::Red(),
+                 pabsIsSolid,
+                 forceAuxEdgeVisible,
+                 placePV,
+                 doSurfaceCheck );
+
+        // Place the frame just downstream of the filter
+        CLHEP::Hep3Vector trans_frame(trans_filter.x(), trans_filter.y(),
+                                      trans_filter.z() + frameDims.at(2) + filterDims.at(2));
         nestTubs("degraderFrame",
                  TubsParams(frameDims.at(0),frameDims.at(1),frameDims.at(2),
                             -frameDims.at(4)/2 * CLHEP::degree,
                             frameDims.at(4)*CLHEP::degree ),
                  findMaterialOrThrow(pabs->degraderFrameMaterial()),
-                 0, trans1, degraderMother,
+                 0, trans_frame, degraderMother,
                  0, pabsIsVisible, G4Color::Red(),
                  pabsIsSolid,
                  forceAuxEdgeVisible,
@@ -1417,31 +1428,19 @@ namespace mu2e {
                  doSurfaceCheck );
 
 
-        // Now put filter in mother
-        CLHEP::Hep3Vector trans1b(frameDims.at(1) - lengthPDMoBox/2.0,0,
-                                  -(frameDims.at(2) + filterDims.at(2)));
-        nestTubs("degraderFilter",
-                 TubsParams(filterDims.at(0),filterDims.at(1),filterDims.at(2)),
-                 findMaterialOrThrow(pabs->degraderFilterMaterial()),
-                 0, trans1b, degraderMother,
-                 0, pabsIsVisible, G4Color::Red(),
-                 pabsIsSolid,
-                 forceAuxEdgeVisible,
-                 placePV,
-                 doSurfaceCheck );
 
         // Create rod rep
         double lenRod = frameDims.at(3) + counterDims.at(3) - frameDims.at(1)
           - 0.1;
         std::vector<double> lwhs = {lenRod/2.0,rodDims.at(0)/2.0,rodDims.at(1)/2.0};
         // Now put rod in mother volume
-        CLHEP::Hep3Vector trans3(frameDims.at(1),
-                                 0.0, 0.0);
+        CLHEP::Hep3Vector trans_rod(frameDims.at(1),
+                                    0.0, trans_frame.z()); // same z location as the frame
 
         nestBox ("degraderRod",
                  lwhs,
                  findMaterialOrThrow(pabs->degraderRodMaterial()),
-                 0, trans3, degraderMother,
+                 0, trans_rod, degraderMother,
                  0, pabsIsVisible, G4Color::Red(),
                  pabsIsSolid,
                  forceAuxEdgeVisible,
@@ -1458,10 +1457,7 @@ namespace mu2e {
           (counterDims.at(3) + counterDims.at(2))*sin(pabs->degraderRotation()
                                                       *CLHEP::degree);
 
-        CLHEP::Hep3Vector location2InMu2e (xLocMoBox2, yLocMoBox2,
-                                           pabs->degraderZ0()
-                                           + 2.0*filterDims.at(2)
-                                           + frameDims.at(2) );
+        CLHEP::Hep3Vector location2InMu2e (xLocMoBox2, yLocMoBox2, dgr_z0 + mother_half_width );
 
 
         // Now put counterweight in DS2Vacuum

--- a/Mu2eG4/src/constructProtonAbsorber.cc
+++ b/Mu2eG4/src/constructProtonAbsorber.cc
@@ -1373,7 +1373,7 @@ namespace mu2e {
                                                       *CLHEP::degree);
         double yLocMoBox = pivotPos.at(1) + dptoc*sin(pabs->degraderRotation()
                                                       *CLHEP::degree);
-        const float dgr_z0 = pabs->degraderZ0(); // front face of the degrader
+        const double dgr_z0 = pabs->degraderZ0(); // front face of the degrader
         const double mother_half_width = filterDims.at(2) + frameDims.at(2) + 0.1; // contain both the frame and the filter
         CLHEP::Hep3Vector locationInMu2e (xLocMoBox, yLocMoBox, dgr_z0 + mother_half_width);
 

--- a/Mu2eG4/src/constructStoppingTarget.cc
+++ b/Mu2eG4/src/constructStoppingTarget.cc
@@ -75,15 +75,24 @@ namespace mu2e {
     Mu2eG4Helper    & _helper = *(art::ServiceHandle<Mu2eG4Helper>());
     AntiLeakRegistry & reg = _helper.antiLeakRegistry();
 
+    // Determine the largest radius object to ensure the mother volume encloses it
+    double maxMotherRadius = target->cylinderRadius();
+    double maxFoilRadius(0.);
+    for (int itf=0; itf<target->nFoils(); ++itf)
+      maxFoilRadius = std::max(maxFoilRadius, target->foil(itf).rOut());
+    for (int itf=0; itf<target->nSupportStructures(); ++itf)
+      maxMotherRadius = std::max(maxMotherRadius, target->supportStructure(itf).length() + maxFoilRadius + 0.1);
+
     //get the proton absorber elements to prevent overlaps
     bool overlapPabs = false;
     double rAtZClosest, opaZCenter, opaR1, opaR2, opaHL, stZCenter, zclosest;
     if ( config.getBool("hasProtonAbsorber", true) ) {
       GeomHandle<MECOStyleProtonAbsorber> pabs;
-      double cylinderRadius = target->cylinderRadius();
+      const double cylinderRadius = maxMotherRadius; // default cylindrical mother volume radius
       if(pabs->isAvailable(2)) { //there is the OPA in DS2
         opaR1 = pabs->part(2).innerRadiusAtStart();
         opaR2 = pabs->part(2).innerRadiusAtEnd();
+        if ( verbosity > 1) std::cout << "  OPA R1 = " << opaR1 << " OPA R2 = " << opaR2 << " target mother R = " << cylinderRadius << std::endl;
         if(!(cylinderRadius < opaR1 && cylinderRadius < opaR2)) { //could overlap
           if(cylinderRadius > opaR1 && cylinderRadius > opaR2) {
             throw cet::exception("GEOM") << "constructStoppingTarget::" << __func__
@@ -93,18 +102,25 @@ namespace mu2e {
           opaZCenter = CLHEP::mm * pabs->part(2).center().z();
           opaHL = pabs->part(2).halfLength();
           stZCenter = target->centerInMu2e().z();
+          if ( verbosity > 1) std::cout << "  OPA Z = " << opaZCenter << " target center Z = " << stZCenter << std::endl;
           int side = (opaR1 <= opaR2) ? 1 : -1; //check which way the cone opens
           zclosest = stZCenter - side*target->cylinderLength()/2.;
           //make sure closest point is within OPA region
           if(zclosest > opaZCenter + opaHL) zclosest = opaZCenter+opaHL;
           else if(zclosest < opaZCenter - opaHL) zclosest = opaZCenter-opaHL;
           rAtZClosest = opaR1 + (opaR2-opaR1)*(zclosest - (opaZCenter-opaHL))/(2.*opaHL); //linear radius change in z
-          if(rAtZClosest < cylinderRadius + 0.001) overlapPabs = true; //require a small buffer
+          if(rAtZClosest < cylinderRadius + 0.001) {
+            overlapPabs = true; //require a small buffer
+            if ( verbosity > 1) std::cout << "  Identified an overlap with the OPA! Adjusting to compensate...\n";
+          }
         } //end possible radius overlap check
       } //end OPA is available check
+      else {
+        if ( verbosity > 1) std::cout << "  OPA (2) not available!\n";
+      }
     }
 
-    TubsParams targetMotherParams(0., target->cylinderRadius(), target->cylinderLength()/2.);
+    TubsParams targetMotherParams(0., maxMotherRadius, target->cylinderLength()/2.);
 
     VolumeInfo targetInfo;
     std::string targetMotherName = "StoppingTargetMother";

--- a/Mu2eG4/src/constructVirtualDetectors.cc
+++ b/Mu2eG4/src/constructVirtualDetectors.cc
@@ -499,7 +499,7 @@ namespace mu2e {
           TubsParams vdParamsTrackerInner(0.,irvd-2.*vdHalfLength,vdHalfLength);
           std::string theDS3("DS3Vacuum");
           if ( _config.getBool("inGaragePosition",false) ) theDS3 = "garageFakeDS3Vacuum";
-          VolumeInfo const & parent = ( _config.getBool("isDumbbell",false) ) ?
+          VolumeInfo const & parent = ( !_config.getBool("tracker.inDS2Vacuum",false) ) ?
             _helper->locateVolInfo(theDS3) :
             _helper->locateVolInfo("DS2Vacuum"); //DS3Vacuum to move the targets
 
@@ -789,7 +789,7 @@ namespace mu2e {
 
           std::string theDS3("DS3Vacuum");
           if ( _config.getBool("inGaragePosition",false) ) theDS3 = "garageFakeDS3Vacuum";
-          VolumeInfo const & parent = ( _config.getBool("isDumbbell",false) ) ?
+          VolumeInfo const & parent = ( !_config.getBool("tracker.inDS2Vacuum",false) ) ?
             _helper->locateVolInfo(theDS3) :
             _helper->locateVolInfo("DS2Vacuum"); //DS3Vacuum to move the targets
 
@@ -837,7 +837,7 @@ namespace mu2e {
 
         std::string theDS3("DS3Vacuum");
         if ( _config.getBool("inGaragePosition",false) ) theDS3 = "garageFakeDS3Vacuum";
-        VolumeInfo const & parent = ( _config.getBool("isDumbbell",false) ) ?
+        VolumeInfo const & parent = ( !_config.getBool("tracker.inDS2Vacuum",false) ) ?
           _helper->locateVolInfo(theDS3) :
           _helper->locateVolInfo("DS2Vacuum"); //DS3Vacuum to move the targets
 
@@ -886,7 +886,7 @@ namespace mu2e {
 
         std::string theDS3("DS3Vacuum");
         if ( _config.getBool("inGaragePosition",false) ) theDS3 = "garageFakeDS3Vacuum";
-        VolumeInfo const & parent = ( _config.getBool("isDumbbell",false) ) ?
+        VolumeInfo const & parent = ( !_config.getBool("tracker.inDS2Vacuum",false) ) ?
           _helper->locateVolInfo(theDS3) :
           _helper->locateVolInfo("DS2Vacuum"); //DS3Vacuum to move the targets
 
@@ -937,7 +937,7 @@ namespace mu2e {
 
         std::string theDS3("DS3Vacuum");
         if ( _config.getBool("inGaragePosition",false) ) theDS3 = "garageFakeDS3Vacuum";
-        VolumeInfo const & parent = ( _config.getBool("isDumbbell",false) ) ?
+        VolumeInfo const & parent = ( !_config.getBool("tracker.inDS2Vacuum",false) ) ?
           _helper->locateVolInfo(theDS3) :
           _helper->locateVolInfo("DS2Vacuum"); //DS3Vacuum to move the targets
 
@@ -2014,7 +2014,7 @@ vdParamsInnerFEB,downstreamVacuumMaterial,0,posInnerFEB,caloFEBParent,vdIdFEBEdg
 
     vdId = VirtualDetectorId::EMC_0_Front;
 
-    if ( !_config.getBool("isDumbbell",false) ){
+    if (_config.getBool("tracker.inDS2Vacuum",false) && !_config.getBool("isDumbbell",false) ){ // for now, only include in altered setup
       double Ravr = ds->rIn1();
 
       if ( _config.getBool("hasTSdA",false) ) {
@@ -2051,7 +2051,7 @@ vdParamsInnerFEB,downstreamVacuumMaterial,0,posInnerFEB,caloFEBParent,vdIdFEBEdg
         std::string theDS3("DS3Vacuum");
         if ( _config.getBool("inGaragePosition",false) ) theDS3 = "garageFakeDS3Vacuum";
 
-        VolumeInfo const & parent = ( _config.getBool("isDumbbell",false) ) ?
+        VolumeInfo const & parent = ( !_config.getBool("tracker.inDS2Vacuum",false) ) ?
           _helper->locateVolInfo(theDS3) :
           _helper->locateVolInfo("DS2Vacuum"); //DS3Vacuum to move the targets
 


### PR DESCRIPTION
This resolves geometry overlap issues seen with Run 1B geom v40. There were two sources: 1) restoring Run 1A elements introduced overlaps due to code changes made to accommodate Run 1B and 2) the degrader mother volume wasn't quite correct and the thicker degrader also needed adjustments in its support plate. Both sources should now be resolved, which I tested using a surface check with the DS-off and DS-on v40 configuration files.