### PR TITLE
feat(geom): add Run1B production geometry and virtual detector ids

### DIFF
--- a/DataProducts/inc/VirtualDetectorId.hh
+++ b/DataProducts/inc/VirtualDetectorId.hh
@@ -88,6 +88,25 @@ namespace mu2e {
       STM_Final, // 114
       STM_UpStrHole, //115
       STM_UpStrLarge, //116
+      Tracker_FEB_0_SurfIn, // 117 before tracker station 0
+      Tracker_FEB_1_SurfIn, // 118 before tracker station 1
+      Tracker_FEB_2_SurfIn, // 119 before tracker station 2
+      Tracker_FEB_3_SurfIn, // 120 before tracker station 3
+      Tracker_FEB_4_SurfIn, // 121 before tracker station 4
+      Tracker_FEB_5_SurfIn, // 122 before tracker station 5
+      Tracker_FEB_6_SurfIn, // 123 before tracker station 6
+      Tracker_FEB_7_SurfIn, // 124 before tracker station 7
+      Tracker_FEB_8_SurfIn, // 125 before tracker station 8
+      Tracker_FEB_9_SurfIn, // 126 before tracker station 9
+      Tracker_FEB_10_SurfIn, // 127 before tracker station 10
+      Tracker_FEB_11_SurfIn, // 128 before tracker station 11
+      Tracker_FEB_12_SurfIn, // 129 before tracker station 12
+      Tracker_FEB_13_SurfIn, // 130 before tracker station 13
+      Tracker_FEB_14_SurfIn, // 131 before tracker station 14
+      Tracker_FEB_15_SurfIn, // 132 before tracker station 15
+      Tracker_FEB_16_SurfIn, // 133 before tracker station 16
+      Tracker_FEB_17_SurfIn, // 134 before tracker station 17
+      Tracker_FEB_18_SurfIn, // 135 after tracker station 17
       lastEnum
     };
 
@@ -139,7 +158,26 @@ namespace mu2e {
       "PTM_1_In", "PTM_2_In", \
       "STM_Final", \
       "STM_UpStrHole", \
-      "STM_UpStrLarge"
+      "STM_UpStrLarge", \
+      "Tracker_FEB_0_SurfIn", \
+      "Tracker_FEB_1_SurfIn", \
+      "Tracker_FEB_2_SurfIn", \
+      "Tracker_FEB_3_SurfIn", \
+      "Tracker_FEB_4_SurfIn", \
+      "Tracker_FEB_5_SurfIn", \
+      "Tracker_FEB_6_SurfIn", \
+      "Tracker_FEB_7_SurfIn", \
+      "Tracker_FEB_8_SurfIn", \
+      "Tracker_FEB_9_SurfIn", \
+      "Tracker_FEB_10_SurfIn", \
+      "Tracker_FEB_11_SurfIn", \
+      "Tracker_FEB_12_SurfIn", \
+      "Tracker_FEB_13_SurfIn", \
+      "Tracker_FEB_14_SurfIn", \
+      "Tracker_FEB_15_SurfIn", \
+      "Tracker_FEB_16_SurfIn", \
+      "Tracker_FEB_17_SurfIn", \
+      "Tracker_FEB_18_SurfIn"
   public:
 
     // The most important c'tor and accessor methods are first.
@@ -190,6 +228,10 @@ namespace mu2e {
 
     bool isTrackerBack() const {
       return ( _id == TT_Back || _id == IT_VD_EndCap_Back );
+    }
+
+    bool isFEBTracker() const{
+      return (_id >= Tracker_FEB_0_SurfIn && _id <= Tracker_FEB_18_SurfIn );
     }
 
     bool isVaneCalorimeter0() const{

--- a/GeometryService/src/VirtualDetectorMaker.cc
+++ b/GeometryService/src/VirtualDetectorMaker.cc
@@ -237,6 +237,36 @@ namespace mu2e {
         //         }
         //       }
 
+        // Optional virtual detectors on the upstream face of the front-end
+        // board (FEB) of every second tracker plane, plus one behind the last
+        // plane.  Off unless a geometry explicitly asks for them.
+        if ( c.getBool("hasTrackerFEBVirtualDetectors",false) ){
+          TubsParams planeEnvelope = tracker.g4Tracker()->getPlaneEnvelopeParams();
+          double dzplane = planeEnvelope.zHalfLength();
+          for ( int ipln=0; ipln<StrawId::_nplanes+1; ipln+=2 ){
+            Hep3Vector vdTracker_FEB_offset(0.,0.,0.);
+            double zplane;
+            double z_Tracker_FEB;
+            if (ipln < StrawId::_nplanes){
+              zplane = tracker.getPlane(ipln).origin().z();
+              z_Tracker_FEB = zplane-dzplane-vdHL;
+            }
+            else{
+              zplane = -tracker.getPlane(0).origin().z();
+              z_Tracker_FEB = zplane+dzplane+vdHL;
+            }
+            vdTracker_FEB_offset.setZ(z_Tracker_FEB);
+
+            if ( verbosityLevel > 0 ) {
+              cout << " z_Tracker_FEB_" << ipln/2 << "=" << z_Tracker_FEB
+                   << " zplane=" << zplane << " dzplane=" << dzplane << endl;
+            }
+
+            int vdId = VirtualDetectorId::Tracker_FEB_0_SurfIn+ipln/2;
+            vd->addVirtualDetector( vdId, ttOffset, 0, vdTracker_FEB_offset);
+          }
+        }
+
         // Global position is in Mu2e coordinates; local position in the detector system.
         double zFrontGlobal = tracker.g4Tracker()->mother().position().z()-tracker.g4Tracker()->mother().tubsParams().zHalfLength()-vdHL;
         double zBackGlobal  = tracker.g4Tracker()->mother().position().z()+tracker.g4Tracker()->mother().tubsParams().zHalfLength()+vdHL;

--- a/Mu2eG4/fcl/gdmldump_run1_b_v40.fcl
+++ b/Mu2eG4/fcl/gdmldump_run1_b_v40.fcl
@@ -1,0 +1,3 @@
+#include "Offline/Mu2eG4/fcl/gdmldump.fcl"
+services.GeometryService.inputFile : "Offline/Mu2eG4/geom/geom_run1_b_v40.txt"
+physics.producers.g4run.debug.GDMLFileName: "mu2e_run1_b_v40.gdml"

--- a/Mu2eG4/geom/geom_run1_b_ds_on_v40.txt
+++ b/Mu2eG4/geom/geom_run1_b_ds_on_v40.txt
@@ -1,0 +1,10 @@
+// Run1B v40: 1.75 cm thick mobile target, 1.75 cm thick Al TS5 endcap plate with 135 mm hole added, otherwise a normal Run 1A config
+// Run 1A version with mobile target moved out of the beam for DS-on running
+#include "Offline/Mu2eG4/geom/geom_run1_b_v40.txt"
+
+double degrader.rotation = 120.0; // out of the beam
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/geom/geom_run1_b_v40.txt
+++ b/Mu2eG4/geom/geom_run1_b_v40.txt
@@ -1,0 +1,25 @@
+// Run1B v40: 1.75 cm thick mobile target, 1.75 cm thick Al TS5 endcap plate with 135 mm hole added, otherwise a normal Run 1A config
+#include "Offline/Mu2eG4/geom/geom_run1_a.txt"
+
+// Use the pion degrader as a Run 1B target
+bool   degrader.build               = true;
+double degrader.rotation            = 60.0; // in the beam
+string degrader.filter.materialName = "StoppingTarget_Al"; // stopping target material
+double degrader.filter.halfLength   = 8.75; // 1.75 cm plate
+double degrader.filter.rIn          = 0.0;
+double degrader.filter.rOut         = 150.0; // 150 mm radius disk
+double degrader.supportArm.offsetz  = 245.0;
+double degrader.supportArm.dz       = 186.0;
+
+// Use the TSdA as an aluminum collimator, helping Run 1B
+bool hasTSdA             = true;
+double tsda.z0           = 4195;
+double tsda.r4           = 600;                 // cover the TS5
+double tsda.rin          = 135.;                // 135 mm hole for normal beam to pass through
+double tsda.halfLength4  = 8.75;                // 1.75 cm plate
+string tsda.materialName = "StoppingTarget_Al"; // stopping target material to capture in the stops finder
+
+// This tells emacs to view this file in c++ mode.
+// Local Variables:
+// mode:c++
+// End:

--- a/Mu2eG4/src/constructVirtualDetectors.cc
+++ b/Mu2eG4/src/constructVirtualDetectors.cc
@@ -1906,5 +1906,50 @@ namespace mu2e {
     }
 
 
+    // Optional virtual detectors in front of the tracker front-end boards.
+    // These only exist if VirtualDetectorMaker registered them, which it does
+    // only when the geometry sets hasTrackerFEBVirtualDetectors.
+    if ( _config.getBool("hasTracker",false) &&
+         vdg->exist(VirtualDetectorId::Tracker_FEB_0_SurfIn) ) {
+      Tracker const & tracker = *(GeomHandle<Tracker>());
+      // the radius of tracker support
+      double orvd = tracker.g4Tracker()->getSupportParams().getTubsParams().outerRadius()-20.1; // Avoid tracker support beam
+      double irvd = tracker.g4Tracker()->mother().tubsParams().innerRadius();
+
+      TubsParams vdParamsTracker(irvd,orvd,vdHalfLength);
+
+      if ( verbosityLevel > 0) {
+        cout << __func__ << " tracker FEB VD outer, inner radius: " << orvd << " " << irvd << endl;
+        cout << __func__ << " tracker FEB VD parameters: " << vdParamsTracker << endl;
+      }
+
+      VolumeInfo const & trackerMother = _helper->locateVolInfo("TrackerMother");
+
+      for ( int ipln=0; ipln<StrawId::_nplanes+1; ipln+=2 ){
+        // placing virtual detectors before FEB of tracker stations
+        vdId = VirtualDetectorId::Tracker_FEB_0_SurfIn+ipln/2;
+        if( vdg->exist(vdId) ) {
+          CLHEP::Hep3Vector vdPos = vdg->getGlobal(vdId)-trackerMother.centerInMu2e();
+
+          if ( verbosityLevel > 0) {
+            cout << __func__ << " constructing " << VirtualDetector::volumeName(vdId)
+                 << " at " << vdPos << " or local " << vdg->getLocal(vdId) << endl;
+          }
+
+          VolumeInfo vd = nestTubs( VirtualDetector::volumeName(vdId),
+                                    vdParamsTracker, downstreamVacuumMaterial, 0,
+                                    vdPos,
+                                    trackerMother,
+                                    vdId, vdIsVisible, G4Color::Red(), vdIsSolid,
+                                    forceAuxEdgeVisible,
+                                    placePV,
+                                    false);
+
+          doSurfaceCheck && checkForOverlaps(vd.physical, _config, verbosityLevel>0);
+        }
+      }
+    }
+
+
   } // constructVirtualDetectors()
 }


### PR DESCRIPTION
Ports the Run1B production geometry to main.

`geom_common.txt` is deliberately **not** changed — main keeps
`geom_run1_a_stickman.txt` as its default. That was the review comment that
blocked #1849, and it is addressed by construction here.

## Why

Production main's `Tests/Run1BReco.fcl` and the prodtools Run1B digi/reco
templates already reference `Offline/Mu2eG4/geom/geom_run1_b_v40.txt`, which
today exists only on the `Run1B` branch. This repairs that dangling cross-repo
reference.

## Only v40 is ported

Run1B has two stopping targets: the thin 37-foil target shared with Run1A, and
a disk at the face of TS5. `geom_run1_b_v40.txt` models this correctly — it
inherits `geom_run1_a.txt` untouched, so the 37 foils and their support
structure survive, and adds a two-piece aluminium assembly at the TS5 face (the
TSdA as a 600 mm plate with a 135 mm aperture at z = 4195, and the pion degrader
repurposed as a 150 mm mobile target at z = 4235). `ds_on_v40` is v40 with the
mobile target rotated out of the beam.

The earlier v01–v06 line instead overrode `stoppingTarget.radii` to a single
600 mm disk, *replacing* the foil target rather than adding to it. v40
superseded that line and is what the Run1Ban and Run1Bap campaigns run, so only
v40 is ported here.

Everything v40 needs already exists on main — no `constructTSdA.cc`,
`constructStoppingTarget.cc` or `Mu2eWorld.cc` changes are required. Confirmed
from the dump: v40 yields `TSdA4` at rmax 600 / rmin 135 / z 17.5 in
`StoppingTarget_Al` (nominal gives 525 / 235 / 50.8), and its stopping-target
foil count is identical to `geom_run1_a.txt`.

## Tracker FEB virtual detectors, off by default

19 identifiers (117–135) and the code that builds them: annular virtual
detectors on the upstream face of every second tracker plane's front-end board,
plus one behind the last plane.

These are gated on a new key, **`hasTrackerFEBVirtualDetectors`, defaulting
false**, which no geometry file sets. This deliberately differs from the `Run1B`
branch, which gates them on `TrackerHasBrassRings` — a key set `true` in
`tracker_v4/v5/v6/v7.txt`, i.e. every current geometry, so on the branch these
detectors are built in nominal running. Re-gating keeps the capability available
without changing anyone's simulation.

The registration block is the only place the key is read; placement follows via
the existing `vdg->exist(vdId)` guard and is additionally fenced behind
`vdg->exist(Tracker_FEB_0_SurfIn)`, so the disabled path constructs nothing and
performs no geometry lookups. Diagnostic output is behind `verbosityLevel > 0`,
matching the surrounding code.

## Enum safety

The identifiers are appended before `lastEnum`, so no existing enumerator
changes position or value and existing art files stay readable.
`VIRTUALDETECTORID_NAMES` gains 19 matching strings in the same order; the
`BOOST_STATIC_ASSERT` at `VirtualDetectorId.cc:65` is satisfied at 136 == 136,
verified pairwise across all 136 entries. A survey of `lastEnum` consumers found
no fixed-size array dimensioned on a literal, no persisted format with a baked-in
width, and no switch assuming a maximum id.

Per review, the branch's `EMC_Source`, `EMC_Source2` and `EMC_0_Front`
identifiers are **not** included — the first two served a study calorimeter
between Coll5 and the tracker rather than production hardware, and `EMC_0_Front`
duplicates the existing `EMC_0_FrontIn`/`EMC_0_FrontOut` that already back
`isDisk0()`.

## Verification

Normalized gdml dumps (Geant4 pointer suffixes stripped) of both nominal
geometries are **byte-identical** to main:

| geometry | volumes | md5, unchanged |
|---|---|---|
| `geom_common.txt` | 13767 | `85b9f421823ab803c4250e95214ff8f1` |
| `geom_run1_a.txt` | 14355 | `1d0cbf23ebbae35a2c14660cc535f90b` |

The harness was validated before being trusted: two dumps of the same unchanged
geometry are byte-identical after normalization, while the raw pre-normalization
dumps differ by 125,118 lines from pointer addresses alone.

The FEB detectors were also exercised in the enabled state — a scratch geometry
setting `hasTrackerFEBVirtualDetectors = true` on top of v40 produces exactly 19
volumes at copy numbers 117–135 with no Geant4 overlaps, while a plain v40 dump
produces none and is byte-identical to v40 before this change.
