### PR TITLE
Add info for carbon muon stop resampling

### DIFF
--- a/EventGenerator/src/Pileup_module.cc
+++ b/EventGenerator/src/Pileup_module.cc
@@ -103,9 +103,10 @@ namespace mu2e {
          <<std::endl;
     }
 
-    if(conf().stoppingTargetMaterial() != "Al" and conf().stoppingTargetMaterial() != "IPA" ) {
+    if(conf().stoppingTargetMaterial() != "Al" and conf().stoppingTargetMaterial() != "IPA"
+       and conf().stoppingTargetMaterial() != "C") {
       throw   cet::exception("NOT_IMPLEMENTED")
-        <<"Pileup_module: emisson spectra for other than Al target are not impelmented\n";
+        <<"Pileup_module: emisson spectra for other than Al/IPA/C targets are not impelmented\n";
     }
 
     const auto cap_psets = conf().captureProducts.get<std::vector<fhicl::ParameterSet>>();

--- a/GlobalConstantsService/data/globalConstants_01.txt
+++ b/GlobalConstantsService/data/globalConstants_01.txt
@@ -130,6 +130,13 @@ double physicsParams.Al.capture.RMCInternalRate = 0.0069; //measurement of inter
 double physicsParams.Al.capture.photon.1809keV.energy = 1.809;
 double physicsParams.Al.capture.photon.1809keV.intensity = 0.51;
 
+double physicsParams.C.capture.protonRate = 0.33; // Per capture rates, measured with Geant4 on G4_C
+double physicsParams.C.capture.deuteronRate = 0.15;
+double physicsParams.C.capture.neutronRate = 1.77;
+double physicsParams.C.capture.photonRate = 1.73;
+double physicsParams.C.capture.RMCRate = 1.22e-4; //TRIUMF measured 1.67e-5 for E > 57 on Oxygen, full rate taken by dividing by closure fraction above 57 MeV for kmax = 88.4
+double physicsParams.C.capture.RMCInternalRate = 0.0069; //measurement of internal conversion rate for RPC on hydrogen
+
 //Ce+ endpoint energy
 double physicsParams.Al.ePlusEndpointEnergy = 92.32;
 


### PR DESCRIPTION
This will allow for approximate pileup generation using muon stops in the COL5 poly. I measured the proton/neutron/deuteron/photon rates from carbon muon stops using Geant4 and G4_C material. The RMC rate is taken from the TRIUMF oxygen measurement since I didn't see one for carbon (it's pretty similar for most light nuclei though).