### PR TITLE
Add validation for invalid offline ID during digi creation

### DIFF
--- a/CaloConditions/src/CalDAQMapMaker.cc
+++ b/CaloConditions/src/CalDAQMapMaker.cc
@@ -52,12 +52,14 @@ namespace mu2e {
         throw cet::exception("CALDAQMAPMAKER_RANGE") << "CalDAQMapMaker read invalid rawId" << rid << endl;
       }
 
-      if(oid >= CaloConst::_nChannel) {
+      if(oid != CaloConst::_invalid && oid >= CaloConst::_nChannel) {
         throw cet::exception("CALDAQMAPMAKER_RANGE") << "CalDAQMapMaker read invalid offlineId " << oid << endl;
       }
 
       raw2Offline[rid] = CaloSiPMId(oid);
-      offline2Raw[oid] = CaloRawSiPMId(rid);
+      if(oid < CaloConst::_nChannel) {
+        offline2Raw[oid] = CaloRawSiPMId(rid);
+      }
       ++nRead;
     }
 

--- a/DAQ/inc/CaloDAQUtilities.hh
+++ b/DAQ/inc/CaloDAQUtilities.hh
@@ -33,7 +33,8 @@ public:
     MaxSampleIndex = 5,
     BoardID = 6,
     ChannelID = 7,
-    ErrorFlags = 8
+    ErrorFlags = 8,
+    InvalidChannel = 9
   };
 
   std::string getCaloHitErrorName(CaloHitError error) {
@@ -56,6 +57,8 @@ public:
       return "ChannelID";
     case ErrorFlags:
       return "ErrorFlags";
+    case InvalidChannel:
+      return "InvalidChannel";
     default:
       return "Unknown";
     }

--- a/DAQ/src/CaloDigisFromDTCEvents_module.cc
+++ b/DAQ/src/CaloDigisFromDTCEvents_module.cc
@@ -197,7 +197,7 @@ void art::CaloDigiFromDTCEvents::analyze_calorimeter_(
         uint16_t SiPMID = (useOfflineID_ ? calodaqconds.offlineId(rawId).id() : rawId.id());
 
         //Check that the channel is valid in the offline world
-        if (SiPMID >= mu2e::CaloConst::_nChannel){
+        if (useOfflineID_ && SiPMID >= mu2e::CaloConst::_nChannel){
           if (diagLevel_ > 1) {
             std::cout << "[CaloDigiFromDTCEvents] Invalid channel! DTC: " << dtcID << ", ROC: " << iROC
                       << ", Board " << thisHitPacket.BoardID << " Ch " << thisHitPacket.ChannelID

--- a/DAQ/src/CaloDigisFromDTCEvents_module.cc
+++ b/DAQ/src/CaloDigisFromDTCEvents_module.cc
@@ -208,7 +208,7 @@ void art::CaloDigiFromDTCEvents::analyze_calorimeter_(
           continue;
         }
 
-        if (useDTCROCID_)
+        if (!useOfflineID_ && useDTCROCID_)
           SiPMID = dtcID * 120 + iROC * 20 + thisHitPacket.ChannelID;
         // Constructor: CaloDigi(int SiPMID, int t0, const std::vector<int>& waveform, size_t
         // peakpos)
@@ -272,7 +272,7 @@ void art::CaloDigiFromDTCEvents::analyze_calorimeter_(
         // Fill the CaloDigiCollection
         mu2e::CaloRawSiPMId rawId(thisHitPacket.BoardID, thisHitPacket.ChannelID);
         uint16_t SiPMID = (useOfflineID_ ? calodaqconds.offlineId(rawId).id() : rawId.id());
-        if (useDTCROCID_)
+        if (!useOfflineID_ && useDTCROCID_)
           SiPMID = dtcID * 120 + iROC * 20 + thisHitPacket.ChannelID;
         // Constructor: CaloDigi(int SiPMID, int t0, const std::vector<int>& waveform, size_t
         // peakpos)

--- a/DAQ/src/CaloDigisFromDTCEvents_module.cc
+++ b/DAQ/src/CaloDigisFromDTCEvents_module.cc
@@ -195,6 +195,19 @@ void art::CaloDigiFromDTCEvents::analyze_calorimeter_(
         // Fill the CaloDigiCollection
         mu2e::CaloRawSiPMId rawId(thisHitPacket.BoardID, thisHitPacket.ChannelID);
         uint16_t SiPMID = (useOfflineID_ ? calodaqconds.offlineId(rawId).id() : rawId.id());
+
+        //Check that the channel is valid in the offline world
+        if (SiPMID >= mu2e::CaloConst::_nChannel){
+          if (diagLevel_ > 1) {
+            std::cout << "[CaloDigiFromDTCEvents] Invalid channel! DTC: " << dtcID << ", ROC: " << iROC
+                      << ", Board " << thisHitPacket.BoardID << " Ch " << thisHitPacket.ChannelID
+                      << " offlineID " << SiPMID <<  std::endl;
+          }
+          failure_counter[mu2e::CaloDAQUtilities::CaloHitError::InvalidChannel]++;
+          total_hits_bad++;
+          continue;
+        }
+
         if (useDTCROCID_)
           SiPMID = dtcID * 120 + iROC * 20 + thisHitPacket.ChannelID;
         // Constructor: CaloDigi(int SiPMID, int t0, const std::vector<int>& waveform, size_t

--- a/DAQ/src/CaloHitsFromDTCEvents_module.cc
+++ b/DAQ/src/CaloHitsFromDTCEvents_module.cc
@@ -315,9 +315,21 @@ void art::CaloHitsFromDataDTCEvents::analyze_calorimeter_(
         // Fill the CaloHitCollection
         mu2e::CaloRawSiPMId rawId(thisHitPacket.BoardID, thisHitPacket.ChannelID);
         mu2e::CaloSiPMId offlineId = calodaqconds.offlineId(rawId);
-        uint16_t crystalID = offlineId.crystal().id();
         uint16_t SiPMID = offlineId.id();
 
+        //Check that the channel is valid in the offline world
+        if (SiPMID >= mu2e::CaloConst::_nChannel){
+          if (diagLevel_ > 1) {
+            std::cout << "[CaloHitsFromDataDTCEvents] Invalid channel! DTC: " << dtcID << ", ROC: " << iROC
+                      << ", Board " << thisHitPacket.BoardID << " Ch " << thisHitPacket.ChannelID
+                      << " offlineID " << SiPMID <<  std::endl;
+          }
+          failure_counter[mu2e::CaloDAQUtilities::CaloHitError::InvalidChannel]++;
+          total_hits_bad++;
+          continue;
+        }
+
+        uint16_t crystalID = offlineId.crystal().id();
         size_t peakIndex = thisHitPacket.IndexOfMaxDigitizerSample;
         float eDep = thisHitPeak * peakADC2MeV_[SiPMID];
         float time = thisHitPacket.Time + peakIndex * digiSampling_ + timeCalib_[SiPMID];

--- a/DAQ/src/CaloHitsFromDTCEvents_module.cc
+++ b/DAQ/src/CaloHitsFromDTCEvents_module.cc
@@ -390,9 +390,21 @@ void art::CaloHitsFromDataDTCEvents::analyze_calorimeter_(
         // Fill the CaloHitCollection
         mu2e::CaloRawSiPMId rawId(thisHitPacket.BoardID, thisHitPacket.ChannelID);
         mu2e::CaloSiPMId offlineId = calodaqconds.offlineId(rawId);
-        uint16_t crystalID = offlineId.crystal().id();
         uint16_t SiPMID = offlineId.id();
 
+        //Check that the channel is valid in the offline world
+        if (SiPMID >= mu2e::CaloConst::_nChannel){
+          if (diagLevel_ > 1) {
+            std::cout << "[CaloHitsFromDataDTCEvents] Invalid channel! DTC: " << dtcID << ", ROC: " << iROC
+                      << ", Board " << thisHitPacket.BoardID << " Ch " << thisHitPacket.ChannelID
+                      << " offlineID " << SiPMID <<  std::endl;
+          }
+          failure_counter[mu2e::CaloDAQUtilities::CaloHitError::InvalidChannel]++;
+          total_hits_bad++;
+          continue;
+        }
+
+        uint16_t crystalID = offlineId.crystal().id();
         size_t peakIndex = thisHitPacket.IndexOfMaxDigitizerSample;
         float eDep = thisHitPeak * peakADC2MeV_[SiPMID];
         float time = thisHitPacket.Time + peakIndex * digiSampling_ + timeCalib_[SiPMID];


### PR DESCRIPTION
Reverted some unwanted changes introduced in https://github.com/Mu2e/Offline/pull/1887

And added offline id check for hits appearing in channels that are supposed to be empty / invalid

