### PR TITLE
Size the degrader mother volume to its contents

### DIFF
--- a/Mu2eG4/src/constructProtonAbsorber.cc
+++ b/Mu2eG4/src/constructProtonAbsorber.cc
@@ -1373,10 +1373,9 @@ namespace mu2e {
                                                       *CLHEP::degree);
         double yLocMoBox = pivotPos.at(1) + dptoc*sin(pabs->degraderRotation()
                                                       *CLHEP::degree);
-        CLHEP::Hep3Vector locationInMu2e (xLocMoBox, yLocMoBox,
-                                          pabs->degraderZ0()
-                                          + 2.0*filterDims.at(2)
-                                          + frameDims.at(2) );
+        const double dgr_z0 = pabs->degraderZ0(); // front face of the degrader
+        const double mother_half_width = filterDims.at(2) + frameDims.at(2) + 0.1; // contain both the frame and the filter
+        CLHEP::Hep3Vector locationInMu2e (xLocMoBox, yLocMoBox, dgr_z0 + mother_half_width);
 
         // Make mother volume for degrader
         std::string motherName("Degrader");
@@ -1387,8 +1386,7 @@ namespace mu2e {
         G4Box* motherBox = new G4Box ( "degraderOutline",
                                        lengthPDMoBox/2.0,
                                        frameDims.at(1),
-                                       2.0*filterDims.at(2) + frameDims.at(2)
-                                       + 1 );
+                                       mother_half_width);
         degraderMother.solid = motherBox;
 
         // Now put degraderMother in DS2Vacuum
@@ -1401,15 +1399,28 @@ namespace mu2e {
                         placePV,
                         doSurfaceCheck );
 
-        // Start cobbling pieces together by putting frame in mother
-        CLHEP::Hep3Vector trans1( frameDims.at(1) - lengthPDMoBox/2.0,
-                                  0,0);
+        // First put the filter in the mother
+        CLHEP::Hep3Vector trans_filter(frameDims.at(1) - lengthPDMoBox/2.0,0,
+                                       filterDims.at(2) - mother_half_width); // upstream edge of the mother box
+        nestTubs("degraderFilter",
+                 TubsParams(filterDims.at(0),filterDims.at(1),filterDims.at(2)),
+                 findMaterialOrThrow(pabs->degraderFilterMaterial()),
+                 0, trans_filter, degraderMother,
+                 0, pabsIsVisible, G4Color::Red(),
+                 pabsIsSolid,
+                 forceAuxEdgeVisible,
+                 placePV,
+                 doSurfaceCheck );
+
+        // Place the frame just downstream of the filter
+        CLHEP::Hep3Vector trans_frame(trans_filter.x(), trans_filter.y(),
+                                      trans_filter.z() + frameDims.at(2) + filterDims.at(2));
         nestTubs("degraderFrame",
                  TubsParams(frameDims.at(0),frameDims.at(1),frameDims.at(2),
                             -frameDims.at(4)/2 * CLHEP::degree,
                             frameDims.at(4)*CLHEP::degree ),
                  findMaterialOrThrow(pabs->degraderFrameMaterial()),
-                 0, trans1, degraderMother,
+                 0, trans_frame, degraderMother,
                  0, pabsIsVisible, G4Color::Red(),
                  pabsIsSolid,
                  forceAuxEdgeVisible,
@@ -1417,31 +1428,19 @@ namespace mu2e {
                  doSurfaceCheck );
 
 
-        // Now put filter in mother
-        CLHEP::Hep3Vector trans1b(frameDims.at(1) - lengthPDMoBox/2.0,0,
-                                  -(frameDims.at(2) + filterDims.at(2)));
-        nestTubs("degraderFilter",
-                 TubsParams(filterDims.at(0),filterDims.at(1),filterDims.at(2)),
-                 findMaterialOrThrow(pabs->degraderFilterMaterial()),
-                 0, trans1b, degraderMother,
-                 0, pabsIsVisible, G4Color::Red(),
-                 pabsIsSolid,
-                 forceAuxEdgeVisible,
-                 placePV,
-                 doSurfaceCheck );
 
         // Create rod rep
         double lenRod = frameDims.at(3) + counterDims.at(3) - frameDims.at(1)
           - 0.1;
         std::vector<double> lwhs = {lenRod/2.0,rodDims.at(0)/2.0,rodDims.at(1)/2.0};
         // Now put rod in mother volume
-        CLHEP::Hep3Vector trans3(frameDims.at(1),
-                                 0.0, 0.0);
+        CLHEP::Hep3Vector trans_rod(frameDims.at(1),
+                                    0.0, trans_frame.z()); // same z location as the frame
 
         nestBox ("degraderRod",
                  lwhs,
                  findMaterialOrThrow(pabs->degraderRodMaterial()),
-                 0, trans3, degraderMother,
+                 0, trans_rod, degraderMother,
                  0, pabsIsVisible, G4Color::Red(),
                  pabsIsSolid,
                  forceAuxEdgeVisible,
@@ -1459,7 +1458,7 @@ namespace mu2e {
                                                       *CLHEP::degree);
 
         CLHEP::Hep3Vector location2InMu2e (xLocMoBox2, yLocMoBox2,
-                                           pabs->degraderZ0()
+                                           dgr_z0
                                            + 2.0*filterDims.at(2)
                                            + frameDims.at(2) );
 


### PR DESCRIPTION
Sizes the pion degrader's mother volume to its contents.

## The bug

The mother's half-width was computed as `2*filter_hl + frame_hl + 1` while its
children were placed from a different expression, so the mother overran its
contents downstream — by 1.9 mm in nominal geometries and 9.65 mm with
`geom_run1_b_v40.txt`, whose filter is 8.75 mm half-length rather than 1.00 mm.

On v40 that overrun produced two real Geant4 overlaps:

```
Overlap is detected for volume Degrader:0 (G4Box) with protonabs3:0 (G4SubtractionSolid)
  overlap at local point (219.934,-404.385,-2025.8) by 3.7 mm  (max of 73 cases)
Overlap is detected for volume degraderSupportPlate:0 (G4Box) with Degrader:0 (G4Box)
  overlap at local point (287.173,-70.8224,22.55) by 2.3 mm  (max of 175 cases)
```

Both reproduce exactly from the geometry constants. The support-plate case:
the old v40 mother's downstream face sits at `4258.85 + 24.85 = 4283.70`, and
the plate's front face at `4235 + 245 - 186 - 6.25 - 0.1 - 6.25 = 4281.40` —
a 2.30 mm overlap, matching what Geant4 reports.

Nominal was never affected: its mother face at 4252.70 is already 8.7 mm clear
of a plate face at 4261.40.

## The fix

Size the mother as `filter_hl + frame_hl + 0.1` and place the filter at its
upstream edge with the frame directly downstream. With surface checking
enabled (`g4.doSurfaceCheck = true`), v40 goes from **2 overlaps to 0**.

## Effect on nominal running

The degrader is built in nominal geometries — `degrader_v02.txt` sets
`degrader.build = true`, and "off by default" means `rotation = 120.0`, swung
out of the beam rather than absent. So this is not dead code and the nominal
gdml dump does change. It changes in a bounded way:

**No material moves.** The `Degrader` mother is filled with `DSVacuum` and sits
inside `DS2Vacuum`, which is also `DSVacuum` — resizing it displaces nothing.
The filter, frame, rod and counterweight all keep their exact absolute z:

| volume | absolute z, nominal | absolute z, v40 |
|---|---|---|
| filter | 4236.00 → 4236.00 | 4243.75 → 4243.75 |
| frame | 4243.35 → 4243.35 | 4258.85 → 4258.85 |
| rod | 4243.35 → 4243.35 | 4258.85 → 4258.85 |
| counterweight | 4243.35 → 4243.35 | 4258.85 → 4258.85 |

The normalized gdml diff against `geom_common.txt` and `geom_run1_a.txt` is 39
lines each and identical between them. 34 of those lines are file reordering
(the filter is now emitted before the frame; `degraderFrame`'s solid is
byte-identical). The remaining changes are the `degraderOutline` box dimension,
the `degraderMother` placement, and three compensating child offsets that exist
precisely so the absolute positions above stay fixed. x and y are untouched
throughout, and no volume outside the degrader assembly appears in either diff.

Step boundaries do shift even where material does not, so re-simulations will
not be bit-reproducible against earlier output.

## One deliberate deviation from the Run1B branch

The branch also rewrote `location2InMu2e` to reuse the mother-centre
expression, which dragged `degraderCounterweight` upstream by 0.90 mm in
nominal and 8.65 mm on v40 — leaving it non-coplanar with the rod it
counterbalances. That reads as incidental rather than intended, so this PR
keeps the original `dgr_z0 + 2.0*filterDims.at(2) + frameDims.at(2)`. Neither
overlap involves the counterweight, and the 0-overlap result was re-measured
after the revert to confirm the fix still holds. @sdifalco / Run1B authors:
please confirm this was not deliberate.

## Minor, noted not fixed

The filter's upstream face is exactly flush with the mother wall — all 0.2 mm
of slack sits downstream. Legal and overlap-free, but coincident surfaces are
generally discouraged, and on v40 that filter is in the beam. Happy to bias the
filter 0.1 mm downstream if reviewers prefer.
