### PR TITLE
Add back services and normal DS volume

### DIFF
--- a/Mu2eG4/geom/geom_run1_b_v40.txt
+++ b/Mu2eG4/geom/geom_run1_b_v40.txt
@@ -20,16 +20,16 @@ double tsda.halfLength4  = 8.75;                // 1.75 cm plate
 string tsda.materialName = "StoppingTarget_Al"; // stopping target material to capture in the stops finder
 
 // Place tracker in DS2Vacuum (keeps TT_MidInner VD within DS2Vacuum bounds)
-bool tracker.inDS2Vacuum = true;
+// bool tracker.inDS2Vacuum = true;
 
 // Extend DS2Vacuum to contain the tracker at nominal position z=10171 mm.
 // Split lands at 11829 mm, between tracker mother end (11811) and calo face (11842).
-double ds2.halfLength = 3825;
+// double ds2.halfLength = 3825;
 
 // Disable DS3 service pipes: their upstream face is at z~11480 mm, which falls
 // inside the extended DS2Vacuum (DS3 now starts at 11829 mm), causing extrusion
 // overlaps. geom_run1_b_v01.txt uses the same flag for the same reason.
-bool ds.hasServicePipes = false;
+// bool ds.hasServicePipes = false;
 
 // This tells emacs to view this file in c++ mode.
 // Local Variables:


### PR DESCRIPTION
In Run 1B v40 geom, we don't need to alter the nominal geometry as the detector positions are restored.