### PR TITLE
p103 for KinKal 3.7.0

### DIFF
--- a/.muse
+++ b/.muse
@@ -1,5 +1,5 @@
 # prefer to build with this environment
-ENVSET p101
+ENVSET p103
 # add Offline/bin to path
 PATH bin
 # recent commits can take enforce these flags


### PR DESCRIPTION
create p103 envset, which only adds KinKal 3.7.0.  A quick test shows this builds with the current Offline head