### PR TITLE
update RunTool for new run_info database schema

### DIFF
--- a/DbService/inc/RunConfig.hh
+++ b/DbService/inc/RunConfig.hh
@@ -1,0 +1,41 @@
+#ifndef DbService_RunConfig_hh
+#define DbService_RunConfig_hh
+
+// holds info for one row in the config table
+
+#include <string>
+#include <vector>
+
+namespace mu2e {
+
+class RunConfig {
+ public:
+  typedef std::vector<RunConfig> RunConfigVec;
+
+  RunConfig() : _run_number(0), _version(0) {}
+
+  int runNumber() const { return _run_number; }
+  const std::string& subsystem() const { return _subsystem; }
+  const std::string& settings() const { return _settings; }
+  const std::string& createTime() const { return _create_time; }
+  int version() const { return _version; }
+
+  void setRunNumber(int run_number) { _run_number = run_number; }
+  void setSubsystem(const std::string& subsystem) { _subsystem = subsystem; }
+  void setSettings(const std::string& settings) { _settings = settings; }
+  void setCreateTime(const std::string& create_time) {
+    _create_time = create_time;
+  }
+  void setVersion(int version) { _version = version; }
+
+ private:
+  int _run_number;
+  std::string _subsystem;
+  std::string _settings;  // jsonb stored as string
+  std::string _create_time;
+  int _version;
+};
+
+}  // namespace mu2e
+
+#endif

--- a/DbService/inc/RunInfo.hh
+++ b/DbService/inc/RunInfo.hh
@@ -1,9 +1,13 @@
 #ifndef DbService_RunInfo_hh
 #define DbService_RunInfo_hh
 
-// holds info for one run for runTool
+// holds info for one run, including related records from multiple tables
 
-#include <string>
+#include "Offline/DbService/inc/RunConfig.hh"
+#include "Offline/DbService/inc/RunRecord.hh"
+#include "Offline/DbService/inc/RunSubRun.hh"
+#include "Offline/DbService/inc/RunTransition.hh"
+
 #include <vector>
 
 namespace mu2e {
@@ -12,49 +16,58 @@ class RunInfo {
  public:
   typedef std::vector<RunInfo> RunVec;
 
-  RunInfo(std::string csv, std::string conditions, std::string transitions);
+  RunInfo() {}
 
-  int runNumber() const { return _run_number; }
-  int runType() const { return _run_type; }
-  int conditionId() const { return _condition_id; }
-  int artdaqPartition() const { return _artdaq_partition; }
-  const std::string& hostName() const { return _host_name; }
-  const std::string& configurationName() const { return _configuration_name; }
-  int configurationVersion() const { return _configuration_version; }
-  const std::string& contextName() const { return _context_name; }
-  int contextVersion() const { return _context_version; }
-  const std::string& triggerTableName() const { return _trigger_table_name; }
-  int triggerTableVersion() const { return _trigger_table_version; }
-  const std::string& onlineSoftwareVersion() const {
-    return _online_software_version;
+  // Access to the main run record
+  const RunRecord& runRecord() const { return _run_record; }
+  RunRecord& runRecord() { return _run_record; }
+  void setRunRecord(const RunRecord& run_record) { _run_record = run_record; }
+
+  // Access to configuration records for this run
+  const RunConfig::RunConfigVec& configs() const { return _configs; }
+  RunConfig::RunConfigVec& configs() { return _configs; }
+  void setConfigs(const RunConfig::RunConfigVec& configs) {
+    _configs = configs;
   }
-  const std::string& commitTime() const { return _commit_time; }
-  const std::string& shifterNote() const { return _shifter_note; }
-  const std::string& conditions() const { return _conditions; }
-  const std::string& transitions() const { return _transitions; }
+  void addConfig(const RunConfig& config) { _configs.push_back(config); }
 
-  const std::string& csv() const { return _csv; }
+  // Access to transition records for this run
+  const RunTransition::RunTransitionVec& transitions() const {
+    return _transitions;
+  }
+  RunTransition::RunTransitionVec& transitions() { return _transitions; }
+  void setTransitions(const RunTransition::RunTransitionVec& transitions) {
+    _transitions = transitions;
+  }
+  void addTransition(const RunTransition& transition) {
+    _transitions.push_back(transition);
+  }
+
+  // Access to subrun records for this run
+  const RunSubRun::RunSubRunVec& subruns() const { return _subruns; }
+  RunSubRun::RunSubRunVec& subruns() { return _subruns; }
+  void setSubruns(const RunSubRun::RunSubRunVec& subruns) {
+    _subruns = subruns;
+  }
+  void addSubrun(const RunSubRun& subrun) { _subruns.push_back(subrun); }
+
+  // Convenience accessor for run number
+  int runNumber() const { return _run_record.runNumber(); }
+
+  // Check if run is done and return status code
+  // Returns:
+  //   0 = still running
+  //   1 = user stop (transitions 0,1,6,7)
+  //   2 = error stop (transition 2)
+  //   3 = probably crash end (timeout exceeded)
+  // Throws exception if subruns or transitions are empty
+  int isDone(int timeout_seconds = 3600) const;
 
  private:
-  std::string _csv;
-
-  int _run_number;
-  int _run_type;
-  int _condition_id;
-  int _artdaq_partition;
-  std::string _host_name;
-  std::string _configuration_name;
-  int _configuration_version;
-  std::string _context_name;
-  int _context_version;
-  std::string _trigger_table_name;
-  int _trigger_table_version;
-  std::string _online_software_version;
-  std::string _commit_time;
-  std::string _shifter_note;
-
-  std::string _conditions;
-  std::string _transitions;
+  RunRecord _run_record;
+  RunConfig::RunConfigVec _configs;
+  RunTransition::RunTransitionVec _transitions;
+  RunSubRun::RunSubRunVec _subruns;
 };
 
 }  // namespace mu2e

--- a/DbService/inc/RunRecord.hh
+++ b/DbService/inc/RunRecord.hh
@@ -1,0 +1,38 @@
+#ifndef DbService_RunRecord_hh
+#define DbService_RunRecord_hh
+
+// holds info for one row in the runs table
+
+#include <string>
+#include <vector>
+
+namespace mu2e {
+
+class RunRecord {
+ public:
+  typedef std::vector<RunRecord> RunRecordVec;
+
+  RunRecord() : _run_number(0), _run_type_id(0) {}
+
+  int runNumber() const { return _run_number; }
+  const std::string& comment() const { return _comment; }
+  const std::string& createTime() const { return _create_time; }
+  int runTypeId() const { return _run_type_id; }
+
+  void setRunNumber(int run_number) { _run_number = run_number; }
+  void setComment(const std::string& comment) { _comment = comment; }
+  void setCreateTime(const std::string& create_time) {
+    _create_time = create_time;
+  }
+  void setRunTypeId(int run_type_id) { _run_type_id = run_type_id; }
+
+ private:
+  int _run_number;
+  std::string _comment;
+  std::string _create_time;
+  int _run_type_id;
+};
+
+}  // namespace mu2e
+
+#endif

--- a/DbService/inc/RunSelect.hh
+++ b/DbService/inc/RunSelect.hh
@@ -9,7 +9,6 @@ namespace mu2e {
 
 class RunSelect {
  public:
-
   // run:
   //     runnumber, like "110000", means just this one run
   //     start-stop (inclusive) like "110000-120000",
@@ -20,8 +19,7 @@ class RunSelect {
   // days only runs take in the last N days, 0 means all
   RunSelect(const std::string& run, int last, const std::string& type,
             const std::string& time, int days) :
-      _run(run),
-      _last(last), _type(type), _time(time), _days(days) {}
+      _run(run), _last(last), _type(type), _time(time), _days(days) {}
 
   const std::string& run() const { return _run; }
   int last() const { return _last; }

--- a/DbService/inc/RunSubRun.hh
+++ b/DbService/inc/RunSubRun.hh
@@ -1,0 +1,67 @@
+#ifndef DbService_RunSubRun_hh
+#define DbService_RunSubRun_hh
+
+// holds info for one row in the subrun table
+
+#include <string>
+#include <vector>
+
+namespace mu2e {
+
+class RunSubRun {
+ public:
+  typedef std::vector<RunSubRun> RunSubRunVec;
+
+  RunSubRun() :
+      _run_number(0), _subrun_number(0), _n_events(0), _n_on_spill(0),
+      _n_off_spill(0), _n_null(0), _min_ewt(0), _max_ewt(0),
+      _start_time_unix(0), _stop_time_unix(0) {}
+
+  int runNumber() const { return _run_number; }
+  int subrunNumber() const { return _subrun_number; }
+  long nEvents() const { return _n_events; }
+  long nOnSpill() const { return _n_on_spill; }
+  long nOffSpill() const { return _n_off_spill; }
+  long nNull() const { return _n_null; }
+  long minEwt() const { return _min_ewt; }
+  long maxEwt() const { return _max_ewt; }
+  int startTimeUnix() const { return _start_time_unix; }
+  int stopTimeUnix() const { return _stop_time_unix; }
+  const std::string& eventModeCounts() const { return _event_mode_counts; }
+  const std::string& createdAt() const { return _created_at; }
+
+  void setRunNumber(int run_number) { _run_number = run_number; }
+  void setSubrunNumber(int subrun_number) { _subrun_number = subrun_number; }
+  void setNEvents(long n_events) { _n_events = n_events; }
+  void setNOnSpill(long n_on_spill) { _n_on_spill = n_on_spill; }
+  void setNOffSpill(long n_off_spill) { _n_off_spill = n_off_spill; }
+  void setNNull(long n_null) { _n_null = n_null; }
+  void setMinEwt(long min_ewt) { _min_ewt = min_ewt; }
+  void setMaxEwt(long max_ewt) { _max_ewt = max_ewt; }
+  void setStartTimeUnix(int start_time_unix) {
+    _start_time_unix = start_time_unix;
+  }
+  void setStopTimeUnix(int stop_time_unix) { _stop_time_unix = stop_time_unix; }
+  void setEventModeCounts(const std::string& event_mode_counts) {
+    _event_mode_counts = event_mode_counts;
+  }
+  void setCreatedAt(const std::string& created_at) { _created_at = created_at; }
+
+ private:
+  int _run_number;
+  int _subrun_number;
+  long _n_events;
+  long _n_on_spill;
+  long _n_off_spill;
+  long _n_null;
+  long _min_ewt;
+  long _max_ewt;
+  int _start_time_unix;
+  int _stop_time_unix;
+  std::string _event_mode_counts;  // jsonb stored as string
+  std::string _created_at;
+};
+
+}  // namespace mu2e
+
+#endif

--- a/DbService/inc/RunTool.hh
+++ b/DbService/inc/RunTool.hh
@@ -7,21 +7,22 @@
 #include "Offline/DbService/inc/DbReader.hh"
 #include "Offline/DbService/inc/RunInfo.hh"
 #include "Offline/DbService/inc/RunSelect.hh"
+
 #include <string>
 
 namespace mu2e {
 
 class RunTool {
  public:
-  enum class FlagType { run = 0, transition = 1, cause = 2 };
+  enum class FlagType { run = 0, transition = 1 };
 
   RunTool();
 
-  // fill argument with the names of all channels
+  // fill argument with the names of all flag types
   std::map<int, std::string> flags(FlagType ftype);
-  RunInfo::RunVec listRuns(const RunSelect& runsel, bool conditions = false,
-                           bool transitions = false);
-  void printRun(const RunInfo& info, bool longp = false);
+  RunInfo::RunVec listRuns(const RunSelect& runsel, bool configs = false,
+                           bool transitions = false, bool subruns = false);
+  void printRun(const RunInfo& info);
 
  private:
   // read the database via query_engine

--- a/DbService/inc/RunTransition.hh
+++ b/DbService/inc/RunTransition.hh
@@ -1,0 +1,38 @@
+#ifndef DbService_RunTransition_hh
+#define DbService_RunTransition_hh
+
+// holds info for one row in the run_transition table
+
+#include <string>
+#include <vector>
+
+namespace mu2e {
+
+class RunTransition {
+ public:
+  typedef std::vector<RunTransition> RunTransitionVec;
+
+  RunTransition() : _run_number(0), _type_id(0), _cause_id(0) {}
+
+  int runNumber() const { return _run_number; }
+  int typeId() const { return _type_id; }
+  int causeId() const { return _cause_id; }
+  const std::string& transitionTime() const { return _transition_time; }
+
+  void setRunNumber(int run_number) { _run_number = run_number; }
+  void setTypeId(int type_id) { _type_id = type_id; }
+  void setCauseId(int cause_id) { _cause_id = cause_id; }
+  void setTransitionTime(const std::string& transition_time) {
+    _transition_time = transition_time;
+  }
+
+ private:
+  int _run_number;
+  int _type_id;
+  int _cause_id;
+  std::string _transition_time;
+};
+
+}  // namespace mu2e
+
+#endif

--- a/DbService/src/RunInfo.cc
+++ b/DbService/src/RunInfo.cc
@@ -1,42 +1,63 @@
 #include "Offline/DbService/inc/RunInfo.hh"
-#include "Offline/GeneralUtilities/inc/splitString.hh"
+
+#include "Offline/GeneralUtilities/inc/TimeUtility.hh"
+
 #include "cetlib_except/exception.h"
+
+#include <ctime>
 
 using namespace mu2e;
 
 //**************************************************
-
-RunInfo::RunInfo(std::string csv, std::string conditions,
-                 std::string transitions) {
-  //  run_number,run_type,condition_id,artdaq_partition,host_name,configuration_name,configuration_version,context_name,context_version,trigger_table_name,trigger_table_version,online_software_version,commit_time,shifter_note
-  // 1,4,7,14,mu2edaq13.fnal.gov,dcsConfig,53,dcsContext,52,None,None,None,2024-05-06 16:17:21.973417-05:00,None
-  _csv = csv;
-  StringVec sv = splitString(csv);
-  if (sv.size() != 14) {
-    throw cet::exception("RUNTOOL_BAD_INFO_CSV")
-        << " RunInfo: failed to construct from " << sv.size() << "fields in\n"
-        << csv << "\n";
+int RunInfo::isDone(int timeout_seconds) const {
+  // Check if we have the required data
+  if (_transitions.empty() || _subruns.empty()) {
+    throw cet::exception("RUNINFO_INCOMPLETE")
+        << "RunInfo::isDone() cannot determine status: "
+        << "transitions or subruns list is empty\n";
   }
 
-  _run_number = std::stoi(sv[0]);
-  _run_type = std::stoi(sv[1]);
-  _condition_id = std::stoi(sv[2]);
-  _artdaq_partition = std::stoi(sv[3]);
-  _host_name = sv[4];
-  _configuration_name = sv[5];
-  _configuration_version = std::stoi(sv[6]);
-  _context_name = sv[7];
-  _context_version = std::stoi(sv[8]);
-  _trigger_table_name = sv[9];
-  if(sv[10]=="None") {
-    _trigger_table_version = 0;
-  } else {
-    _trigger_table_version = std::stoi(sv[10]);
-  }
-  _online_software_version = sv[11];
-  _commit_time = sv[12];
-  _shifter_note = sv[13];
+  // Get the last transition
+  const RunTransition& lastTransition = _transitions.back();
+  int lastTransitionType = lastTransition.typeId();
 
-  _conditions = conditions;
-  _transitions = transitions;
+  // Check for user stop (transitions 0, 1, 6, 7)
+  if (lastTransitionType == 0 || lastTransitionType == 1 ||
+      lastTransitionType == 6 || lastTransitionType == 7) {
+    return 1;  // user stop
+  }
+
+  // Check for error stop (transition 2)
+  if (lastTransitionType == 2) {
+    return 2;  // error stop
+  }
+
+  // Check for timeout (probable crash)
+  // Get the last transition time
+  std::string lastTransTime = lastTransition.transitionTime();
+  std::time_t lastTransTimeT;
+  int rc = TimeUtility::parseTimeTZ(lastTransTime, lastTransTimeT);
+  if (rc != 0) {
+    throw cet::exception("RUNINFO_BAD_TIME")
+        << "RunInfo::isDone() cannot parse transition time: " << lastTransTime
+        << "\n";
+  }
+
+  // Get the last subrun stop time
+  const RunSubRun& lastSubrun = _subruns.back();
+  std::time_t lastSubrunTimeT = lastSubrun.stopTimeUnix();
+
+  // Use the more recent of the two times
+  std::time_t lastActivityTime = std::max(lastTransTimeT, lastSubrunTimeT);
+
+  // Get current time
+  std::time_t currentTime = std::time(nullptr);
+
+  // Check if timeout exceeded
+  if ((currentTime - lastActivityTime) > timeout_seconds) {
+    return 3;  // probably crash end
+  }
+
+  // Still running
+  return 0;
 }

--- a/DbService/src/RunTool.cc
+++ b/DbService/src/RunTool.cc
@@ -1,9 +1,13 @@
 #include "Offline/DbService/inc/RunTool.hh"
+
 #include "Offline/DbService/inc/DbIdList.hh"
 #include "Offline/GeneralUtilities/inc/TimeUtility.hh"
 #include "Offline/GeneralUtilities/inc/splitString.hh"
+
 #include "cetlib_except/exception.h"
+
 #include <algorithm>
+#include <iomanip>
 
 using namespace mu2e;
 
@@ -25,11 +29,9 @@ std::map<int, std::string> RunTool::flags(FlagType ftype) {
 
   select = "";
   if (ftype == FlagType::run) {
-    table = "production.run_type";
+    table = "online.run_type";
   } else if (ftype == FlagType::transition) {
-    table = "production.transition_type";
-  } else if (ftype == FlagType::cause) {
-    table = "production.cause_type";
+    table = "online.run_transition_type";
   }
   // where.push_back("name:eq:" + name);
   rc = _reader.query(tcsv, select, table, where, order);
@@ -41,23 +43,29 @@ std::map<int, std::string> RunTool::flags(FlagType ftype) {
   StringVec rows = splitString(tcsv, "\n", "\"", "\\", true, false);
   for (auto const& csv : rows) {
     StringVec sv = splitString(csv);
-    flags.insert({std::stoi(sv[0]), sv[1]});
+    // Table columns are: id, description, name
+    // We want the "name" column (index 2) for transitions, not description
+    // (index 1)
+    if (sv.size() >= 3) {
+      flags.insert({std::stoi(sv[0]), sv[2]});  // Use name column
+    } else if (sv.size() >= 2) {
+      flags.insert({std::stoi(sv[0]),
+                    sv[1]});  // Fallback to description if name not available
+    }
   }
   return flags;
 }
 
 //**************************************************
-RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool conditions,
-                                  bool transitions) {
+RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
+                                  bool transitions, bool subruns) {
   RunInfo::RunVec runv;
   std::string tcsv, select, table, order;
   StringVec where;
-  std::string conditionss, transitionss;
 
-  // fetch the list of all runs
-
+  // fetch the list of all runs from the run table
   select = "";
-  table = "production.run_configuration";
+  table = "online.run";
   order = "-run_number";
   int rc = _reader.query(tcsv, select, table, where, order);
   if (rc != 0 || tcsv.empty()) {
@@ -66,13 +74,9 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool conditions,
   }
 
   StringVec rows = splitString(tcsv, "\n", "\"", "\\", true, false);
-  // if (rows.size() > 0) {
-  //  std::cout << "HEADERS"<<rows[0] <<std::endl;
-  //  // header = rows[0];  The first row is column names
-  //  rows.erase(rows.begin());
-  //}
 
-  // apply the selection and fetch conditions and transitions if requested
+  // apply the selection and fetch configs, transitions, and subruns if
+  // requested
 
   // setup run cuts
   std::string rr = runsel.run();
@@ -119,73 +123,237 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool conditions,
   if (runsel.days() > 0) {
     dtime = std::time(0) - runsel.days() * 24 * 60 * 60;
   }
+
   // loop over all runs, starting with highest run number
   for (auto const& csv : rows) {
     // apply cuts on this run
     bool pass = true;
-    // use this temp RunInfo to parse the csv
-    RunInfo ri(csv, std::string(), std::string());
-    int run = ri.runNumber();
+
+    // Parse the run table row: run_number,comment,create_time,run_type_id
+    StringVec sv = splitString(csv);
+    if (sv.size() < 3) continue;  // skip malformed rows
+
+    int run = std::stoi(sv[0]);
+    std::string comment = (sv.size() > 1) ? sv[1] : "";
+    std::string create_time = (sv.size() > 2) ? sv[2] : "";
+    int run_type_id = 0;
+    if (sv.size() > 3 && !sv[3].empty() && sv[3] != "None") {
+      run_type_id = std::stoi(sv[3]);
+    }
+
     // limit on the range
     if (run < rmin || run > rmax) pass = false;
     // limit on the number of runs
     if (runsel.last() > 0 && runv.size() >= size_t(runsel.last())) pass = false;
-    std::string srtime = ri.commitTime();
+
     std::time_t rtime;
-    rc = TimeUtility::parseTimeTZ(srtime, rtime);
+    rc = TimeUtility::parseTimeTZ(create_time, rtime);
     if (rc != 0) {
       throw cet::exception("RUNTOOL_BAD_TIME")
-          << " RunTool::listRuns can't parse time" << srtime << " \n";
+          << " RunTool::listRuns can't parse time" << create_time << " \n";
     }
     // limit on time range
     if (rtime < tmin || rtime > tmax) pass = false;
-    // limt on daysage
+    // limit on daysage
     if (rtime < dtime) pass = false;
     // limits on run types
     if (itypes.size() > 0) {
-      int type = ri.runType();
-      if (std::find(itypes.begin(), itypes.end(), type) == itypes.end())
+      if (std::find(itypes.begin(), itypes.end(), run_type_id) == itypes.end())
         pass = false;
     }
 
     if (pass) {
-      if (conditions) {
-        tcsv.clear();
-        select = "condition";
-        table = "production.run_condition";
-        where.clear();
-        std::string ww =
-            std::string("condition_id:eq:") + std::to_string(ri.conditionId());
-        where.emplace_back(ww);
-        order.clear();
-        int rc = _reader.query(tcsv, select, table, where, order);
-        if (rc != 0) {
-          throw cet::exception("RUNTOOL_BAD_CONDITIONS_QUERY")
-              << " RunTool::listRuns failed to retrieve conditions \n";
-        }
-        conditionss = tcsv;
-      }  // end conditions
+      RunInfo runInfo;
 
-      if (transitions) {
-        StringVec sv = splitString(csv);
+      // Set the main run record
+      RunRecord runRecord;
+      runRecord.setRunNumber(run);
+      runRecord.setComment(comment);
+      runRecord.setCreateTime(create_time);
+      runRecord.setRunTypeId(run_type_id);
+      runInfo.setRunRecord(runRecord);
+
+      // Fetch config records if requested
+      if (configs) {
         tcsv.clear();
-        select = "transition_type,cause_type,transition_time";
-        table = "production.run_transition";
+        select = "";
+        table = "online.config";
         where.clear();
-        std::string ww =
-            std::string("run_number:eq:") + std::to_string(ri.runNumber());
+        std::string ww = std::string("run_number:eq:") + std::to_string(run);
+        where.emplace_back(ww);
+        order = "subsystem";
+        rc = _reader.query(tcsv, select, table, where, order);
+        if (rc != 0) {
+          throw cet::exception("RUNTOOL_BAD_CONFIG_QUERY")
+              << " RunTool::listRuns failed to retrieve configs for run " << run
+              << "\n";
+        }
+
+        if (!tcsv.empty()) {
+          // Split by newlines only, don't try to parse escape sequences in
+          // JSONB
+          size_t start = 0;
+          size_t end = tcsv.find('\n');
+
+          while (start < tcsv.length()) {
+            std::string configCsv;
+            if (end == std::string::npos) {
+              configCsv = tcsv.substr(start);
+              start = tcsv.length();
+            } else {
+              configCsv = tcsv.substr(start, end - start);
+              start = end + 1;
+              end = tcsv.find('\n', start);
+            }
+
+            if (configCsv.empty()) continue;
+
+            // For config table, the settings field is JSONB which may contain
+            // complex escapes. Parse carefully - don't use splitString.
+            // Expected format:
+            // run_number,subsystem,settings,create_time,version
+
+            // Find the first two commas to extract run_number, subsystem
+            size_t pos1 = configCsv.find(',');
+            if (pos1 == std::string::npos) continue;
+
+            size_t pos2 = configCsv.find(',', pos1 + 1);
+            if (pos2 == std::string::npos) continue;
+
+            // The rest after pos2 is: settings,create_time,version
+            // The settings field is the third field, wrapped in quotes
+            std::string run_num_str = configCsv.substr(0, pos1);
+            std::string subsystem = configCsv.substr(pos1 + 1, pos2 - pos1 - 1);
+            std::string remainder = configCsv.substr(pos2 + 1);
+
+            // Extract just the settings field (third field in CSV)
+            // It starts with a quote, so find the matching closing quote
+            std::string settings;
+            if (!remainder.empty() && remainder[0] == '"') {
+              // Find the closing quote (accounting for escaped quotes "")
+              size_t i = 1;
+              while (i < remainder.length()) {
+                if (remainder[i] == '"') {
+                  // Check if it's an escaped quote
+                  if (i + 1 < remainder.length() && remainder[i + 1] == '"') {
+                    // Escaped quote, skip both
+                    i += 2;
+                  } else {
+                    // Found the closing quote
+                    settings = remainder.substr(1, i - 1);
+                    break;
+                  }
+                } else {
+                  i++;
+                }
+              }
+
+              // Now unescape the double-quotes
+              size_t pos = 0;
+              while ((pos = settings.find("\"\"", pos)) != std::string::npos) {
+                settings.replace(pos, 2, "\"");
+                pos += 1;
+              }
+            } else {
+              // No quotes, just use the remainder
+              settings = remainder;
+            }
+
+            RunConfig config;
+            if (!run_num_str.empty())
+              config.setRunNumber(std::stoi(run_num_str));
+            config.setSubsystem(subsystem);
+            config.setSettings(settings);
+            runInfo.addConfig(config);
+          }
+        }
+      }  // end configs
+
+      // Fetch transition records if requested
+      if (transitions) {
+        tcsv.clear();
+        select = "";
+        table = "online.run_transition";
+        where.clear();
+        std::string ww = std::string("run_number:eq:") + std::to_string(run);
         where.emplace_back(ww);
         order = "transition_time";
-        int rc = _reader.query(tcsv, select, table, where, order);
+        rc = _reader.query(tcsv, select, table, where, order);
         if (rc != 0) {
           throw cet::exception("RUNTOOL_BAD_TRANSITION_QUERY")
               << " RunTool::listRuns failed to retrieve transitions for run "
-              << sv[0] << "\n";
+              << run << "\n";
         }
-        transitionss = tcsv;
+
+        if (!tcsv.empty()) {
+          StringVec transRows =
+              splitString(tcsv, "\n", "\"", "\\", true, false);
+          for (auto const& transCsv : transRows) {
+            StringVec transSv = splitString(transCsv);
+            if (transSv.size() >= 3) {
+              RunTransition trans;
+              trans.setRunNumber(std::stoi(transSv[0]));
+              trans.setTypeId(std::stoi(transSv[1]));
+              trans.setCauseId((transSv.size() > 2 && transSv[2] != "None")
+                                   ? std::stoi(transSv[2])
+                                   : 0);
+              if (transSv.size() > 3) trans.setTransitionTime(transSv[3]);
+              runInfo.addTransition(trans);
+            }
+          }
+        }
       }  // end transitions
 
-      runv.emplace_back(csv, conditionss, transitionss);
+      // Fetch subrun records if requested
+      if (subruns) {
+        tcsv.clear();
+        select = "";
+        table = "online.subrun";
+        where.clear();
+        std::string ww = std::string("run_number:eq:") + std::to_string(run);
+        where.emplace_back(ww);
+        order = "subrun_number";
+        rc = _reader.query(tcsv, select, table, where, order);
+        if (rc != 0) {
+          throw cet::exception("RUNTOOL_BAD_SUBRUN_QUERY")
+              << " RunTool::listRuns failed to retrieve subruns for run " << run
+              << "\n";
+        }
+
+        if (!tcsv.empty()) {
+          StringVec subrunRows =
+              splitString(tcsv, "\n", "\"", "\\", true, false);
+          for (auto const& subrunCsv : subrunRows) {
+            StringVec subrunSv = splitString(subrunCsv);
+            if (subrunSv.size() >= 2) {
+              RunSubRun subrun;
+              subrun.setRunNumber(std::stoi(subrunSv[0]));
+              subrun.setSubrunNumber(std::stoi(subrunSv[1]));
+              if (subrunSv.size() > 2 && subrunSv[2] != "None")
+                subrun.setNEvents(std::stol(subrunSv[2]));
+              if (subrunSv.size() > 3 && subrunSv[3] != "None")
+                subrun.setNOnSpill(std::stol(subrunSv[3]));
+              if (subrunSv.size() > 4 && subrunSv[4] != "None")
+                subrun.setNOffSpill(std::stol(subrunSv[4]));
+              if (subrunSv.size() > 5 && subrunSv[5] != "None")
+                subrun.setMinEwt(std::stol(subrunSv[5]));
+              if (subrunSv.size() > 6 && subrunSv[6] != "None")
+                subrun.setMaxEwt(std::stol(subrunSv[6]));
+              if (subrunSv.size() > 7 && subrunSv[7] != "None")
+                subrun.setStartTimeUnix(std::stoi(subrunSv[7]));
+              if (subrunSv.size() > 8 && subrunSv[8] != "None")
+                subrun.setStopTimeUnix(std::stoi(subrunSv[8]));
+              if (subrunSv.size() > 9) subrun.setEventModeCounts(subrunSv[9]);
+              if (subrunSv.size() > 10) subrun.setCreatedAt(subrunSv[10]);
+              if (subrunSv.size() > 11 && subrunSv[11] != "None")
+                subrun.setNNull(std::stol(subrunSv[11]));
+              runInfo.addSubrun(subrun);
+            }
+          }
+        }
+      }  // end subruns
+
+      runv.emplace_back(runInfo);
     }  // end if pass
   }
 
@@ -193,210 +361,74 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool conditions,
 }
 
 //**************************************************
-void RunTool::printRun(const RunInfo& info, bool longp) {
-  std::string committ = info.commitTime().substr(0, size_t(19));
-  if (longp) {
-    std::cout << "\n";
-    std::cout << "runNumber             : " << info.runNumber() << "\n";
-    std::cout << "runType               : " << info.runType() << "\n";
-    std::cout << "commitTime            : " << committ << "\n";
-    std::cout << "conditionId           : " << info.conditionId() << "\n";
-    std::cout << "artdaqPartition       : " << info.artdaqPartition() << "\n";
-    std::cout << "hostName              : " << info.hostName() << "\n";
-    std::cout << "configurationName     : " << info.configurationName() << "\n";
-    std::cout << "configurationVersion  : " << info.configurationVersion()
-              << "\n";
-    std::cout << "contextName           : " << info.contextName() << "\n";
-    std::cout << "contextVersion        : " << info.contextVersion() << "\n";
-    std::cout << "triggerTableName      : " << info.triggerTableName() << "\n";
-    std::cout << "triggerTableVersion   : " << info.triggerTableVersion()
-              << "\n";
-    std::cout << "onlineSoftwareVersion : " << info.onlineSoftwareVersion()
-              << "\n";
-    std::cout << "shifterNote           : " << info.shifterNote() << "\n";
-  } else {
-    std::cout << std::setw(8) << info.runNumber();
-    std::cout << std::setw(5) << info.runType();
-    std::cout << std::setw(23) << committ;
-    std::cout << "\n";
+void RunTool::printRun(const RunInfo& info) {
+  const RunRecord& runRecord = info.runRecord();
+  std::string create_time = runRecord.createTime();
+  if (create_time.size() > 19) {
+    create_time = create_time.substr(0, 19);
   }
 
-  if (info.conditions().size() > 0) {
-    std::cout << "conditions:\n" << info.conditions() << "\n";
+  // Print basic run info
+  std::cout << std::setw(8) << runRecord.runNumber();
+  std::cout << std::setw(5) << runRecord.runTypeId();
+  std::cout << std::setw(23) << create_time;
+  std::cout << "\n";
+
+  // Print configs if present
+  if (info.configs().size() > 0) {
+    std::cout << "  configs (" << info.configs().size() << "):\n";
+    for (const auto& config : info.configs()) {
+      std::cout << "    subsystem: " << config.subsystem()
+                << ", version: " << config.version() << "\n";
+    }
   }
+
+  // Print transitions if present with column headers
   if (info.transitions().size() > 0) {
-    std::cout << "transitions:\n" << info.transitions();
-  }
-  // std::cout << " : " << info. << "\n";
+    // Get transition type names
+    std::map<int, std::string> transitionTypes = flags(FlagType::transition);
 
-  //  const std::string& conditions() const { return _conditions; }
-  // const std::string& transitions() const { return _transitions; }
-}
-/*
-EpicsVar::EpicsVec RunTool::get(std::string const& name,
-                                  std::string const& time, float daysAgo) {
-  EpicsVar::EpicsVec ev;
-
-  // run query url, answer returned in csv
-  int rc;
-  std::string tcsv, select, table, order;
-  StringVec where;
-
-  select = "channel_id";
-  table = "channel";
-  where.push_back("name:eq:" + name);
-  rc = _reader.query(tcsv, select, table, where, order);
-  if (rc != 0 || tcsv.empty()) {
-    throw cet::exception("EPICSTOOL_BAD_CHANNEL")
-        << " RunTool::get failed to find channel number for name\n";
-  }
-
-  std::string id = tcsv;
-  size_t inl = id.find('\n');
-  if (inl != std::string::npos) {
-    id.erase(inl, 1);
-  }
-
-  select.clear();
-  table = "sample";
-  where.clear();
-  where.push_back("channel_id:eq:" + id);
-  order = "smpl_time";
-  tcsv.clear();
-  rc = _reader.query(tcsv, select, table, where, order);
-
-  if (rc != 0) {
-    throw cet::exception("EPICSTOOL_BAD_SAMPLE")
-        << "RunTool::get could not lookup data for channel id " << id << "\n";
-  }
-
-  // the table is delivered with rows separated by \n, split them
-  StringVec rows = splitString(tcsv, "\n", "\"", "\\", true, false);
-
-  for (auto const& csv : rows) {
-    // Example csv:
-    //
-channel_id,smpl_time,nanosecs,severity_id,status_id,num_val,float_val,str_val,datatype
-    // 642,2022-05-05 14:10:02.089404-05:00,89404264,5,9,None,55.0,None, ,None
-
-    // split on commas
-    StringVec sv = splitString(csv);
-
-    if (sv.size() != 10) {
-      throw cet::exception("EPICSTOOL_BAD_CSV")
-          << " RunTool::get number of csv fields !=10, csv: \n"
-          << csv << " \n";
-    }
-
-    int64_t channel_id = std::stoll(sv[0]);
-    std::time_t smpl_time_t;
-    if (TimeUtility::parseTimeTZ(sv[1], smpl_time_t)) {
-      throw cet::exception("EPICSTOOL_BAD_TIME")
-          << " RunTool::get could not parse time " << sv[1] << " \n";
-    }
-    int64_t nanosecs = std::stoll(sv[2]);
-    int64_t severity_id = std::stoll(sv[3]);
-    int64_t status_id = std::stoll(sv[4]);
-    EpicsVar::variVar value;
-    if (sv[6] == "None" && sv[7] == "None") {
-      value = std::stoi(sv[5]);
-    } else if (sv[5] == "None" && sv[7] == "None") {
-      value = std::stod(sv[6]);
-    } else if (sv[5] == "None" && sv[6] == "None") {
-      value = sv[7];
-    } else {
-      throw cet::exception("EPICSTOOL_BAD_CSV_ROW")
-          << " RunTool::get could not parse csv row:\n"
-          << csv << " \n";
-    }
-
-    ev.emplace_back(csv, channel_id, sv[1], smpl_time_t, nanosecs, severity_id,
-                    status_id, value);
-
-  }  // loop over db sample rows
-
-  if (ev.empty()) {
-    return ev;
-  }
-
-  // if no constraints, return the whole list
-  if ( time.empty() && daysAgo<=0.0 ) {
-    return ev;
-  }
-
-  EpicsVar::EpicsVec evt;
-  if (time.find('/') != std::string::npos) {
-    // time interval
-    size_t idiv = time.find('/');
-    std::string st1 = time.substr(0, idiv);
-    std::string st2 = time.substr(idiv + 1, std::string::npos);
-    std::time_t t1;
-    if (TimeUtility::parseTimeTZ(st1, t1)) {
-      throw cet::exception("EPICSTOOL_BAD_TIME")
-          << " RunTool::get could not parse time " << st1 << " \n";
-    }
-    std::time_t t2;
-    if (TimeUtility::parseTimeTZ(st2, t2)) {
-      throw cet::exception("EPICSTOOL_BAD_TIME")
-          << " RunTool::get could not parse time " << st2 << " \n";
-    }
-    for (auto& e : ev) {
-      if (e.ttime() >= t1 && e.ttime() <= t2) {
-        evt.push_back(e);
+    std::cout << "  transitions (" << info.transitions().size() << "):\n";
+    std::cout << "    " << std::setw(8) << "type_id" << std::setw(20)
+              << "type_name"
+              << "  transition_time\n";
+    for (const auto& trans : info.transitions()) {
+      std::string type_name = "";
+      auto it = transitionTypes.find(trans.typeId());
+      if (it != transitionTypes.end()) {
+        type_name = it->second;
       }
+
+      std::cout << "    " << std::setw(8) << trans.typeId() << std::setw(20)
+                << type_name << "  " << trans.transitionTime() << "\n";
     }
-  } else if (time.find('-') != std::string::npos) {
-    // single time, find nearest entry before
-    std::time_t tt;
-    if (TimeUtility::parseTimeTZ(time, tt)) {
-      throw cet::exception("EPICSTOOL_BAD_TIME")
-          << " RunTool::get could not parse time " << time << " \n";
-    }
-    size_t i = ev.size() - 1;
-    while (i > 0 && ev[i].ttime() > tt) {
-      i--;
-    }
-    evt.push_back(ev[i]);
-  } else if (daysAgo > 0.0) {
-    // integer or float back n days
-    std::time_t now = std::time(nullptr);
-    std::time_t delta = std::time_t(daysAgo * 86400.0);
-    std::time_t tmin = now - delta;
-    for (auto& e : ev) {
-      if (e.ttime() > tmin) {
-        evt.push_back(e);
-      }
-    }
-  } else {
-    throw cet::exception("EPICSTOOL_BAD_ARGS")
-        << " RunTool::get could not parse arguments "
-        << " \n";
   }
 
-  return evt;
-}
+  // Print subruns if present with column headers
+  if (info.subruns().size() > 0) {
+    std::cout << "  subruns (" << info.subruns().size() << "):\n";
+    std::cout << "    " << std::setw(8) << "subrun" << std::setw(12) << "events"
+              << std::setw(15) << "min_ewt" << std::setw(15) << "max_ewt"
+              << "  start_time                stop_time\n";
+    for (const auto& subrun : info.subruns()) {
+      // Convert Unix timestamps to ISO8601 format in Central US time
+      std::time_t start_t = subrun.startTimeUnix();
+      std::time_t stop_t = subrun.stopTimeUnix();
+      char start_buf[32], stop_buf[32];
 
-// **************************************************
+      // Set timezone to Central US (America/Chicago)
+      setenv("TZ", "America/Chicago", 1);
+      tzset();
 
-int RunTool::names(StringVec& names) {
-  // run query url, answer returned in csv
-  int rc;
-  std::string csv, select, table, order;
-  StringVec where;
+      std::strftime(start_buf, sizeof(start_buf), "%Y-%m-%d %H:%M:%S",
+                    std::localtime(&start_t));
+      std::strftime(stop_buf, sizeof(stop_buf), "%Y-%m-%d %H:%M:%S",
+                    std::localtime(&stop_t));
 
-  names.clear();
-
-  select = "name";
-  table = "channel";
-  order = "name";
-  rc = _reader.query(csv, select, table, where, order);
-  if (rc != 0 || csv.empty()) {
-    std::cout << "Error - RunTool could not list names" << std::endl;
-    return 1;
+      std::cout << "    " << std::setw(8) << subrun.subrunNumber()
+                << std::setw(12) << subrun.nEvents() << std::setw(15)
+                << subrun.minEwt() << std::setw(15) << subrun.maxEwt() << "  "
+                << start_buf << "  " << stop_buf << "\n";
+    }
   }
-
-  names = splitString(csv, "\n", "\"", "\\", true, false);
-
-  return 0;
 }
-*/

--- a/DbService/src/RunTool.cc
+++ b/DbService/src/RunTool.cc
@@ -1,6 +1,7 @@
 #include "Offline/DbService/inc/RunTool.hh"
 
 #include "Offline/DbService/inc/DbIdList.hh"
+#include "Offline/DbTables/inc/DbUtil.hh"
 #include "Offline/GeneralUtilities/inc/TimeUtility.hh"
 #include "Offline/GeneralUtilities/inc/splitString.hh"
 
@@ -64,7 +65,7 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
   StringVec where;
 
   // fetch the list of all runs from the run table
-  select = "";
+  select = "run_number,comment,create_time,run_type_id";
   table = "online.run";
   order = "-run_number";
   int rc = _reader.query(tcsv, select, table, where, order);
@@ -131,15 +132,11 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
 
     // Parse the run table row: run_number,comment,create_time,run_type_id
     StringVec sv = splitString(csv);
-    if (sv.size() < 3) continue;  // skip malformed rows
 
     int run = std::stoi(sv[0]);
-    std::string comment = (sv.size() > 1) ? sv[1] : "";
-    std::string create_time = (sv.size() > 2) ? sv[2] : "";
-    int run_type_id = 0;
-    if (sv.size() > 3 && !sv[3].empty() && sv[3] != "None") {
-      run_type_id = std::stoi(sv[3]);
-    }
+    std::string comment = sv[1];
+    std::string create_time = sv[2];
+    int run_type_id = std::stoi(sv[3]);
 
     // limit on the range
     if (run < rmin || run > rmax) pass = false;
@@ -176,7 +173,7 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
       // Fetch config records if requested
       if (configs) {
         tcsv.clear();
-        select = "";
+        select = "run_number,subsystem,settings,create_time,version";
         table = "online.config";
         where.clear();
         std::string ww = std::string("run_number:eq:") + std::to_string(run);
@@ -190,80 +187,16 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
         }
 
         if (!tcsv.empty()) {
-          // Split by newlines only, don't try to parse escape sequences in
-          // JSONB
-          size_t start = 0;
-          size_t end = tcsv.find('\n');
-
-          while (start < tcsv.length()) {
-            std::string configCsv;
-            if (end == std::string::npos) {
-              configCsv = tcsv.substr(start);
-              start = tcsv.length();
-            } else {
-              configCsv = tcsv.substr(start, end - start);
-              start = end + 1;
-              end = tcsv.find('\n', start);
-            }
-
-            if (configCsv.empty()) continue;
-
-            // For config table, the settings field is JSONB which may contain
-            // complex escapes. Parse carefully - don't use splitString.
-            // Expected format:
-            // run_number,subsystem,settings,create_time,version
-
-            // Find the first two commas to extract run_number, subsystem
-            size_t pos1 = configCsv.find(',');
-            if (pos1 == std::string::npos) continue;
-
-            size_t pos2 = configCsv.find(',', pos1 + 1);
-            if (pos2 == std::string::npos) continue;
-
-            // The rest after pos2 is: settings,create_time,version
-            // The settings field is the third field, wrapped in quotes
-            std::string run_num_str = configCsv.substr(0, pos1);
-            std::string subsystem = configCsv.substr(pos1 + 1, pos2 - pos1 - 1);
-            std::string remainder = configCsv.substr(pos2 + 1);
-
-            // Extract just the settings field (third field in CSV)
-            // It starts with a quote, so find the matching closing quote
-            std::string settings;
-            if (!remainder.empty() && remainder[0] == '"') {
-              // Find the closing quote (accounting for escaped quotes "")
-              size_t i = 1;
-              while (i < remainder.length()) {
-                if (remainder[i] == '"') {
-                  // Check if it's an escaped quote
-                  if (i + 1 < remainder.length() && remainder[i + 1] == '"') {
-                    // Escaped quote, skip both
-                    i += 2;
-                  } else {
-                    // Found the closing quote
-                    settings = remainder.substr(1, i - 1);
-                    break;
-                  }
-                } else {
-                  i++;
-                }
-              }
-
-              // Now unescape the double-quotes
-              size_t pos = 0;
-              while ((pos = settings.find("\"\"", pos)) != std::string::npos) {
-                settings.replace(pos, 2, "\"");
-                pos += 1;
-              }
-            } else {
-              // No quotes, just use the remainder
-              settings = remainder;
-            }
-
+          StringVec crows = splitString(tcsv, "\n", "", "", true, false);
+          for (auto const& crow : crows) {
+            StringVec cfields = DbUtil::splitCsv(crow, true);
             RunConfig config;
-            if (!run_num_str.empty())
-              config.setRunNumber(std::stoi(run_num_str));
-            config.setSubsystem(subsystem);
-            config.setSettings(settings);
+            config.setRunNumber(std::stoi(cfields[0]));
+            config.setSubsystem(cfields[1]);
+            std::string json = DbUtil::simplfyQeString(cfields[2]);
+            config.setSettings(json);
+            config.setCreateTime(cfields[3]);
+            config.setVersion(std::stoi(cfields[4]));
             runInfo.addConfig(config);
           }
         }
@@ -272,7 +205,7 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
       // Fetch transition records if requested
       if (transitions) {
         tcsv.clear();
-        select = "";
+        select = "run_number,type_id,cause_id,transition_time";
         table = "online.run_transition";
         where.clear();
         std::string ww = std::string("run_number:eq:") + std::to_string(run);
@@ -307,7 +240,10 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
       // Fetch subrun records if requested
       if (subruns) {
         tcsv.clear();
-        select = "";
+        select =
+            "run_number,subrun_number,n_events,n_on_spill,n_off_spill,min_ewt,"
+            "max_ewt,start_time_unix,stop_time_unix,event_mode_counts,created_"
+            "at,n_null";
         table = "online.subrun";
         where.clear();
         std::string ww = std::string("run_number:eq:") + std::to_string(run);
@@ -369,7 +305,7 @@ void RunTool::printRun(const RunInfo& info) {
   }
 
   // Print basic run info
-  std::cout << std::setw(8) << runRecord.runNumber();
+  std::cout << runRecord.runNumber();
   std::cout << std::setw(5) << runRecord.runTypeId();
   std::cout << std::setw(23) << create_time;
   std::cout << "\n";
@@ -378,8 +314,8 @@ void RunTool::printRun(const RunInfo& info) {
   if (info.configs().size() > 0) {
     std::cout << "  configs (" << info.configs().size() << "):\n";
     for (const auto& config : info.configs()) {
-      std::cout << "    subsystem: " << config.subsystem()
-                << ", version: " << config.version() << "\n";
+      std::cout << std::setw(12) << config.subsystem() << std::setw(3)
+                << config.version() << "   " << config.createTime() << "\n";
     }
   }
 
@@ -410,15 +346,20 @@ void RunTool::printRun(const RunInfo& info) {
     std::cout << "    " << std::setw(8) << "subrun" << std::setw(12) << "events"
               << std::setw(15) << "min_ewt" << std::setw(15) << "max_ewt"
               << "  start_time                stop_time\n";
+
+    // Save current TZ environment variable to restore later
+    const char* old_tz = std::getenv("TZ");
+    std::string saved_tz = old_tz ? old_tz : "";
+
+    // Set timezone to Central US (America/Chicago) once before the loop
+    setenv("TZ", "America/Chicago", 1);
+    tzset();
+
     for (const auto& subrun : info.subruns()) {
       // Convert Unix timestamps to ISO8601 format in Central US time
       std::time_t start_t = subrun.startTimeUnix();
       std::time_t stop_t = subrun.stopTimeUnix();
       char start_buf[32], stop_buf[32];
-
-      // Set timezone to Central US (America/Chicago)
-      setenv("TZ", "America/Chicago", 1);
-      tzset();
 
       std::strftime(start_buf, sizeof(start_buf), "%Y-%m-%d %H:%M:%S",
                     std::localtime(&start_t));
@@ -430,5 +371,13 @@ void RunTool::printRun(const RunInfo& info) {
                 << subrun.minEwt() << std::setw(15) << subrun.maxEwt() << "  "
                 << start_buf << "  " << stop_buf << "\n";
     }
+
+    // Restore original TZ environment variable
+    if (!saved_tz.empty()) {
+      setenv("TZ", saved_tz.c_str(), 1);
+    } else {
+      unsetenv("TZ");
+    }
+    tzset();
   }
 }

--- a/DbService/src/pywrap.i
+++ b/DbService/src/pywrap.i
@@ -6,17 +6,39 @@
 
 %include "std_vector.i"
 %include "std_string.i"
+%include "std_map.i"
 %include "stdint.i"
 
 %apply const std::string& {std::string* foo};
 %template(vec_str) std::vector<std::string>;
+%template(map_int_str) std::map<int, std::string>;
 
 %{
 #include "Offline/DbTables/inc/DbTable.hh"
 #include "Offline/DbTables/inc/DbTableCollection.hh"
 #include "Offline/DbService/inc/DbTool.hh"
+#include "Offline/DbService/inc/RunConfig.hh"
+#include "Offline/DbService/inc/RunRecord.hh"
+#include "Offline/DbService/inc/RunTransition.hh"
+#include "Offline/DbService/inc/RunSubRun.hh"
+#include "Offline/DbService/inc/RunInfo.hh"
+#include "Offline/DbService/inc/RunSelect.hh"
+#include "Offline/DbService/inc/RunTool.hh"
 %}
 
 %include "Offline/DbTables/inc/DbTable.hh"
 %include "Offline/DbTables/inc/DbTableCollection.hh"
 %include "Offline/DbService/inc/DbTool.hh"
+%include "Offline/DbService/inc/RunConfig.hh"
+%include "Offline/DbService/inc/RunRecord.hh"
+%include "Offline/DbService/inc/RunTransition.hh"
+%include "Offline/DbService/inc/RunSubRun.hh"
+%include "Offline/DbService/inc/RunInfo.hh"
+%include "Offline/DbService/inc/RunSelect.hh"
+%include "Offline/DbService/inc/RunTool.hh"
+
+// Template instantiations for vectors
+%template(RunConfigVec) std::vector<mu2e::RunConfig>;
+%template(RunTransitionVec) std::vector<mu2e::RunTransition>;
+%template(RunSubRunVec) std::vector<mu2e::RunSubRun>;
+%template(RunInfoVec) std::vector<mu2e::RunInfo>;

--- a/DbService/src/runTool_main.cc
+++ b/DbService/src/runTool_main.cc
@@ -3,124 +3,183 @@
 // which reads data from the run conditions database
 //
 
-#include "Offline/DbService/inc/RunTool.hh"
 #include "Offline/DbService/inc/RunSelect.hh"
-#include <boost/program_options.hpp>
-#include <iostream>
+#include "Offline/DbService/inc/RunTool.hh"
+#include "Offline/GeneralUtilities/inc/ParseCLI.hh"
+
 #include <iomanip>
+#include <iostream>
 
 using namespace mu2e;
-namespace po = boost::program_options;
 
 int main(int argc, char** argv) {
-  std::vector<std::string> words;
+  ParseCLI cli("Run database query tool");
 
-  bool flags = false, conditions = false, longp = false, transitions = false;
-  std::string run, time, type;
-  int last = 0, days = 0;
+  // Add the global subcommand (no subcommands in this tool)
+  cli.addSubcommand("", "");
 
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "describe arguments")(
-      "flags,f", "print types of runs, ..")(
-      "run,r", po::value(&run), "run range")(
-      "last,n", po::value(&last), "print last N runs")(
-      "type,y", po::value(&type), "comma-seperated list of run types")(
-      "time,t", po::value(&time), "Restrict times for print, see help")(
-      "days,d", po::value(&days), "restrict time to N days ago to now")(
-      "long,l", "print longer report")(
-      "conditions,c","also print conditions")(
-      "transitions,a","also print transitions");
+  // Add switches
+  cli.addSwitch("", "flags", "f", "flags", false,
+                "print run and transition types");
+  cli.addSwitch("", "run", "r", "run", true,
+                "run range (e.g., 100000 or 100000-101000)");
+  cli.addSwitch("", "last", "n", "last", true, "last N runs");
+  cli.addSwitch("", "type", "y", "type", true,
+                "comma-separated list of run types");
+  cli.addSwitch("", "time", "t", "time", true,
+                "time restriction (ISO8601 format)\n         since: "
+                "2026-06-05T18:38:20-05:00 or range: 2026-06-01/2026-06-05");
+  cli.addSwitch("", "days", "d", "days", true, "since N days ago to now");
+  cli.addSwitch("", "configs", "c", "configs", false,
+                "also print configuration records");
+  cli.addSwitch("", "transitions", "a", "transitions", false,
+                "also print transitions");
+  cli.addSwitch("", "subruns", "s", "subruns", false, "also print subruns");
+  cli.addSwitch("", "blob", "b", "blob", true,
+                "print formatted JSON blob for specified subsystem");
 
-  po::variables_map vm;
-  po::store(po::parse_command_line(argc, argv, desc), vm);
-  po::notify(vm);
-
-  if (vm.count("help")) {
-    std::cout <<
-        R"(
-
-  runTool [OPTIONS]
-
-  A program to read run configuration data from the run_info
-  replica database and print it out.
-
-  -f, --flags
-       print list of run, transition, and cause flags
-
-  run selection:
-  -r, --run=RUNRANGE
-       Select a run range, like
-       100000 (one run)
-       100000-101000 (range)
-  -n, --last=N
-       Select N most recent runs
-  -y, --type=A,B
-       Select only runs of these types (see --flags)
-  -t, --time=TIME1 or TIME1/TIME2
-       The time restriction in ISO8601 format. This can be one time
-       to select all runs since that time, or two times for a range
-  -d, --days=N
-       all runs since N days ago
-
-    extend print:
-  -l, --long
-       Also print the details
-  -c, --conditions
-       Also print the conditions text block for selected runs
-  -a, --transitions
-       Also print the transitions
-
-    Runs default print will have format:
-   run   run_type   commit_time
- 103025    4    2024-06-12 23:08:36
-    Transitions will print in format
-transition_flag, cause_flag, time
-5,0,2024-06-06 17:27:42.666540-05:000
-
-)" << std::endl;
-
-    return 1;
-  }
-
-  if (vm.count("flags")) flags = true;
-
-  RunTool tool;
-  int rc = 0;
-
-  if (flags) {
-    std::map<int,std::string> flags;
-    flags = tool.flags(RunTool::FlagType::run);
-    std::cout << "run flags:"<<std::endl;
-    for (auto pp : flags) {
-      std::cout << std::setw(4)<<pp.first<< "  " <<pp.second <<std::endl;
-    }
-
-    flags = tool.flags(RunTool::FlagType::transition);
-    std::cout << "transition flags:"<<std::endl;
-    for (auto pp : flags) {
-      std::cout << std::setw(4)<<pp.first<< "  " <<pp.second <<std::endl;
-    }
-
-    flags = tool.flags(RunTool::FlagType::cause);
-    std::cout << "cause flags:"<<std::endl;
-    for (auto pp : flags) {
-      std::cout << std::setw(4)<<pp.first<< "  " <<pp.second <<std::endl;
-    }
-
+  // Parse command line
+  int rc = cli.setArgs(argc, argv);
+  if (rc != 0) {
     return rc;
   }
 
-
-  RunSelect runsel(run,last,type,time,days);
-
-  if (vm.count("long")) longp = true;
-  if (vm.count("conditions")) conditions = true;
-  if (vm.count("transitions")) transitions = true;
-
-  RunInfo::RunVec runvec = tool.listRuns(runsel,conditions,transitions);
-  for(auto const& rr : runvec) {
-    tool.printRun(rr,longp);
+  // Check for help (autohelp handles this, but we return after)
+  if (cli.getBool("", "help")) {
+    return 0;
   }
 
-  return rc;
+  RunTool tool;
+
+  // Handle flags request
+  if (cli.getBool("", "flags")) {
+    std::map<int, std::string> flags;
+
+    flags = tool.flags(RunTool::FlagType::run);
+    std::cout << "run flags:" << std::endl;
+    for (auto pp : flags) {
+      std::cout << std::setw(4) << pp.first << "  " << pp.second << std::endl;
+    }
+
+    flags = tool.flags(RunTool::FlagType::transition);
+    std::cout << "transition flags:" << std::endl;
+    for (auto pp : flags) {
+      std::cout << std::setw(4) << pp.first << "  " << pp.second << std::endl;
+    }
+
+    return 0;
+  }
+
+  // Build RunSelect from command line arguments
+  std::string run = cli.getString("", "run");
+  std::string last_str = cli.getString("", "last");
+  int last = last_str.empty() ? 0 : std::stoi(last_str);
+  std::string type = cli.getString("", "type");
+  std::string time = cli.getString("", "time");
+  std::string days_str = cli.getString("", "days");
+  int days = days_str.empty() ? 0 : std::stoi(days_str);
+
+  RunSelect runsel(run, last, type, time, days);
+
+  // Get print options
+  bool configs = cli.getBool("", "configs");
+  bool transitions = cli.getBool("", "transitions");
+  bool subruns = cli.getBool("", "subruns");
+  std::string blob_subsystem = cli.getString("", "blob");
+
+  // If blob subsystem is specified, we need to fetch configs
+  bool need_configs = configs || !blob_subsystem.empty();
+
+  // Query and print runs
+  RunInfo::RunVec runvec =
+      tool.listRuns(runsel, need_configs, transitions, subruns);
+
+  // Handle JSON blob output for specific subsystem
+  if (!blob_subsystem.empty()) {
+    for (auto const& rr : runvec) {
+      std::cout << "Run " << rr.runNumber() << ":\n";
+      bool found = false;
+      for (const auto& config : rr.configs()) {
+        if (config.subsystem() == blob_subsystem) {
+          found = true;
+          // Get the settings string (already cleaned in RunTool.cc)
+          std::string settings = config.settings();
+
+          // Replace literal \n with actual newlines
+          size_t pos = 0;
+          while ((pos = settings.find("\\n", pos)) != std::string::npos) {
+            settings.replace(pos, 2, "\n");
+            pos += 1;
+          }
+
+          // Simple JSON pretty-printing: add indentation after { [ and newlines
+          // after , ; :
+          std::string formatted;
+          int indent = 0;
+          bool in_string = false;
+          char prev_char = '\0';
+
+          for (size_t i = 0; i < settings.length(); ++i) {
+            char c = settings[i];
+
+            // Track if we're inside a string
+            if (c == '"' && prev_char != '\\') {
+              in_string = !in_string;
+            }
+
+            if (!in_string) {
+              // Add newline and indent after opening braces/brackets
+              if (c == '{' || c == '[') {
+                formatted += c;
+                formatted += '\n';
+                indent += 2;
+                formatted += std::string(indent, ' ');
+                prev_char = c;
+                continue;
+              }
+              // Add newline and unindent before closing braces/brackets
+              else if (c == '}' || c == ']') {
+                formatted += '\n';
+                indent -= 2;
+                formatted += std::string(indent, ' ');
+                formatted += c;
+                prev_char = c;
+                continue;
+              }
+              // Add newline and indent after commas
+              else if (c == ',') {
+                formatted += c;
+                formatted += '\n';
+                formatted += std::string(indent, ' ');
+                prev_char = c;
+                continue;
+              }
+              // Skip extra whitespace
+              else if (c == ' ' && (prev_char == ',' || prev_char == '{' ||
+                                    prev_char == '[')) {
+                continue;
+              }
+            }
+
+            formatted += c;
+            prev_char = c;
+          }
+
+          std::cout << formatted << "\n";
+          break;
+        }
+      }
+      if (!found) {
+        std::cout << "  Subsystem '" << blob_subsystem
+                  << "' not found in configs\n";
+      }
+    }
+  } else {
+    // Normal print
+    for (auto const& rr : runvec) {
+      tool.printRun(rr);
+    }
+  }
+
+  return 0;
 }

--- a/DbTables/inc/DbUtil.hh
+++ b/DbTables/inc/DbUtil.hh
@@ -14,11 +14,15 @@ class DbUtil {
   // split a csv string into lines on \n
   static std::vector<std::string> splitCsvLines(std::string const& csv);
   // split a line of csv into columns
-  static std::vector<std::string> splitCsv(std::string const& line);
+  static std::vector<std::string> splitCsv(std::string const& line,
+                                           bool qemode = false);
   // clean up a csv row for SQL insert
   static std::string sqlLine(std::string const& line);
   // provide the current local time as a string
   static std::string timeString();
+  // usually for json fields, change | " { ""abc"": "" comment \""OK\"" ""}"|
+  // -> |{ "abc": " comment \"OK\" "}|
+  static std::string simplfyQeString(std::string const& ss);
 };
 
 }  // namespace mu2e

--- a/DbTables/src/DbUtil.cc
+++ b/DbTables/src/DbUtil.cc
@@ -191,7 +191,8 @@ std::vector<std::string> mu2e::DbUtil::splitCsvLines(const std::string& csv) {
 // ****************************************************************
 // split a line by csv rules, including quotes
 // assumes comment lines have been removed
-std::vector<std::string> mu2e::DbUtil::splitCsv(const std::string& line) {
+std::vector<std::string> mu2e::DbUtil::splitCsv(const std::string& line,
+                                                bool qemode) {
   std::vector<std::string> columns;  // columns of a line of csv
 
   std::size_t i, j;
@@ -202,9 +203,9 @@ std::vector<std::string> mu2e::DbUtil::splitCsv(const std::string& line) {
       if (!quote) {
         quote = true;
         j++;
-      } else {                      // could be embedded quote
-        if (line[j - 1] == '\\') {  // has form \"
-          j++;                      // just continue, slash already processed
+      } else {                                 // could be embedded quote
+        if (!qemode && line[j - 1] == '\\') {  // has form \"
+          j++;  // just continue, slash already processed
         } else if (j < line.size() - 1 && line[j + 1] == '"') {  // has form ""
           j = j + 2;  // just continue, skip second quote
         } else {      // must be end quote
@@ -289,4 +290,25 @@ std::string mu2e::DbUtil::timeString() {
      << mtm->tm_year % 100 << " " << std::setw(2) << mtm->tm_hour << ":"
      << std::setw(2) << mtm->tm_min << ":" << std::setw(2) << mtm->tm_sec;
   return ss.str();
+}
+
+// ****************************************************************
+std::string mu2e::DbUtil::simplfyQeString(std::string const& ss) {
+  std::string cc = ss;
+  boost::trim(cc);
+  if (cc.size() <= 1) return cc;
+  if (cc.front() == '"' && cc.back() == '"') {
+    cc = cc.substr(1,cc.size()-2);
+    boost::trim(cc);
+  }
+  if (cc.empty()) return cc;
+  std::string from("\"\""),to("\"");
+  size_t start_pos = 0;
+  while ((start_pos = cc.find(from, start_pos)) != std::string::npos) {
+    cc.replace(start_pos, from.length(), to);
+    // Advance start_pos past the replaced substring to avoid infinite loops
+    // if 'to' contains 'from'
+    start_pos += to.length();
+  }
+  return cc;
 }

--- a/DbTables/src/DbUtil.cc
+++ b/DbTables/src/DbUtil.cc
@@ -314,6 +314,7 @@ std::string mu2e::DbUtil::simplfyQeString(std::string const& ss) {
     start_pos += to.length();
   }
   return cc;
+}
 
 // ****************************************************************
 // return a hash of the csv of a table

--- a/GeneralUtilities/src/ParseCLI.cc
+++ b/GeneralUtilities/src/ParseCLI.cc
@@ -257,11 +257,17 @@ int ParseCLI::autohelp() const {
   if (!need)
     return 0;
 
+  bool realSubs = ( _subs.size() > 1 ||
+                    ( _subs.size() == 1 &&  ! _subs[0].subcommand.empty() ) );
+
   std::cout << "\n";
   if (_subcommand.empty()) {
-    std::cout << "   " << _command << " [GLOBAL OPTIONS] [SUBCOMMAND] [SUBCOMMAND OPTIONS]"
-              << "\n\n";
-    std::cout << "   " << _helpstr << "\n\n";
+    if ( realSubs ) {
+      std::cout << "   " << _command << " [GLOBAL OPTIONS] [SUBCOMMAND] [SUBCOMMAND OPTIONS]";
+    } else {
+      std::cout << "   " << _command << " [GLOBAL OPTIONS]";
+    }
+    std::cout << "\n\n   " << _helpstr << "\n\n";
   } else {
     std::cout << _command << " " << _subcommand << " [SUBCOMMAND OPTIONS]"
               << "\n";
@@ -303,7 +309,7 @@ int ParseCLI::autohelp() const {
     }
   }
 
-  if (_subcommand.empty()) {
+  if (_subcommand.empty() && realSubs) {
     std::cout << "\n   subcommands:\n";
     for (const auto& ss : _subs) {
       if (!ss.subcommand.empty()) {


### PR DESCRIPTION
The run_info database schema ahs been developed over the last few months.  It is at a stable point and so in this PR we adapt the RunTool to the new schema.  The content is basically the same, but the tables have be reorganized.  The old schema is not supported.  Several classes are added to represent the new organization. The command line tool has the same interface, but the output is updated.  RunTool can be include in c++ code and used anywhere.  The python interface generated by pywrap has been tested.  This update is necessary to move ahead pass1 automation.  There should be no effect on validation or operations, so low risk merge.