### PR TITLE
extract cat3 tables from blobs

### DIFF
--- a/DbService/CMakeLists.txt
+++ b/DbService/CMakeLists.txt
@@ -12,6 +12,7 @@ cet_make_library(
       src/GrlList.cc
       src/GrlTool.cc
       src/OpenTool.cc
+      src/RunConfig.cc
       src/RunInfo.cc
       src/RunTool.cc
     LIBRARIES PUBLIC

--- a/DbService/inc/RunConfig.hh
+++ b/DbService/inc/RunConfig.hh
@@ -32,7 +32,7 @@ class RunConfig {
   // from every "DBServiceTables" dictionary found at any depth.
   // If json=true  -> returns a JSON object string with all merged pairs.
   // If json=false -> returns one VALUE per line (flat list).
-  std::string dbTables3(bool json = false) const;
+  std::string dbTables3(bool qjson = false) const;
 
  private:
   int _run_number;

--- a/DbService/inc/RunConfig.hh
+++ b/DbService/inc/RunConfig.hh
@@ -28,6 +28,12 @@ class RunConfig {
   }
   void setVersion(int version) { _version = version; }
 
+  // Walk the entire JSON tree in _settings, collect all key-value pairs
+  // from every "DBServiceTables" dictionary found at any depth.
+  // If json=true  -> returns a JSON object string with all merged pairs.
+  // If json=false -> returns one VALUE per line (flat list).
+  std::string dbTables3(bool json = false) const;
+
  private:
   int _run_number;
   std::string _subsystem;

--- a/DbService/src/RunConfig.cc
+++ b/DbService/src/RunConfig.cc
@@ -1,10 +1,11 @@
 #include "Offline/DbService/inc/RunConfig.hh"
-
+#include "cetlib_except/exception.h"
+#include "nlohmann/json.hpp"
 #include <string>
 #include <utility>
 #include <vector>
+#include <iostream>
 
-#include "nlohmann/json.hpp"
 
 // ---------------------------------------------------------------------------
 // The _settings field stores a JSONB blob retrieved from PostgreSQL as a
@@ -51,7 +52,7 @@ void walk(const json& node,
 // ---------------------------------------------------------------------------
 // mu2e::RunConfig::dbTables3
 // ---------------------------------------------------------------------------
-std::string mu2e::RunConfig::dbTables3(bool json) const {
+std::string mu2e::RunConfig::dbTables3(bool qjson) const {
   std::vector<std::pair<std::string, std::string>> pairs;
 
   // Parse the settings blob; tolerate malformed/empty content by returning
@@ -63,13 +64,21 @@ std::string mu2e::RunConfig::dbTables3(bool json) const {
 
   std::string result;
 
-  if (json) {
+  if (qjson) {
     // Build a JSON object and let nlohmann serialize it.  dump() correctly
     // escapes any control characters (e.g. newlines become \n in the text),
     // so the result is always valid JSON that json.loads can parse back into
     // values that retain their embedded newlines.
     nlohmann::json out = nlohmann::json::object();
     for (auto const& p : pairs) {
+      // A duplicate key would silently overwrite the earlier value, losing
+      // data, so refuse to continue if one is found.
+      std::cout << "DEB " << p.first << "\n";
+      if (out.contains(p.first)) {
+        throw cet::exception("RUNCONFIG_DUPLICATE_KEY")
+            << " RunConfig::dbTables3 found duplicate DBServiceTables key "
+            << p.first << " which would overwrite an existing value \n";
+      }
       out[p.first] = p.second;
     }
     result = out.dump(1, ' ');

--- a/DbService/src/RunConfig.cc
+++ b/DbService/src/RunConfig.cc
@@ -1,0 +1,85 @@
+#include "Offline/DbService/inc/RunConfig.hh"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+// ---------------------------------------------------------------------------
+// The _settings field stores a JSONB blob retrieved from PostgreSQL as a
+// string.  We parse it with nlohmann::json and walk the full tree, collecting
+// every key-value pair inside every "DBServiceTables" dictionary found at any
+// nesting depth.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using nlohmann::json;
+
+// Convert a JSON value to a plain string: use the raw content for strings,
+// and a compact dump() for anything else (number, bool, etc.).
+std::string valueToString(const json& v) {
+  return v.is_string() ? v.get<std::string>() : v.dump();
+}
+
+// Recursively walk a JSON node.  Whenever an object contains the key
+// "DBServiceTables" whose value is an object, its key-value pairs are appended
+// to `collected`.  Nested objects and arrays are always traversed so that
+// "DBServiceTables" entries at any depth are found.
+void walk(const json& node,
+          std::vector<std::pair<std::string, std::string>>& collected) {
+  if (node.is_object()) {
+    for (auto it = node.begin(); it != node.end(); ++it) {
+      if (it.key() == "DBServiceTables" && it.value().is_object()) {
+        for (auto jt = it.value().begin(); jt != it.value().end(); ++jt) {
+          collected.emplace_back(jt.key(), valueToString(jt.value()));
+        }
+      } else {
+        walk(it.value(), collected);
+      }
+    }
+  } else if (node.is_array()) {
+    for (auto const& elem : node) {
+      walk(elem, collected);
+    }
+  }
+}
+
+}  // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// mu2e::RunConfig::dbTables3
+// ---------------------------------------------------------------------------
+std::string mu2e::RunConfig::dbTables3(bool json) const {
+  std::vector<std::pair<std::string, std::string>> pairs;
+
+  // Parse the settings blob; tolerate malformed/empty content by returning
+  // an empty result rather than throwing.
+  nlohmann::json root = nlohmann::json::parse(_settings, nullptr, false);
+  if (!root.is_discarded()) {
+    walk(root, pairs);
+  }
+
+  std::string result;
+
+  if (json) {
+    // Build a JSON object and let nlohmann serialize it.  dump() correctly
+    // escapes any control characters (e.g. newlines become \n in the text),
+    // so the result is always valid JSON that json.loads can parse back into
+    // values that retain their embedded newlines.
+    nlohmann::json out = nlohmann::json::object();
+    for (auto const& p : pairs) {
+      out[p.first] = p.second;
+    }
+    result = out.dump(1, ' ');
+  } else {
+    for (auto const& p : pairs) {
+      result += p.second;
+      result += "\n";
+    }
+    if (!result.empty() && result.back() == '\n') result.pop_back();
+  }
+
+  return result;
+}

--- a/DbService/src/runTool_main.cc
+++ b/DbService/src/runTool_main.cc
@@ -37,6 +37,8 @@ int main(int argc, char** argv) {
   cli.addSwitch("", "subruns", "s", "subruns", false, "also print subruns");
   cli.addSwitch("", "blob", "b", "blob", true,
                 "print formatted JSON blob for specified subsystem");
+  cli.addSwitch("", "dbtables", "q", "dbtables", false,
+                "print the cat 3 DbService tables");
 
   // Parse command line
   int rc = cli.setArgs(argc, argv);
@@ -86,13 +88,29 @@ int main(int argc, char** argv) {
   bool transitions = cli.getBool("", "transitions");
   bool subruns = cli.getBool("", "subruns");
   std::string blob_subsystem = cli.getString("", "blob");
+  bool dbtables = cli.getBool("", "dbtables");
 
-  // If blob subsystem is specified, we need to fetch configs
-  bool need_configs = configs || !blob_subsystem.empty();
+  // If blob subsystem or dbtables is specified, we need to fetch configs
+  bool need_configs = configs || !blob_subsystem.empty() || dbtables;
 
   // Query and print runs
   RunInfo::RunVec runvec =
       tool.listRuns(runsel, need_configs, transitions, subruns);
+
+  // Handle dbtables output: concatenated cat-3 DbService table values
+  // for machine reading.  No labels or adornment - just the values,
+  // looping over every config in every run.
+  if (dbtables) {
+    for (auto const& rr : runvec) {
+      for (const auto& config : rr.configs()) {
+        std::string tables = config.dbTables3(false);
+        if (!tables.empty()) {
+          std::cout << tables << "\n";
+        }
+      }
+    }
+    return 0;
+  }
 
   // Handle JSON blob output for specific subsystem
   if (!blob_subsystem.empty()) {


### PR DESCRIPTION
This adds a routine to search run_info json blobs to find the keyword DBServiceTables and pull out the following values, which will be cat3 table content.  This is niche development, no change to validation or ops.