### PR TITLE
Adds ParameterHit info to KalSeed so it can be regrown

### DIFF
--- a/CosmicReco/src/LineFinder_module.cc
+++ b/CosmicReco/src/LineFinder_module.cc
@@ -190,8 +190,8 @@ int LineFinder::findLine(const ComboHitCollection& shC, std::vector<StrawHitInde
                 Straw const& strawk = tracker->getStraw(shC[kloc].strawId());
                 TwoLinePCA pca( strawk.getMidPoint(), strawk.getDirection(),
                     ipos, newdir);
-                double dist = (pca.point1()-strawk.getMidPoint()).mag();
-                if (pca.dca() < _maxDOCA && dist < strawk.halfLength()){
+                double dist = (pca.point1()-strawk.getMidPoint()).dot(strawk.getDirection());
+                if (pca.dca() < _maxDOCA && fabs(dist) < strawk.halfLength()){
                   count += 1;
                   ll += pow(dist-shC[kloc].wireDist(),2)/shC[kloc].wireVar();
                 }

--- a/Mu2eKinKal/inc/KKFit.hh
+++ b/Mu2eKinKal/inc/KKFit.hh
@@ -102,6 +102,7 @@ namespace mu2e {
       bool makeStrawHits(Tracker const& tracker,StrawResponse const& strawresponse, BFieldMap const& kkbf,
           PTRAJ const& ptraj, ComboHitCollection const& chcol, StrawHitIndexCollection const& strawHitIdxs,
           KKSTRAWHITCOL& hits, KKSTRAWXINGCOL& exings) const;
+      void makeSeedParamHit(KTRAJ const& seedtraj, std::vector<double> const& paramconstraints, PARAMHITCOL& paramhits) const;
       // regrow KKTrack components from a KalSeed
       bool regrowComponents(KalSeed const& kseed, ComboHitCollection const& chcol, mu2e::IndexMap const& strawindexmap,
           Tracker const& tracker,Calorimeter const& calo, StrawResponse const& strawresponse,BFieldMap const& kkbf,
@@ -255,6 +256,23 @@ namespace mu2e {
     return ngood >= minNStrawHits_;
   }
 
+  template <class KTRAJ> void KKFit<KTRAJ>::makeSeedParamHit(KTRAJ const& seedtraj, std::vector<double> const& paramconstraints, PARAMHITCOL& paramhits) const {
+    std::array<bool,KinKal::NParams()> mask = {false};
+    KinKal::Parameters cparams = seedtraj.params();
+    for (size_t ipar=0;ipar<KinKal::NParams();ipar++){
+      for (size_t jpar=0;jpar<KinKal::NParams();jpar++){
+        cparams.covariance()[ipar][jpar] = 0.0;
+      }
+      if (paramconstraints[ipar] > 0){
+        mask[ipar] = true;
+        cparams.covariance()[ipar][ipar] = paramconstraints[ipar]*paramconstraints[ipar];
+      }else{
+        cparams.covariance()[ipar][ipar] = 1.0; // otherwise inversion fails
+      }
+    }
+    paramhits.push_back(std::make_shared<PARAMHIT>(seedtraj.range().mid(),seedtraj,cparams,mask));
+  }
+
   template <class KTRAJ> bool KKFit<KTRAJ>::regrowComponents(KalSeed const& kseed, // primary event input
       ComboHitCollection const& chcol, mu2e::IndexMap const& strawindexmap, // ancillary event input
       Tracker const& tracker,Calorimeter const& calo, // geometries
@@ -367,7 +385,6 @@ namespace mu2e {
     KKSTRAWHITCOL addstrawhits;
     KKCALOHITCOL addcalohits;
     KKSTRAWXINGCOL addstrawxings;
-    PARAMHITCOL addparamhits;
     if(addhits_)addStrawHits(tracker, strawresponse, kkbf, kktrk, chcol, addstrawhits, addstrawxings );
     if(matcorr_ && addmat_)addStraws(tracker, kktrk, addstrawxings);
     if(addhits_ && usecalo_ && kktrk.caloHits().size()==0)addCaloHit(calo, kktrk, cchandle, addcalohits);
@@ -377,7 +394,7 @@ namespace mu2e {
         << addcalohits.size() << " CaloHits and "
         << addstrawxings.size() << " Straw Xings" << std::endl;
     }
-    kktrk.extendTrack(exconfig,addstrawhits,addstrawxings,addcalohits,addparamhits);
+    kktrk.extendTrack(exconfig,addstrawhits,addstrawxings,addcalohits);
   }
 
   template <class KTRAJ> void KKFit<KTRAJ>::addStrawHits(Tracker const& tracker,StrawResponse const& strawresponse, BFieldMap const& kkbf,

--- a/Mu2eKinKal/inc/KKFit.hh
+++ b/Mu2eKinKal/inc/KKFit.hh
@@ -82,6 +82,9 @@ namespace mu2e {
       using KKCALOHIT = KKCaloHit<KTRAJ>;
       using KKCALOHITPTR = std::shared_ptr<KKCALOHIT>;
       using KKCALOHITCOL = std::vector<KKCALOHITPTR>;
+      using PARAMHIT = KinKal::ParameterHit<KTRAJ>;
+      using PARAMHITPTR = std::shared_ptr<PARAMHIT>;
+      using PARAMHITCOL = std::vector<PARAMHITPTR>;
       //      using KKPANELHIT = KKPanelHit<KTRAJ>;
       using MEAS = KinKal::Hit<KTRAJ>;
       using MEASPTR = std::shared_ptr<MEAS>;
@@ -102,7 +105,8 @@ namespace mu2e {
       // regrow KKTrack components from a KalSeed
       bool regrowComponents(KalSeed const& kseed, ComboHitCollection const& chcol, mu2e::IndexMap const& strawindexmap,
           Tracker const& tracker,Calorimeter const& calo, StrawResponse const& strawresponse,BFieldMap const& kkbf,
-          PTRAJPTR& ptraj, KKSTRAWHITCOL& strawhits, KKCALOHITCOL& calohits, KKSTRAWXINGCOL& exings, DOMAINCOL& domains) const;
+          PTRAJPTR& ptraj, KKSTRAWHITCOL& strawhits, KKCALOHITCOL& calohits, PARAMHITCOL& paramhits,
+          KKSTRAWXINGCOL& exings, DOMAINCOL& domains) const;
       std::shared_ptr<SensorLine> caloAxis(CaloCluster const& cluster, Calorimeter const& calo) const; // should come from CaloCluster TODO
       bool makeCaloHit(CCPtr const& cluster, Calorimeter const& calo, PTRAJ const& pktraj, KKCALOHITCOL& hits) const;
       // extend a track with a new configuration, optionally searching for and adding hits and straw material
@@ -255,7 +259,8 @@ namespace mu2e {
       ComboHitCollection const& chcol, mu2e::IndexMap const& strawindexmap, // ancillary event input
       Tracker const& tracker,Calorimeter const& calo, // geometries
       StrawResponse const& strawresponse,BFieldMap const& kkbf, // other conditions
-      PTRAJPTR& ptraj, KKSTRAWHITCOL& strawhits, KKCALOHITCOL& calohits, KKSTRAWXINGCOL& exings, DOMAINCOL& domains) const { // return values
+      PTRAJPTR& ptraj, KKSTRAWHITCOL& strawhits, KKCALOHITCOL& calohits, PARAMHITCOL& paramhits,
+      KKSTRAWXINGCOL& exings, DOMAINCOL& domains) const { // return values
     GeomHandle<mu2e::KKMaterial> kkmat_h;
     auto const& smat = kkmat_h->strawMaterial();
     unsigned ngood(0), nactive(0), nsactive(0);
@@ -281,6 +286,9 @@ namespace mu2e {
     }
     if(kseed.caloCluster()){
       makeCaloHit(kseed.caloCluster(),calo,*ptraj,calohits);
+    }
+    for (auto const& paramhit : kseed.paramHits()){
+      paramhits.push_back(std::make_shared<PARAMHIT>(paramhit.time(),*ptraj,paramhit.params(),paramhit.pmask()));
     }
     if(matcorr_){
       // add Straw Xings for straws without hits
@@ -359,6 +367,7 @@ namespace mu2e {
     KKSTRAWHITCOL addstrawhits;
     KKCALOHITCOL addcalohits;
     KKSTRAWXINGCOL addstrawxings;
+    PARAMHITCOL addparamhits;
     if(addhits_)addStrawHits(tracker, strawresponse, kkbf, kktrk, chcol, addstrawhits, addstrawxings );
     if(matcorr_ && addmat_)addStraws(tracker, kktrk, addstrawxings);
     if(addhits_ && usecalo_ && kktrk.caloHits().size()==0)addCaloHit(calo, kktrk, cchandle, addcalohits);
@@ -368,7 +377,7 @@ namespace mu2e {
         << addcalohits.size() << " CaloHits and "
         << addstrawxings.size() << " Straw Xings" << std::endl;
     }
-    kktrk.extendTrack(exconfig,addstrawhits,addstrawxings,addcalohits);
+    kktrk.extendTrack(exconfig,addstrawhits,addstrawxings,addcalohits,addparamhits);
   }
 
   template <class KTRAJ> void KKFit<KTRAJ>::addStrawHits(Tracker const& tracker,StrawResponse const& strawresponse, BFieldMap const& kkbf,
@@ -723,6 +732,9 @@ namespace mu2e {
           ca.tpData(),
           calohit->unbiasedClosestApproach().tpData(),
           ctres,ca.particleTraj().momentum3(ca.particleToca()));
+    }
+    for (auto const& paramhit : kktrk.paramHits()){
+      kseed._paramhits.emplace_back(paramhit->time(),paramhit->constraintParameters(),paramhit->constraintMask());
     }
     kseed._straws.reserve(kktrk.strawXings().size());
     for(auto const& sxing : kktrk.strawXings()) {

--- a/Mu2eKinKal/inc/KKTrack.hh
+++ b/Mu2eKinKal/inc/KKTrack.hh
@@ -121,7 +121,7 @@ namespace mu2e {
 
       // extend the track according to new configuration, hits, and/or exings
       void extendTrack(Config const& config,
-          KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings, KKCALOHITCOL const& calohits, PARAMHITCOL const& paramhits );
+          KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings, KKCALOHITCOL const& calohits);
       // extend the track to cover a new set of material Xings.  This will reuse the existing config object
       void extendTrack(EXINGCOL const& xings);
       // add IPA Xing
@@ -259,8 +259,7 @@ namespace mu2e {
   }
 
   template <class KTRAJ> void KKTrack<KTRAJ>::extendTrack(Config const& config,
-      KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings, KKCALOHITCOL const& calohits,
-      PARAMHITCOL const& paramhits) {
+      KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings, KKCALOHITCOL const& calohits) {
     // convert the hits and Xings to generic types and extend the track
     MEASCOL hits; // polymorphic container of hits
     EXINGCOL exings; // polymorphic container of detector element crossings
@@ -280,16 +279,15 @@ namespace mu2e {
       }
       if(nhit != strawhits_.size()+strawhits.size()) std::cout << "cluster hit sum doesn't match " << nhit << " " << strawhits_.size() << std::endl;
     }
+    PARAMHITCOL paramhits;
     convertTypes(strawhits,strawxings,calohits,paramhits,hits,exings);
     this->extend(config,hits,exings);
     // store the new hits
     strawhits_.reserve(strawhits_.size()+strawhits.size());
     calohits_.reserve(calohits_.size()+calohits.size());
-    paramhits_.reserve(paramhits_.size()+paramhits.size());
     strawxings_.reserve(strawxings_.size()+strawxings.size());
     for(auto const& strawhit : strawhits)strawhits_.emplace_back(strawhit);
     for(auto const& calohit : calohits)calohits_.emplace_back(calohit);
-    for(auto const& paramhit : paramhits)paramhits_.emplace_back(paramhit);
     for(auto const& strawxing : strawxings)strawxings_.emplace_back(strawxing);
   }
 

--- a/Mu2eKinKal/inc/KKTrack.hh
+++ b/Mu2eKinKal/inc/KKTrack.hh
@@ -36,6 +36,9 @@ namespace mu2e {
       using KKCALOHIT = KKCaloHit<KTRAJ>;
       using KKCALOHITPTR = std::shared_ptr<KKCALOHIT>;
       using KKCALOHITCOL = std::vector<KKCALOHITPTR>;
+      using PARAMHIT = KinKal::ParameterHit<KTRAJ>;
+      using PARAMHITPTR = std::shared_ptr<PARAMHIT>;
+      using PARAMHITCOL = std::vector<PARAMHITPTR>;
       using MEAS = KinKal::Hit<KTRAJ>;
       using MEASPTR = std::shared_ptr<MEAS>;
       using MEASCOL = std::vector<MEASPTR>;
@@ -60,10 +63,10 @@ namespace mu2e {
       using DOMAINCOL = std::set<DOMAINPTR>;
       // construct from configuration, fit environment, and hits and materials
       KKTrack(Config const& config, BFieldMap const& bfield, KTRAJ const& seedtraj, PDGCode::type tpart, KKSTRAWHITCLUSTERER const& shclusterer,
-          KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings, KKCALOHITCOL const& calohits, std::array<double, KinKal::NParams()> constraints = {0});
+          KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings, KKCALOHITCOL const& calohits, PARAMHITCOL const& paramhits);
       // construct from regrown constituants
       KKTrack(Config const& config, BFieldMap const& bfield, PDGCode::type tpart,
-          PKTRAJPTR& fittraj, KKSTRAWHITCOL& strawhits, KKSTRAWXINGCOL& strawxings, KKCALOHITCOL& calohits, DOMAINCOL& domains);
+          PKTRAJPTR& fittraj, KKSTRAWHITCOL& strawhits, KKSTRAWXINGCOL& strawxings, KKCALOHITCOL& calohits, PARAMHITCOL const& paramhits, DOMAINCOL& domains);
       // copy constructor
       KKTrack(KKTrack<KTRAJ> const& rhs, CloneContext& context): KinKal::Track<KTRAJ>(rhs, context),
           tpart_(rhs.fitParticle()),
@@ -118,7 +121,7 @@ namespace mu2e {
 
       // extend the track according to new configuration, hits, and/or exings
       void extendTrack(Config const& config,
-          KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings, KKCALOHITCOL const& calohits );
+          KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings, KKCALOHITCOL const& calohits, PARAMHITCOL const& paramhits );
       // extend the track to cover a new set of material Xings.  This will reuse the existing config object
       void extendTrack(EXINGCOL const& xings);
       // add IPA Xing
@@ -135,6 +138,7 @@ namespace mu2e {
       KKSTRAWHITCOL const& strawHits() const { return strawhits_; }
       KKSTRAWHITCLUSTERCOL const& strawHitClusters() const { return strawhitclusters_; }
       KKSTRAWXINGCOL const& strawXings() const { return strawxings_; }
+      PARAMHITCOL const& paramHits() const { return paramhits_; }
       KKIPAXINGCOL const& IPAXings() const { return ipaxings_; }
       KKSTXINGCOL const& STXings() const { return stxings_; }
       KKCRVXINGCOL const& CRVXings() const { return crvxings_; }
@@ -153,13 +157,14 @@ namespace mu2e {
       KKSTRAWHITCOL strawhits_;  // straw hits used in this fit
       KKSTRAWXINGCOL strawxings_;  // straw material crossings used in this fit
       KKCALOHITCOL calohits_;  // calo hits used in this fit
+      PARAMHITCOL paramhits_;
       KKIPAXINGCOL ipaxings_;  // ipa material crossings used in extrapolation
       KKSTXINGCOL stxings_;  // stopping target material crossings used in extrapolation
       KKCRVXINGCOL crvxings_; // crv crossings using in extrapolation
       KKINTERCOL inters_; // other recorded intersections
       KKSTRAWHITCLUSTERCOL strawhitclusters_;  // straw hit clusters used in this fit
       // utility function to convert to generic types
-      void convertTypes( KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings,KKCALOHITCOL const& calohits,
+      void convertTypes( KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings,KKCALOHITCOL const& calohits, PARAMHITCOL const& paramhits,
           MEASCOL& hits, EXINGCOL& exings);
       // add hits to clusters
       void addHitClusters(KKSTRAWHITCOL const& strawhits,KKSTRAWXINGCOL const& strawxings, MEASCOL& hits);
@@ -170,9 +175,9 @@ namespace mu2e {
       KKSTRAWHITCOL const& strawhits,
       KKSTRAWXINGCOL const& strawxings,
       KKCALOHITCOL const& calohits,
-      std::array<double, KinKal::NParams()> constraints) :
+      PARAMHITCOL const& paramhits) :
     KinKal::Track<KTRAJ>(config,bfield), tpart_(tpart), shclusterer_(shclusterer),
-    strawhits_(strawhits), strawxings_(strawxings), calohits_(calohits) {
+    strawhits_(strawhits), strawxings_(strawxings), calohits_(calohits), paramhits_(paramhits) {
       MEASCOL hits; // polymorphic container of hits
       EXINGCOL exings; // polymorphic container of detector element crossings
       // add the hits to clusters, as required
@@ -183,44 +188,22 @@ namespace mu2e {
           shcluster->print(std::cout,this->config().plevel_);
         }
       }
-      convertTypes(strawhits_, strawxings_, calohits_,  hits, exings);
+      convertTypes(strawhits_, strawxings_, calohits_, paramhits_, hits, exings);
 
-      std::array<bool,KinKal::NParams()> mask = {false};
-      bool constraining = false;
-      for (size_t i=0;i<KinKal::NParams();i++){
-        if (constraints[i] > 0){
-          mask[i] = true;
-          constraining = true;
-        }
-      }
-      if (constraining){
-        KinKal::Parameters cparams = seedtraj.params();
-        for (size_t ipar=0;ipar<KinKal::NParams();ipar++){
-          for (size_t jpar=0;jpar<KinKal::NParams();jpar++){
-            cparams.covariance()[ipar][jpar] = 0.0;
-          }
-        }
-        for(size_t ipar=0; ipar < KinKal::NParams(); ipar++){
-          if (mask[ipar])
-            cparams.covariance()[ipar][ipar] = constraints[ipar]*constraints[ipar];
-          else
-            cparams.covariance()[ipar][ipar] = 1.0; // otherwise inversion fails
-        }
-        hits.push_back(std::make_shared<KinKal::ParameterHit<KTRAJ>>(seedtraj.range().mid(),seedtraj,cparams,mask));
-      }
       // now fit these
       this->fit(hits, exings, seedtraj);
     }
 
 
   template <class KTRAJ> KKTrack<KTRAJ>::KKTrack(Config const& config, BFieldMap const& bfield, PDGCode::type tpart,
-      PKTRAJPTR& fittraj, KKSTRAWHITCOL& strawhits, KKSTRAWXINGCOL& strawxings, KKCALOHITCOL& calohits, DOMAINCOL& domains) :
+      PKTRAJPTR& fittraj, KKSTRAWHITCOL& strawhits, KKSTRAWXINGCOL& strawxings, KKCALOHITCOL& calohits,
+      PARAMHITCOL const& paramhits, DOMAINCOL& domains) :
     KinKal::Track<KTRAJ>(config,bfield), tpart_(tpart),shclusterer_(StrawIdMask::none,0,0.0),
-    strawhits_(strawhits), strawxings_(strawxings), calohits_(calohits) {
+    strawhits_(strawhits), strawxings_(strawxings), calohits_(calohits), paramhits_(paramhits) {
     // convert types
     MEASCOL hits; // polymorphic container of hits
     EXINGCOL exings; // polymorphic container of detector element crossings
-    convertTypes(strawhits_, strawxings_, calohits_,  hits, exings);
+    convertTypes(strawhits_, strawxings_, calohits_, paramhits_, hits, exings);
     this->fit(hits,exings,domains,fittraj);
     // add ParameterHit, intersect, extrapolate, ... TODO
   }
@@ -265,16 +248,19 @@ namespace mu2e {
       KKSTRAWHITCOL const& strawhits,
       KKSTRAWXINGCOL const& strawxings,
       KKCALOHITCOL const& calohits,
+      PARAMHITCOL const& paramhits,
       MEASCOL& hits, EXINGCOL& exings) {
-    hits.reserve(strawhits_.size() + calohits_.size());
+    hits.reserve(strawhits_.size() + calohits_.size()+paramhits_.size());
     exings.reserve(strawxings_.size());
     for(auto const& strawhit : strawhits)hits.emplace_back(std::static_pointer_cast<MEAS>(strawhit));
     for(auto const& calohit : calohits)hits.emplace_back(std::static_pointer_cast<MEAS>(calohit));
+    for(auto const& paramhit : paramhits)hits.emplace_back(std::static_pointer_cast<MEAS>(paramhit));
     for(auto const& strawxing : strawxings)exings.emplace_back(std::static_pointer_cast<EXING>(strawxing));
   }
 
   template <class KTRAJ> void KKTrack<KTRAJ>::extendTrack(Config const& config,
-      KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings, KKCALOHITCOL const& calohits) {
+      KKSTRAWHITCOL const& strawhits, KKSTRAWXINGCOL const& strawxings, KKCALOHITCOL const& calohits,
+      PARAMHITCOL const& paramhits) {
     // convert the hits and Xings to generic types and extend the track
     MEASCOL hits; // polymorphic container of hits
     EXINGCOL exings; // polymorphic container of detector element crossings
@@ -294,14 +280,16 @@ namespace mu2e {
       }
       if(nhit != strawhits_.size()+strawhits.size()) std::cout << "cluster hit sum doesn't match " << nhit << " " << strawhits_.size() << std::endl;
     }
-    convertTypes(strawhits,strawxings,calohits,hits,exings);
+    convertTypes(strawhits,strawxings,calohits,paramhits,hits,exings);
     this->extend(config,hits,exings);
     // store the new hits
     strawhits_.reserve(strawhits_.size()+strawhits.size());
     calohits_.reserve(calohits_.size()+calohits.size());
+    paramhits_.reserve(paramhits_.size()+paramhits.size());
     strawxings_.reserve(strawxings_.size()+strawxings.size());
     for(auto const& strawhit : strawhits)strawhits_.emplace_back(strawhit);
     for(auto const& calohit : calohits)calohits_.emplace_back(calohit);
+    for(auto const& paramhit : paramhits)paramhits_.emplace_back(paramhit);
     for(auto const& strawxing : strawxings)strawxings_.emplace_back(strawxing);
   }
 

--- a/Mu2eKinKal/src/CentralHelixFit_module.cc
+++ b/Mu2eKinKal/src/CentralHelixFit_module.cc
@@ -116,7 +116,7 @@ namespace mu2e {
     fhicl::OptionalAtom<double> fixedBField { Name("ConstantBField"), Comment("Constant BField value") };
     fhicl::Atom<double> seedMom { Name("SeedMomentum"), Comment("Seed momentum") };
     fhicl::Atom<int> seedCharge { Name("SeedCharge"), Comment("Seed charge MAGNITUDE, in electron charge units") };
-    fhicl::Sequence<float> parconst { Name("ParameterConstraints"), Comment("External constraint on parameters to seed values (rms, various units)") };
+    fhicl::Sequence<double> parconst { Name("ParameterConstraints"), Comment("External constraint on parameters to seed values (rms, various units)") };
     fhicl::Sequence<std::string> sampleSurfaces { Name("SampleSurfaces"), Comment("When creating the KalSeed, sample the fit at these surfaces") };
     fhicl::Atom<bool> sampleInRange { Name("SampleInRange"), Comment("Require sample times to be inside the fit trajectory time range") };
     fhicl::Atom<bool> sampleInBounds { Name("SampleInBounds"), Comment("Require sample intersection point be inside surface bounds (within tolerance)") };
@@ -168,6 +168,7 @@ namespace mu2e {
       bool fixedfield_; //
       double seedMom_;
       int seedCharge_;
+      std::vector<double> paramconstraints_;
       double intertol_; // surface intersection tolerance (mm)
       double sampletbuff_; // simple time buffer; replace this with extrapolation TODO
       bool useFitCharge_; // Set the PDG particle to agree with the fit charge
@@ -175,7 +176,6 @@ namespace mu2e {
       bool sampleinrange_, sampleinbounds_; // require samples to be in range or on surface
       SurfaceIdCollection ssids_;
       KinKalGeom::SurfacePairCollection surfacess_to_sample_; // surfaces to sample the fit
-      std::array<double,KinKal::NParams()> paramconstraints_;
       bool constraining_;
   };
 
@@ -193,6 +193,7 @@ namespace mu2e {
     fixedfield_(false),
     seedMom_(settings().modSettings().seedMom()),
     seedCharge_(settings().modSettings().seedCharge()),
+    paramconstraints_(settings().modSettings().parconst()),
     intertol_(settings().modSettings().interTol()),
     sampletbuff_(settings().modSettings().sampleTBuff()),
     useFitCharge_(settings().modSettings().useFitCharge()),
@@ -213,11 +214,13 @@ namespace mu2e {
         seedcov_[ipar][ipar] = seederrors[ipar]*seederrors[ipar];
       }
       constraining_ = false;
-      auto const& parerrors = settings().modSettings().parconst();
-      for (size_t ipar=0;ipar<KinKal::NParams();ipar++){
-        paramconstraints_[ipar] = parerrors[ipar];
-        if (parerrors[ipar] > 0)
-          constraining_ = true;
+      if (paramconstraints_.size() == KinKal::NParams()){
+        for (size_t ipar=0;ipar<KinKal::NParams();ipar++){
+          if (paramconstraints_[ipar] > 0)
+            constraining_ = true;
+        }
+      }else if (paramconstraints_.size() > 0){
+        throw cet::exception("RECO")<<"mu2e::CentralHelixFit: Parameter constraint configuration error"<< endl;
       }
 
       if(print_ > 0) std::cout << "Fit " << config_ << "Extension " << exconfig_;
@@ -341,22 +344,7 @@ namespace mu2e {
           // create parameter constraint, use seedtrajectory parameters
           PARAMHITCOL paramhits;
           if (constraining_){
-            std::array<bool,KinKal::NParams()> mask = {false};
-            KinKal::Parameters cparams = seedtraj.params();
-            for (size_t ipar=0;ipar<KinKal::NParams();ipar++){
-              for (size_t jpar=0;jpar<KinKal::NParams();jpar++){
-                cparams.covariance()[ipar][jpar] = 0.0;
-              }
-            }
-            for(size_t ipar=0; ipar < KinKal::NParams(); ipar++){
-              if (paramconstraints_[ipar] > 0){
-                mask[ipar] = true;
-                cparams.covariance()[ipar][ipar] = paramconstraints_[ipar]*paramconstraints_[ipar];
-              }else{
-                cparams.covariance()[ipar][ipar] = 1.0; // otherwise inversion fails
-              }
-            }
-            paramhits.push_back(std::make_shared<PARAMHIT>(seedtraj.range().mid(),seedtraj,cparams,mask));
+            kkfit_.makeSeedParamHit(seedtraj,paramconstraints_,paramhits);
           }
 
           // create and fit the track

--- a/Mu2eKinKal/src/CentralHelixFit_module.cc
+++ b/Mu2eKinKal/src/CentralHelixFit_module.cc
@@ -91,6 +91,9 @@ namespace mu2e {
   using KKCALOHIT = KKCaloHit<KTRAJ>;
   using KKCALOHITPTR = std::shared_ptr<KKCALOHIT>;
   using KKCALOHITCOL = std::vector<KKCALOHITPTR>;
+  using PARAMHIT = KinKal::ParameterHit<KTRAJ>;
+  using PARAMHITPTR = std::shared_ptr<PARAMHIT>;
+  using PARAMHITCOL = std::vector<PARAMHITPTR>;
   using KKFIT = KKFit<KTRAJ>;
   using KinKal::VEC3;
   using KinKal::DMAT;
@@ -173,6 +176,7 @@ namespace mu2e {
       SurfaceIdCollection ssids_;
       KinKalGeom::SurfacePairCollection surfacess_to_sample_; // surfaces to sample the fit
       std::array<double,KinKal::NParams()> paramconstraints_;
+      bool constraining_;
   };
 
   CentralHelixFit::CentralHelixFit(const Parameters& settings) : art::EDProducer{settings},
@@ -208,9 +212,13 @@ namespace mu2e {
       for(size_t ipar=0;ipar < seederrors.size(); ++ipar){
         seedcov_[ipar][ipar] = seederrors[ipar]*seederrors[ipar];
       }
+      constraining_ = false;
       auto const& parerrors = settings().modSettings().parconst();
-      for (size_t ipar=0;ipar<KinKal::NParams();ipar++)
+      for (size_t ipar=0;ipar<KinKal::NParams();ipar++){
         paramconstraints_[ipar] = parerrors[ipar];
+        if (parerrors[ipar] > 0)
+          constraining_ = true;
+      }
 
       if(print_ > 0) std::cout << "Fit " << config_ << "Extension " << exconfig_;
       double bz(0.0);
@@ -330,8 +338,29 @@ namespace mu2e {
 
         try {
           seedtraj.range() = kkfit_.range(strawhits,calohits,strawxings);
+          // create parameter constraint, use seedtrajectory parameters
+          PARAMHITCOL paramhits;
+          if (constraining_){
+            std::array<bool,KinKal::NParams()> mask = {false};
+            KinKal::Parameters cparams = seedtraj.params();
+            for (size_t ipar=0;ipar<KinKal::NParams();ipar++){
+              for (size_t jpar=0;jpar<KinKal::NParams();jpar++){
+                cparams.covariance()[ipar][jpar] = 0.0;
+              }
+            }
+            for(size_t ipar=0; ipar < KinKal::NParams(); ipar++){
+              if (paramconstraints_[ipar] > 0){
+                mask[ipar] = true;
+                cparams.covariance()[ipar][ipar] = paramconstraints_[ipar]*paramconstraints_[ipar];
+              }else{
+                cparams.covariance()[ipar][ipar] = 1.0; // otherwise inversion fails
+              }
+            }
+            paramhits.push_back(std::make_shared<PARAMHIT>(seedtraj.range().mid(),seedtraj,cparams,mask));
+          }
+
           // create and fit the track
-          auto ktrk = make_unique<KKTRK>(config_,*kkbf_,seedtraj,fitpart,kkfit_.strawHitClusterer(),strawhits,strawxings,calohits,paramconstraints_);
+          auto ktrk = make_unique<KKTRK>(config_,*kkbf_,seedtraj,fitpart,kkfit_.strawHitClusterer(),strawhits,strawxings,calohits,paramhits);
           // Check the fit
           auto goodfit = goodFit(*ktrk);
           // if we have an extension schedule, extend.

--- a/Mu2eKinKal/src/KinematicLineFit_module.cc
+++ b/Mu2eKinKal/src/KinematicLineFit_module.cc
@@ -114,7 +114,7 @@ namespace mu2e {
     struct KKLineModuleConfig : public KKModuleConfig {
       fhicl::Sequence<art::InputTag> seedCollections         {Name("CosmicTrackSeedCollections"),     Comment("Seed fit collections to be processed ") };
       fhicl::Atom<float> seedmom { Name("SeedMomentum"), Comment("Initial momentum value")};
-      fhicl::Sequence<float> paramconstraints { Name("ParameterConstraints"), Comment("Sigma of direct gaussian constraints on each parameter (0=no constraint)")};
+      fhicl::Sequence<double> paramconstraints { Name("ParameterConstraints"), Comment("Sigma of direct gaussian constraints on each parameter (0=no constraint)")};
       fhicl::Sequence<std::string> sampleSurfaces { Name("SampleSurfaces"), Comment("When creating the KalSeed, sample the fit at these surfaces") };
       fhicl::Atom<bool> sampleInRange { Name("SampleInRange"), Comment("Require sample times to be inside the fit trajectory time range") };
       fhicl::Atom<bool> sampleInBounds { Name("SampleInBounds"), Comment("Require sample intersection point be inside surface bounds (within tolerance)") };
@@ -153,11 +153,11 @@ namespace mu2e {
     ProditionsHandle<Tracker> alignedTracker_h_;
     int print_;
     float seedmom_;
+    std::vector<double> paramconstraints_;
     PDGCode::type fpart_;
     TrkFitDirection fdir_;
     KKFIT kkfit_; // fit helper
     DMAT seedcov_; // seed covariance matrix
-    std::array<double,KinKal::NParams()> paramconstraints_;
     bool constraining_;
     double mass_; // particle mass
     int charge_; // particle charge
@@ -179,6 +179,7 @@ namespace mu2e {
     saveall_(settings().modSettings().saveAll()),
     print_(settings().modSettings().printLevel()),
     seedmom_(settings().modSettings().seedmom()),
+    paramconstraints_(settings().modSettings().paramconstraints()),
     fpart_(static_cast<PDGCode::type>(settings().modSettings().fitParticle())),
     kkfit_(settings().mu2eSettings()),
     intertol_(settings().modSettings().interTol()),
@@ -203,17 +204,12 @@ namespace mu2e {
         seedcov_[ipar][ipar] = seederrors[ipar]*seederrors[ipar];
       }
       constraining_ = false;
-      auto const& tempconstraints = settings().modSettings().paramconstraints();
-      if (tempconstraints.size() == 0){
-        for (size_t ipar=0;ipar<KinKal::NParams();ipar++)
-          paramconstraints_[ipar] = 0.0;
-      }else if (tempconstraints.size() == KinKal::NParams()){
+      if (paramconstraints_.size() == KinKal::NParams()){
         for (size_t ipar=0;ipar<KinKal::NParams();ipar++){
-          paramconstraints_[ipar] = tempconstraints[ipar];
-          if (tempconstraints[ipar] > 0)
+          if (paramconstraints_[ipar] > 0)
             constraining_ = true;
         }
-      }else{
+      }else if (paramconstraints_.size() > 0){
         throw cet::exception("RECO")<<"mu2e::KinematicLineFit: Parameter constraint configuration error"<< endl;
       }
       for(auto const& sidname : settings().modSettings().sampleSurfaces()) {
@@ -300,22 +296,7 @@ namespace mu2e {
           // create parameter constraint, use seedtrajectory parameters
           PARAMHITCOL paramhits;
           if (constraining_){
-            std::array<bool,KinKal::NParams()> mask = {false};
-            KinKal::Parameters cparams = seedtraj.params();
-            for (size_t ipar=0;ipar<KinKal::NParams();ipar++){
-              for (size_t jpar=0;jpar<KinKal::NParams();jpar++){
-                cparams.covariance()[ipar][jpar] = 0.0;
-              }
-            }
-            for(size_t ipar=0; ipar < KinKal::NParams(); ipar++){
-              if (paramconstraints_[ipar] > 0){
-                mask[ipar] = true;
-                cparams.covariance()[ipar][ipar] = paramconstraints_[ipar]*paramconstraints_[ipar];
-              }else{
-                cparams.covariance()[ipar][ipar] = 1.0; // otherwise inversion fails
-              }
-            }
-            paramhits.push_back(std::make_shared<PARAMHIT>(seedtraj.range().mid(),seedtraj,cparams,mask));
+            kkfit_.makeSeedParamHit(seedtraj,paramconstraints_,paramhits);
           }
 
           if(print_ > 0){

--- a/Mu2eKinKal/src/KinematicLineFit_module.cc
+++ b/Mu2eKinKal/src/KinematicLineFit_module.cc
@@ -79,6 +79,9 @@ namespace mu2e {
   using KKCALOHIT = KKCaloHit<KTRAJ>;
   using KKCALOHITPTR = std::shared_ptr<KKCALOHIT>;
   using KKCALOHITCOL = std::vector<KKCALOHITPTR>;
+  using PARAMHIT = KinKal::ParameterHit<KTRAJ>;
+  using PARAMHITPTR = std::shared_ptr<PARAMHIT>;
+  using PARAMHITCOL = std::vector<PARAMHITPTR>;
   using MEAS = KinKal::Hit<KTRAJ>;
   using MEASPTR = std::shared_ptr<MEAS>;
   using MEASCOL = std::vector<MEASPTR>;
@@ -155,6 +158,7 @@ namespace mu2e {
     KKFIT kkfit_; // fit helper
     DMAT seedcov_; // seed covariance matrix
     std::array<double,KinKal::NParams()> paramconstraints_;
+    bool constraining_;
     double mass_; // particle mass
     int charge_; // particle charge
     std::unique_ptr<KKBField> kkbf_;
@@ -198,13 +202,17 @@ namespace mu2e {
       for(size_t ipar=0;ipar < seederrors.size(); ++ipar){
         seedcov_[ipar][ipar] = seederrors[ipar]*seederrors[ipar];
       }
+      constraining_ = false;
       auto const& tempconstraints = settings().modSettings().paramconstraints();
       if (tempconstraints.size() == 0){
         for (size_t ipar=0;ipar<KinKal::NParams();ipar++)
           paramconstraints_[ipar] = 0.0;
       }else if (tempconstraints.size() == KinKal::NParams()){
-        for (size_t ipar=0;ipar<KinKal::NParams();ipar++)
+        for (size_t ipar=0;ipar<KinKal::NParams();ipar++){
           paramconstraints_[ipar] = tempconstraints[ipar];
+          if (tempconstraints[ipar] > 0)
+            constraining_ = true;
+        }
       }else{
         throw cet::exception("RECO")<<"mu2e::KinematicLineFit: Parameter constraint configuration error"<< endl;
       }
@@ -288,12 +296,34 @@ namespace mu2e {
           }
           // set the seed range given the hit TPOCA values
           seedtraj.range() = kkfit_.range(strawhits,calohits, strawxings);
+
+          // create parameter constraint, use seedtrajectory parameters
+          PARAMHITCOL paramhits;
+          if (constraining_){
+            std::array<bool,KinKal::NParams()> mask = {false};
+            KinKal::Parameters cparams = seedtraj.params();
+            for (size_t ipar=0;ipar<KinKal::NParams();ipar++){
+              for (size_t jpar=0;jpar<KinKal::NParams();jpar++){
+                cparams.covariance()[ipar][jpar] = 0.0;
+              }
+            }
+            for(size_t ipar=0; ipar < KinKal::NParams(); ipar++){
+              if (paramconstraints_[ipar] > 0){
+                mask[ipar] = true;
+                cparams.covariance()[ipar][ipar] = paramconstraints_[ipar]*paramconstraints_[ipar];
+              }else{
+                cparams.covariance()[ipar][ipar] = 1.0; // otherwise inversion fails
+              }
+            }
+            paramhits.push_back(std::make_shared<PARAMHIT>(seedtraj.range().mid(),seedtraj,cparams,mask));
+          }
+
           if(print_ > 0){
             //std::cout << "Seed line parameters " << hseed.track() << std::endl;
             seedtraj.print(std::cout,print_);
           }
           // create and fit the track
-          auto kktrk = make_unique<KKTRK>(config_,*kkbf_,seedtraj,fpart_,kkfit_.strawHitClusterer(),strawhits,strawxings,calohits,paramconstraints_);
+          auto kktrk = make_unique<KKTRK>(config_,*kkbf_,seedtraj,fpart_,kkfit_.strawHitClusterer(),strawhits,strawxings,calohits,paramhits);
           auto goodfit = goodFit(*kktrk);
           if(goodfit && exconfig_.schedule().size() > 0){
             kkfit_.extendTrack(exconfig_,*kkbf_, *tracker,*strawresponse, chcol, *calo_h, cc_H, *kktrk );

--- a/Mu2eKinKal/src/LoopHelixFit_module.cc
+++ b/Mu2eKinKal/src/LoopHelixFit_module.cc
@@ -84,6 +84,9 @@ namespace mu2e {
   using KKCALOHIT = KKCaloHit<KTRAJ>;
   using KKCALOHITPTR = std::shared_ptr<KKCALOHIT>;
   using KKCALOHITCOL = std::vector<KKCALOHITPTR>;
+  using PARAMHIT = KinKal::ParameterHit<KTRAJ>;
+  using PARAMHITPTR = std::shared_ptr<PARAMHIT>;
+  using PARAMHITCOL = std::vector<PARAMHITPTR>;
   using KKFIT = KKFit<KTRAJ>;
   using KinKal::VEC3;
   using KinKal::DMAT;
@@ -338,10 +341,11 @@ namespace mu2e {
     if (kkfit_.useCalo() && hseed.caloCluster().isNonnull()) {
       kkfit_.makeCaloHit(hseed.caloCluster(),*calo_h, pseedtraj, calohits);
     }
+    PARAMHITCOL paramhits;
     // set the seed range given the hits and xings
     seedtraj.range() = kkfit_.range(strawhits,calohits,strawxings);
     // create and fit the track
-    auto ktrk = make_unique<KKTRK>(config_,*kkbf_,seedtraj,fitpart,kkfit_.strawHitClusterer(),strawhits,strawxings,calohits);
+    auto ktrk = make_unique<KKTRK>(config_,*kkbf_,seedtraj,fitpart,kkfit_.strawHitClusterer(),strawhits,strawxings,calohits,paramhits);
     if(!ktrk) // check that the track exists
       throw cet::exception("RECO")<<"mu2e::LoopHelixFit: Track fit was performed but no track is found\n";
 

--- a/Mu2eKinKal/src/RegrowKinematicLine_module.cc
+++ b/Mu2eKinKal/src/RegrowKinematicLine_module.cc
@@ -116,6 +116,9 @@ namespace mu2e {
       using KKCALOHIT = KKCaloHit<KTRAJ>;
       using KKCALOHITPTR = std::shared_ptr<KKCALOHIT>;
       using KKCALOHITCOL = std::vector<KKCALOHITPTR>;
+      using PARAMHIT = KinKal::ParameterHit<KTRAJ>;
+      using PARAMHITPTR = std::shared_ptr<PARAMHIT>;
+      using PARAMHITCOL = std::vector<PARAMHITPTR>;
       using KKFIT = KKFit<KTRAJ>;
 
       using MEAS = KinKal::Hit<KTRAJ>;
@@ -209,13 +212,14 @@ namespace mu2e {
       KKSTRAWXINGCOL strawxings;
       strawxings.reserve(kseed.straws().size());
       KKCALOHITCOL calohits;
+      PARAMHITCOL paramhits;
       DOMAINCOL domains;
       // create the trajectory. This is done here to be strongly typed
       auto goodhits = kkfit_.regrowComponents(kseed, chcol, indexmap,
           *tracker,*calo_h,*strawresponse,*kkbf_,
-          trajptr, strawhits, calohits, strawxings, domains);
+          trajptr, strawhits, calohits, paramhits, strawxings, domains);
       if(debug_ > 0){
-        std::cout << "Regrew " << strawhits.size() << " straw hits, " << strawxings.size() << " straw xings, " << calohits.size() << " CaloHits and " << domains.size() << " domains, status = " << goodhits << std::endl;
+        std::cout << "Regrew " << strawhits.size() << " straw hits, " << strawxings.size() << " straw xings, " << calohits.size() << " CaloHits, " << paramhits.size() << " ParameterHits, and " << domains.size() << " domains, status = " << goodhits << std::endl;
       }
       if(debug_ > 2){
         unsigned nhactive(0);
@@ -228,7 +232,7 @@ namespace mu2e {
       if(debug_ > 5)static_cast<KinKal::PiecewiseTrajectory<KTRAJ>*>(trajptr.get())->print(std::cout,2);
       if(goodhits){
       // create the KKTrack from these components
-        auto ktrk = std::make_unique<KKTRK>(config_,*kkbf_,kseed.particle(),trajptr,strawhits,strawxings,calohits,domains);
+        auto ktrk = std::make_unique<KKTRK>(config_,*kkbf_,kseed.particle(),trajptr,strawhits,strawxings,calohits,paramhits,domains);
         if(ktrk && ktrk->fitStatus().usable()){
           if(debug_ > 0) std::cout << "RegrowKinematicLine: successful track refit" << std::endl;
           // extrapolate as requested

--- a/Mu2eKinKal/src/RegrowLoopHelix_module.cc
+++ b/Mu2eKinKal/src/RegrowLoopHelix_module.cc
@@ -119,6 +119,9 @@ namespace mu2e {
       using KKCALOHIT = KKCaloHit<KTRAJ>;
       using KKCALOHITPTR = std::shared_ptr<KKCALOHIT>;
       using KKCALOHITCOL = std::vector<KKCALOHITPTR>;
+      using PARAMHIT = KinKal::ParameterHit<KTRAJ>;
+      using PARAMHITPTR = std::shared_ptr<PARAMHIT>;
+      using PARAMHITCOL = std::vector<PARAMHITPTR>;
       using KKFIT = KKFit<KTRAJ>;
 
       using MEAS = KinKal::Hit<KTRAJ>;
@@ -216,13 +219,14 @@ namespace mu2e {
       KKSTRAWXINGCOL strawxings;
       strawxings.reserve(kseed.straws().size());
       KKCALOHITCOL calohits;
+      PARAMHITCOL paramhits;
       DOMAINCOL domains;
       // create the trajectory. This is done here to be strongly typed
       auto goodhits = kkfit_.regrowComponents(kseed, chcol, indexmap,
           *tracker,*calo_h,*strawresponse,*kkbf_,
-          trajptr, strawhits, calohits, strawxings, domains);
+          trajptr, strawhits, calohits, paramhits, strawxings, domains);
       if(debug_ > 1){
-        std::cout << "Regrew " << strawhits.size() << " straw hits, " << strawxings.size() << " straw xings, " << calohits.size() << " CaloHits and " << domains.size() << " domains, status = " << goodhits << std::endl;
+        std::cout << "Regrew " << strawhits.size() << " straw hits, " << strawxings.size() << " straw xings, " << calohits.size() << " CaloHits, " << paramhits.size() << " ParameterHits, and " << domains.size() << " domains, status = " << goodhits << std::endl;
       }
       if(debug_ > 2){
         unsigned nhactive(0);
@@ -235,7 +239,7 @@ namespace mu2e {
       // require hits and consistent BField domains
       if(goodhits && (domains.size() > 0 || !config_.bfcorr_)){
       // create the KKTrack from these components
-        auto ktrk = std::make_unique<KKTRK>(config_,*kkbf_,kseed.particle(),trajptr,strawhits,strawxings,calohits,domains);
+        auto ktrk = std::make_unique<KKTRK>(config_,*kkbf_,kseed.particle(),trajptr,strawhits,strawxings,calohits,paramhits,domains);
         if(ktrk && ktrk->fitStatus().usable()){
           if(debug_ > 0) std::cout << "RegrowLoopHelix: successful track refit" << std::endl;
           if(extend_)kkfit_.extendTrack(config_,*kkbf_, *tracker,*strawresponse, chcol, *calo_h, cc_H , *ktrk );

--- a/RecoDataProducts/inc/KalSeed.hh
+++ b/RecoDataProducts/inc/KalSeed.hh
@@ -11,6 +11,7 @@
 #include "Offline/RecoDataProducts/inc/TrkStrawHitSeed.hh"
 #include "Offline/RecoDataProducts/inc/TrkStrawHitCalib.hh"
 #include "Offline/RecoDataProducts/inc/TrkCaloHitSeed.hh"
+#include "Offline/RecoDataProducts/inc/TrkParamHitSeed.hh"
 #include "Offline/RecoDataProducts/inc/TrkStraw.hh"
 #include "Offline/RecoDataProducts/inc/KalSegment.hh"
 #include "Offline/RecoDataProducts/inc/KalIntersection.hh"
@@ -45,6 +46,7 @@ namespace mu2e {
     auto const& hitCalibInfos() const { return _hitcalibs;}
     auto const& caloHit() const { return _chit; }
     auto const& straws() const { return _straws;}
+    auto const& paramHits() const { return _paramhits;}
     auto const& segments() const { return _segments; }
     auto const& intersections() const { return _inters; }
     auto const& status() const { return _status; }
@@ -90,6 +92,7 @@ namespace mu2e {
     std::vector<TrkStrawHitSeed>  _hits; // hit seeds for all the hits used in this fit
     std::vector<TrkStrawHitCalib> _hitcalibs; // extra calibration/alignment info
     std::vector<TrkStraw>         _straws; // straws interesected by this fit
+    std::vector<TrkParamHitSeed>  _paramhits; // parameter constraint hits
     std::vector<double>           _domainbounds; // domain time boundaries
     TrkCaloHitSeed                _chit;  // CaloCluster-based hit.  If it has no CaloCluster, this has no content
     // static value used in regrowing

--- a/RecoDataProducts/inc/TrkParamHitSeed.hh
+++ b/RecoDataProducts/inc/TrkParamHitSeed.hh
@@ -1,0 +1,29 @@
+//
+//  Persistent representation of a KinKal ParameterHit, used in the
+//  persistent representation of Kalman Fit
+//
+#ifndef RecoDataProducts_TrkParamHitSeed_HH
+#define RecoDataProducts_TrkParamHitSeed_HH
+#include "KinKal/Detector/ParameterHit.hh"
+namespace mu2e {
+  struct TrkParamHitSeed {
+      using PMASK = std::array<bool,KinKal::NParams()>; // parameter mask
+    // default constructor: initialization on declaration
+    TrkParamHitSeed() {}
+    //KinKal constructor
+    TrkParamHitSeed(double time, KinKal::Parameters const& params, PMASK const& pmask) :
+      time_(time), params_(params), pmask_(pmask) {}
+
+    double time() const { return time_; }
+    KinKal::Parameters const& params() const { return params_; }
+    PMASK const& pmask() const { return pmask_; }
+
+    //
+    //  Payload
+    //
+    double time_; // time of this constraint: must be supplied on construction and does not change
+    KinKal::Parameters params_; // constraint parameters with covariance
+    PMASK pmask_; // subset of parmeters to constrain
+  };
+}
+#endif

--- a/RecoDataProducts/src/classes_def.xml
+++ b/RecoDataProducts/src/classes_def.xml
@@ -195,6 +195,7 @@
  <class name="mu2e::TrkStrawHitSeed"/>
  <class name="mu2e::TrkStrawHitCalib"/>
  <class name="mu2e::TrkCaloHitSeed"/>
+ <class name="mu2e::TrkParamHitSeed"/>
  <class name="mu2e::TrkStraw"/>
  <class name="mu2e::KalSegment"/>
  <class name="mu2e::KKSHFlag"/>
@@ -202,6 +203,7 @@
  <class name="std::vector<mu2e::TrkStrawHitSeed>"/>
  <class name="std::vector<mu2e::TrkStrawHitCalib>"/>
  <class name="std::vector<mu2e::TrkCaloHitSeed>"/>
+ <class name="std::vector<mu2e::TrkParamHitSeed>"/>
  <class name="std::vector<mu2e::TrkStraw>"/>
  <class name="std::vector<mu2e::KalSegment>"/>
  <class name="KinKal::IntersectFlag"/>


### PR DESCRIPTION
KKLine uses parameterhit to constrain momentum etc., plus we expect to add constraints for reflecting cosmics etc. This adds the info to the persistent object so we can regrow it