### PR TITLE
db table hash infrastructure

### DIFF
--- a/DbService/src/DbTool.cc
+++ b/DbService/src/DbTool.cc
@@ -943,6 +943,7 @@ int mu2e::DbTool::commitCalibration() {
   args["file"] = "";
   args["addIOV"] = "";
   args["addGroup"] = "";
+  args["verify"] = "";
   if ((rc = getArgs(args))) return rc;
 
   if (args["file"].empty()) {
@@ -952,6 +953,7 @@ int mu2e::DbTool::commitCalibration() {
 
   bool qai = !args["addIOV"].empty();
   bool qag = !args["addGroup"].empty();
+  bool qverify = !args["verify"].empty();
 
   if (qag && !qai) {
     std::cout << "commit-calibration: addGroup requested without addIOV "
@@ -976,6 +978,16 @@ int mu2e::DbTool::commitCalibration() {
     std::cout << "commit-calibration: no table found in file " << args["file"]
               << std::endl;
     return 2;
+  }
+
+  if (qverify) {
+    for (auto lt : coll) {
+      std::cout << std::setw(25) << lt.table().name()
+                << std::setw(30) << lt.iov().to_string(true)
+                << std::setw(18) << lt.table().hash() << std::endl;
+      if (_verbose > 5) std::cout << lt.table().csv();
+    }
+    return 0;
   }
 
   rc = commitCalibrationList(coll, qai, qag, _admin);
@@ -2888,6 +2900,7 @@ int mu2e::DbTool::help() {
                  "    --addGroup : after adding IOV's, also create a new group "
                  "(requires --addIOV)\n"
                  "    --dry-run : do everything except final database commit\n"
+                 "    --verify : only read fle and summarize with hash\n"
               << std::endl;
   } else if (_action == "commit-iov") {
     std::cout

--- a/DbService/src/DbTool.cc
+++ b/DbService/src/DbTool.cc
@@ -2900,7 +2900,7 @@ int mu2e::DbTool::help() {
                  "    --addGroup : after adding IOV's, also create a new group "
                  "(requires --addIOV)\n"
                  "    --dry-run : do everything except final database commit\n"
-                 "    --verify : only read fle and summarize with hash\n"
+                 "    --verify : only read file and summarize with hash\n"
               << std::endl;
   } else if (_action == "commit-iov") {
     std::cout

--- a/DbTables/inc/DbTable.hh
+++ b/DbTables/inc/DbTable.hh
@@ -40,9 +40,13 @@ class DbTable {
   // if table needs to be sorted
   virtual const std::string orderBy() const { return std::string(); }
   virtual tableType type() const { return Calibration; }
+  // the hash of the csv content
+  const std::string& hash() const { return _hash; }
 
   // take the cvs text from a query and build out the table contents
   int fill(const std::string& csv, bool saveCsv = true);
+  // fill the hash member
+  void hashCsv();
   // in case table was filled with binary values, convert to csv
   int toCsv();
 
@@ -52,13 +56,14 @@ class DbTable {
   virtual void rowToCsv(std::ostringstream& stream, size_t irow) const = 0;
   // remove all rows
   virtual void clear() = 0;
-  void baseClear() { _csv.clear(); }
+  void baseClear() { _csv.clear(); _hash.clear(); }
 
  private:
   std::string _name;
   std::string _dbname;
   std::string _query;
   std::string _csv;
+  std::string _hash;
 };
 
 }  // namespace mu2e

--- a/DbTables/inc/DbUtil.hh
+++ b/DbTables/inc/DbUtil.hh
@@ -19,6 +19,8 @@ class DbUtil {
   static std::string sqlLine(std::string const& line);
   // provide the current local time as a string
   static std::string timeString();
+  // compute the hash of a canoniacal format of a csv string
+  static std::string hash(const std::string& csv);
 };
 
 }  // namespace mu2e

--- a/DbTables/inc/DbUtil.hh
+++ b/DbTables/inc/DbUtil.hh
@@ -19,7 +19,7 @@ class DbUtil {
   static std::string sqlLine(std::string const& line);
   // provide the current local time as a string
   static std::string timeString();
-  // compute the hash of a canoniacal format of a csv string
+  // compute the hash of a canonical format of a csv string
   static std::string hash(const std::string& csv);
 };
 

--- a/DbTables/src/DbTable.cc
+++ b/DbTables/src/DbTable.cc
@@ -38,6 +38,12 @@ int mu2e::DbTable::fill(const std::string& csv, bool saveCsv) {
   return 0;
 }
 
+void mu2e::DbTable::hashCsv() {
+  if (_csv.empty()) return;
+  _hash = DbUtil::hash(_csv);
+  return;
+}
+
 int mu2e::DbTable::toCsv() {
   if (!_csv.empty()) return 0;
   std::ostringstream ss;

--- a/DbTables/src/DbUtil.cc
+++ b/DbTables/src/DbUtil.cc
@@ -2,6 +2,7 @@
 #include "Offline/DbTables/inc/DbIoV.hh"
 #include "Offline/DbTables/inc/DbTableFactory.hh"
 #include "cetlib_except/exception.h"
+#include "cetlib/sha1.h"
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -24,7 +25,7 @@
 // # can include comment lines with hash as first char
 mu2e::DbTableCollection mu2e::DbUtil::readFile(std::string const& fn,
                                                bool saveCsv) {
-  if (fn.size() <= 0) {
+  if (fn.empty()) {
     throw cet::exception("DBFILE_NO_FILE_NAME")
         << "DbUtil::read called with no file name\n";
   }
@@ -44,7 +45,7 @@ mu2e::DbTableCollection mu2e::DbUtil::readFile(std::string const& fn,
   while (std::getline(myfile, line)) {
     boost::trim(line);  // remove whitespace
     // line was blank or comment, skip to next
-    if (line.size() <= 0 || line[0] == '#') continue;
+    if (line.empty() || line[0] == '#') continue;
 
     // if this line starts a new table
     if (line.substr(0, 5) == "TABLE") {
@@ -130,12 +131,12 @@ mu2e::DbTableCollection mu2e::DbUtil::readFile(std::string const& fn,
 // output will respect the input format for easy read-edit-commit
 void mu2e::DbUtil::writeFile(std::string const& fn,
                              DbTableCollection const& coll) {
-  if (fn.size() <= 0) {
+  if (fn.empty()) {
     throw cet::exception("DBFILE_NO_FILE_NAME")
         << "DbUtil::write called with no file name\n";
   }
   // silently succeed if nothing to write
-  if (coll.size() <= 0) return;
+  if (coll.empty()) return;
 
   std::ofstream myfile;
   myfile.open(fn);
@@ -294,13 +295,13 @@ std::string mu2e::DbUtil::timeString() {
 }
 
 // ****************************************************************
-// return a hash of the the csv of a table
+// return a hash of the csv of a table
 std::string mu2e::DbUtil::hash(const std::string& csv) {
   std::string nominal;
   nominal.reserve(csv.size());
   std::vector<std::string> lines = mu2e::DbUtil::splitCsvLines(csv);
   for (auto const& line : lines) {
-    bool qcontent = (line.size()>0 && line[0]!='#');
+    bool qcontent = (!line.empty() && line[0]!='#');
     bool qtable = (line.size()>=5 && line.substr(0,5)=="TABLE");
     if(qcontent && ! qtable) {
       std::vector<std::string> words = splitCsv(line);
@@ -308,17 +309,25 @@ std::string mu2e::DbUtil::hash(const std::string& csv) {
         std::string temp = word;
         boost::trim(temp);
         if(temp.size()>1) {
-          // in addition to removing surounding whitespace, also remove
+          // in addition to removing surrounding whitespace, also remove
           // whitespace of quoted string since this happens on commit
           if(temp[0]=='"' && temp[temp.size()-1]=='"') {
             temp = temp.substr(1,temp.size()-2);
             boost::trim(temp);
           }
         }
-        nominal=nominal.append(temp);
+        // add a comma to avoid rare ambiguity between columns
+        nominal = nominal.append(temp+",");
       }
     }
   }
-  std::string fullhash = std::to_string( std::hash<std::string>()(nominal) );
-  return fullhash.substr(0,16);
+  auto sha1 = cet::sha1(nominal);
+  auto digest = sha1.digest();
+  std::stringstream ss;
+  for (u_char byte : digest) {
+    // Force each byte to print as a 2-digit lowercase hexadecimal value
+    ss << std::hex << std::setw(2) << std::setfill('0')
+       << static_cast<int>(byte);
+  }
+  return ss.str().substr(0,16);
 }

--- a/DbTables/src/DbUtil.cc
+++ b/DbTables/src/DbUtil.cc
@@ -53,6 +53,7 @@ mu2e::DbTableCollection mu2e::DbUtil::readFile(std::string const& fn,
       // then add it to the vector as a DbLiveTable
       if (current.get() != nullptr) {
         current->fill(csv, saveCsv);
+        current->hashCsv();
         for (auto const& ii : iovv) {
           coll.emplace_back(ii, current, -1, -1);
         }
@@ -114,6 +115,7 @@ mu2e::DbTableCollection mu2e::DbUtil::readFile(std::string const& fn,
   // then add it to the vector as a DbLiveTable
   if (current.get() != nullptr) {
     current->fill(csv, saveCsv);
+    current->hashCsv();
     for (auto const& ii : iovv) {
       coll.emplace_back(ii, current, -1, -1);
     }
@@ -289,4 +291,34 @@ std::string mu2e::DbUtil::timeString() {
      << mtm->tm_year % 100 << " " << std::setw(2) << mtm->tm_hour << ":"
      << std::setw(2) << mtm->tm_min << ":" << std::setw(2) << mtm->tm_sec;
   return ss.str();
+}
+
+// ****************************************************************
+// return a hash of the the csv of a table
+std::string mu2e::DbUtil::hash(const std::string& csv) {
+  std::string nominal;
+  nominal.reserve(csv.size());
+  std::vector<std::string> lines = mu2e::DbUtil::splitCsvLines(csv);
+  for (auto const& line : lines) {
+    bool qcontent = (line.size()>0 && line[0]!='#');
+    bool qtable = (line.size()>=5 && line.substr(0,5)=="TABLE");
+    if(qcontent && ! qtable) {
+      std::vector<std::string> words = splitCsv(line);
+      for(auto const& word : words) {
+        std::string temp = word;
+        boost::trim(temp);
+        if(temp.size()>1) {
+          // in addition to removing surounding whitespace, also remove
+          // whitespace of quoted string since this happens on commit
+          if(temp[0]=='"' && temp[temp.size()-1]=='"') {
+            temp = temp.substr(1,temp.size()-2);
+            boost::trim(temp);
+          }
+        }
+        nominal=nominal.append(temp);
+      }
+    }
+  }
+  std::string fullhash = std::to_string( std::hash<std::string>()(nominal) );
+  return fullhash.substr(0,16);
 }


### PR DESCRIPTION
One of the issues with transferring database tables from online to offline is that some tables (cat3 in doc 54331) might already have the same content in the offline database or might have new content added online.  So we need to ask does this content already exist offline?  This PR adds a hash to tables when their content is committed, so we can can just ask if the hash already exists.  When table content is stored and retrieved by Query Engine, the text can be tweaked a bit to deal with quoting, so that is removed in the hash process.  This PR just establishes the hash, it does not store it in the ValCalibrations table yet, that will be a second PR.  In this PR there should be no effect on validation or operations.