### PR TITLE
add expected Proditions get calls

### DIFF
--- a/TrackerConditions/inc/AlignedTrackerCache.hh
+++ b/TrackerConditions/inc/AlignedTrackerCache.hh
@@ -54,6 +54,10 @@ namespace mu2e {
         DbIoV iov;
         iov.setMax(); // start with full IOV range
         if(_useDb) {
+          _tatr_p->get(eid);
+          _tapl_p->get(eid);
+          _tapa_p->get(eid);
+          _tast_p->get(eid);
           iov.overlap(_tatr_p->iov());
           iov.overlap(_tapl_p->iov());
           iov.overlap(_tapa_p->iov());

--- a/TrackerConditions/inc/TrackerStatusCache.hh
+++ b/TrackerConditions/inc/TrackerStatusCache.hh
@@ -44,6 +44,10 @@ namespace mu2e {
         DbIoV iov;
         iov.setMax(); // start with full IOV range
         if(_useDb) {
+          _tpls_p->get(eid);
+          _tpas_p->get(eid);
+          _tssl_p->get(eid);
+          _tsss_p->get(eid);
           iov.overlap(_tpls_p->iov());
           iov.overlap(_tpas_p->iov());
           iov.overlap(_tssl_p->iov());


### PR DESCRIPTION
These calls should be here to be consistent with the standard pattern.  In briefly reviewing the current calling code, I think they may be redundant, with negligible cost, but until all the Proditions can be rewritten, possibly, with a more compact approach, I'd prefer the patterns are consistent across the code base.