### PR TITLE
Allow per-foil stopping-target hole radii

### DIFF
--- a/GeometryService/inc/StoppingTargetMaker.hh
+++ b/GeometryService/inc/StoppingTargetMaker.hh
@@ -51,6 +51,7 @@ private:
   double _rIn; // inner radius of foils.  Currently 0.
 
   std::vector<double> _rOut; //outer Radii of foils
+  std::vector<double> _holeRadii; //optional per-foil hole radii; overrides the scalar _rIn
   std::vector<double> _halfThicknesses; //half thicknesses of foils
   std::vector<double> _xVars; //variation of x position from axis of foils
   std::vector<double> _yVars; //variation of y position from axis of foils

--- a/GeometryService/src/StoppingTargetMaker.cc
+++ b/GeometryService/src/StoppingTargetMaker.cc
@@ -40,10 +40,24 @@ namespace mu2e {
     c.getVectorDouble("stoppingTarget.radii", _rOut);
     _rIn = c.getDouble("stoppingTarget.holeRadius", 0);
 
+    // Optional per-foil hole radii.  When present this takes precedence over
+    // the scalar stoppingTarget.holeRadius; when absent the scalar is used for
+    // every foil, so existing geometry files are unaffected.
+    c.getVectorDouble("stoppingTarget.holeRadii", _holeRadii,
+                      std::vector<double>());
+
     // Downstream code counts on this so test it here.
     if ( _rOut.size() < 1 ){
       throw cet::exception("GEOM")
         << "Specified a stopping target with no foils!\n";
+    }
+
+    // A length mismatch would silently mis-assign holes to foils, so reject it.
+    if ( !_holeRadii.empty() && _holeRadii.size() != _rOut.size() ){
+      throw cet::exception("GEOM")
+        << "stoppingTarget.holeRadii has " << _holeRadii.size()
+        << " entries but stoppingTarget.radii has " << _rOut.size()
+        << "; they must match.\n";
     }
 
     // halfThicknesses can be repeated from last element specified
@@ -183,7 +197,7 @@ namespace mu2e {
                                                              z),
                                            CLHEP::Hep3Vector(_xCos[i],_yCos[i],zCos),
                                            _rOut[i],
-                                           _rIn,
+                                           _holeRadii.empty() ? _rIn : _holeRadii[i],
                                            _halfThicknesses[i],
                                            _materials[i],
                                            _detSysOrigin
@@ -278,6 +292,14 @@ namespace mu2e {
     for (unsigned int itf=0; itf<_rOut.size(); itf++)
       cout <<" "<<_rOut[itf];
     cout <<std::endl;
+    if ( _holeRadii.empty() ){
+      std::cout <<"Hole Radius=" <<_rIn <<" (scalar, all foils)" <<std::endl;
+    } else {
+      std::cout <<"Hole Radii= (per-foil vector, n=" <<_holeRadii.size() <<")" <<std::endl;
+      for (unsigned int itf=0; itf<_holeRadii.size(); itf++)
+        cout <<" "<<_holeRadii[itf];
+      cout <<std::endl;
+    }
     std::cout <<"1/2 Thicknesses="<<std::endl;
     for (unsigned int itf=0; itf<_rOut.size(); itf++)
       cout <<" "<<_halfThicknesses[itf];


### PR DESCRIPTION
## Summary

`StoppingTargetMaker` currently reads a single `stoppingTarget.holeRadius` and applies it to every foil. This adds an optional `stoppingTarget.holeRadii` vector so each foil can carry its own hole radius.

The motivation is stopping-target studies that vary the central hole along z. Mu2e-doc-10898 (Edmonds, 2017) reports that a central hole of R ≈ 18–21.5 mm reduces the beam flash by ~30% and tracker dose by ~30% at essentially unchanged SES, for a 2–3% stop loss at fixed mass. Investigating that trade-off — and any z-dependence of it — needs per-foil control, which the scalar cannot express.

## The change

Two files, 24 insertions, 1 deletion. The functional part is one line:

```cpp
-                     _rIn,
+                     _holeRadii.empty() ? _rIn : _holeRadii[i],
```

Everything else is the member declaration, the optional config read, a length check, and reporting.

## Backward compatibility

Strictly additive:

- When `stoppingTarget.holeRadii` is absent — the default, and the case for every geometry file in the repository — the scalar `stoppingTarget.holeRadius` is used for every foil exactly as before. No existing geometry changes behaviour.
- When present, its length must equal `stoppingTarget.radii`. A mismatch throws `cet::exception("GEOM")` rather than silently mis-assigning holes to foils.
- `PrintConfig()` reports whichever form is in use, alongside the outer radii it already prints (shown when `stoppingTarget.verbosity > 0`).