### PR TITLE
Add a summary SpectrumConfig object to generator outputs

### DIFF
--- a/EventGenerator/inc/ParticleGeneratorTool.hh
+++ b/EventGenerator/inc/ParticleGeneratorTool.hh
@@ -13,6 +13,7 @@
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/ProcessCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 
 #include "Offline/GeneralUtilities/inc/RSNTIO.hh"
 
@@ -34,6 +35,11 @@ namespace mu2e {
 
     // This interface should be removed when we retire ntuple-based muon resampling
     virtual void generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) = 0;
+
+    virtual std::unique_ptr<SpectrumConfig> spectrumConfig() {
+      auto config = std::make_unique<SpectrumConfig>();
+      return config;
+    }
 
     virtual ~ParticleGeneratorTool() noexcept = default;
 

--- a/EventGenerator/src/AntiProtonGun_module.cc
+++ b/EventGenerator/src/AntiProtonGun_module.cc
@@ -21,6 +21,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -32,6 +33,7 @@
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
 #include "Offline/Mu2eUtilities/inc/CzarneckiSpectrum.hh"
 #include "Offline/Mu2eUtilities/inc/SimpleSpectrum.hh"
@@ -104,6 +106,7 @@ namespace mu2e {
     explicit AntiProtonGun(const fhicl::ParameterSet& pset);
     virtual void produce(art::Event& event);
     virtual void beginRun(art::Run& run);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
 
   //================================================================
@@ -119,6 +122,7 @@ namespace mu2e {
     , firstEvent_(true)
   {
     produces<mu2e::GenParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
     if(verbosityLevel_ > 0) {
       std::cout<<"AntiProtonGun: producing particle "
@@ -231,6 +235,13 @@ namespace mu2e {
 
     return total;
   } // dsigma
+
+  //================================================================
+  void AntiProtonGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
+  }
 
   //================================================================
   void AntiProtonGun::produce(art::Event& event) {

--- a/EventGenerator/src/AntiProtonGun_module.cc
+++ b/EventGenerator/src/AntiProtonGun_module.cc
@@ -239,7 +239,6 @@ namespace mu2e {
   //================================================================
   void AntiProtonGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/AntiprotonResampling_module.cc
+++ b/EventGenerator/src/AntiprotonResampling_module.cc
@@ -154,7 +154,6 @@ namespace mu2e {
   //================================================================
   void AntiprotonResampling::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/AntiprotonResampling_module.cc
+++ b/EventGenerator/src/AntiprotonResampling_module.cc
@@ -12,6 +12,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -26,6 +27,7 @@
 #include "Offline/MCDataProducts/inc/ProcessCode.hh"
 #include "Offline/MCDataProducts/inc/SimParticle.hh"
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/simParticleList.hh"
 
 #include "TH1.h"
@@ -68,6 +70,7 @@ namespace mu2e {
     explicit AntiprotonResampling(const Parameters& conf);
 
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
 
   //================================================================
@@ -81,6 +84,7 @@ namespace mu2e {
     , makeHistograms_(conf().makeHistograms())
   {
     produces<mu2e::StageParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
     if(verbosity_ > 0) {
       std::cout<<"AntiprotonResampling: using process code " << processCode_ << std::endl;
@@ -145,6 +149,13 @@ namespace mu2e {
       const double r = std::sqrt(std::pow(pos.x() + 3904., 2) + std::pow(pos.y(), 2));
       _hR->Fill(r);
     }
+  }
+
+  //================================================================
+  void AntiprotonResampling::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/CORSIKAEventGenerator_module.cc
+++ b/EventGenerator/src/CORSIKAEventGenerator_module.cc
@@ -30,6 +30,7 @@
 #include "Offline/GeometryService/inc/Mu2eEnvelope.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
 #include "Offline/MCDataProducts/inc/CosmicLivetime.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
 #include "Offline/MCDataProducts/inc/SimTimeOffset.hh"
 #include "Offline/CalorimeterGeom/inc/Calorimeter.hh"
@@ -117,6 +118,7 @@ namespace mu2e {
   {
     produces<GenParticleCollection>();
     produces<CosmicLivetime,art::InSubRun>();
+    produces<SpectrumConfig,art::InSubRun>();
     if (_applyTimeOffset) {
       _timeOffsetTag = conf().simTimeOffset().value();
     }
@@ -132,6 +134,10 @@ namespace mu2e {
     std::unique_ptr<CosmicLivetime> livetime(new CosmicLivetime(_primaries, _area, _lowE, _highE, _fluxConstant));
     std::cout << *livetime << std::endl;
     subrun.put(std::move(livetime), art::fullSubRun());
+
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    subrun.put(std::move(config), art::fullSubRun());
   }
 
   void CorsikaEventGenerator::produce(art::Event &evt)

--- a/EventGenerator/src/CORSIKAEventGenerator_module.cc
+++ b/EventGenerator/src/CORSIKAEventGenerator_module.cc
@@ -136,7 +136,6 @@ namespace mu2e {
     subrun.put(std::move(livetime), art::fullSubRun());
 
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     subrun.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/CRYEventGenerator_module.cc
+++ b/EventGenerator/src/CRYEventGenerator_module.cc
@@ -5,6 +5,7 @@
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
 #include "Offline/MCDataProducts/inc/G4BeamlineInfo.hh"
 #include "Offline/MCDataProducts/inc/CosmicLivetime.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 
 // Particular generators that this code knows about.
 #include "Offline/SeedService/inc/SeedService.hh"
@@ -51,6 +52,7 @@ namespace mu2e {
   {
     produces<GenParticleCollection>();
     produces<CosmicLivetime,art::InSubRun>();
+    produces<SpectrumConfig,art::InSubRun>();
   }
 
   void CryEventGenerator::beginRun( art::Run &run){
@@ -83,6 +85,10 @@ namespace mu2e {
                                                                 cryGen->getLiveTime()  ));
     std::cout << *livetime << std::endl;
     subrun.put(std::move(livetime), art::fullSubRun());
+
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    subrun.put(std::move(config), art::fullSubRun());
   }
 
 }

--- a/EventGenerator/src/CRYEventGenerator_module.cc
+++ b/EventGenerator/src/CRYEventGenerator_module.cc
@@ -87,7 +87,6 @@ namespace mu2e {
     subrun.put(std::move(livetime), art::fullSubRun());
 
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     subrun.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/CaloCalibGun_module.cc
+++ b/EventGenerator/src/CaloCalibGun_module.cc
@@ -11,6 +11,7 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 
 // Mu2e includes
@@ -23,6 +24,7 @@
 #include "Offline/MCDataProducts/inc/GenId.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
 #include "Offline/MCDataProducts/inc/PrimaryParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 
 // Other external includes.
 #include "CLHEP/Random/RandFlat.h"
@@ -65,6 +67,7 @@ namespace mu2e {
 
     virtual void produce(art::Event& event) override;
     virtual void beginRun(art::Run& run) override;
+    virtual void endSubRun(art::SubRun& sr) override;
 
   private:
 
@@ -121,6 +124,7 @@ namespace mu2e {
   {
     produces<mu2e::GenParticleCollection>();
     produces<mu2e::PrimaryParticle>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
   }
 
@@ -231,6 +235,12 @@ namespace mu2e {
     event.put(std::move(output));
     event.put(std::make_unique<PrimaryParticle>(primaryParticles));
 
+  }
+
+  void CaloCalibGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/CaloCalibGun_module.cc
+++ b/EventGenerator/src/CaloCalibGun_module.cc
@@ -239,7 +239,6 @@ namespace mu2e {
 
   void CaloCalibGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/CaloTBGun_module.cc
+++ b/EventGenerator/src/CaloTBGun_module.cc
@@ -10,6 +10,7 @@
 // Framework includes
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -20,6 +21,7 @@
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
 #include "Offline/CalorimeterGeom/inc/DiskCalorimeter.hh"
@@ -34,6 +36,7 @@ namespace mu2e {
      public:
        explicit     CaloTBGun  (const fhicl::ParameterSet& pset);
        virtual void produce (art::Event& event);
+       virtual void endSubRun(art::SubRun& sr) override;
 
      private:
        int                 verbosityLevel_;
@@ -54,6 +57,7 @@ namespace mu2e {
 
   {
       produces<mu2e::GenParticleCollection>();
+      produces<mu2e::SpectrumConfig, art::InSubRun>();
       if (verbosityLevel_ > 0) std::cout<<"CaloTB gun: shoot! " << std::endl;
   }
 
@@ -71,6 +75,13 @@ namespace mu2e {
        std::unique_ptr<GenParticleCollection> output(new GenParticleCollection);
        output->emplace_back(PDGCode::e_minus,GenId::CeEndpoint,pos,mom,time_);
        event.put(std::move(output));
+  }
+
+  void CaloTBGun::endSubRun(art::SubRun& sr)
+  {
+      auto config = std::make_unique<SpectrumConfig>();
+      config->type_ = SpectrumConfig::Type::kOther;
+      sr.put(std::move(config), art::fullSubRun());
   }
 
 }

--- a/EventGenerator/src/CaloTBGun_module.cc
+++ b/EventGenerator/src/CaloTBGun_module.cc
@@ -80,7 +80,6 @@ namespace mu2e {
   void CaloTBGun::endSubRun(art::SubRun& sr)
   {
       auto config = std::make_unique<SpectrumConfig>();
-      config->type_ = SpectrumConfig::Type::kOther;
       sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/CeEndpoint_module.cc
+++ b/EventGenerator/src/CeEndpoint_module.cc
@@ -157,9 +157,8 @@ namespace mu2e {
   void CeEndpoint::endSubRun(art::SubRun& sr) {
     // Make a summary of how this generator was configured
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1.                  , endPointEnergy_, endPointEnergy_));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz"  , (czMax_ - czMin_)/2., czMin_         , czMax_         ));
-    config->type_ = SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", 1.                  , endPointEnergy_, endPointEnergy_));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz"  , (czMax_ - czMin_)/2., czMin_         , czMax_         ));
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/CeEndpoint_module.cc
+++ b/EventGenerator/src/CeEndpoint_module.cc
@@ -29,6 +29,7 @@
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
 #include "Offline/Mu2eUtilities/inc/simParticleList.hh"
 
@@ -53,6 +54,7 @@ namespace mu2e {
     explicit CeEndpoint(const Parameters& conf);
 
     virtual void produce(art::Event& event) override;
+    virtual void endSubRun(art::SubRun& sr) override;
 
     //----------------------------------------------------------------
   private:
@@ -93,6 +95,7 @@ namespace mu2e {
     , pdgId_(conf().pdgId())
   {
     produces<mu2e::StageParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
     pid = static_cast<PDGCode::type>(pdgId_);
     if(czMax_ < czMin_ || czMin_ < -1. || czMax_ > 1.) throw cet::exception("BADCONFIG") << "CeEndpoint generator cos(theta_z) range is not defined\n";
 
@@ -148,6 +151,19 @@ namespace mu2e {
 
 
     event.put(std::move(output));
+  }
+
+  //================================================================
+  void CeEndpoint::endSubRun(art::SubRun& sr) {
+    // Make a summary of how this generator was configured
+    auto config = std::make_unique<SpectrumConfig>();
+    config->emin_  = endPointEnergy_;
+    config->emax_  = endPointEnergy_;
+    config->czmin_ = czMin_;
+    config->czmax_ = czMax_;
+    config->fraction_sampled_ = (czMax_ - czMin_)/2.; // range that was sampled overall
+    config->type_  = SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/CeEndpoint_module.cc
+++ b/EventGenerator/src/CeEndpoint_module.cc
@@ -157,12 +157,9 @@ namespace mu2e {
   void CeEndpoint::endSubRun(art::SubRun& sr) {
     // Make a summary of how this generator was configured
     auto config = std::make_unique<SpectrumConfig>();
-    config->emin_  = endPointEnergy_;
-    config->emax_  = endPointEnergy_;
-    config->czmin_ = czMin_;
-    config->czmax_ = czMax_;
-    config->fraction_sampled_ = (czMax_ - czMin_)/2.; // fraction of full spectrum that was sampled (only cz can be constrained)
-    config->type_  = SpectrumConfig::Type::kPhysical;
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1.                  , endPointEnergy_, endPointEnergy_));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz"  , (czMax_ - czMin_)/2., czMin_         , czMax_         ));
+    config->type_ = SpectrumConfig::Type::kPhysical;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/CeEndpoint_module.cc
+++ b/EventGenerator/src/CeEndpoint_module.cc
@@ -161,7 +161,7 @@ namespace mu2e {
     config->emax_  = endPointEnergy_;
     config->czmin_ = czMin_;
     config->czmax_ = czMax_;
-    config->fraction_sampled_ = (czMax_ - czMin_)/2.; // range that was sampled overall
+    config->fraction_sampled_ = (czMax_ - czMin_)/2.; // fraction of full spectrum that was sampled (only cz can be constrained)
     config->type_  = SpectrumConfig::Type::kPhysical;
     sr.put(std::move(config), art::fullSubRun());
   }

--- a/EventGenerator/src/CryResampler_module.cc
+++ b/EventGenerator/src/CryResampler_module.cc
@@ -13,6 +13,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -21,6 +22,7 @@
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/GeneralUtilities/inc/RSNTIO.hh"
 
 #include "TTree.h"
@@ -60,6 +62,7 @@ namespace mu2e {
     public:
     explicit CryResampler(const fhicl::ParameterSet& pset);
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
 
   //================================================================
@@ -88,6 +91,7 @@ namespace mu2e {
       inputFile_ << std::endl;
 
     produces<GenParticleCollection>();
+    produces<SpectrumConfig, art::InSubRun>();
   }
 
   //================================================================
@@ -117,6 +121,13 @@ namespace mu2e {
     }
 
     event.put(std::move(output));
+  }
+
+  //================================================================
+  void CryResampler::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/CryResampler_module.cc
+++ b/EventGenerator/src/CryResampler_module.cc
@@ -126,7 +126,6 @@ namespace mu2e {
   //================================================================
   void CryResampler::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/DIOGenerator_tool.cc
+++ b/EventGenerator/src/DIOGenerator_tool.cc
@@ -45,6 +45,8 @@ namespace mu2e {
       }
 
       auto fullconfig = conf().spectrum.get<fhicl::ParameterSet>();
+      _emin = fullconfig.get<double>("elow");
+      _emax = fullconfig.get<double>("ehi");
       fullconfig.erase(std::string("elow"));
       fullconfig.erase(std::string("ehi"));
       fullconfig.put(std::string("elow"),double(0.0));
@@ -59,6 +61,7 @@ namespace mu2e {
       double pdfmin = _spectrum.getPDF(0);
       double binsize = _spectrum.getBinWidth();
       fullintegral += 0.5*pdfmin*pmin/binsize;
+      _energy_fraction = (fullintegral > 0.) ? integral / fullintegral : 0.;
       std::cout << "Cos(theta_z) min " << _czmin << " max " << _czmax << std::endl;
       std::cout << "Restricted Spectrum min " << _spectrum.getAbscissa(0) << " max " << _spectrum.getAbscissa(_spectrum.getNbins()-1) << std::endl;
       std::cout << "Full Spectrum min " << fullspect.getAbscissa(0) << " max " << fullspect.getAbscissa(fullspect.getNbins()-1) << std::endl;
@@ -72,6 +75,7 @@ namespace mu2e {
 
     std::vector<ParticleGeneratorTool::Kinematic> generate() override;
     void generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) override;
+    std::unique_ptr<SpectrumConfig> spectrumConfig() override;
 
     void finishInitialization(art::RandomNumberGenerator::base_engine_t& eng, const std::string&, const bool isPrimary) override {
       _isPrimary = isPrimary;
@@ -87,6 +91,9 @@ namespace mu2e {
     const double _czmin;
     const double _czmax;
     BinnedSpectrum    _spectrum;
+    double _emin;
+    double _emax;
+    double _energy_fraction;
 
     std::unique_ptr<RandomUnitSphere>   _randomUnitSphere;
     std::unique_ptr<CLHEP::RandGeneral> _randSpectrum;
@@ -122,6 +129,17 @@ namespace mu2e {
                         d.fourmom,
                         stop.t);
     }
+  }
+
+  std::unique_ptr<SpectrumConfig> DIOGenerator::spectrumConfig() {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->emin_  = _emin;
+    config->emax_  = _emax;
+    config->czmin_ = _czmin;
+    config->czmax_ = _czmax;
+    config->fraction_sampled_ = _energy_fraction * (_czmax - _czmin)/2.;
+    config->type_  = SpectrumConfig::Type::kPhysical;
+    return config;
   }
 
 }

--- a/EventGenerator/src/DIOGenerator_tool.cc
+++ b/EventGenerator/src/DIOGenerator_tool.cc
@@ -34,7 +34,8 @@ namespace mu2e {
       _mass(GlobalConstantsHandle<ParticleDataList>()->particle(_pdgId).mass()),
       _czmin(conf().czmin()),
       _czmax(conf().czmax()),
-      _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>()))
+      _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>())),
+      _flatSpectrum(conf().spectrum.get<fhicl::ParameterSet>().get<std::string>("spectrumShape", "") == "flat")
     {
       if(_czmin > _czmax || _czmin < -1. || _czmax > 1.) throw cet::exception("BADCONFIG") << "DIOGenerator cos(theta_z) range is not defined\n";
 
@@ -94,6 +95,7 @@ namespace mu2e {
     double _emin;
     double _emax;
     double _energy_fraction;
+    bool _flatSpectrum;
 
     std::unique_ptr<RandomUnitSphere>   _randomUnitSphere;
     std::unique_ptr<CLHEP::RandGeneral> _randSpectrum;
@@ -133,12 +135,9 @@ namespace mu2e {
 
   std::unique_ptr<SpectrumConfig> DIOGenerator::spectrumConfig() {
     auto config = std::make_unique<SpectrumConfig>();
-    config->emin_  = _emin;
-    config->emax_  = _emax;
-    config->czmin_ = _czmin;
-    config->czmax_ = _czmax;
-    config->fraction_sampled_ = _energy_fraction * (_czmax - _czmin)/2.;
-    config->type_  = SpectrumConfig::Type::kPhysical;
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", _energy_fraction    , _emin , _emax ));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz"  , (_czmax - _czmin)/2., _czmin, _czmax));
+    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
     return config;
   }
 

--- a/EventGenerator/src/DIOGenerator_tool.cc
+++ b/EventGenerator/src/DIOGenerator_tool.cc
@@ -135,9 +135,9 @@ namespace mu2e {
 
   std::unique_ptr<SpectrumConfig> DIOGenerator::spectrumConfig() {
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", _energy_fraction    , _emin , _emax ));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz"  , (_czmax - _czmin)/2., _czmin, _czmax));
-    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", _energy_fraction    , _emin , _emax,
+                                                  _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz"  , (_czmax - _czmin)/2., _czmin, _czmax));
     return config;
   }
 

--- a/EventGenerator/src/DIOGenerator_tool.cc
+++ b/EventGenerator/src/DIOGenerator_tool.cc
@@ -46,8 +46,8 @@ namespace mu2e {
       }
 
       auto fullconfig = conf().spectrum.get<fhicl::ParameterSet>();
-      _emin = fullconfig.get<double>("elow");
-      _emax = fullconfig.get<double>("ehi");
+      _emin = fullconfig.get<double>("elow", _spectrum.getXMin());
+      _emax = fullconfig.get<double>("ehi", _spectrum.getXMax());
       fullconfig.erase(std::string("elow"));
       fullconfig.erase(std::string("ehi"));
       fullconfig.put(std::string("elow"),double(0.0));

--- a/EventGenerator/src/EplusFromStoppedPion_module.cc
+++ b/EventGenerator/src/EplusFromStoppedPion_module.cc
@@ -15,11 +15,13 @@
 #include "Offline/GeneralUtilities/inc/TwoBodyKinematics.hh"
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/SeedService/inc/SeedService.hh"
 
 // art includes.
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art_root_io/TFileService.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -45,6 +47,7 @@ namespace mu2e {
 
     void beginRun(art::Run& run);
     void produce( art::Event& event);
+    void endSubRun(art::SubRun& sr) override;
 
   private:
 
@@ -109,6 +112,7 @@ namespace mu2e {
 
     // What does this module produce?
     produces<GenParticleCollection>();
+    produces<SpectrumConfig, art::InSubRun>();
 
   }
 
@@ -211,6 +215,12 @@ namespace mu2e {
     event.put(std::move(output));
 
   } // end of ::analyze.
+
+  void EplusFromStoppedPion::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
+  }
 
 }
 

--- a/EventGenerator/src/EplusFromStoppedPion_module.cc
+++ b/EventGenerator/src/EplusFromStoppedPion_module.cc
@@ -218,7 +218,6 @@ namespace mu2e {
 
   void EplusFromStoppedPion::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kPhysical;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/EventGenerator_module.cc
+++ b/EventGenerator/src/EventGenerator_module.cc
@@ -216,7 +216,6 @@ namespace mu2e {
 
   void EventGenerator::endSubRun(art::SubRun& sr){
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/EventGenerator_module.cc
+++ b/EventGenerator/src/EventGenerator_module.cc
@@ -32,6 +32,7 @@
 #include "Offline/MCDataProducts/inc/GenId.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
 #include "Offline/MCDataProducts/inc/G4BeamlineInfo.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 
 // Particular generators that this code knows about.
 #include "Offline/EventGenerator/inc/CosmicDYB.hh"
@@ -43,6 +44,7 @@
 // Includes from art and its toolchain.
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art/Framework/Principal/Handle.h"
 #include "fhiclcpp/ParameterSet.h"
@@ -70,6 +72,7 @@ namespace mu2e {
 
     virtual void produce (art::Event& e);
     virtual void beginRun(art::Run&   r);
+    virtual void endSubRun(art::SubRun& sr) override;
 
   private:
 
@@ -118,6 +121,7 @@ namespace mu2e {
     _engine{createEngine(art::ServiceHandle<SeedService>{}->getSeed())}
   {
     produces<GenParticleCollection>();
+    produces<SpectrumConfig, art::InSubRun>();
     if ( _produceG4blInfo  ){
       produces<G4BeamlineInfoCollection>();
     }
@@ -208,6 +212,12 @@ namespace mu2e {
       evt.put(std::move(g4beamlineData));
     }
 
+  }
+
+  void EventGenerator::endSubRun(art::SubRun& sr){
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   // Look for inconsistencies in the config file.

--- a/EventGenerator/src/ExtMonFNALBoxGenerator_module.cc
+++ b/EventGenerator/src/ExtMonFNALBoxGenerator_module.cc
@@ -657,7 +657,6 @@ namespace mu2e {
 
     void ExtMonFNALBoxGenerator::endSubRun(art::SubRun& sr) {
       auto config = std::make_unique<SpectrumConfig>();
-      config->type_ = SpectrumConfig::Type::kOther;
       sr.put(std::move(config), art::fullSubRun());
     }
 

--- a/EventGenerator/src/ExtMonFNALBoxGenerator_module.cc
+++ b/EventGenerator/src/ExtMonFNALBoxGenerator_module.cc
@@ -24,6 +24,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -38,6 +39,7 @@
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/DataProducts/inc/VirtualDetectorId.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/MCDataProducts/inc/MARSInfo.hh"
 #include "Offline/MCDataProducts/inc/GenParticleMARSAssns.hh"
 
@@ -157,6 +159,7 @@ namespace mu2e {
       explicit ExtMonFNALBoxGenerator(const fhicl::ParameterSet& pset);
       virtual void produce(art::Event& event);
       virtual void beginRun(art::Run& run);
+      virtual void endSubRun(art::SubRun& sr) override;
     };
 
     //================================================================
@@ -190,6 +193,7 @@ namespace mu2e {
       produces<mu2e::GenParticleCollection>();
       produces<mu2e::MARSInfoCollection>();
       produces<mu2e::GenParticleMARSAssns>();
+      produces<mu2e::SpectrumConfig, art::InSubRun>();
 
       if(inputFiles_.empty()) {
         throw cet::exception("BADCONFIG")<<"Error: no inputFiles";
@@ -649,6 +653,12 @@ namespace mu2e {
                          posMu2e,
                          momMu2e,
                          muonTime);
+    }
+
+    void ExtMonFNALBoxGenerator::endSubRun(art::SubRun& sr) {
+      auto config = std::make_unique<SpectrumConfig>();
+      config->type_ = SpectrumConfig::Type::kOther;
+      sr.put(std::move(config), art::fullSubRun());
     }
 
     //================================================================

--- a/EventGenerator/src/ExtMonFNALGun_module.cc
+++ b/EventGenerator/src/ExtMonFNALGun_module.cc
@@ -78,7 +78,6 @@ namespace mu2e {
 
   void ExtMonFNALGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/ExtMonFNALGun_module.cc
+++ b/EventGenerator/src/ExtMonFNALGun_module.cc
@@ -11,12 +11,14 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "fhiclcpp/types/Sequence.h"
 
 #include "Offline/SeedService/inc/SeedService.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 
 #include "Offline/EventGenerator/inc/ExtMonFNALGunImpl.hh"
 
@@ -31,6 +33,7 @@ namespace mu2e {
 
     void produce(art::Event& event) override;
     void beginRun(art::Run& run) override;
+    void endSubRun(art::SubRun& sr) override;
   public:
 
     struct Config {
@@ -52,6 +55,7 @@ namespace mu2e {
     , engine_{createEngine(art::ServiceHandle<SeedService>{}->getSeed())}
     {
       produces<GenParticleCollection>();
+      produces<SpectrumConfig, art::InSubRun>();
       if(conf_.empty()) {
         throw cet::exception("BADCONFIG")<<"Error: no ExtMon guns defined.\n";
       }
@@ -70,6 +74,12 @@ namespace mu2e {
       gun->generate(*output);
     }
     event.put(std::move(output));
+  }
+
+  void ExtMonFNALGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
 } // namespace mu2e

--- a/EventGenerator/src/ExtMonFNALRoomGenerator_module.cc
+++ b/EventGenerator/src/ExtMonFNALRoomGenerator_module.cc
@@ -24,6 +24,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -41,6 +42,7 @@
 #include "Offline/GlobalConstantsService/inc/MassCache.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/MCDataProducts/inc/MARSInfo.hh"
 #include "Offline/MCDataProducts/inc/GenParticleMARSAssns.hh"
 
@@ -114,6 +116,7 @@ namespace mu2e {
       explicit ExtMonFNALRoomGenerator(const fhicl::ParameterSet& pset);
       virtual void produce(art::Event& event);
       virtual void beginRun(art::Run& run);
+      virtual void endSubRun(art::SubRun& sr) override;
     };
 
     //================================================================
@@ -140,6 +143,7 @@ namespace mu2e {
       produces<mu2e::GenParticleCollection>();
       produces<mu2e::MARSInfoCollection>();
       produces<mu2e::GenParticleMARSAssns>();
+      produces<mu2e::SpectrumConfig, art::InSubRun>();
 
       if(inputFiles_.empty()) {
         throw cet::exception("BADCONFIG")<<"Error: no inputFiles\n";
@@ -365,6 +369,12 @@ namespace mu2e {
       const CLHEP::HepLorentzVector momMu2e(randomized3mom, particles_[ip].energy);
 
       return GenParticle(PDGCode::type(pp.pdgId), GenId::MARS, posMu2e, momMu2e, pp.time);
+    }
+
+    void ExtMonFNALRoomGenerator::endSubRun(art::SubRun& sr) {
+      auto config = std::make_unique<SpectrumConfig>();
+      config->type_ = SpectrumConfig::Type::kOther;
+      sr.put(std::move(config), art::fullSubRun());
     }
 
     //================================================================

--- a/EventGenerator/src/ExtMonFNALRoomGenerator_module.cc
+++ b/EventGenerator/src/ExtMonFNALRoomGenerator_module.cc
@@ -373,7 +373,6 @@ namespace mu2e {
 
     void ExtMonFNALRoomGenerator::endSubRun(art::SubRun& sr) {
       auto config = std::make_unique<SpectrumConfig>();
-      config->type_ = SpectrumConfig::Type::kOther;
       sr.put(std::move(config), art::fullSubRun());
     }
 

--- a/EventGenerator/src/FlatGeneratorFromStoppedMuon_module.cc
+++ b/EventGenerator/src/FlatGeneratorFromStoppedMuon_module.cc
@@ -21,6 +21,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art_root_io/TFileService.h"
 #include "Offline/SeedService/inc/SeedService.hh"
@@ -30,6 +31,7 @@
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/simParticleList.hh"
 
 #include <TTree.h>
@@ -55,6 +57,7 @@ namespace mu2e {
     explicit FlatGeneratorFromStoppedMuon(const Parameters& conf);
 
     virtual void produce(art::Event& event) override;
+    virtual void endSubRun(art::SubRun& sr) override;
 
     //----------------------------------------------------------------
   private:
@@ -75,6 +78,8 @@ namespace mu2e {
     ProcessCode process;
     int pdgId_;
     PDGCode::type pid;
+    double czMin_;
+    double czMax_;
   };
 
   //================================================================
@@ -91,9 +96,12 @@ namespace mu2e {
     , randExp_{eng_}
     , randomUnitSphere_{eng_, conf().czMin(), conf().czMax()}
     , pdgId_(conf().pdgId())
+    , czMin_(conf().czMin())
+    , czMax_(conf().czMax())
 
   {
     produces<mu2e::StageParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
     pid = static_cast<PDGCode::type>(pdgId_);
 
     if (pid == PDGCode::e_minus) { process = ProcessCode::mu2eFlateMinus; }
@@ -136,6 +144,15 @@ namespace mu2e {
                          );
 
     event.put(std::move(output));
+  }
+
+  //================================================================
+  void FlatGeneratorFromStoppedMuon::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("momentum", 1., startMom_, endMom_));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (czMax_ - czMin_)/2., czMin_, czMax_));
+    config->type_ = SpectrumConfig::Type::kFlat;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/FlatGeneratorFromStoppedMuon_module.cc
+++ b/EventGenerator/src/FlatGeneratorFromStoppedMuon_module.cc
@@ -149,9 +149,8 @@ namespace mu2e {
   //================================================================
   void FlatGeneratorFromStoppedMuon::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("momentum", 1., startMom_, endMom_));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (czMax_ - czMin_)/2., czMin_, czMax_));
-    config->type_ = SpectrumConfig::Type::kFlat;
+    config->add_var(SpectrumConfig::RestrictedVar("momentum", 1., startMom_, endMom_, SpectrumConfig::Type::kFlat));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz", (czMax_ - czMin_)/2., czMin_, czMax_));
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/FromSimParticleCompact_module.cc
+++ b/EventGenerator/src/FromSimParticleCompact_module.cc
@@ -246,7 +246,6 @@ namespace mu2e {
   //================================================================
   void FromSimParticleCompact::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/FromSimParticleCompact_module.cc
+++ b/EventGenerator/src/FromSimParticleCompact_module.cc
@@ -20,6 +20,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -31,6 +32,7 @@
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
 #include "Offline/Mu2eUtilities/inc/CzarneckiSpectrum.hh"
 #include "Offline/Mu2eUtilities/inc/SimpleSpectrum.hh"
@@ -99,6 +101,7 @@ namespace mu2e {
     explicit FromSimParticleCompact(const fhicl::ParameterSet& pset);
     virtual void produce(art::Event& event);
     virtual void beginRun(art::Run& run);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
 
   //================================================================
@@ -115,6 +118,7 @@ namespace mu2e {
     , firstEvent_(true)
   {
     produces<mu2e::GenParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
     if(inputFiles_.empty()) {
       throw cet::exception("BADCONFIG")<<"Error: no inputFiles";
     }
@@ -237,6 +241,13 @@ namespace mu2e {
     output->push_back(outGen);
 
     event.put(std::move(output));
+  }
+
+  //================================================================
+  void FromSimParticleCompact::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/FromStepPointMCsRotateTarget_module.cc
+++ b/EventGenerator/src/FromStepPointMCsRotateTarget_module.cc
@@ -13,6 +13,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art/Framework/Services/Optional/RandomNumberGenerator.h"
@@ -26,6 +27,7 @@
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include "Offline/MCDataProducts/inc/GenParticleSPMHistory.hh"
 #include "Offline/SeedService/inc/SeedService.hh"
@@ -66,6 +68,7 @@ namespace mu2e {
   public:
     explicit FromStepPointMCsRotateTarget(fhicl::ParameterSet const& pset);
     void produce(art::Event& event) override;
+    void endSubRun(art::SubRun& sr) override;
 
   private:
     typedef std::vector<art::InputTag> InputTags;
@@ -100,6 +103,7 @@ namespace mu2e {
   {
     produces<GenParticleCollection>();
     produces<GenParticleSPMHistory>();
+    produces<SpectrumConfig, art::InSubRun>();
 
     typedef std::vector<std::string> Strings;
     Strings tagstr(pset.get<Strings>("inputTags", Strings()));
@@ -219,6 +223,12 @@ namespace mu2e {
 
     event.put(std::move(output));
     event.put(std::move(history));
+  }
+
+  void FromStepPointMCsRotateTarget::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 } // namespace mu2e
 

--- a/EventGenerator/src/FromStepPointMCsRotateTarget_module.cc
+++ b/EventGenerator/src/FromStepPointMCsRotateTarget_module.cc
@@ -227,7 +227,6 @@ namespace mu2e {
 
   void FromStepPointMCsRotateTarget::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 } // namespace mu2e

--- a/EventGenerator/src/FromStepPointMCs_module.cc
+++ b/EventGenerator/src/FromStepPointMCs_module.cc
@@ -151,7 +151,6 @@ namespace mu2e {
 
   void FromStepPointMCs::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 } // namespace mu2e

--- a/EventGenerator/src/FromStepPointMCs_module.cc
+++ b/EventGenerator/src/FromStepPointMCs_module.cc
@@ -11,6 +11,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "canvas/Persistency/Common/Assns.h"
@@ -18,6 +19,7 @@
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include "Offline/MCDataProducts/inc/GenParticleSPMHistory.hh"
 
@@ -52,6 +54,7 @@ namespace mu2e {
   public:
     explicit FromStepPointMCs(fhicl::ParameterSet const& pset);
     void produce(art::Event& event) override;
+    void endSubRun(art::SubRun& sr) override;
 
   private:
     typedef std::vector<art::InputTag> InputTags;
@@ -68,6 +71,7 @@ namespace mu2e {
   {
     produces<GenParticleCollection>();
     produces<GenParticleSPMHistory>();
+    produces<SpectrumConfig, art::InSubRun>();
 
     typedef std::vector<std::string> Strings;
     Strings tagstr(pset.get<Strings>("inputTags", Strings()));
@@ -143,6 +147,12 @@ namespace mu2e {
 
     event.put(std::move(output));
     event.put(std::move(history));
+  }
+
+  void FromStepPointMCs::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 } // namespace mu2e
 

--- a/EventGenerator/src/G4BeamlineGenerator_module.cc
+++ b/EventGenerator/src/G4BeamlineGenerator_module.cc
@@ -14,11 +14,13 @@
 #include "Offline/MCDataProducts/inc/G4BeamlineInfo.hh"
 #include "Offline/MCDataProducts/inc/GenId.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/SeedService/inc/SeedService.hh"
 
 // Includes from art and its toolchain.
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art/Framework/Principal/Handle.h"
 #include "fhiclcpp/ParameterSet.h"
@@ -49,6 +51,7 @@ namespace mu2e {
 
     virtual void produce (art::Event& e);
     virtual void beginRun(art::Run&   r);
+    virtual void endSubRun(art::SubRun& sr) override;
 
   private:
 
@@ -88,6 +91,7 @@ namespace mu2e {
   {
     produces<GenParticleCollection>();
     produces<G4BeamlineInfoCollection>();
+    produces<SpectrumConfig, art::InSubRun>();
   }
 
 
@@ -139,6 +143,12 @@ namespace mu2e {
 
     // There is nothing to do for this generator
 
+  }
+
+  void G4BeamlineGenerator::endSubRun(art::SubRun& sr){
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
 

--- a/EventGenerator/src/G4BeamlineGenerator_module.cc
+++ b/EventGenerator/src/G4BeamlineGenerator_module.cc
@@ -147,7 +147,6 @@ namespace mu2e {
 
   void G4BeamlineGenerator::endSubRun(art::SubRun& sr){
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/GammaConvFlat_module.cc
+++ b/EventGenerator/src/GammaConvFlat_module.cc
@@ -16,6 +16,7 @@
 #include <string>
 #include <cmath>
 #include <memory>
+#include <limits>
 
 #include "CLHEP/Vector/LorentzVector.h"
 #include "CLHEP/Random/RandFlat.h"
@@ -154,7 +155,10 @@ namespace mu2e {
 
   void GammaConvFlat::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kFlat;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", 1.,
+                                                  std::numeric_limits<double>::lowest(),
+                                                  std::numeric_limits<double>::max(),
+                                                  SpectrumConfig::Type::kFlat));
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/GammaConvFlat_module.cc
+++ b/EventGenerator/src/GammaConvFlat_module.cc
@@ -25,11 +25,13 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "Offline/SeedService/inc/SeedService.hh"
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
 #include "Offline/Mu2eUtilities/inc/simParticleList.hh"
 
@@ -49,6 +51,7 @@ namespace mu2e {
     explicit GammaConvFlat(const Parameters& conf);
 
     virtual void produce(art::Event& event) override;
+    virtual void endSubRun(art::SubRun& sr) override;
 
     //----------------------------------------------------------------
   private:
@@ -74,6 +77,7 @@ namespace mu2e {
     , randFlat_{eng_}
   {
     produces<mu2e::StageParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
     process = ProcessCode::mu2eGammaConversion;
   }
 
@@ -146,6 +150,12 @@ namespace mu2e {
     }
 
     event.put(std::move(output));
+  }
+
+  void GammaConvFlat::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kFlat;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/GammaConversion_module.cc
+++ b/EventGenerator/src/GammaConversion_module.cc
@@ -207,7 +207,6 @@ namespace mu2e {
 
   void GammaConversion::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kPhysical;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/GammaConversion_module.cc
+++ b/EventGenerator/src/GammaConversion_module.cc
@@ -18,12 +18,14 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art_root_io/TFileService.h"
 
 #include "Offline/SeedService/inc/SeedService.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/ProcessCode.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
 #include "Offline/Mu2eUtilities/inc/simParticleList.hh"
 #include "Offline/Mu2eUtilities/inc/GammaPairConversionSpectrum.hh"
@@ -52,6 +54,7 @@ namespace mu2e {
     explicit GammaConversion(const Parameters& conf);
 
     virtual void produce(art::Event& event) override;
+    virtual void endSubRun(art::SubRun& sr) override;
 
     //----------------------------------------------------------------
   private:
@@ -92,6 +95,7 @@ namespace mu2e {
     , makeHistograms_(conf().makeHistograms())
   {
     produces<mu2e::StageParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
     // make histograms of the conversion kinematics if requested
     if(makeHistograms_) {
@@ -199,6 +203,12 @@ namespace mu2e {
       hy_->Fill(y);
     }
     event.put(std::move(output));
+  }
+
+  void GammaConversion::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/InFlightParticleSampler_module.cc
+++ b/EventGenerator/src/InFlightParticleSampler_module.cc
@@ -117,7 +117,6 @@ namespace mu2e {
   //================================================================
   void InFlightParticleSampler::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/InFlightParticleSampler_module.cc
+++ b/EventGenerator/src/InFlightParticleSampler_module.cc
@@ -19,6 +19,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -29,6 +30,7 @@
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/RootTreeSampler.hh"
 #include "Offline/GeneralUtilities/inc/RSNTIO.hh"
 
@@ -64,6 +66,7 @@ namespace mu2e {
     explicit InFlightParticleSampler(const Parameters& conf);
 
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
   //================================================================
   InFlightParticleSampler::InFlightParticleSampler(const Parameters& conf)
@@ -76,6 +79,7 @@ namespace mu2e {
     , verbosityLevel_(conf().verbosityLevel())
   {
     produces<mu2e::GenParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
     if(verbosityLevel_ > 0) {
       std::cout<<"InFlightParticleSampler: using = "
@@ -108,6 +112,13 @@ namespace mu2e {
     }
 
     event.put(std::move(output));
+  }
+
+  //================================================================
+  void InFlightParticleSampler::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/LeadingLog_module.cc
+++ b/EventGenerator/src/LeadingLog_module.cc
@@ -159,7 +159,6 @@ namespace mu2e {
 
   void LeadingLog::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kPhysical;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/LeadingLog_module.cc
+++ b/EventGenerator/src/LeadingLog_module.cc
@@ -21,6 +21,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art/Utilities/make_tool.h"
 
@@ -29,6 +30,7 @@
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
 #include "Offline/Mu2eUtilities/inc/simParticleList.hh"
 #include "Offline/EventGenerator/inc/ParticleGeneratorTool.hh"
@@ -60,6 +62,7 @@ namespace mu2e {
     explicit LeadingLog(const Parameters& conf);
 
     virtual void produce(art::Event& event) override;
+    virtual void endSubRun(art::SubRun& sr) override;
 
     void addParticles(StageParticleCollection* output, art::Ptr<SimParticle> mustop, double time);
     //----------------------------------------------------------------
@@ -97,6 +100,7 @@ namespace mu2e {
     , spectrum_(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>()))
   {
     produces<mu2e::StageParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
     pid_ = static_cast<PDGCode::type>(pdgId_);
 
     if (pid_ == PDGCode::e_minus) {
@@ -151,6 +155,12 @@ namespace mu2e {
                        time
                        );
 
+  }
+
+  void LeadingLog::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
 

--- a/EventGenerator/src/Mu2eXGenerator_tool.cc
+++ b/EventGenerator/src/Mu2eXGenerator_tool.cc
@@ -123,8 +123,8 @@ namespace mu2e {
 
   std::unique_ptr<SpectrumConfig> Mu2eXGenerator::spectrumConfig() {
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", _energy_fraction, _emin, _emax));
-    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", _energy_fraction, _emin, _emax,
+                                                  _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
     return config;
   }
 

--- a/EventGenerator/src/Mu2eXGenerator_tool.cc
+++ b/EventGenerator/src/Mu2eXGenerator_tool.cc
@@ -30,13 +30,20 @@ namespace mu2e {
     explicit Mu2eXGenerator(Parameters const& conf) :
       _pdgId(PDGCode::e_minus),
       _mass(GlobalConstantsHandle<ParticleDataList>()->particle(_pdgId).mass()),
-      _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>()))
+      _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>())),
+      _emin(0.),
+      _emax(0.),
+      _energy_fraction(1.),
+      _flatSpectrum(conf().spectrum.get<fhicl::ParameterSet>().get<std::string>("spectrumShape", "") == "flat")
     {
       // compute normalization
       double integral(0.0);
       for(size_t ibin=0;ibin < _spectrum.getNbins();++ibin){
         integral += _spectrum.getPDF(ibin);
       }
+
+      _emin = _spectrum.getXMin();
+      _emax = _spectrum.getXMax();
 
       auto fullconfig = conf().spectrum.get<fhicl::ParameterSet>();
       fullconfig.erase(std::string("elow"));
@@ -53,16 +60,18 @@ namespace mu2e {
       double pdfmin = _spectrum.getPDF(0);
       double binsize = _spectrum.getBinWidth();
       fullintegral += 0.5*pdfmin*pmin/binsize;
+      _energy_fraction = (fullintegral > 0.) ? integral/fullintegral : 0.;
       std::cout << "Restricted Spectrum min " << _spectrum.getAbscissa(0) << " max " << _spectrum.getAbscissa(_spectrum.getNbins()-1) << std::endl;
       std::cout << "Full Spectrum min " << fullspect.getAbscissa(0) << " max " << fullspect.getAbscissa(fullspect.getNbins()-1) << std::endl;
       std::cout << "Restricted Spectrum integral " << integral << std::endl;
       std::cout << "Full Spectrum integral " << fullintegral << std::endl;
-      std::cout << "Sampled spectrum fraction " << integral/fullintegral << std::endl;
+      std::cout << "Sampled spectrum fraction " << _energy_fraction << std::endl;
 
     }
 
     std::vector<ParticleGeneratorTool::Kinematic> generate() override;
     void generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) override;
+    std::unique_ptr<SpectrumConfig> spectrumConfig() override;
 
     void finishInitialization(art::RandomNumberGenerator::base_engine_t& eng, const std::string&, const bool isPrimary) override {
       _isPrimary = isPrimary;
@@ -75,6 +84,10 @@ namespace mu2e {
     double _mass;
 
     BinnedSpectrum    _spectrum;
+    double _emin;
+    double _emax;
+    double _energy_fraction;
+    bool _flatSpectrum;
 
     std::unique_ptr<RandomUnitSphere>   _randomUnitSphere;
     std::unique_ptr<CLHEP::RandGeneral> _randSpectrum;
@@ -106,6 +119,13 @@ namespace mu2e {
                         d.fourmom,
                         stop.t);
     }
+  }
+
+  std::unique_ptr<SpectrumConfig> Mu2eXGenerator::spectrumConfig() {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", _energy_fraction, _emin, _emax));
+    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    return config;
   }
 
 }

--- a/EventGenerator/src/MuCap1809keVGammaGenerator_tool.cc
+++ b/EventGenerator/src/MuCap1809keVGammaGenerator_tool.cc
@@ -36,6 +36,7 @@ namespace mu2e {
 
     std::vector<ParticleGeneratorTool::Kinematic> generate() override;
     void generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) override;
+    std::unique_ptr<SpectrumConfig> spectrumConfig() override;
 
     void finishInitialization(art::RandomNumberGenerator::base_engine_t& eng, const std::string& material, const bool isPrimary) override {
       _isPrimary = isPrimary;
@@ -82,6 +83,14 @@ namespace mu2e {
                         d.fourmom,
                         stop.t);
     }
+  }
+
+  std::unique_ptr<SpectrumConfig> MuCap1809keVGammaGenerator::spectrumConfig() {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., _energy, _energy));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
+    config->type_ = SpectrumConfig::Type::kPhysical;
+    return config;
   }
 
 }

--- a/EventGenerator/src/MuCap1809keVGammaGenerator_tool.cc
+++ b/EventGenerator/src/MuCap1809keVGammaGenerator_tool.cc
@@ -87,9 +87,8 @@ namespace mu2e {
 
   std::unique_ptr<SpectrumConfig> MuCap1809keVGammaGenerator::spectrumConfig() {
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., _energy, _energy));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
-    config->type_ = SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", 1., _energy, _energy));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
     return config;
   }
 

--- a/EventGenerator/src/MuCapDeuteronGenerator_tool.cc
+++ b/EventGenerator/src/MuCapDeuteronGenerator_tool.cc
@@ -38,13 +38,17 @@ namespace mu2e {
       _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>())),
       _spectrumVariable(parseSpectrumVar(conf().spectrumVariable())),
       _czMin(conf().czMin()),
-      _czMax(conf().czMax())
+      _czMax(conf().czMax()),
+      _spectrumXMin(_spectrum.getXMin()),
+      _spectrumXMax(_spectrum.getXMax()),
+      _flatSpectrum(conf().spectrum.get<fhicl::ParameterSet>().get<std::string>("spectrumShape", "") == "flat")
     {
       if(_czMin < -1. || _czMax > 1. || _czMin > _czMax) throw cet::exception("BADCONFIG") << "Cos(theta_z) range unphysical: " << _czMin << " - " << _czMax;
     }
 
     std::vector<ParticleGeneratorTool::Kinematic> generate() override;
     void generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) override;
+    std::unique_ptr<SpectrumConfig> spectrumConfig() override;
 
     void finishInitialization(art::RandomNumberGenerator::base_engine_t& eng, const std::string& material, const bool isPrimary) override {
       _isPrimary = isPrimary;
@@ -64,6 +68,9 @@ namespace mu2e {
     SpectrumVar       _spectrumVariable;
     double _czMin;
     double _czMax;
+    double _spectrumXMin;
+    double _spectrumXMax;
+    bool _flatSpectrum;
 
     std::unique_ptr<CLHEP::RandPoissonQ> _randomPoissonQ;
     std::unique_ptr<RandomUnitSphere>    _randomUnitSphere;
@@ -104,6 +111,22 @@ namespace mu2e {
                         d.fourmom,
                         stop.t);
     }
+  }
+
+  std::unique_ptr<SpectrumConfig> MuCapDeuteronGenerator::spectrumConfig() {
+    auto config = std::make_unique<SpectrumConfig>();
+
+    std::string spectrumVarName("energy");
+    switch(_spectrumVariable) {
+      case KINETIC_ENERY: spectrumVarName = "kineticEnergy"; break;
+      case MOMENTUM:      spectrumVarName = "momentum";      break;
+      default:            spectrumVarName = "energy";        break;
+    }
+
+    config->vars_.push_back(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
+    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    return config;
   }
 }
 DEFINE_ART_CLASS_TOOL(mu2e::MuCapDeuteronGenerator)

--- a/EventGenerator/src/MuCapDeuteronGenerator_tool.cc
+++ b/EventGenerator/src/MuCapDeuteronGenerator_tool.cc
@@ -123,9 +123,9 @@ namespace mu2e {
       default:            spectrumVarName = "energy";        break;
     }
 
-    config->vars_.push_back(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
-    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax,
+                                                  _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
     return config;
   }
 }

--- a/EventGenerator/src/MuCapDeuteronGenerator_tool.cc
+++ b/EventGenerator/src/MuCapDeuteronGenerator_tool.cc
@@ -123,6 +123,7 @@ namespace mu2e {
       default:            spectrumVarName = "energy";        break;
     }
 
+    // FIXME: calculate the spectrum fraction simulated
     config->add_var(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax,
                                                   _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
     config->add_var(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));

--- a/EventGenerator/src/MuCapDeuteronGenerator_tool.cc
+++ b/EventGenerator/src/MuCapDeuteronGenerator_tool.cc
@@ -87,7 +87,7 @@ namespace mu2e {
 
       switch(_spectrumVariable) {
       case TOTAL_ENERGY  : break;
-      case KINETIC_ENERY : energy += _mass; break;
+      case KINETIC_ENERGY : energy += _mass; break;
       case MOMENTUM      : energy = sqrt(energy*energy+_mass*_mass); break;
       }
 
@@ -118,7 +118,7 @@ namespace mu2e {
 
     std::string spectrumVarName("energy");
     switch(_spectrumVariable) {
-      case KINETIC_ENERY: spectrumVarName = "kineticEnergy"; break;
+      case KINETIC_ENERGY: spectrumVarName = "kineticEnergy"; break;
       case MOMENTUM:      spectrumVarName = "momentum";      break;
       default:            spectrumVarName = "energy";        break;
     }

--- a/EventGenerator/src/MuCapNeutronGenerator_tool.cc
+++ b/EventGenerator/src/MuCapNeutronGenerator_tool.cc
@@ -85,7 +85,7 @@ namespace mu2e {
 
       switch(_spectrumVariable) {
       case TOTAL_ENERGY  : break;
-      case KINETIC_ENERY : energy += _mass; break;
+      case KINETIC_ENERGY : energy += _mass; break;
       case MOMENTUM      : energy = sqrt(energy*energy+_mass*_mass); break;
       }
 
@@ -116,7 +116,7 @@ namespace mu2e {
 
     std::string spectrumVarName("energy");
     switch(_spectrumVariable) {
-      case KINETIC_ENERY: spectrumVarName = "kineticEnergy"; break;
+      case KINETIC_ENERGY: spectrumVarName = "kineticEnergy"; break;
       case MOMENTUM:      spectrumVarName = "momentum";      break;
       default:            spectrumVarName = "energy";        break;
     }

--- a/EventGenerator/src/MuCapNeutronGenerator_tool.cc
+++ b/EventGenerator/src/MuCapNeutronGenerator_tool.cc
@@ -37,13 +37,17 @@ namespace mu2e {
       _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>())),
       _spectrumVariable(parseSpectrumVar(conf().spectrumVariable())),
       _czMin(conf().czMin()),
-      _czMax(conf().czMax())
+      _czMax(conf().czMax()),
+      _spectrumXMin(_spectrum.getXMin()),
+      _spectrumXMax(_spectrum.getXMax()),
+      _flatSpectrum(conf().spectrum.get<fhicl::ParameterSet>().get<std::string>("spectrumShape", "") == "flat")
     {
       if(_czMin < -1. || _czMax > 1. || _czMin > _czMax) throw cet::exception("BADCONFIG") << "Cos(theta_z) range unphysical: " << _czMin << " - " << _czMax;
     }
 
     std::vector<ParticleGeneratorTool::Kinematic> generate() override;
     void generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) override;
+    std::unique_ptr<SpectrumConfig> spectrumConfig() override;
 
     void finishInitialization(art::RandomNumberGenerator::base_engine_t& eng, const std::string& material, const bool isPrimary) override {
       _isPrimary = isPrimary;
@@ -63,6 +67,9 @@ namespace mu2e {
     SpectrumVar       _spectrumVariable;
     double _czMin;
     double _czMax;
+    double _spectrumXMin;
+    double _spectrumXMax;
+    bool _flatSpectrum;
 
     std::unique_ptr<CLHEP::RandPoissonQ> _randomPoissonQ;
     std::unique_ptr<RandomUnitSphere>    _randomUnitSphere;
@@ -102,6 +109,22 @@ namespace mu2e {
                         d.fourmom,
                         stop.t);
     }
+  }
+
+  std::unique_ptr<SpectrumConfig> MuCapNeutronGenerator::spectrumConfig() {
+    auto config = std::make_unique<SpectrumConfig>();
+
+    std::string spectrumVarName("energy");
+    switch(_spectrumVariable) {
+      case KINETIC_ENERY: spectrumVarName = "kineticEnergy"; break;
+      case MOMENTUM:      spectrumVarName = "momentum";      break;
+      default:            spectrumVarName = "energy";        break;
+    }
+
+    config->vars_.push_back(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
+    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    return config;
   }
 }
 DEFINE_ART_CLASS_TOOL(mu2e::MuCapNeutronGenerator)

--- a/EventGenerator/src/MuCapNeutronGenerator_tool.cc
+++ b/EventGenerator/src/MuCapNeutronGenerator_tool.cc
@@ -121,9 +121,9 @@ namespace mu2e {
       default:            spectrumVarName = "energy";        break;
     }
 
-    config->vars_.push_back(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
-    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax,
+                                                  _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
     return config;
   }
 }

--- a/EventGenerator/src/MuCapPhotonGenerator_tool.cc
+++ b/EventGenerator/src/MuCapPhotonGenerator_tool.cc
@@ -98,9 +98,9 @@ namespace mu2e {
 
   std::unique_ptr<SpectrumConfig> MuCapPhotonGenerator::spectrumConfig() {
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
-    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax,
+                                                  _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
     return config;
   }
 }

--- a/EventGenerator/src/MuCapPhotonGenerator_tool.cc
+++ b/EventGenerator/src/MuCapPhotonGenerator_tool.cc
@@ -98,6 +98,7 @@ namespace mu2e {
 
   std::unique_ptr<SpectrumConfig> MuCapPhotonGenerator::spectrumConfig() {
     auto config = std::make_unique<SpectrumConfig>();
+    // FIXME: calculate the spectrum fraction simulated
     config->add_var(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax,
                                                   _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
     config->add_var(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));

--- a/EventGenerator/src/MuCapPhotonGenerator_tool.cc
+++ b/EventGenerator/src/MuCapPhotonGenerator_tool.cc
@@ -31,13 +31,17 @@ namespace mu2e {
     explicit MuCapPhotonGenerator(Parameters const& conf) :
       _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>())),
       _czMin(conf().czMin()),
-      _czMax(conf().czMax())
+      _czMax(conf().czMax()),
+      _spectrumXMin(_spectrum.getXMin()),
+      _spectrumXMax(_spectrum.getXMax()),
+      _flatSpectrum(conf().spectrum.get<fhicl::ParameterSet>().get<std::string>("spectrumShape", "") == "flat")
     {
       if(_czMin < -1. || _czMax > 1. || _czMin > _czMax) throw cet::exception("BADCONFIG") << "Cos(theta_z) range unphysical: " << _czMin << " - " << _czMax;
     }
 
     std::vector<ParticleGeneratorTool::Kinematic> generate() override;
     void generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) override;
+    std::unique_ptr<SpectrumConfig> spectrumConfig() override;
 
     void finishInitialization(art::RandomNumberGenerator::base_engine_t& eng, const std::string& material, const bool isPrimary) override {
       _isPrimary = isPrimary;
@@ -54,6 +58,9 @@ namespace mu2e {
     BinnedSpectrum    _spectrum;
     double _czMin;
     double _czMax;
+    double _spectrumXMin;
+    double _spectrumXMax;
+    bool _flatSpectrum;
 
     std::unique_ptr<CLHEP::RandPoissonQ> _randomPoissonQ;
     std::unique_ptr<RandomUnitSphere>    _randomUnitSphere;
@@ -87,6 +94,14 @@ namespace mu2e {
                         d.fourmom,
                         stop.t);
     }
+  }
+
+  std::unique_ptr<SpectrumConfig> MuCapPhotonGenerator::spectrumConfig() {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
+    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    return config;
   }
 }
 DEFINE_ART_CLASS_TOOL(mu2e::MuCapPhotonGenerator)

--- a/EventGenerator/src/MuCapProtonGenerator_tool.cc
+++ b/EventGenerator/src/MuCapProtonGenerator_tool.cc
@@ -121,9 +121,9 @@ namespace mu2e {
       default:            spectrumVarName = "energy";        break;
     }
 
-    config->vars_.push_back(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
-    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax,
+                                                  _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
     return config;
   }
 

--- a/EventGenerator/src/MuCapProtonGenerator_tool.cc
+++ b/EventGenerator/src/MuCapProtonGenerator_tool.cc
@@ -37,13 +37,17 @@ namespace mu2e {
       _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>())),
       _spectrumVariable(parseSpectrumVar(conf().spectrumVariable())),
       _czMin(conf().czMin()),
-      _czMax(conf().czMax())
+      _czMax(conf().czMax()),
+      _spectrumXMin(_spectrum.getXMin()),
+      _spectrumXMax(_spectrum.getXMax()),
+      _flatSpectrum(conf().spectrum.get<fhicl::ParameterSet>().get<std::string>("spectrumShape", "") == "flat")
     {
       if(_czMin < -1. || _czMax > 1. || _czMin > _czMax) throw cet::exception("BADCONFIG") << "Cos(theta_z) range unphysical: " << _czMin << " - " << _czMax;
     }
 
     std::vector<ParticleGeneratorTool::Kinematic> generate() override;
     void generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) override;
+    std::unique_ptr<SpectrumConfig> spectrumConfig() override;
 
     void finishInitialization(art::RandomNumberGenerator::base_engine_t& eng, const std::string& material, const bool isPrimary) override {
       _isPrimary = isPrimary;
@@ -63,6 +67,9 @@ namespace mu2e {
     SpectrumVar       _spectrumVariable;
     double _czMin;
     double _czMax;
+    double _spectrumXMin;
+    double _spectrumXMax;
+    bool _flatSpectrum;
 
     std::unique_ptr<CLHEP::RandPoissonQ> _randomPoissonQ;
     std::unique_ptr<RandomUnitSphere>    _randomUnitSphere;
@@ -102,6 +109,22 @@ namespace mu2e {
                         d.fourmom,
                         stop.t);
     }
+  }
+
+  std::unique_ptr<SpectrumConfig> MuCapProtonGenerator::spectrumConfig() {
+    auto config = std::make_unique<SpectrumConfig>();
+
+    std::string spectrumVarName("energy");
+    switch(_spectrumVariable) {
+      case KINETIC_ENERY: spectrumVarName = "kineticEnergy"; break;
+      case MOMENTUM:      spectrumVarName = "momentum";      break;
+      default:            spectrumVarName = "energy";        break;
+    }
+
+    config->vars_.push_back(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
+    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    return config;
   }
 
 }

--- a/EventGenerator/src/MuCapProtonGenerator_tool.cc
+++ b/EventGenerator/src/MuCapProtonGenerator_tool.cc
@@ -85,7 +85,7 @@ namespace mu2e {
 
       switch(_spectrumVariable) {
       case TOTAL_ENERGY  : break;
-      case KINETIC_ENERY : energy += _mass; break;
+      case KINETIC_ENERGY : energy += _mass; break;
       case MOMENTUM      : energy = sqrt(energy*energy+_mass*_mass); break;
       }
 
@@ -116,7 +116,7 @@ namespace mu2e {
 
     std::string spectrumVarName("energy");
     switch(_spectrumVariable) {
-      case KINETIC_ENERY: spectrumVarName = "kineticEnergy"; break;
+      case KINETIC_ENERGY: spectrumVarName = "kineticEnergy"; break;
       case MOMENTUM:      spectrumVarName = "momentum";      break;
       default:            spectrumVarName = "energy";        break;
     }

--- a/EventGenerator/src/MuCapProtonGenerator_tool.cc
+++ b/EventGenerator/src/MuCapProtonGenerator_tool.cc
@@ -121,6 +121,7 @@ namespace mu2e {
       default:            spectrumVarName = "energy";        break;
     }
 
+    // FIXME: calculate the spectrum fraction simulated
     config->add_var(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax,
                                                   _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
     config->add_var(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));

--- a/EventGenerator/src/MuStopProductsGun_module.cc
+++ b/EventGenerator/src/MuStopProductsGun_module.cc
@@ -17,6 +17,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -32,6 +33,7 @@
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/RootTreeSampler.hh"
 #include "Offline/GeneralUtilities/inc/RSNTIO.hh"
 #include "Offline/EventGenerator/inc/ParticleGeneratorTool.hh"
@@ -79,6 +81,7 @@ namespace mu2e {
     explicit MuStopProductsGun(const Parameters& conf);
 
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
 
   //================================================================
@@ -94,6 +97,7 @@ namespace mu2e {
     , _captureFraction(1 - _decayFraction)
   {
     produces<mu2e::GenParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
     if (verbosityLevel_ > 0) {
       std::cout<<"MuStopProductsGun: using = "
@@ -136,6 +140,13 @@ namespace mu2e {
     }
 
     event.put(std::move(output));
+  }
+
+  //================================================================
+  void MuStopProductsGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
   }
   //================================================================
 } // namespace mu2e

--- a/EventGenerator/src/MuStopProductsGun_module.cc
+++ b/EventGenerator/src/MuStopProductsGun_module.cc
@@ -145,7 +145,6 @@ namespace mu2e {
   //================================================================
   void MuStopProductsGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kPhysical;
     sr.put(std::move(config), art::fullSubRun());
   }
   //================================================================

--- a/EventGenerator/src/MuplusMichelGenerator_tool.cc
+++ b/EventGenerator/src/MuplusMichelGenerator_tool.cc
@@ -88,8 +88,8 @@ namespace mu2e {
 
   std::unique_ptr<SpectrumConfig> MuplusMichelGenerator::spectrumConfig() {
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax));
-    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax,
+                                                  _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
     return config;
   }
 

--- a/EventGenerator/src/MuplusMichelGenerator_tool.cc
+++ b/EventGenerator/src/MuplusMichelGenerator_tool.cc
@@ -30,11 +30,15 @@ namespace mu2e {
     explicit MuplusMichelGenerator(Parameters const& conf) :
       _pdgId(PDGCode::e_plus),
       _mass(GlobalConstantsHandle<ParticleDataList>()->particle(_pdgId).mass()),
-      _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>()))
+      _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>())),
+      _spectrumXMin(_spectrum.getXMin()),
+      _spectrumXMax(_spectrum.getXMax()),
+      _flatSpectrum(conf().spectrum.get<fhicl::ParameterSet>().get<std::string>("spectrumShape", "") == "flat")
     {}
 
     std::vector<ParticleGeneratorTool::Kinematic> generate() override;
     void generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) override;
+    std::unique_ptr<SpectrumConfig> spectrumConfig() override;
 
     void finishInitialization(art::RandomNumberGenerator::base_engine_t& eng, const std::string&, const bool isPrimary) override {
       _isPrimary = isPrimary;
@@ -47,6 +51,9 @@ namespace mu2e {
     double _mass;
 
     BinnedSpectrum    _spectrum;
+    double _spectrumXMin;
+    double _spectrumXMax;
+    bool _flatSpectrum;
 
     std::unique_ptr<RandomUnitSphere>  _randomUnitSphere;
     std::unique_ptr<CLHEP::RandGeneral> _randSpectrum;
@@ -77,6 +84,13 @@ namespace mu2e {
                         d.fourmom,
                         stop.t);
     }
+  }
+
+  std::unique_ptr<SpectrumConfig> MuplusMichelGenerator::spectrumConfig() {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax));
+    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    return config;
   }
 
 }

--- a/EventGenerator/src/MuplusMichelGenerator_tool.cc
+++ b/EventGenerator/src/MuplusMichelGenerator_tool.cc
@@ -88,6 +88,7 @@ namespace mu2e {
 
   std::unique_ptr<SpectrumConfig> MuplusMichelGenerator::spectrumConfig() {
     auto config = std::make_unique<SpectrumConfig>();
+    // FIXME: calculate the spectrum fraction simulated
     config->add_var(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax,
                                                   _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
     return config;

--- a/EventGenerator/src/PhotonGun_module.cc
+++ b/EventGenerator/src/PhotonGun_module.cc
@@ -8,6 +8,7 @@
 // art includes
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 
 // exception handling
 #include "cetlib_except/exception.h"
@@ -21,6 +22,7 @@
 
 // Offline includes
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 
 // CLHEP includes
@@ -43,6 +45,7 @@ namespace mu2e {
     using Parameters = art::EDProducer::Table<Config>;
     explicit PhotonGun(const Parameters& conf);
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
   private:
     double x = 0.0, y = 0.0, z = 0.0;
     double px = 0.0, py = 0.0, pz = 0.0;
@@ -56,6 +59,7 @@ namespace mu2e {
     z(conf().z()),
     E(conf().E()) {
       produces<GenParticleCollection>();
+      produces<SpectrumConfig, art::InSubRun>();
       px = conf().px() ? *conf().px() : 0;
       px = conf().py() ? *conf().py() : 0;
       if ((px*px + py*py) > (E*E))
@@ -71,6 +75,12 @@ namespace mu2e {
     output->push_back(GenParticle(PDGCode::gamma, GenId::particleGun, pos, mom, 0.));
     event.put(std::move(output));
   };
+
+  void PhotonGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
+  }
 }; // end namespace mu2e
 
 DEFINE_ART_MODULE(mu2e::PhotonGun)

--- a/EventGenerator/src/PhotonGun_module.cc
+++ b/EventGenerator/src/PhotonGun_module.cc
@@ -78,7 +78,6 @@ namespace mu2e {
 
   void PhotonGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 }; // end namespace mu2e

--- a/EventGenerator/src/Pileup_module.cc
+++ b/EventGenerator/src/Pileup_module.cc
@@ -25,6 +25,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art/Utilities/make_tool.h"
 
@@ -32,6 +33,7 @@
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
 #include "Offline/Mu2eUtilities/inc/simParticleList.hh"
 #include "Offline/EventGenerator/inc/ParticleGeneratorTool.hh"
@@ -62,6 +64,7 @@ namespace mu2e {
     explicit Pileup(const Parameters& conf);
 
     virtual void produce(art::Event& event) override;
+    virtual void endSubRun(art::SubRun& sr) override;
 
     //----------------------------------------------------------------
   private:
@@ -95,6 +98,7 @@ namespace mu2e {
     , randExp_{eng_}
   {
     produces<mu2e::StageParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
     if(verbosity_ > 0) {
       mf::LogInfo log("Pileup");
       log<<"stoppingTargetMaterial = "<<conf().stoppingTargetMaterial()
@@ -154,6 +158,13 @@ namespace mu2e {
     }
 
     event.put(std::move(output));
+  }
+
+  //================================================================
+  void Pileup::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/Pileup_module.cc
+++ b/EventGenerator/src/Pileup_module.cc
@@ -163,7 +163,6 @@ namespace mu2e {
   //================================================================
   void Pileup::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kPhysical;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/PrimaryProtonGun_module.cc
+++ b/EventGenerator/src/PrimaryProtonGun_module.cc
@@ -69,7 +69,7 @@ namespace mu2e {
         _engine{createEngine(art::ServiceHandle<SeedService>{}->getSeed())}
     {
         produces<GenParticleCollection>();
-      produces<SpectrumConfig, art::InSubRun>();
+        produces<SpectrumConfig, art::InSubRun>();
     }
 
     void PrimaryProtonGun::beginRun(art::Run& run ){

--- a/EventGenerator/src/PrimaryProtonGun_module.cc
+++ b/EventGenerator/src/PrimaryProtonGun_module.cc
@@ -16,6 +16,7 @@
 // Mu2e includes.
 #include "Offline/MCDataProducts/inc/GenId.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 
 // Particular generators that this code knows about.
 #include "Offline/EventGenerator/inc/PrimaryProtonGunImpl.hh"
@@ -24,6 +25,7 @@
 // Includes from art and its toolchain.
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
@@ -47,6 +49,7 @@ namespace mu2e {
 
       virtual void produce(art::Event& e ) override;
       virtual void beginRun(art::Run& r ) override;
+      virtual void endSubRun(art::SubRun& sr) override;
 
   private:
 
@@ -66,6 +69,7 @@ namespace mu2e {
         _engine{createEngine(art::ServiceHandle<SeedService>{}->getSeed())}
     {
         produces<GenParticleCollection>();
+      produces<SpectrumConfig, art::InSubRun>();
     }
 
     void PrimaryProtonGun::beginRun(art::Run& run ){
@@ -92,6 +96,12 @@ namespace mu2e {
         evt.put(std::move(genParticles));
 
     }//produce()
+
+      void PrimaryProtonGun::endSubRun(art::SubRun& sr ) {
+        auto config = std::make_unique<SpectrumConfig>();
+        config->type_ = SpectrumConfig::Type::kOther;
+        sr.put(std::move(config), art::fullSubRun());
+      }
 
 }
 

--- a/EventGenerator/src/PrimaryProtonGun_module.cc
+++ b/EventGenerator/src/PrimaryProtonGun_module.cc
@@ -99,7 +99,6 @@ namespace mu2e {
 
       void PrimaryProtonGun::endSubRun(art::SubRun& sr ) {
         auto config = std::make_unique<SpectrumConfig>();
-        config->type_ = SpectrumConfig::Type::kOther;
         sr.put(std::move(config), art::fullSubRun());
       }
 

--- a/EventGenerator/src/RMCGenerator_tool.cc
+++ b/EventGenerator/src/RMCGenerator_tool.cc
@@ -210,9 +210,9 @@ namespace mu2e {
 
   std::unique_ptr<SpectrumConfig> RMCGenerator::spectrumConfig() {
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czmax - _czmin)/2., _czmin, _czmax));
-    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax,
+                                                  _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz", (_czmax - _czmin)/2., _czmin, _czmax));
     return config;
   }
 

--- a/EventGenerator/src/RMCGenerator_tool.cc
+++ b/EventGenerator/src/RMCGenerator_tool.cc
@@ -52,6 +52,9 @@ namespace mu2e {
       _czmin(conf().czmin()),
       _czmax(conf().czmax()),
       _spectrum(BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>())),
+      _spectrumXMin(_spectrum.getXMin()),
+      _spectrumXMax(_spectrum.getXMax()),
+      _flatSpectrum(conf().spectrum.get<fhicl::ParameterSet>().get<std::string>("spectrumShape", "") == "flat"),
       _internalRate((_external) ? 0. : 1.),
       _makeHistograms(conf().makeHistograms())
     {
@@ -97,6 +100,7 @@ namespace mu2e {
 
     std::vector<ParticleGeneratorTool::Kinematic> generate() override;
     void generate(std::unique_ptr<GenParticleCollection>& out, const IO::StoppedParticleF& stop) override;
+    std::unique_ptr<SpectrumConfig> spectrumConfig() override;
 
     void finishInitialization(art::RandomNumberGenerator::base_engine_t& eng, const std::string& material, const bool isPrimary) override {
       _isPrimary = isPrimary;
@@ -121,6 +125,9 @@ namespace mu2e {
     const double _czmin; //range of cos(theta_z) generated
     const double _czmax;
     BinnedSpectrum _spectrum; //RMC photon spectrum
+    const double _spectrumXMin;
+    const double _spectrumXMax;
+    const bool _flatSpectrum;
     std::unique_ptr<MuonCaptureSpectrum> _muonCaptureSpectrum; // internal conversion spectrum
     double _internalRate;
 
@@ -199,6 +206,14 @@ namespace mu2e {
                         d.fourmom,
                         stop.t);
     }
+  }
+
+  std::unique_ptr<SpectrumConfig> RMCGenerator::spectrumConfig() {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (_czmax - _czmin)/2., _czmin, _czmax));
+    config->type_ = _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    return config;
   }
 
 }

--- a/EventGenerator/src/RMCGenerator_tool.cc
+++ b/EventGenerator/src/RMCGenerator_tool.cc
@@ -210,6 +210,7 @@ namespace mu2e {
 
   std::unique_ptr<SpectrumConfig> RMCGenerator::spectrumConfig() {
     auto config = std::make_unique<SpectrumConfig>();
+    // FIXME: calculate the spectrum fraction simulated
     config->add_var(SpectrumConfig::RestrictedVar("energy", 1., _spectrumXMin, _spectrumXMax,
                                                   _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
     config->add_var(SpectrumConfig::RestrictedVar("cosz", (_czmax - _czmin)/2., _czmin, _czmax));

--- a/EventGenerator/src/RMCGun_module.cc
+++ b/EventGenerator/src/RMCGun_module.cc
@@ -233,9 +233,11 @@ namespace mu2e {
   //================================================================
   void RMCGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
+    // FIXME: calculate the spectrum fraction simulated
     config->add_var(SpectrumConfig::RestrictedVar("energy", 1., spectrum_.getXMin(), spectrum_.getXMax(),
                                                   (psphys_.get<std::string>("spectrumShape", "") == "flat") ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
     config->add_var(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
+    config->add_var(SpectrumConfig::RestrictedVar("phi", (phimax_ - phimin_)/CLHEP::twopi, phimin_, phimax_));
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/RMCGun_module.cc
+++ b/EventGenerator/src/RMCGun_module.cc
@@ -233,9 +233,9 @@ namespace mu2e {
   //================================================================
   void RMCGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., spectrum_.getXMin(), spectrum_.getXMax()));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
-    config->type_ = (psphys_.get<std::string>("spectrumShape", "") == "flat") ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", 1., spectrum_.getXMin(), spectrum_.getXMax(),
+                                                  (psphys_.get<std::string>("spectrumShape", "") == "flat") ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/RMCGun_module.cc
+++ b/EventGenerator/src/RMCGun_module.cc
@@ -20,6 +20,7 @@
 // Framework includes
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -33,6 +34,7 @@
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
 #include "Offline/MCDataProducts/inc/EventWeight.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
 #include "Offline/Mu2eUtilities/inc/MuonCaptureSpectrum.hh"
 #include "Offline/Mu2eUtilities/inc/SimpleSpectrum.hh"
@@ -91,6 +93,7 @@ namespace mu2e {
   public:
     explicit RMCGun(const fhicl::ParameterSet& pset);
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
 
   //================================================================
@@ -114,6 +117,7 @@ namespace mu2e {
     , doHistograms_( pset.get<bool>("doHistograms",true ) )
   {
     produces<mu2e::GenParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
     if(verbosityLevel_ > 0) {
       std::cout<<"RMCGun: using = "
@@ -224,6 +228,15 @@ namespace mu2e {
   //================================================================
   double RMCGun::generateEnergy() {
     return spectrum_.sample(randSpectrum_.fire());
+  }
+
+  //================================================================
+  void RMCGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., spectrum_.getXMin(), spectrum_.getXMax()));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
+    config->type_ = (psphys_.get<std::string>("spectrumShape", "") == "flat") ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/RPCGun_module.cc
+++ b/EventGenerator/src/RPCGun_module.cc
@@ -297,9 +297,9 @@ namespace mu2e {
   //================================================================
   void RPCGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., spectrum_.getXMin(), spectrum_.getXMax()));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
-    config->type_ = flatSpectrum_ ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", 1., spectrum_.getXMin(), spectrum_.getXMax(),
+                                                  flatSpectrum_ ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/RPCGun_module.cc
+++ b/EventGenerator/src/RPCGun_module.cc
@@ -22,6 +22,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 
 #include "Offline/SeedService/inc/SeedService.hh"
@@ -30,6 +31,7 @@
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include "Offline/MCDataProducts/inc/EventWeight.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/simParticleList.hh"
 #include "Offline/Mu2eUtilities/inc/BinnedSpectrum.hh"
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
@@ -69,6 +71,7 @@ namespace mu2e {
     explicit RPCGun(const Parameters& conf);
 
     virtual void produce(art::Event& event) override;
+    virtual void endSubRun(art::SubRun& sr) override;
     void addParticles(StageParticleCollection* output,art::Ptr<SimParticle> pistop);
     double MakeEventWeight(art::Ptr<SimParticle> p);
     //----------------------------------------------------------------
@@ -81,6 +84,7 @@ namespace mu2e {
     CLHEP::RandFlat     randomFlat_;
     std::string RPCType_;
     BinnedSpectrum    spectrum_;
+    bool flatSpectrum_;
     const double czmin_;
     const double czmax_;
     bool pionDecayOff_;
@@ -123,6 +127,7 @@ namespace mu2e {
     , randomFlat_{eng_}
     , RPCType_{conf().RPCType()}
     , spectrum_{BinnedSpectrum(conf().spectrum.get<fhicl::ParameterSet>())}
+    , flatSpectrum_{conf().spectrum.get<fhicl::ParameterSet>().get<std::string>("spectrumShape", "") == "flat"}
     , czmin_(conf().czmin())
     , czmax_(conf().czmax())
     , pionDecayOff_{conf().pionDecayOff()}
@@ -133,6 +138,7 @@ namespace mu2e {
   {
     produces<mu2e::StageParticleCollection>();
     produces<mu2e::EventWeight>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
     if(RPCType_ == "mu2eExternalRPC") process_ = ProcessCode::mu2eExternalRPC;
     else if(RPCType_ == "mu2eInternalRPC") process_ = ProcessCode::mu2eInternalRPC;
     else {
@@ -287,6 +293,15 @@ namespace mu2e {
       }
 
    }
+
+  //================================================================
+  void RPCGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., spectrum_.getXMin(), spectrum_.getXMax()));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
+    config->type_ = flatSpectrum_ ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
+  }
 
 
   //================================================================

--- a/EventGenerator/src/RanTest_module.cc
+++ b/EventGenerator/src/RanTest_module.cc
@@ -6,11 +6,13 @@
 
 // Mu2e includes.
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/SeedService/inc/SeedService.hh"
 
 // Includes from art and its tool chain
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "fhiclcpp/ParameterSet.h"
 
@@ -29,6 +31,7 @@ namespace mu2e {
     virtual ~RanTest();
 
     virtual void produce(art::Event& e);
+    virtual void endSubRun(art::SubRun& sr) override;
 
   private:
 
@@ -37,6 +40,7 @@ namespace mu2e {
   RanTest::RanTest(fhicl::ParameterSet const& pSet) : EDProducer{pSet} {
 
     produces<GenParticleCollection>();
+    produces<SpectrumConfig, art::InSubRun>();
 
     // Provide a common engine for the generators to use via the service
     createEngine( art::ServiceHandle<SeedService>()->getSeed() );
@@ -51,6 +55,12 @@ namespace mu2e {
     unique_ptr<GenParticleCollection> genParticles(new GenParticleCollection);
     evt.put(std::move(genParticles));
 
+  }
+
+  void RanTest::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 }
 

--- a/EventGenerator/src/RanTest_module.cc
+++ b/EventGenerator/src/RanTest_module.cc
@@ -59,7 +59,6 @@ namespace mu2e {
 
   void RanTest::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 }

--- a/EventGenerator/src/SimpleAntiprotonGun_module.cc
+++ b/EventGenerator/src/SimpleAntiprotonGun_module.cc
@@ -14,6 +14,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -27,6 +28,7 @@
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenId.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/StoppingTargetGeom/inc/StoppingTarget.hh"
 #include "Offline/StoppingTargetGeom/inc/TargetFoil.hh"
@@ -93,6 +95,7 @@ namespace mu2e {
 
     virtual void beginRun(art::Run& run);
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
     Stop_t generateStop();
   };
 
@@ -111,6 +114,7 @@ namespace mu2e {
     , makeHistograms_(conf().makeHistograms())
   {
     produces<mu2e::GenParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
     if(verbosity_ > 0) {
       std::cout<<"SimpleAntiprotonGun: using gen ID " << genId_ << std::endl;
@@ -210,6 +214,13 @@ namespace mu2e {
       _hR->Fill(r);
       _hPz->Fill(p3.z());
     }
+  }
+
+  //================================================================
+  void SimpleAntiprotonGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/SimpleAntiprotonGun_module.cc
+++ b/EventGenerator/src/SimpleAntiprotonGun_module.cc
@@ -219,7 +219,6 @@ namespace mu2e {
   //================================================================
   void SimpleAntiprotonGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/SingleProcessGenerator_module.cc
+++ b/EventGenerator/src/SingleProcessGenerator_module.cc
@@ -22,6 +22,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art/Utilities/make_tool.h"
 
@@ -29,6 +30,7 @@
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
 #include "Offline/Mu2eUtilities/inc/simParticleList.hh"
 #include "Offline/EventGenerator/inc/ParticleGeneratorTool.hh"
@@ -58,6 +60,7 @@ namespace mu2e {
     explicit SingleProcessGenerator(const Parameters& conf);
 
     virtual void produce(art::Event& event) override;
+    virtual void endSubRun(art::SubRun& sr) override;
 
     //----------------------------------------------------------------
   private:
@@ -90,6 +93,7 @@ namespace mu2e {
     , randFlat_{eng_}
   {
     produces<mu2e::StageParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
     if(verbosity_ > 0) {
       mf::LogInfo log("SingleProcessGenerator");
       log<<"stoppingTargetMaterial = "<<conf().stoppingTargetMaterial()
@@ -124,6 +128,11 @@ namespace mu2e {
     }
 
     event.put(std::move(output));
+  }
+
+  //================================================================
+  void SingleProcessGenerator::endSubRun(art::SubRun& sr) {
+    sr.put(Generator_->spectrumConfig(), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/StoppedMuonRMCGun_module.cc
+++ b/EventGenerator/src/StoppedMuonRMCGun_module.cc
@@ -364,9 +364,9 @@ namespace mu2e {
   //================================================================
   void StoppedMuonRMCGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., spectrum_.getXMin(), spectrum_.getXMax()));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
-    config->type_ = (psphys_.get<std::string>("spectrumShape", "") == "flat") ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", 1., spectrum_.getXMin(), spectrum_.getXMax(),
+                                                  (psphys_.get<std::string>("spectrumShape", "") == "flat") ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/StoppedMuonRMCGun_module.cc
+++ b/EventGenerator/src/StoppedMuonRMCGun_module.cc
@@ -20,6 +20,7 @@
 // Framework includes
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -34,6 +35,7 @@
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
 #include "Offline/MCDataProducts/inc/EventWeight.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
 #include "Offline/Mu2eUtilities/inc/MuonCaptureSpectrum.hh"
 #include "Offline/Mu2eUtilities/inc/SimpleSpectrum.hh"
@@ -108,6 +110,7 @@ namespace mu2e {
     explicit StoppedMuonRMCGun(const fhicl::ParameterSet& pset);
     ~StoppedMuonRMCGun();
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
 
 //================================================================
@@ -129,6 +132,7 @@ namespace mu2e {
   {
     produces<mu2e::GenParticleCollection>();
     produces<mu2e::EventWeight>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
     fractionSpectrum_ = 0.;
     omcNormalization_ = 0.;
@@ -355,6 +359,15 @@ namespace mu2e {
     double result = (xHi2)/2. - (4./3.)*xHi2*xHigh + (7./4.)*(xHi2*xHi2) - (6./5.)*(xHi2)*(xHi2)*xHigh + (1./3.)*(xHi2*xHi2*xHi2)
       - ( (xLow*xLow)/2. - (4./3.)*xLow2*xLow + (7./4.)*(xLow2*xLow2) - (6./5.)*(xLow2)*(xLow2)*xLow + (1./3.)*(xLow2*xLow2*xLow2) );
     return result;
+  }
+
+  //================================================================
+  void StoppedMuonRMCGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., spectrum_.getXMin(), spectrum_.getXMax()));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
+    config->type_ = (psphys_.get<std::string>("spectrumShape", "") == "flat") ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/StoppedMuonXRayGammaRayGun_module.cc
+++ b/EventGenerator/src/StoppedMuonXRayGammaRayGun_module.cc
@@ -25,6 +25,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -33,6 +34,7 @@
 #include "Offline/SeedService/inc/SeedService.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
 #include "CLHEP/Random/RandFlat.h"
 #include "Offline/Mu2eUtilities/inc/Table.hh"
@@ -94,6 +96,7 @@ namespace mu2e {
   public:
     explicit StoppedMuonXRayGammaRayGun(const fhicl::ParameterSet& pset);
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
 
   //================================================================
@@ -125,6 +128,7 @@ namespace mu2e {
     _hxyPos(0){ //,_hrzPos(0)
 
     produces<mu2e::GenParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
     if ( _doHistograms ) bookHistograms();
   }
@@ -248,6 +252,12 @@ namespace mu2e {
     //                                   "MuonicXRay Photon (z,r) at Production;(mm)",
     //                                   bins2.nbins(), bins2.low(), bins2.high(), 60, 0., 120. );
 
+  }
+
+  void StoppedMuonXRayGammaRayGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
 } // end namespace mu2e

--- a/EventGenerator/src/StoppedMuonXRayGammaRayGun_module.cc
+++ b/EventGenerator/src/StoppedMuonXRayGammaRayGun_module.cc
@@ -256,7 +256,6 @@ namespace mu2e {
 
   void StoppedMuonXRayGammaRayGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kPhysical;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/StoppedMuplusDecayGun_module.cc
+++ b/EventGenerator/src/StoppedMuplusDecayGun_module.cc
@@ -107,9 +107,8 @@ namespace mu2e {
   //================================================================
   void StoppedMuplusDecayGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., emin_, muMass()/2.));
-    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
-    config->type_ = SpectrumConfig::Type::kPhysical;
+    config->add_var(SpectrumConfig::RestrictedVar("energy", 1., emin_, muMass()/2.));
+    config->add_var(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/StoppedMuplusDecayGun_module.cc
+++ b/EventGenerator/src/StoppedMuplusDecayGun_module.cc
@@ -17,6 +17,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "Offline/SeedService/inc/SeedService.hh"
 
@@ -26,6 +27,7 @@
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
 #include "Offline/Mu2eUtilities/inc/RootTreeSampler.hh"
 #include "Offline/GeneralUtilities/inc/RSNTIO.hh"
@@ -58,6 +60,7 @@ namespace mu2e {
   public:
     explicit StoppedMuplusDecayGun(const fhicl::ParameterSet& pset);
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
 
   //================================================================
@@ -74,6 +77,7 @@ namespace mu2e {
     , flat_        (eng_)
   {
     produces<mu2e::GenParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
   }
 
   //================================================================
@@ -98,6 +102,15 @@ namespace mu2e {
     std::unique_ptr<GenParticleCollection> output(new GenParticleCollection);
     output->emplace_back(PDGCode::e_plus, GenId::muplusDecayGun, pos, p4, stop.t);
     event.put(std::move(output));
+  }
+
+  //================================================================
+  void StoppedMuplusDecayGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("energy", 1., emin_, muMass()/2.));
+    config->vars_.push_back(SpectrumConfig::RestrictedVar("cosz", (czmax_ - czmin_)/2., czmin_, czmax_));
+    config->type_ = SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/StoppedParticleG4Gun_module.cc
+++ b/EventGenerator/src/StoppedParticleG4Gun_module.cc
@@ -124,7 +124,6 @@ namespace mu2e {
   //================================================================
   void StoppedParticleG4Gun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/StoppedParticleG4Gun_module.cc
+++ b/EventGenerator/src/StoppedParticleG4Gun_module.cc
@@ -25,6 +25,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -35,6 +36,7 @@
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/RootTreeSampler.hh"
 #include "Offline/GeneralUtilities/inc/RSNTIO.hh"
 
@@ -73,6 +75,7 @@ namespace mu2e {
     explicit StoppedParticleG4Gun(const Parameters& conf);
 
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
 
   //================================================================
@@ -85,6 +88,7 @@ namespace mu2e {
              conf().muonStops())
   {
     produces<mu2e::GenParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
     if(verbosityLevel_ > 0) {
       std::cout<<"StoppedParticleG4Gun: using = "
@@ -115,6 +119,13 @@ namespace mu2e {
                          stop.t);
 
     event.put(std::move(output));
+  }
+
+  //================================================================
+  void StoppedParticleG4Gun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/StoppedParticleReactionGun_module.cc
+++ b/EventGenerator/src/StoppedParticleReactionGun_module.cc
@@ -53,7 +53,7 @@ namespace mu2e {
     PDGCode::type       pdgId_;
     double              mass_;
 
-    enum SpectrumVar  { TOTAL_ENERGY, KINETIC_ENERY, MOMENTUM };
+    enum SpectrumVar  { TOTAL_ENERGY, KINETIC_ENERGY, MOMENTUM };
     SpectrumVar       spectrumVariable_;
 
     BinnedSpectrum    spectrum_;
@@ -153,7 +153,7 @@ namespace mu2e {
   //================================================================
   StoppedParticleReactionGun::SpectrumVar StoppedParticleReactionGun::parseSpectrumVar(const std::string& name) {
     if (name == "totalEnergy"  )  return TOTAL_ENERGY;
-    if (name == "kineticEnergy")  return KINETIC_ENERY;
+    if (name == "kineticEnergy")  return KINETIC_ENERGY;
     if (name == "momentum"     )  return MOMENTUM;
     throw cet::exception("BADCONFIG")<<"StoppedParticleReactionGun: unknown spectrum variable "<<name<<"\n";
   }
@@ -207,7 +207,7 @@ namespace mu2e {
 
     switch(spectrumVariable_) {
     case TOTAL_ENERGY  : break;
-    case KINETIC_ENERY : res += mass_; break;
+    case KINETIC_ENERGY : res += mass_; break;
     case MOMENTUM      : res = sqrt(res*res+mass_*mass_); break;
     }
     return res;
@@ -217,7 +217,7 @@ namespace mu2e {
     auto config = std::make_unique<SpectrumConfig>();
     std::string varName("energy");
     switch(spectrumVariable_) {
-      case KINETIC_ENERY: varName = "kineticEnergy"; break;
+      case KINETIC_ENERGY: varName = "kineticEnergy"; break;
       case MOMENTUM:      varName = "momentum";      break;
       default:            varName = "energy";        break;
     }

--- a/EventGenerator/src/StoppedParticleReactionGun_module.cc
+++ b/EventGenerator/src/StoppedParticleReactionGun_module.cc
@@ -18,6 +18,7 @@
 
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Principal/Run.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -29,6 +30,7 @@
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 #include "Offline/Mu2eUtilities/inc/RandomUnitSphere.hh"
 #include "Offline/Mu2eUtilities/inc/CzarneckiSpectrum.hh"
 #include "Offline/Mu2eUtilities/inc/ConversionSpectrum.hh"
@@ -84,6 +86,7 @@ namespace mu2e {
     explicit StoppedParticleReactionGun(const fhicl::ParameterSet& pset);
 
     virtual void produce(art::Event& event);
+    virtual void endSubRun(art::SubRun& sr) override;
   };
 
   //================================================================
@@ -105,6 +108,7 @@ namespace mu2e {
     , reseeder_(eng_,seed_,verbosityLevel_)
   {
     produces<mu2e::GenParticleCollection>();
+    produces<mu2e::SpectrumConfig, art::InSubRun>();
 
     if(genId_ == GenId::enum_type::unknown) {
       throw cet::exception("BADCONFIG")<<"StoppedParticleReactionGun: unknown genId "
@@ -207,6 +211,12 @@ namespace mu2e {
     case MOMENTUM      : res = sqrt(res*res+mass_*mass_); break;
     }
     return res;
+  }
+
+  void StoppedParticleReactionGun::endSubRun(art::SubRun& sr) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = (psphys_.get<std::string>("spectrumShape", "") == "flat") ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/EventGenerator/src/StoppedParticleReactionGun_module.cc
+++ b/EventGenerator/src/StoppedParticleReactionGun_module.cc
@@ -215,7 +215,14 @@ namespace mu2e {
 
   void StoppedParticleReactionGun::endSubRun(art::SubRun& sr) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = (psphys_.get<std::string>("spectrumShape", "") == "flat") ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical;
+    std::string varName("energy");
+    switch(spectrumVariable_) {
+      case KINETIC_ENERY: varName = "kineticEnergy"; break;
+      case MOMENTUM:      varName = "momentum";      break;
+      default:            varName = "energy";        break;
+    }
+    config->add_var(SpectrumConfig::RestrictedVar(varName, 1., spectrum_.getXMin(), spectrum_.getXMax(),
+                                                  (psphys_.get<std::string>("spectrumShape", "") == "flat") ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/deltaFunctionGun_module.cc
+++ b/EventGenerator/src/deltaFunctionGun_module.cc
@@ -104,7 +104,6 @@ namespace mu2e {
   //================================================================
   void deltaFunctionGun::endSubRun(art::SubRun& sr, const art::ProcessingFrame&) {
     auto config = std::make_unique<SpectrumConfig>();
-    config->type_ = SpectrumConfig::Type::kOther;
     sr.put(std::move(config), art::fullSubRun());
   }
 

--- a/EventGenerator/src/deltaFunctionGun_module.cc
+++ b/EventGenerator/src/deltaFunctionGun_module.cc
@@ -23,11 +23,13 @@
 
 #include "art/Framework/Core/SharedProducer.h"
 #include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
 
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/DataProducts/inc/PDGCode.hh"
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 
 namespace mu2e {
 
@@ -75,6 +77,7 @@ namespace mu2e {
     explicit deltaFunctionGun(const Parameters& conf, const art::ProcessingFrame&);
 
     void produce(art::Event& event, const art::ProcessingFrame&) override;
+    void endSubRun(art::SubRun& sr, const art::ProcessingFrame&) override;
 
   private:
     const GenParticle particle_;
@@ -88,6 +91,7 @@ namespace mu2e {
     {
       async<art::InEvent>();
       produces<GenParticleCollection>();
+      produces<SpectrumConfig, art::InSubRun>();
     }
 
   //================================================================
@@ -95,6 +99,13 @@ namespace mu2e {
     using namespace std;
     auto output{make_unique<GenParticleCollection,initializer_list<GenParticle>>({particle_})};
     event.put(move(output));
+  }
+
+  //================================================================
+  void deltaFunctionGun::endSubRun(art::SubRun& sr, const art::ProcessingFrame&) {
+    auto config = std::make_unique<SpectrumConfig>();
+    config->type_ = SpectrumConfig::Type::kOther;
+    sr.put(std::move(config), art::fullSubRun());
   }
 
   //================================================================

--- a/MCDataProducts/inc/SpectrumConfig.hh
+++ b/MCDataProducts/inc/SpectrumConfig.hh
@@ -1,0 +1,31 @@
+// Relevant event generator configuration information
+// Michael MacKenzie, 2026
+
+#ifndef MCDataProducts_inc_SpectrumConfig_hh
+#define MCDataProducts_inc_SpectrumConfig_hh
+
+namespace mu2e {
+
+  class SpectrumConfig {
+  public:
+    enum Type {kPhysical = 0, kFlat, kOther};
+
+    SpectrumConfig() {}
+
+    // Common operations for normalization
+    double ediff()  const { return emax_ - emin_; }
+    double czfrac() const { return (czmax_ - czmin_)/2.; }
+
+  public: // allow direct access/manipulation of the fields
+    double emin_             = -1.;
+    double emax_             = -1.;
+    double tmin_             =  0.;
+    double tmax_             =  0.;
+    double czmin_            = -1.;
+    double czmax_            =  1.;
+    double fraction_sampled_ = 1.;
+    int    type_             = Type::kOther;
+  };
+}
+
+#endif/*MCDataProducts_inc_SpectrumConfig_hh*/

--- a/MCDataProducts/inc/SpectrumConfig.hh
+++ b/MCDataProducts/inc/SpectrumConfig.hh
@@ -17,7 +17,7 @@ namespace mu2e {
 
     // A variable that can be restricted in a simulation
     struct RestrictedVar {
-      RestrictedVar(const std::string name,
+      RestrictedVar(const std::string name = "default",
                     const double fraction = 1.,
                     const double xmin = std::numeric_limits<double>::lowest(),
                     const double xmax = std::numeric_limits<double>::max()) : name_(name),

--- a/MCDataProducts/inc/SpectrumConfig.hh
+++ b/MCDataProducts/inc/SpectrumConfig.hh
@@ -5,7 +5,7 @@
 #define MCDataProducts_inc_SpectrumConfig_hh
 
 #include <limits>
-#include <vector>
+#include <map>
 #include <string>
 
 namespace mu2e {
@@ -54,7 +54,7 @@ namespace mu2e {
     }
 
     // Check if provided variables pass the selection
-    bool accepted(const std::map<std::string, double>& vars) {
+    bool accepted(const std::map<std::string, double>& vars) const {
       for(const auto& [name, value] : vars) {
         // check if this name is defined
         if(!vars_.contains(name)) {
@@ -63,7 +63,7 @@ namespace mu2e {
           return false;
         }
         // Check if it's accepted
-        if(!vars_[name].accepted(value)) return false;
+        if(!vars_.at(name).accepted(value)) return false;
       }
 
       // Passes all selections

--- a/MCDataProducts/inc/SpectrumConfig.hh
+++ b/MCDataProducts/inc/SpectrumConfig.hh
@@ -4,6 +4,8 @@
 #ifndef MCDataProducts_inc_SpectrumConfig_hh
 #define MCDataProducts_inc_SpectrumConfig_hh
 
+#include <limits>
+
 namespace mu2e {
 
   class SpectrumConfig {
@@ -19,8 +21,8 @@ namespace mu2e {
   public: // allow direct access/manipulation of the fields
     double emin_             = -1.;
     double emax_             = -1.;
-    double tmin_             =  0.;
-    double tmax_             =  0.;
+    double tmin_             = std::numeric_limits<double>::lowest();
+    double tmax_             = std::numeric_limits<double>::max();
     double czmin_            = -1.;
     double czmax_            =  1.;
     double fraction_sampled_ = 1.;

--- a/MCDataProducts/inc/SpectrumConfig.hh
+++ b/MCDataProducts/inc/SpectrumConfig.hh
@@ -5,28 +5,47 @@
 #define MCDataProducts_inc_SpectrumConfig_hh
 
 #include <limits>
+#include <vector>
+#include <string>
 
 namespace mu2e {
 
   class SpectrumConfig {
   public:
+    // Indicate the broad class of primary simulations this falls under
     enum Type {kPhysical = 0, kFlat, kOther};
 
-    SpectrumConfig() {}
+    // A variable that can be restricted in a simulation
+    struct RestrictedVar {
+      RestrictedVar(const std::string name,
+                    const double fraction = 1.,
+                    const double xmin = std::numeric_limits<double>::lowest(),
+                    const double xmax = std::numeric_limits<double>::max()) : name_(name),
+                                                                              fraction_(fraction),
+                                                                              xmin_(xmin),
+                                                                              xmax_(xmax) {}
 
-    // Common operations for normalization
-    double ediff()  const { return emax_ - emin_; }
-    double czfrac() const { return (czmax_ - czmin_)/2.; }
+      std::string name_     ;
+      double      fraction_ ;
+      double      xmin_     ;
+      double      xmax_     ;
+    };
+
+    SpectrumConfig(const int type = Type::kOther) : type_(type) {}
+
+    double total_fraction(const bool verbose = false) {
+      double fraction = 1.;
+      for(const auto& var : vars_) {
+        fraction *= var.fraction_;
+        if(verbose) printf("  Component %12s has fraction %.4e\n", var.name_.c_str(), var.fraction_);
+      }
+      if(verbose) printf("  Total fraction: %.4e\n", fraction);
+      return fraction;
+    }
 
   public: // allow direct access/manipulation of the fields
-    double emin_             = -1.;
-    double emax_             = -1.;
-    double tmin_             = std::numeric_limits<double>::lowest();
-    double tmax_             = std::numeric_limits<double>::max();
-    double czmin_            = -1.;
-    double czmax_            =  1.;
-    double fraction_sampled_ = 1.;
-    int    type_             = Type::kOther;
+    std::vector<RestrictedVar> vars_;
+    int type_;
   };
 }
 

--- a/MCDataProducts/inc/SpectrumConfig.hh
+++ b/MCDataProducts/inc/SpectrumConfig.hh
@@ -13,6 +13,8 @@ namespace mu2e {
   class SpectrumConfig {
   public:
     // Indicate the broad class of primary simulations this falls under
+    // Physical indicates it followed a physical distribution (including flat if it's physical, e.g. cos(theta_z) for CEs)
+    // Flat is for flat and non-physical distributions, like flat electron energy from the target
     enum Type {kPhysical = 0, kFlat, kOther};
 
     // A variable that can be restricted in a simulation
@@ -20,22 +22,66 @@ namespace mu2e {
       RestrictedVar(const std::string name = "default",
                     const double fraction = 1.,
                     const double xmin = std::numeric_limits<double>::lowest(),
-                    const double xmax = std::numeric_limits<double>::max()) : name_(name),
-                                                                              fraction_(fraction),
-                                                                              xmin_(xmin),
-                                                                              xmax_(xmax) {}
+                    const double xmax = std::numeric_limits<double>::max(),
+                    const Type type = kPhysical) : name_(name),
+                                                   fraction_(fraction),
+                                                   xmin_(xmin),
+                                                   xmax_(xmax),
+                                                   type_(type) {}
 
-      std::string name_     ;
-      double      fraction_ ;
-      double      xmin_     ;
+      // Check if a value is within the restricted range
+      bool accepted(double value) const {
+        return value >= xmin_ && value <= xmax_; // allow the bounds
+      }
+
+      std::string name_     ; // variable identifier, e.g. "energy"
+      double      fraction_ ; // normalization correction factor
+      double      xmin_     ; // variable range restriction (inclusive)
       double      xmax_     ;
+      Type        type_     ; // variable sampling configuration
     };
 
-    SpectrumConfig(const int type = Type::kOther) : type_(type) {}
+    SpectrumConfig() {}
 
-    double total_fraction(const bool verbose = false) {
+    // Add a variable
+    void add_var(const RestrictedVar var) {
+      vars_[var.name_] = var;
+    }
+
+    // Get the variables
+    const std::map<std::string, RestrictedVar>& get_variables() const {
+      return vars_;
+    }
+
+    // Check if provided variables pass the selection
+    bool accepted(const std::map<std::string, double>& vars) {
+      for(const auto& [name, value] : vars) {
+        // check if this name is defined
+        if(!vars_.contains(name)) {
+          printf("[SpectrumConfig::%s] No variable %s is defined!\n",
+                 __func__, name.c_str());
+          return false;
+        }
+        // Check if it's accepted
+        if(!vars_[name].accepted(value)) return false;
+      }
+
+      // Passes all selections
+      return true;
+    }
+
+    // Check if all variables are configured as physical
+    bool is_physical() const {
+      for(const auto& [_, var] : vars_) {
+        if(var.type_ != Type::kPhysical) return false;
+      }
+      return true;
+    }
+
+    // Get the total fraction, assuming each component is independent
+    double total_fraction(const bool verbose = false) const {
       double fraction = 1.;
-      for(const auto& var : vars_) {
+      for(const auto& [_,var] : vars_) {
         fraction *= var.fraction_;
         if(verbose) printf("  Component %12s has fraction %.4e\n", var.name_.c_str(), var.fraction_);
       }
@@ -43,9 +89,19 @@ namespace mu2e {
       return fraction;
     }
 
-  public: // allow direct access/manipulation of the fields
-    std::vector<RestrictedVar> vars_;
-    int type_;
+    // Get the fraction for one component
+    double var_fraction(const std::string name) const {
+      // check if this name is defined
+      if(!vars_.contains(name)) {
+        printf("[SpectrumConfig::%s] No variable %s is defined!\n",
+               __func__, name.c_str());
+        return 0.;
+      }
+      return vars_.at(name).fraction_;
+    }
+
+  private:
+    std::map<std::string,RestrictedVar> vars_; // map of (potentially) restricted variables
   };
 }
 

--- a/MCDataProducts/src/classes.h
+++ b/MCDataProducts/src/classes.h
@@ -21,6 +21,7 @@
 #include "Offline/MCDataProducts/inc/GenSimParticleLink.hh"
 #include "Offline/MCDataProducts/inc/GenEventCount.hh"
 #include "Offline/MCDataProducts/inc/StageParticle.hh"
+#include "Offline/MCDataProducts/inc/SpectrumConfig.hh"
 
 // simulation
 #include "Offline/MCDataProducts/inc/StatusG4.hh"

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -38,8 +38,8 @@
  <class name="art::Wrapper<mu2e::SpectrumConfig>"/>
  <class name="mu2e::SpectrumConfig::RestrictedVar"/>
  <class name="art::Wrapper<mu2e::SpectrumConfig::RestrictedVar>"/>
- <class name="std::vector<mu2e::SpectrumConfig::RestrictedVar>"/>
- <class name="art::Wrapper<std::vector<mu2e::SpectrumConfig::RestrictedVar>>"/>
+ <class name="std::map<std::string,mu2e::SpectrumConfig::RestrictedVar>"/>
+ <class name="art::Wrapper<std::map<std::string,mu2e::SpectrumConfig::RestrictedVar>>"/>
 
 <!--  ********* simulation  ********* -->
  <class name="mu2e::StatusG4"/>

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -36,6 +36,10 @@
 
  <class name="mu2e::SpectrumConfig"/>
  <class name="art::Wrapper<mu2e::SpectrumConfig>"/>
+ <class name="mu2e::SpectrumConfig::RestrictedVar"/>
+ <class name="art::Wrapper<mu2e::SpectrumConfig::RestrictedVar>"/>
+ <class name="std::vector<mu2e::SpectrumConfig::RestrictedVar>"/>
+ <class name="art::Wrapper<std::vector<mu2e::SpectrumConfig::RestrictedVar>>"/>
 
 <!--  ********* simulation  ********* -->
  <class name="mu2e::StatusG4"/>

--- a/MCDataProducts/src/classes_def.xml
+++ b/MCDataProducts/src/classes_def.xml
@@ -34,6 +34,9 @@
  <class name="mu2e::StageParticleCollection"/>
  <class name="art::Wrapper<mu2e::StageParticleCollection>"/>
 
+ <class name="mu2e::SpectrumConfig"/>
+ <class name="art::Wrapper<mu2e::SpectrumConfig>"/>
+
 <!--  ********* simulation  ********* -->
  <class name="mu2e::StatusG4"/>
  <class name="std::vector<mu2e::StatusG4>"/>

--- a/Mu2eUtilities/inc/SpectrumVar.hh
+++ b/Mu2eUtilities/inc/SpectrumVar.hh
@@ -5,11 +5,11 @@
 
 namespace mu2e {
 
-  enum SpectrumVar  { TOTAL_ENERGY, KINETIC_ENERY, MOMENTUM };
+  enum SpectrumVar  { TOTAL_ENERGY, KINETIC_ENERGY, MOMENTUM };
 
   inline SpectrumVar    parseSpectrumVar(const std::string& name) {
     if (name == "totalEnergy"  )  return TOTAL_ENERGY;
-    if (name == "kineticEnergy")  return KINETIC_ENERY;
+    if (name == "kineticEnergy")  return KINETIC_ENERGY;
     if (name == "momentum"     )  return MOMENTUM;
     throw cet::exception("BADCONFIG")<<"parseSpectrumVar(): unknown spectrum variable "<<name<<"\n";
   }


### PR DESCRIPTION
The goal of this data product is to simplify downstream workflows that need to know information about a dataset's primary generator configuration. This includes samples with restricted energy and cos(theta_z) regions. I've added default output of this product to all generators, even where the information is trivial, so downstream workflows will always find it and it can be updated to add more information if restrictions change.