### PR TITLE
start hashing conditions content

### DIFF
--- a/DbService/data/create.sql
+++ b/DbService/data/create.sql
@@ -40,6 +40,7 @@ GRANT UPDATE ON val.tables_tid_seq TO manager_role;
 CREATE TABLE val.calibrations
   (cid SERIAL, 
   tid INTEGER NOT NULL,
+  chash TEXT NOT NULL DEFAULT '',
   create_time TIMESTAMP WITH TIME ZONE NOT NULL, 
   create_user TEXT NOT NULL,  
   CONSTRAINT calibrations_pk PRIMARY KEY (cid), 

--- a/DbService/inc/DbTool.hh
+++ b/DbService/inc/DbTool.hh
@@ -61,6 +61,7 @@ class DbTool {
   int printAdhoc();
 
   std::string getResult() { return _result; }
+  void clearResult() { _result.clear(); }
   int printCIDLine(int cid, int indent = 0);
   int printIOVLine(int iov, int details = 0, int indent = 0);
   int printGIDLine(int gid, int details = 0, int indent = 0);
@@ -85,6 +86,12 @@ class DbTool {
   int commitVersion();
   int commitPatch();
   int verifySet();
+
+  // when committing several items, sometime the later items depend
+  // on fnding the earlier items in the cached val structure
+  // this is a way to refresh the val structure after the earlier commits
+  // Take caution with local caching of val info..
+  int refresh();
 
   int testUrl();
 
@@ -134,12 +141,6 @@ class DbTool {
   // expand a gid into a vetor of iovs for each tid
   // extend because it does not zero eset
   int extendEiovMap(int gid, eiovMap& eset, int& minrun, int& maxrun);
-
-  // when committing several items, sometime the later items depend
-  // on fnding the earlier items in the cached val structure
-  // this is a way to refresh the val structure after the earlier commits
-  // Take caution with local caching of val info..
-  int refresh();
 
   int _verbose;
   bool _pretty;

--- a/DbService/src/DbTool.cc
+++ b/DbService/src/DbTool.cc
@@ -170,11 +170,13 @@ int mu2e::DbTool::printCalibration() {
   args["user"] = "";
   args["cid"] = "";
   args["ctime"] = "";
+  args["hash"] = "";
   if ((rc = getArgs(args))) return rc;
   std::string name = args["name"];
   std::string user = args["user"];
   std::vector<int>  cids = intList(args["cid"]);
   timeInterval tint = parseInterval(args["ctime"]);
+  std::string chash = args["hash"];
 
   // if this is a val table, just exit - there is no summary line
   if (name.substr(0, 3) == "Val") {
@@ -202,7 +204,9 @@ int mu2e::DbTool::printCalibration() {
       if (tid < 0 || cc.tid() == tid) {
         if (user.empty() || user == cc.create_user()) {
           if (tint.start == 0 || inTime(tint, cc.create_time())) {
-            cids.push_back(cc.cid());
+            if (chash.empty() || chash == cc.chash() ) {
+              cids.push_back(cc.cid());
+            }
           }
         }
       }
@@ -764,9 +768,9 @@ int mu2e::DbTool::printCIDLine(int cid, int indent) {
   auto name = tids.row(cr.tid()).name();
 
   std::stringstream ss;
-  ss << "CID " << std::setw(5 + 4 * std::max(indent, 0)) << cid << std::setw(20)
-     << name << std::setw(12) << cr.create_user() << std::setw(35)
-     << cr.create_time() << std::endl;
+  ss << "CID " << std::setw(5 + 4 * std::max(indent, 0)) << cid << std::setw(22)
+     << name << std::setw(12) << cr.create_user()
+     << std::setw(35) << cr.create_time() << std::endl;
   _result.append(ss.str());
 
   return 0;
@@ -1037,13 +1041,21 @@ int mu2e::DbTool::commitCalibrationList(DbTableCollection& coll, bool qai,
 
     liveTable.setTid(tid);
 
+    if (ptr->hash().empty()) {
+      std::cout
+        << "DbTool::commitCalibrationList found empty hash summary for table named "
+        << liveTable.table().name() << std::endl;
+      return 1;
+    }
+
     command = "SET ROLE val_role;";
     rc = _sql.execute(command, result);
     if (rc != 0) return rc;
 
     command =
-        "INSERT INTO val.calibrations (tid,create_time,create_user)  VALUES (" +
-        std::to_string(tid) + ",CURRENT_TIMESTAMP,SESSION_USER) RETURNING cid;";
+        "INSERT INTO val.calibrations (tid,chash,create_time,create_user)  VALUES (" +
+      std::to_string(tid) + ",'" + ptr->hash() +
+      "',CURRENT_TIMESTAMP,SESSION_USER) RETURNING cid;";
     rc = _sql.execute(command, result);
     if (rc != 0) return rc;
 
@@ -2747,6 +2759,7 @@ int mu2e::DbTool::help() {
            " [OPTIONS]\n"
            "    --name NAME : name of the table\n"
            "    --user USERNAME : only print tables committed by this user \n"
+           "    --hash HASH : only print table with this content hash \n"
            "    --ctime TIME/TIME : only print contents created in this "
            "interval \n"
            "    --cid INT or INT LIST : only print this cid \n"

--- a/DbTables/inc/ValCalibrations.hh
+++ b/DbTables/inc/ValCalibrations.hh
@@ -13,17 +13,19 @@ class ValCalibrations : public DbTable {
  public:
   class Row {
    public:
-    Row(int cid, int tid, std::string create_time, std::string create_user) :
-        _cid(cid), _tid(tid), _create_time(create_time),
+    Row(int cid, int tid, std::string chash, std::string create_time, std::string create_user) :
+      _cid(cid), _tid(tid), _chash(chash), _create_time(create_time),
         _create_user(create_user) {}
     int tid() const { return _tid; }
     int cid() const { return _cid; }
+    std::string const& chash() const { return _chash; }
     std::string const& create_time() const { return _create_time; }
     std::string const& create_user() const { return _create_user; }
 
    private:
     int _cid;
     int _tid;
+    std::string _chash;
     std::string _create_time;
     std::string _create_user;
   };
@@ -31,7 +33,7 @@ class ValCalibrations : public DbTable {
   constexpr static const char* cxname = "ValCalibrations";
 
   ValCalibrations() :
-      DbTable(cxname, "val.calibrations", "cid,tid,create_time,create_user") {}
+      DbTable(cxname, "val.calibrations", "cid,tid,chash,create_time,create_user") {}
 
   const Row& rowAt(const std::size_t index) const { return _rows.at(index); }
   const Row& row(const int cid) const { return _rows.at(_index.at(cid)); }
@@ -44,7 +46,7 @@ class ValCalibrations : public DbTable {
 
   void addRow(const std::vector<std::string>& columns) override {
     _rows.emplace_back(std::stoi(columns[0]), std::stoi(columns[1]), columns[2],
-                       columns[3]);
+                       columns[3],columns[4]);
     _index[_rows.back().cid()] = _rows.size() - 1;
   }
 
@@ -52,6 +54,7 @@ class ValCalibrations : public DbTable {
     Row const& r = _rows.at(irow);
     sstream << r.cid() << ",";
     sstream << r.tid() << ",";
+    sstream << r.chash() << ",";
     sstream << r.create_time() << ",";
     sstream << r.create_user();
   }


### PR DESCRIPTION
When conditions content is saved, also write a content hash.  This allows efficient cat3 online/offline processing.  cat3 are tables which are in DbService format and may or may not be modified by the online experts for any given run.  A good example is a bad channel list. Since the content may or may not change, when we need to copy the online content offline, we can hash the content and easily look up if an exact copy of the table has already been stored offline. If it has, we use that copy.  If the hash doesn't match, then we can create the new content offline.
The dev and prd databases have the new column. It will be ignored by old code, which should continue to work fine.  The new code will always commit the hash value, and will be able to look up by hash.