### PR TITLE
Event generator energy fraction for proton tail

### DIFF
--- a/EventGenerator/inc/ParticleGeneratorTool.hh
+++ b/EventGenerator/inc/ParticleGeneratorTool.hh
@@ -46,18 +46,19 @@ namespace mu2e {
     virtual ~ParticleGeneratorTool() noexcept = default;
 
     double calculateBinnedSpectrumEnergyFraction(fhicl::ParameterSet pset,
-                                                 const bool correct_full_integral = true, // correct for missing low tail to full integral
                                                  std::string var_low = "elow", // default to energy spectrum variables
                                                  std::string var_high = "ehi",
-                                                 double full_var_low = 0., // if elow == ehi, it does the full spectrum
-                                                 double full_var_high = 0.) const {
+                                                 const bool correct_full_integral = false, // correct for missing low tail to full integral
+                                                 const double full_var_low = 0.) const {
+
+      // No clear fraction for a flat spectrum
+      const bool flat = pset.get<std::string>("spectrumShape", "") == "flat";
+      if(flat) return 1.;
 
       // Initialize the spectra with and without the (possible) energy restriction
       BinnedSpectrum spectrum(pset);
-      pset.erase(var_low);
+      pset.erase(var_low); // allow the spectrum to pick default values
       pset.erase(var_high);
-      pset.put(var_low, full_var_low);
-      pset.put(var_high, full_var_high);
       BinnedSpectrum fullSpectrum(pset);
 
       // Calculate the integrals

--- a/EventGenerator/src/DIOGenerator_tool.cc
+++ b/EventGenerator/src/DIOGenerator_tool.cc
@@ -50,7 +50,7 @@ namespace mu2e {
       auto fullconfig = conf().spectrum.get<fhicl::ParameterSet>();
       _emin = fullconfig.get<double>("elow", _spectrum.getXMin());
       _emax = fullconfig.get<double>("ehi", _spectrum.getXMax());
-      _energyFraction = calculateBinnedSpectrumEnergyFraction(fullconfig, true); // energy fraction, correcting for missing 0 - 1 MeV component
+      _energyFraction = calculateBinnedSpectrumEnergyFraction(fullconfig, "elow", "ehi", true, 0.); // energy fraction, correcting for missing 0 - 1 MeV component
 
       std::cout << "[" << __func__ << "] Cos(theta_z) min " << _czmin << " max " << _czmax << std::endl;
       std::cout << "[" << __func__ << "] Restricted Spectrum min " << _spectrum.getAbscissa(0) << " max " << _spectrum.getAbscissa(_spectrum.getNbins()-1) << std::endl;

--- a/EventGenerator/src/Mu2eXGenerator_tool.cc
+++ b/EventGenerator/src/Mu2eXGenerator_tool.cc
@@ -44,7 +44,7 @@ namespace mu2e {
       auto fullconfig = conf().spectrum.get<fhicl::ParameterSet>();
       _emin = fullconfig.get<double>("elow", _spectrum.getXMin());
       _emax = fullconfig.get<double>("ehi", _spectrum.getXMax());
-      _energyFraction = calculateBinnedSpectrumEnergyFraction(fullconfig, true); // energy fraction evaluation
+      _energyFraction = calculateBinnedSpectrumEnergyFraction(fullconfig); // energy fraction evaluation
 
       std::cout << "[" << __func__ << "] Restricted Spectrum min " << _spectrum.getAbscissa(0) << " max " << _spectrum.getAbscissa(_spectrum.getNbins()-1) << std::endl;
       std::cout << "[" << __func__ << "] Sampled spectrum fraction " << _energyFraction << std::endl;

--- a/EventGenerator/src/MuCapNeutronGenerator_tool.cc
+++ b/EventGenerator/src/MuCapNeutronGenerator_tool.cc
@@ -47,7 +47,7 @@ namespace mu2e {
     {
       if(_czMin < -1. || _czMax > 1. || _czMin > _czMax) throw cet::exception("BADCONFIG") << "Cos(theta_z) range unphysical: " << _czMin << " - " << _czMax;
       auto fullconfig = conf().spectrum.get<fhicl::ParameterSet>();
-      _energyFraction = (_flatSpectrum) ? 1. : calculateBinnedSpectrumEnergyFraction(fullconfig, false);
+      _energyFraction = (_flatSpectrum) ? 1. : calculateBinnedSpectrumEnergyFraction(fullconfig);
       std::cout << "[" << __func__ << "] Sampled spectrum fraction " << _energyFraction << std::endl;
       std::cout << "[" << __func__ << "] Sampled spectrum fraction (with cos(theta_z)) " << (_energyFraction)*((_czMax - _czMin)/2.) << std::endl;
     }

--- a/EventGenerator/src/MuCapProtonGenerator_tool.cc
+++ b/EventGenerator/src/MuCapProtonGenerator_tool.cc
@@ -43,6 +43,10 @@ namespace mu2e {
       _flatSpectrum(conf().spectrum.get<fhicl::ParameterSet>().get<std::string>("spectrumShape", "") == "flat")
     {
       if(_czMin < -1. || _czMax > 1. || _czMin > _czMax) throw cet::exception("BADCONFIG") << "Cos(theta_z) range unphysical: " << _czMin << " - " << _czMax;
+      auto fullconfig = conf().spectrum.get<fhicl::ParameterSet>();
+      _energyFraction = calculateBinnedSpectrumEnergyFraction(fullconfig);
+      std::cout << "[" << __func__ << "] Sampled spectrum fraction " << _energyFraction << std::endl;
+      std::cout << "[" << __func__ << "] Sampled spectrum fraction (with cos(theta_z)) " << (_energyFraction)*((_czMax - _czMin)/2.) << std::endl;
     }
 
     std::vector<ParticleGeneratorTool::Kinematic> generate() override;
@@ -52,7 +56,7 @@ namespace mu2e {
     void finishInitialization(art::RandomNumberGenerator::base_engine_t& eng, const std::string& material, const bool isPrimary) override {
       _isPrimary = isPrimary;
       _rate = GlobalConstantsHandle<PhysicsParams>()->getCaptureProtonRate(material);
-      const double rate = _rate * (_czMax - _czMin)/2.; // accouunt for potential cz selection in the produced rates
+      const double rate = _rate * _energyFraction * (_czMax - _czMin)/2.; // account for potential spectrum restriction in the produced rates
       _randomUnitSphere = std::make_unique<RandomUnitSphere>(eng, _czMin, _czMax);
       _randomPoissonQ = std::make_unique<CLHEP::RandPoissonQ>(eng, rate);
       _randSpectrum = std::make_unique<CLHEP::RandGeneral>(eng, _spectrum.getPDF(), _spectrum.getNbins());
@@ -69,6 +73,7 @@ namespace mu2e {
     double _czMax;
     double _spectrumXMin;
     double _spectrumXMax;
+    double _energyFraction;
     bool _flatSpectrum;
 
     std::unique_ptr<CLHEP::RandPoissonQ> _randomPoissonQ;
@@ -122,7 +127,7 @@ namespace mu2e {
     }
 
     // FIXME: calculate the spectrum fraction simulated
-    config->add_var(SpectrumConfig::RestrictedVar(spectrumVarName, 1., _spectrumXMin, _spectrumXMax,
+    config->add_var(SpectrumConfig::RestrictedVar(spectrumVarName, _energyFraction, _spectrumXMin, _spectrumXMax,
                                                   _flatSpectrum ? SpectrumConfig::Type::kFlat : SpectrumConfig::Type::kPhysical));
     config->add_var(SpectrumConfig::RestrictedVar("cosz", (_czMax - _czMin)/2., _czMin, _czMax));
     return config;


### PR DESCRIPTION
This adds the energy fraction calculation for the muon capture proton spectrum, as well as updates this fraction evaluation. The missing tail fraction correction is now off by default and it relies on a specific spectrum configuration to know that the full input spectrum is truncated (e.g. DIO or Mu2eX). I also found the neutron tabulated spectrum was configured incorrectly in Production (table values are bin centers, not edges) which was the source of the non-unit fraction previously fixed. I think this is a less fragile implementation, where different generators with different truncated spectra should be responsible for accounting for more complicated corrections for this.