### PR TITLE
Fix LineFinder build: migrate to calo transform API from #1908

### DIFF
--- a/CosmicReco/src/LineFinder_module.cc
+++ b/CosmicReco/src/LineFinder_module.cc
@@ -329,7 +329,7 @@ void LineFinder::addClusterToSeed(CosmicTrackSeed& tseed) {
   constexpr double t0_match_window = 50.; // ns, loose time window for matching
   for(size_t i_cl = 0; i_cl < _cccol->size(); ++i_cl) {
     const CaloCluster& cl = _cccol->at(i_cl);
-    const CLHEP::Hep3Vector cl_pos = _calorimeter->geomUtil().mu2eToTracker(_calorimeter->geomUtil().diskToMu2e(cl.diskID(), cl.cog3Vector()));
+    const CLHEP::Hep3Vector cl_pos = _calorimeter->mu2eToTracker(_calorimeter->diskToMu2e(cl.diskID(), cl.cog3Vector()));
     const double cl_time = cl.time();
     // Get the expected time at the calo disk based on the line seed
     const double speed = CLHEP::c_light; // assume speed of the particle is close to the speed of light


### PR DESCRIPTION
Main is currently broken for every PR buildtest: #1908 removed `Calorimeter::geomUtil()`/`CaloGeomUtil`, but the calo-cluster matching added to `LineFinder` in 0d172558 (2026-07-20, after #1908 branched) still calls it, so `CosmicReco/src/LineFinder_module.cc` no longer compiles against main (`e9b2fbd1`). First seen on #1911's retest:

```
scons: *** [build/al9-prof-e29-p103/Offline/tmp/CosmicReco/src/LineFinder_module.os] Error 1
```

Any PR retested against current main fails the same way, on a file it doesn't touch.

This migrates the one surviving call site to the transforms #1908 hoisted onto the `Calorimeter` interface — the same pattern #1908 itself applied in `CalPatRec` (`CalTimePeakFinder_module.cc:203-204`, `CalLineTimePeakFinder_module.cc:154-155`):

```cpp
- _calorimeter->geomUtil().mu2eToTracker(_calorimeter->geomUtil().diskToMu2e(cl.diskID(), cl.cog3Vector()));
+ _calorimeter->mu2eToTracker(_calorimeter->diskToMu2e(cl.diskID(), cl.cog3Vector()));
```

The transforms are numerically identical to the old `CaloGeomUtil` ones, so this is a pure compile fix with no behavior change. `grep -rn geomUtil` confirms this was the only remaining reference in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
