### PR TITLE
Add optional protonabsorber.zStartInMu2e: absolute IPA position

### DIFF
--- a/GeometryService/src/MECOStyleProtonAbsorberMaker.cc
+++ b/GeometryService/src/MECOStyleProtonAbsorberMaker.cc
@@ -125,6 +125,14 @@ namespace mu2e {
     // we add space for the virtual detector here
     double targetEnd = _target->centerInMu2e().z() + 0.5*_target->cylinderLength() + 2.*vdHL;;
 
+    // Optional absolute pinning: when protonabsorber.zStartInMu2e is set,
+    // the IPA's upstream end sits at that absolute z regardless of the
+    // stopping target; distFromTargetEnd then only anchors the cone-radius
+    // interpolation. Unset (default): stock target-relative behavior.
+    if ( _config.hasName("protonabsorber.zStartInMu2e") ) {
+      targetEnd = _config.getDouble("protonabsorber.zStartInMu2e") - distFromTargetEnd;
+    }
+
     // distance from target end to ds2-ds3 boundary
     double targetEndToDS2End = _ds->vac_zLocDs23Split() - targetEnd;
 

--- a/Mu2eG4/geom/protonAbsorber_cylindrical_v04.txt
+++ b/Mu2eG4/geom/protonAbsorber_cylindrical_v04.txt
@@ -29,6 +29,9 @@ bool   protonabsorber.solid        = false;
 // To make inner part shorter than MECO design
 bool   protonabsorber.isShorterCone = true;
 double protonabsorber.distFromTargetEnd = 625.; //mu2e z positions are 6901-7901 mm
+// Optional: pin the IPA at an absolute z, independent of the stopping
+// target (see MECOStyleProtonAbsorberMaker):
+// double protonabsorber.zStartInMu2e = 6901.;
 double protonabsorber.halfLength   = 500.0;
 
 bool   protonabsorber.ipa.buildSupports = true;


### PR DESCRIPTION
## Motivation

The MECO-style inner proton absorber is placed relative to the stopping
target: `MECOStyleProtonAbsorberMaker` computes `targetEnd` from the live
`StoppingTarget` and derives everything from it — body placement, DS2/DS3
segmentation, the cone-radius interpolation anchor, and the IPA
support-wire ring positions. But the IPA is fixed hardware;
`protonAbsorber_cylindrical_v04.txt` itself documents
`distFromTargetEnd = 625.; //mu2e z positions are 6901-7901 mm`.

Anyone varying stopping-target geometry gets a silently displaced
absorber. In our stopping-target optimization study a longer foil stack
dragged the IPA 133.33 mm downstream as a rigid body (measured with
`protonabsorber.verbosityLevel = 1`: 7034.35–8034.35 vs the design
6901.02–7901.02) through 414 grid evaluations before it was noticed. For
a cylindrical IPA this is exactly compensable by adjusting
`distFromTargetEnd`; for the conical variant it is not (the taper anchor
moves with the target) — hence a first-class option.

## Change

New optional key `protonabsorber.zStartInMu2e`. When present, the maker
derives its reference plane from the given absolute z
(`targetEnd = zStartInMu2e - distFromTargetEnd`), so the absorber's
upstream end lands exactly at the given z and its full geometry (length,
DS2/DS3 split, cone radii, support wires) is independent of the stopping
target. When absent — the default everywhere — the new branch never
executes and output is bit-identical to today. One commented example
added to `protonAbsorber_cylindrical_v04.txt`.

## Validation (Offline v13_32_10 + SimJob/Run1Bap backing)

Six single-event G4 runs with full surface check
(`protonabsorber.verbosityLevel = 1`), stopping-target stack extents
400 / 800 / 1100 mm, each extent probed twice — config-compensated
`distFromTargetEnd` (no new key) vs stock 625 + `zStartInMu2e = 6901.02`:

| probe | mechanism | absorber Z extent printed | overlaps |
|---|---|---|---|
| extent 400, expression | distFromTargetEnd = 825.0 | constructProtonAbsorber protonabs1 Z extent in Mu2e    : 6901.02, 7901.02 | 0 |
| extent 800, expression | distFromTargetEnd = 625.0 | constructProtonAbsorber protonabs1 Z extent in Mu2e    : 6901.02, 7901.02 | 0 |
| extent 1100, expression | distFromTargetEnd = 475.0 | constructProtonAbsorber protonabs1 Z extent in Mu2e    : 6901.02, 7901.02 | 0 |
| extent 400, option only | zStartInMu2e = 6901.02, dist = stock 625 | constructProtonAbsorber protonabs1 Z extent in Mu2e    : 6901.02, 7901.02 | 0 |
| extent 800, option only | zStartInMu2e = 6901.02, dist = stock 625 | constructProtonAbsorber protonabs1 Z extent in Mu2e    : 6901.02, 7901.02 | 0 |
| extent 1100, option only | zStartInMu2e = 6901.02, dist = stock 625 | constructProtonAbsorber protonabs1 Z extent in Mu2e    : 6901.02, 7901.02 | 0 |

All six print the identical absorber extent 6901.02–7901.02 with zero
overlaps. With the key unset, a golden-parity harness (real G4 preflight
replay) reproduces baseline output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
