### PR TITLE
Turn off path length scaling for KKShellXing by default

### DIFF
--- a/KinKalGeom/fcl/prolog.fcl
+++ b/KinKalGeom/fcl/prolog.fcl
@@ -14,6 +14,12 @@ KinKalGeom : {
     SolidScatteringFraction : 0.999999
     GasScatteringFraction : 0.9999999
     ElectronBrehmsFraction : 0.04
+    # Bethe path correction for KKShellXing: off by default; enable per crossing type as needed.
+    # Only effective when IonizationEnergyLossMode is moyalmean.
+    BetheCorrectionIPA : false
+    BetheCorrectionST : false
+    BetheCorrectionCRV : false
+    BetheCorrectionPassive : false
   }
 }
 END_PROLOG

--- a/KinKalGeom/fcl/prolog.fcl
+++ b/KinKalGeom/fcl/prolog.fcl
@@ -19,7 +19,8 @@ KinKalGeom : {
     BetheCorrectionIPA : false
     BetheCorrectionST : false
     BetheCorrectionCRV : false
-    BetheCorrectionPassive : false
+    # Reserved until KKExtrap adds DS/shielding crossings (TODO there).
+    # BetheCorrectionPassive : false
   }
 }
 END_PROLOG

--- a/KinKalGeom/inc/KKMaterial.hh
+++ b/KinKalGeom/inc/KKMaterial.hh
@@ -47,8 +47,9 @@ namespace mu2e {
           Comment("Apply Bethe path correction to stopping-target foil crossings"), false };
         fhicl::Atom<bool> betheCorrCRV { Name("BetheCorrectionCRV"),
           Comment("Apply Bethe path correction to CRV scintillator-sector crossings"), false };
-        fhicl::Atom<bool> betheCorrPassive { Name("BetheCorrectionPassive"),
-          Comment("Apply Bethe path correction to passive material crossings (DS cylinders, concrete/strongback planes)"), false };
+        // Reserved for DS/shielding crossings once KKExtrap wires them (see TODO there).
+        // fhicl::Atom<bool> betheCorrPassive { Name("BetheCorrectionPassive"),
+        //   Comment("Apply Bethe path correction to passive material crossings (DS cylinders, concrete/strongback planes)"), false };
       };
 
       explicit KKMaterial( Config const& config, Tracker const& tracker);
@@ -61,7 +62,7 @@ namespace mu2e {
       bool applyBetheCorrectionIPA() const { return betheCorrIPA_; }
       bool applyBetheCorrectionST() const { return betheCorrST_; }
       bool applyBetheCorrectionCRV() const { return betheCorrCRV_; }
-      bool applyBetheCorrectionPassive() const { return betheCorrPassive_; }
+      // bool applyBetheCorrectionPassive() const { return betheCorrPassive_; }
 
       // FileFinder interface
       std::string matElmDictionaryFileName() const override;
@@ -80,7 +81,7 @@ namespace mu2e {
       bool betheCorrIPA_ = false;
       bool betheCorrST_ = false;
       bool betheCorrCRV_ = false;
-      bool betheCorrPassive_ = false;
+      // bool betheCorrPassive_ = false;
   };
 }
 #endif

--- a/KinKalGeom/inc/KKMaterial.hh
+++ b/KinKalGeom/inc/KKMaterial.hh
@@ -38,6 +38,17 @@ namespace mu2e {
         fhicl::Atom<double> solidScatter{ Name("SolidScatteringFraction"), Comment("DahlLynch Scattering model cutoff Fraction for solids") };
         fhicl::Atom<double> gasScatter{ Name("GasScatteringFraction"), Comment("DahlLynch Scattering model cutoff Fraction for gases") };
         fhicl::Atom<double> eBrehms{ Name("ElectronBrehmsFraction"), Comment("Electron Brehmsstrahlung cutoff Fraction") };
+        // Unrestricted-Bethe path-length scale for KKShellXing (see Mu2eKinKal/inc/KKShellXing.hh).
+        // Off by default for every crossing type; enable only where the thicker-shell correction is wanted.
+        // Effective only when IonizationEnergyLossMode is moyalmean (otherwise forced off with a warning).
+        fhicl::Atom<bool> betheCorrIPA { Name("BetheCorrectionIPA"),
+          Comment("Apply Bethe path correction to IPA shell crossings"), false };
+        fhicl::Atom<bool> betheCorrST { Name("BetheCorrectionST"),
+          Comment("Apply Bethe path correction to stopping-target foil crossings"), false };
+        fhicl::Atom<bool> betheCorrCRV { Name("BetheCorrectionCRV"),
+          Comment("Apply Bethe path correction to CRV scintillator-sector crossings"), false };
+        fhicl::Atom<bool> betheCorrPassive { Name("BetheCorrectionPassive"),
+          Comment("Apply Bethe path correction to passive material crossings (DS cylinders, concrete/strongback planes)"), false };
       };
 
       explicit KKMaterial( Config const& config, Tracker const& tracker);
@@ -46,11 +57,11 @@ namespace mu2e {
       auto STMaterial() const { return matdbinfo_->findDetMaterial(stmatname_); }
       auto CRVMaterial() const { return matdbinfo_->findDetMaterial(crvmatname_); }
       auto material(std::string const& name) const { return matdbinfo_->findDetMaterial(name); }
-      // True when KinKal's ionization energy loss is the (restricted) Moyal mean, the only mode for
-      // which the KKShellXing unrestricted-Bethe-mean path correction is valid. Set from the
-      // IonizationEnergyLossMode fcl parameter so the correction stays consistent with the KinKal
-      // energy-loss model. See Mu2eKinKal/inc/KKShellXing.hh.
-      bool applyBetheCorrection() const { return betheCorrection_; }
+      // Per-crossing-type Bethe path correction (all false by default). See Config atoms above.
+      bool applyBetheCorrectionIPA() const { return betheCorrIPA_; }
+      bool applyBetheCorrectionST() const { return betheCorrST_; }
+      bool applyBetheCorrectionCRV() const { return betheCorrCRV_; }
+      bool applyBetheCorrectionPassive() const { return betheCorrPassive_; }
 
       // FileFinder interface
       std::string matElmDictionaryFileName() const override;
@@ -66,7 +77,10 @@ namespace mu2e {
       std::string wallmatname_, gasmatname_, wirematname_,ipamatname_, stmatname_, crvmatname_;
       std::unique_ptr<MatDBInfo> matdbinfo_; // material database
       std::unique_ptr<KKStrawMaterial> smat_; // straw material
-      bool betheCorrection_ = false; // KinKal eloss mode == Moyal mean (gates the KKShellXing Bethe correction)
+      bool betheCorrIPA_ = false;
+      bool betheCorrST_ = false;
+      bool betheCorrCRV_ = false;
+      bool betheCorrPassive_ = false;
   };
 }
 #endif

--- a/KinKalGeom/src/KKMaterial.cc
+++ b/KinKalGeom/src/KKMaterial.cc
@@ -20,11 +20,18 @@ namespace mu2e {
       MatEnv::DetMaterialConfig dmconf;
       dmconf.elossmode_ = (DetMaterial::energylossmode)matconfig.elossMode();
       // The KKShellXing Bethe (unrestricted ionization mean) correction is derived assuming KinKal
-      // returns the restricted Moyal mean; only enable it in that mode so the two stay consistent.
-      betheCorrection_ = (dmconf.elossmode_ == DetMaterial::moyalmean);
-      if(!betheCorrection_)
-        mf::LogInfo("KKMaterial") << "IonizationEnergyLossMode is not moyalmean ("
-          << matconfig.elossMode() << "): the KKShellXing Bethe-mean path correction is inactive.";
+      // returns the restricted Moyal mean; only enable requested crossing types in that mode.
+      bool const moyal = (dmconf.elossmode_ == DetMaterial::moyalmean);
+      bool const wantAny = matconfig.betheCorrIPA() || matconfig.betheCorrST()
+        || matconfig.betheCorrCRV() || matconfig.betheCorrPassive();
+      if(wantAny && !moyal) {
+        mf::LogWarning("KKMaterial") << "BetheCorrection* requested but IonizationEnergyLossMode is not moyalmean ("
+          << matconfig.elossMode() << "): all Bethe path corrections forced off.";
+      }
+      betheCorrIPA_     = matconfig.betheCorrIPA() && moyal;
+      betheCorrST_      = matconfig.betheCorrST() && moyal;
+      betheCorrCRV_     = matconfig.betheCorrCRV() && moyal;
+      betheCorrPassive_ = matconfig.betheCorrPassive() && moyal;
       dmconf.scatterfrac_solid_ = matconfig.solidScatter();
       dmconf.scatterfrac_gas_ = matconfig.gasScatter();
       dmconf.ebrehmsfrac_ = matconfig.eBrehms();

--- a/KinKalGeom/src/KKMaterial.cc
+++ b/KinKalGeom/src/KKMaterial.cc
@@ -23,7 +23,7 @@ namespace mu2e {
       // returns the restricted Moyal mean; only enable requested crossing types in that mode.
       bool const moyal = (dmconf.elossmode_ == DetMaterial::moyalmean);
       bool const wantAny = matconfig.betheCorrIPA() || matconfig.betheCorrST()
-        || matconfig.betheCorrCRV() || matconfig.betheCorrPassive();
+        || matconfig.betheCorrCRV(); // || matconfig.betheCorrPassive();
       if(wantAny && !moyal) {
         mf::LogWarning("KKMaterial") << "BetheCorrection* requested but IonizationEnergyLossMode is not moyalmean ("
           << matconfig.elossMode() << "): all Bethe path corrections forced off.";
@@ -31,7 +31,7 @@ namespace mu2e {
       betheCorrIPA_     = matconfig.betheCorrIPA() && moyal;
       betheCorrST_      = matconfig.betheCorrST() && moyal;
       betheCorrCRV_     = matconfig.betheCorrCRV() && moyal;
-      betheCorrPassive_ = matconfig.betheCorrPassive() && moyal;
+      // betheCorrPassive_ = matconfig.betheCorrPassive() && moyal;
       dmconf.scatterfrac_solid_ = matconfig.solidScatter();
       dmconf.scatterfrac_gas_ = matconfig.gasScatter();
       dmconf.ebrehmsfrac_ = matconfig.eBrehms();

--- a/Mu2eKinKal/inc/KKExtrap.hh
+++ b/Mu2eKinKal/inc/KKExtrap.hh
@@ -170,7 +170,7 @@ namespace mu2e {
         // we have a good intersection. Use this to create a Shell material Xing
         auto const& reftrajptr = tdir == TimeDir::backwards ? ftraj.frontPtr() : ftraj.backPtr();
         auto const& IPA = kkg_h->DS()->innerProtonAbsorberPtr();
-        KKIPAXINGPTR ipaxingptr = std::make_shared<KKIPAXING>(IPA,IPASID,*kkmat_h->IPAMaterial(),extrapIPA.intersection(),reftrajptr,ipathick_,extrapIPA.interTolerance(),kkmat_h->applyBetheCorrection());
+        KKIPAXINGPTR ipaxingptr = std::make_shared<KKIPAXING>(IPA,IPASID,*kkmat_h->IPAMaterial(),extrapIPA.intersection(),reftrajptr,ipathick_,extrapIPA.interTolerance(),kkmat_h->applyBetheCorrectionIPA());
         if(extrapIPA.debug() > 2){
           double dmom, paramomvar, perpmomvar;
           ipaxingptr->materialEffects(dmom,paramomvar,perpmomvar);
@@ -211,7 +211,7 @@ namespace mu2e {
       if(extrapST.intersection().good()){
         // we have a good intersection. Use this to create a Shell material Xing
         auto const& reftrajptr = tdir == TimeDir::backwards ? ftraj.frontPtr() : ftraj.backPtr();
-        KKSTXINGPTR stxingptr = std::make_shared<KKSTXING>(extrapST.foil(),extrapST.foilId(),*kkmat_h->STMaterial(),extrapST.intersection(),reftrajptr,stthick_,extrapST.interTolerance(),kkmat_h->applyBetheCorrection());
+        KKSTXINGPTR stxingptr = std::make_shared<KKSTXING>(extrapST.foil(),extrapST.foilId(),*kkmat_h->STMaterial(),extrapST.intersection(),reftrajptr,stthick_,extrapST.interTolerance(),kkmat_h->applyBetheCorrectionST());
         if(extrapST.debug() > 2){
           double dmom, paramomvar, perpmomvar;
           stxingptr->materialEffects(dmom,paramomvar,perpmomvar);
@@ -306,7 +306,7 @@ namespace mu2e {
         auto const& reftrajptr = tdir == TimeDir::backwards ? ftraj.frontPtr() : ftraj.backPtr();
         auto crvxingptr = std::make_shared<KKCRVXING>(extrapCRV.sector((size_t)inter.isect_).sector_,
             SurfaceId(kkg_h->CRV()->sectorName(inter.isect_)),*kkmat_h->CRVMaterial(),inter.inter_,reftrajptr,
-            2*inter.whw_, extrapCRV.interTolerance(),kkmat_h->applyBetheCorrection());
+            2*inter.whw_, extrapCRV.interTolerance(),kkmat_h->applyBetheCorrectionCRV());
         ktrk.addCRVXing(crvxingptr,tdir);
         if(debug_ > 1) std::cout << "Good CRV " << inter.inter_ << ftraj.range() << std::endl;
       }

--- a/Mu2eKinKal/inc/KKShellXing.hh
+++ b/Mu2eKinKal/inc/KKShellXing.hh
@@ -17,7 +17,8 @@ namespace mu2e {
   // We correct the eloss for thick passive materials (ie. concrete blocks) by scaling the crossing path length.
   // Side-effect: the multiple-scattering variance scales too (~3-8% larger pointing sigma at high p),
   // which does not touch the |p| residual. f>=1 always (we never reduce the loss).
-  // Only applied if KinKal is configured with IonizationEnergyLossMode = moyalmean (KKMaterial fcl).
+  // Opt-in per crossing type via KKMaterial BetheCorrection{IPA,ST,CRV,Passive} (all default false);
+  // only effective when IonizationEnergyLossMode is moyalmean.
   //
   // This hand-rolls the unrestricted Bethe mean from DetMaterial's eloss_xi/eexc/densityCorrection.
   // It intentionally omits DetMaterial::shellCorrection (which ionizationEnergyLossMPV includes): that

--- a/Mu2eKinKal/inc/KKShellXing.hh
+++ b/Mu2eKinKal/inc/KKShellXing.hh
@@ -17,7 +17,8 @@ namespace mu2e {
   // We correct the eloss for thick passive materials (ie. concrete blocks) by scaling the crossing path length.
   // Side-effect: the multiple-scattering variance scales too (~3-8% larger pointing sigma at high p),
   // which does not touch the |p| residual. f>=1 always (we never reduce the loss).
-  // Opt-in per crossing type via KKMaterial BetheCorrection{IPA,ST,CRV,Passive} (all default false);
+  // Opt-in per crossing type via KKMaterial BetheCorrection{IPA,ST,CRV} (all default false);
+  // BetheCorrectionPassive is commented out until KKExtrap wires DS/shielding crossings.
   // only effective when IonizationEnergyLossMode is moyalmean.
   //
   // This hand-rolls the unrestricted Bethe mean from DetMaterial's eloss_xi/eexc/densityCorrection.


### PR DESCRIPTION
Allow to turn it on for each intersection type separately.