### PR TITLE
extract CID tables from run_info blobs

### DIFF
--- a/DbService/inc/RunConfig.hh
+++ b/DbService/inc/RunConfig.hh
@@ -34,6 +34,13 @@ class RunConfig {
   // If json=false -> returns one VALUE per line (flat list).
   std::string dbTables3(bool qjson = false) const;
 
+  // Walk the entire JSON tree in _settings, collect all (cid, name) pairs
+  // from every "DBServiceCIDTable" array found at any depth.
+  // If json=true  -> returns a JSON list of {"cid":..., "name":...} objects.
+  // If json=false -> returns one "cid name" pair per line.
+  std::string dbTables2(bool qjson = false) const;
+
+
  private:
   int _run_number;
   std::string _subsystem;

--- a/DbService/inc/RunConfig.hh
+++ b/DbService/inc/RunConfig.hh
@@ -1,7 +1,7 @@
 #ifndef DbService_RunConfig_hh
 #define DbService_RunConfig_hh
 
-// holds info for one row in the config table
+// holds info for one row in the run_info config table
 
 #include <string>
 #include <vector>
@@ -39,7 +39,6 @@ class RunConfig {
   // If json=true  -> returns a JSON list of {"cid":..., "name":...} objects.
   // If json=false -> returns one "cid name" pair per line.
   std::string dbTables2(bool qjson = false) const;
-
 
  private:
   int _run_number;

--- a/DbService/src/RunConfig.cc
+++ b/DbService/src/RunConfig.cc
@@ -7,13 +7,6 @@
 #include <iostream>
 
 
-// ---------------------------------------------------------------------------
-// The _settings field stores a JSONB blob retrieved from PostgreSQL as a
-// string.  We parse it with nlohmann::json and walk the full tree, collecting
-// every key-value pair inside every "DBServiceTables" dictionary found at any
-// nesting depth.
-// ---------------------------------------------------------------------------
-
 namespace {
 
 using nlohmann::json;
@@ -75,7 +68,7 @@ void walkCID(const json& node,
   }
 }
 
-}  // anonymous namespace
+}
 
 // ---------------------------------------------------------------------------
 // mu2e::RunConfig::dbTables2

--- a/DbService/src/RunConfig.cc
+++ b/DbService/src/RunConfig.cc
@@ -47,11 +47,80 @@ void walk(const json& node,
   }
 }
 
+// Recursively walk a JSON node.  Whenever an object contains the key
+// "DBServiceCIDTable" whose value is an array, each element (expected to be
+// an object with "cid" and "name" fields) is appended to `collected` as a
+// (cid, name) pair.  Nested objects and arrays are always traversed so that
+// "DBServiceCIDTable" entries at any depth are found.
+void walkCID(const json& node,
+             std::vector<std::pair<std::string, std::string>>& collected) {
+  if (node.is_object()) {
+    for (auto it = node.begin(); it != node.end(); ++it) {
+      if (it.key() == "DBServiceCIDTable" && it.value().is_array()) {
+        for (auto const& elem : it.value()) {
+          if (elem.is_object() && elem.contains("cid") &&
+              elem.contains("name")) {
+            collected.emplace_back(valueToString(elem["cid"]),
+                                   valueToString(elem["name"]));
+          }
+        }
+      } else {
+        walkCID(it.value(), collected);
+      }
+    }
+  } else if (node.is_array()) {
+    for (auto const& elem : node) {
+      walkCID(elem, collected);
+    }
+  }
+}
+
 }  // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// mu2e::RunConfig::dbTables2
+// ---------------------------------------------------------------------------
+std::string mu2e::RunConfig::dbTables2(bool qjson) const {
+  std::vector<std::pair<std::string, std::string>> pairs;
+
+  // Parse the settings blob; tolerate malformed/empty content by returning
+  // an empty result rather than throwing.
+  nlohmann::json root = nlohmann::json::parse(_settings, nullptr, false);
+  if (!root.is_discarded()) {
+    walkCID(root, pairs);
+  }
+
+  std::string result;
+
+  if (qjson) {
+    // Build a JSON array of {"cid":..., "name":...} objects and serialize it,
+    // reproducing the DBServiceCIDTable list.
+    nlohmann::json out = nlohmann::json::array();
+    for (auto const& p : pairs) {
+      nlohmann::json entry = nlohmann::json::object();
+      entry["cid"] = p.first;
+      entry["name"] = p.second;
+      out.push_back(entry);
+    }
+    result = out.dump(1, ' ');
+  } else {
+    // One (cid, name) pair per line: the CID followed by the name.
+    for (auto const& p : pairs) {
+      result += p.first;
+      result += " ";
+      result += p.second;
+      result += "\n";
+    }
+    if (!result.empty() && result.back() == '\n') result.pop_back();
+  }
+
+  return result;
+}
 
 // ---------------------------------------------------------------------------
 // mu2e::RunConfig::dbTables3
 // ---------------------------------------------------------------------------
+
 std::string mu2e::RunConfig::dbTables3(bool qjson) const {
   std::vector<std::pair<std::string, std::string>> pairs;
 

--- a/DbService/src/RunTool.cc
+++ b/DbService/src/RunTool.cc
@@ -74,7 +74,7 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
         << " RunTool::listRuns failed to retrieve runs \n";
   }
 
-  StringVec rows = splitString(tcsv, "\n", "\"", "\\", true, false);
+  StringVec rows = DbUtil::splitCsvLines(tcsv);
 
   // apply the selection and fetch configs, transitions, and subruns if
   // requested
@@ -131,7 +131,7 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
     bool pass = true;
 
     // Parse the run table row: run_number,comment,create_time,run_type_id
-    StringVec sv = splitString(csv);
+    StringVec sv = DbUtil::splitCsv(csv);
 
     int run = std::stoi(sv[0]);
     std::string comment = sv[1];

--- a/DbService/src/RunTool.cc
+++ b/DbService/src/RunTool.cc
@@ -132,6 +132,10 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
 
     // Parse the run table row: run_number,comment,create_time,run_type_id
     StringVec sv = DbUtil::splitCsv(csv);
+    if (sv.size() != 4) {
+      throw cet::exception("RUNTOOL_RUN_PARSE")
+          << " RunTool::listRuns can't parse CSV line" << csv << " \n";
+    }
 
     int run = std::stoi(sv[0]);
     std::string comment = sv[1];

--- a/DbService/src/runTool_main.cc
+++ b/DbService/src/runTool_main.cc
@@ -39,6 +39,9 @@ int main(int argc, char** argv) {
                 "print formatted JSON blob for specified subsystem");
   cli.addSwitch("", "dbtables", "q", "dbtables", false,
                 "print the cat 3 DbService tables");
+  cli.addSwitch("", "cidtables", "e", "cidtables", false,
+                "print the cat 2 DbService CID tables (cid name)");
+
 
   // Parse command line
   int rc = cli.setArgs(argc, argv);
@@ -89,9 +92,12 @@ int main(int argc, char** argv) {
   bool subruns = cli.getBool("", "subruns");
   std::string blob_subsystem = cli.getString("", "blob");
   bool dbtables = cli.getBool("", "dbtables");
+  bool cidtables = cli.getBool("", "cidtables");
 
   // If blob subsystem or dbtables is specified, we need to fetch configs
-  bool need_configs = configs || !blob_subsystem.empty() || dbtables;
+  bool need_configs =
+      configs || !blob_subsystem.empty() || dbtables || cidtables;
+
 
   // Query and print runs
   RunInfo::RunVec runvec =
@@ -111,6 +117,22 @@ int main(int argc, char** argv) {
     }
     return 0;
   }
+
+  // Handle cidtables output: cat-2 DbService CID table entries, printed as
+  // "cid name" one pair per line.  The runTool only emits the non-JSON
+  // format; the JSON format is reserved for the python wrapper.
+  if (cidtables) {
+    for (auto const& rr : runvec) {
+      for (const auto& config : rr.configs()) {
+        std::string tables = config.dbTables2(false);
+        if (!tables.empty()) {
+          std::cout << tables << "\n";
+        }
+      }
+    }
+    return 0;
+  }
+
 
   // Handle JSON blob output for specific subsystem
   if (!blob_subsystem.empty()) {

--- a/DbTables/src/DbUtil.cc
+++ b/DbTables/src/DbUtil.cc
@@ -195,14 +195,27 @@ void mu2e::DbUtil::writeFile(std::string const& fn,
 // the database csv should have a newline at the end of the last line
 std::vector<std::string> mu2e::DbUtil::splitCsvLines(const std::string& csv) {
   std::vector<std::string> lines;
-  boost::split(lines, csv, boost::is_any_of("\n"), boost::token_compress_off);
-  if (!lines.back().empty()) {  // the last \n leads to a blank line at the end
+  bool in_quotes{false};
+  std::string current_line;
+  for (char c : csv) {
+    if (c == '"') {
+        in_quotes = !in_quotes;
+        current_line += c;
+    } else if (c == '\n' && !in_quotes) {
+        lines.push_back(current_line);
+        current_line.clear();
+    } else {
+        current_line += c;
+    }
+  }
+  if (!current_line.empty()) {  // the last \n leads to a blank line at the end
     throw cet::exception("DBUTIL_NO_TERMINAL_NEWLINE")
         << "DbUtil::splitCsvLines csv did not have terminal newline\n";
   }
-  lines.pop_back();  // remove empty line
+
   return lines;
 }
+
 
 // ****************************************************************
 // split a line by csv rules, including quotes


### PR DESCRIPTION
This PR introduces a function to extract the CID (category 2) table information from the run_info database settings blobs.  It follows the same pattern as cat3, walking the json tree to find a specific key and extracting the values.  It prints to the command line from runTool or provides a json text structure to the python interface in the pywrap build.  In the process, I found some run_info text fields contain newlines, which was not coded, so a couple of places had to be adjusted.  The adjusted code is run in several common operations.