### PR TITLE
Fix geometry overlap: nudge dirtCentralStairwellLower3 face by 1 um

### DIFF
--- a/Mu2eG4/geom/bldg/dirtCentralStairwellLower3.txt
+++ b/Mu2eG4/geom/bldg/dirtCentralStairwellLower3.txt
@@ -12,11 +12,13 @@ double dirt.central.stairwell.lower3.offsetFromMu2eOrigin.z   = -3581.4;
 
 double dirt.central.stairwell.lower3.yHalfThickness           = 1260.45;
 
+// the face at 9956.8 abuts CentralStairwellLowerStairs; add 1 um to prevent
+// conflict as that volume's rotation angle is not exactly pi/2
 vector<double> dirt.central.stairwell.lower3.xPositions = {
-  9956.8,   // g1
+  9956.801,   // g1
   11617.2,   // g2
   11617.2,    // g3
-  9956.8   // g4
+  9956.801   // g4
 };
 
 vector<double> dirt.central.stairwell.lower3.yPositions = {


### PR DESCRIPTION
Fixes #1925.

`dirtCentralStairwellLower3`, added in #1918, abuts `CentralStairwellLowerStairs` at Mu2e z = 6375.4. That neighbour is rotated by `-1.5707963268` — π/2 truncated at the 10th decimal — so its face is tilted ~5e-12 rad off square and pokes into the new volume.

`bin/overlapCheck.C` calls `CheckOverlaps(1e-12)`, so the artifact is reported on the **default** geometry (`geom_common.txt`):

```
Overlap ov00000: HallAir/dirtCentralStairwellLower30x545f8d0
  overlapping HallAir/CentralStairwellLowerStairs0x55f22b0  ovlp=3.11047e-10
```

This moves the abutting face out by 1 µm so the volumes no longer touch — the same remedy already applied to the neighbour itself, whose `yHalfThickness` carries *"remove 1 um to prevent conflict as the rotation angle is not exactly pi/2"*.

### Validation

Regenerated `mu2e_common.gdml` from the patched geometry via `gdmldump.fcl` (art exit 0) and reran `overlapCheck.C`:

| | illegal overlaps/extrusions |
|---|---|
| baseline (`main` @ `1891b328`) | **1** |
| this change | **0** |

Diffing the regenerated GDML against the baseline after stripping Geant4 pointer suffixes shows exactly the two `twoDimVertex` entries for this face:

```diff
-<twoDimVertex x="9956.8" y="-12369.8"/>
+<twoDimVertex x="9956.801" y="-12369.8"/>
-<twoDimVertex x="9956.8" y="-13589"/>
+<twoDimVertex x="9956.801" y="-13589"/>
```

Volume counts identical (9987 `physvol`), and the neighbour's rotation is untouched. No physics consequence — 1 µm on a dirt volume, against an original discrepancy of 3e-13 m.

### Why not fix the rotation angle instead

I first tried replacing the truncated literal with a full-precision π/2, which also gives 0 overlaps. Two reasons I abandoned it:

1. **`SimpleConfig` has no π constant and no expression evaluation** — values go through `strtod`, so `M_PI/2` isn't available. It would have to be the bare literal `-1.5707963267948966`, which is unpleasant to read and invites someone to "tidy" it back to something shorter later.
2. **Shortening it doesn't work.** I tested the intermediate `-1.5707963267` (10 decimals, erring *short* of π/2 on the theory it would open a gap) and it still overlaps, at `ovlp=5.78e-09` — worse than the original. Any inexact right angle tilts a corner in somewhere; only the full 16-digit value clears the tolerance. So the angle route is all-or-nothing on that literal.

The 1 µm nudge sidesteps the precision question entirely and matches the idiom already in these files.

### Note for a follow-up

Two sibling volumes carry the same truncated literal:

- `bldg/centralStairwellUpperStairs1.txt:11`
- `bldg/centralStairwellUpperStairs2.txt:11`

Neither currently overlaps anything, so they're out of scope here. Worth knowing they're the same latent pattern if a new volume is ever placed against them. @sdifalco — these are your files, happy to defer if you'd rather handle the family differently.
