### PR TITLE
provide an explicit 'match all' index value to SurfaceId

### DIFF
--- a/DataProducts/inc/SurfaceId.hh
+++ b/DataProducts/inc/SurfaceId.hh
@@ -38,12 +38,10 @@ namespace mu2e {
         CRV_StrongBack=280,                                   // CRV module Al strongback (tracker-side support plate)
         DS_HatchConcrete=300                                  // detector-area hatch concrete block approximation
       };
-
-    // Update this counter whenever you add/remove surface IDs from the enum above.
-    static constexpr std::size_t nSurfaceIds = 64;
-
-    static std::string const& typeName();
-    static std::map<enum_type,std::string> const& names();
+      // Update this counter whenever you add/remove surface IDs from the enum above.
+      static constexpr std::size_t nSurfaceIds = 64;
+      static std::string const& typeName();
+      static std::map<enum_type,std::string> const& names();
   };
   using SurfaceIdEnum = EnumToStringSparse<SurfaceIdDetail>;
   class SurfaceId {
@@ -59,12 +57,13 @@ namespace mu2e {
       int index() const { return index_; }
       auto const& name() const { return sid_.name(); }
 
-      bool indexMatch(SurfaceId const& other) const { return index_ == other.index_ || index_ < 0 || other.index_ < 0; }
-      bool indexCompare(SurfaceId const& other) const { return index_<0 || other.index_ < 0 ? false : index_ < other.index_; }
+      bool indexMatch(SurfaceId const& other) const { return index_ == other.index_ || index_ == allIndices_ || other.index_ == allIndices_; }
+      bool indexCompare(SurfaceId const& other) const { return index_== allIndices_ || other.index_ == allIndices_ ? false : index_ < other.index_; }
       bool operator == (SurfaceId const& other ) const { return sid_ == other.sid_ && indexMatch(other) ; }
       bool operator != (SurfaceId const& other ) const { return sid_ != other.sid_ || !indexMatch(other) ; }
       bool operator < (SurfaceId const& other ) const { return sid_ == other.sid_ ? indexCompare(other) : sid_ < other.sid_; }
-    private:
+      static int allIndices_; // index wildcard
+      private:
       SurfaceIdEnum sid_;
       int index_; // index.  Negative value is a wild card for matching
   };

--- a/DataProducts/inc/SurfaceId.hh
+++ b/DataProducts/inc/SurfaceId.hh
@@ -65,7 +65,7 @@ namespace mu2e {
       static int allIndices_; // index wildcard
       private:
       SurfaceIdEnum sid_;
-      int index_; // index.  Negative value is a wild card for matching
+      int index_; // index
   };
   using SurfaceIdCollection = std::vector<SurfaceId>;
   // printout

--- a/DataProducts/inc/SurfaceId.hh
+++ b/DataProducts/inc/SurfaceId.hh
@@ -46,6 +46,7 @@ namespace mu2e {
   using SurfaceIdEnum = EnumToStringSparse<SurfaceIdDetail>;
   class SurfaceId {
     public:
+      static constexpr int allIndices_ = -1; // index wildcard
       using enum_type = SurfaceIdDetail::enum_type;
       // copy the constructors
       SurfaceId() : index_(0) {}
@@ -62,7 +63,6 @@ namespace mu2e {
       bool operator == (SurfaceId const& other ) const { return sid_ == other.sid_ && indexMatch(other) ; }
       bool operator != (SurfaceId const& other ) const { return sid_ != other.sid_ || !indexMatch(other) ; }
       bool operator < (SurfaceId const& other ) const { return sid_ == other.sid_ ? indexCompare(other) : sid_ < other.sid_; }
-      static int allIndices_; // index wildcard
       private:
       SurfaceIdEnum sid_;
       int index_; // index

--- a/DataProducts/src/SurfaceId.cc
+++ b/DataProducts/src/SurfaceId.cc
@@ -12,7 +12,6 @@ namespace mu2e {
     static const std::string type("SurfaceIdEnum");
     return type;
   }
-  int SurfaceId::allIndices_(-1); // wildcard for index comparison
 
   namespace {
     using SurfaceIdName = std::pair<SurfaceIdEnum::enum_type, char const*>;

--- a/DataProducts/src/SurfaceId.cc
+++ b/DataProducts/src/SurfaceId.cc
@@ -12,6 +12,7 @@ namespace mu2e {
     static const std::string type("SurfaceIdEnum");
     return type;
   }
+  int SurfaceId::allIndices_(-1); // wildcard for index comparison
 
   namespace {
     using SurfaceIdName = std::pair<SurfaceIdEnum::enum_type, char const*>;

--- a/KinKalGeom/CMakeLists.txt
+++ b/KinKalGeom/CMakeLists.txt
@@ -5,6 +5,7 @@ cet_make_library(
       src/KKStrawMaterial.cc
     LIBRARIES PUBLIC
       Offline::ConfigTools
+      Offline::DataProducts
       KinKal::MatEnv
       KinKal::Geometry
       KinKal::Trajectory

--- a/KinKalGeom/src/SConscript
+++ b/KinKalGeom/src/SConscript
@@ -15,6 +15,7 @@ helper = mu2e_helper(env)
 
 mainlib = helper.make_mainlib([
   'mu2e_ConfigTools',
+  'mu2e_DataProducts',
   'KinKal_MatEnv',
   'KinKal_Geometry',
   'KinKal_Trajectory',

--- a/Mu2eKinKal/inc/KKFit.hh
+++ b/Mu2eKinKal/inc/KKFit.hh
@@ -213,7 +213,7 @@ namespace mu2e {
     }
     // surfaces to sample; this interface is deprecatecd and should be replaced with extrapolation TODO
     for(auto const& sidname : fitconfig.sampleSurfaces()){
-      ssids_.push_back(SurfaceId(sidname,-1)); // match all elements
+      ssids_.push_back(SurfaceId(sidname,SurfaceId::allIndices_)); // match all elements
     }
   }
 

--- a/Mu2eKinKal/src/CentralHelixFit_module.cc
+++ b/Mu2eKinKal/src/CentralHelixFit_module.cc
@@ -234,7 +234,7 @@ namespace mu2e {
 
       // surfaces to sample; this interface is deprecatecd and should be replaced with extrapolation TODO
       for(auto const& sidname : settings().modSettings().sampleSurfaces()) {
-        ssids_.push_back(SurfaceId(sidname,-1)); // match all elements
+        ssids_.push_back(SurfaceId(sidname,SurfaceId::allIndices_)); // match all elements
       }
     }
 

--- a/Mu2eKinKal/src/KinematicLineFit_module.cc
+++ b/Mu2eKinKal/src/KinematicLineFit_module.cc
@@ -213,7 +213,7 @@ namespace mu2e {
         throw cet::exception("RECO")<<"mu2e::KinematicLineFit: Parameter constraint configuration error"<< endl;
       }
       for(auto const& sidname : settings().modSettings().sampleSurfaces()) {
-        ssids_.push_back(SurfaceId(sidname,-1)); // match all elements
+        ssids_.push_back(SurfaceId(sidname,SurfaceId::allIndices_)); // match all elements
       }
       // setup extrapolation
       if(settings().extrapSettings())extrap_ = make_unique<KKExtrap>(*settings().extrapSettings());

--- a/Validation/src/ValKalSeed.cc
+++ b/Validation/src/ValKalSeed.cc
@@ -164,7 +164,7 @@ namespace mu2e {
         p = mom3.R();
         rho = ikinter->position3().Rho();
       }
-      auto stinters = ks.intersections(SurfaceId("ST_Foils",-1)); // match all foils
+      auto stinters = ks.intersections(SurfaceId("ST_Foils",SurfaceId::allIndices_)); // match all foils
       _hNST->Fill(stinters.size());
       for (auto stinter : stinters)
         _hSTdP->Fill(stinter->dMom());


### PR DESCRIPTION
Provide an explicit 'match all' value to avoid the implicit 'magic number' value for matching all indices.