### PR TITLE
prepare runTool for agents

### DIFF
--- a/DbService/inc/RunTool.hh
+++ b/DbService/inc/RunTool.hh
@@ -37,6 +37,17 @@ class RunTool {
  private:
   // read the database via query_engine
   DbReader _reader;
+
+  // Memoized flags() results -- online.run_type/online.run_transition_type
+  // are job-constant, so the first query's result is reused for the
+  // lifetime of this RunTool instance rather than re-querying on every
+  // call. Matters because flags() is called once or twice per run from
+  // runJson() (and, with -a, from printRun()) -- unmemoized, that's two
+  // extra database round-trips per run in the JSON run-listing path.
+  std::map<int, std::string> _runFlagsCache;
+  std::map<int, std::string> _transitionFlagsCache;
+  bool _runFlagsCached = false;
+  bool _transitionFlagsCached = false;
 };
 
 }  // namespace mu2e

--- a/DbService/inc/RunTool.hh
+++ b/DbService/inc/RunTool.hh
@@ -20,9 +20,19 @@ class RunTool {
 
   // fill argument with the names of all flag types
   std::map<int, std::string> flags(FlagType ftype);
+  // Both flag types (run, transition) as a single JSON object -- string
+  // return, same SWIG-compatibility reason as runJson(). Lives on the class
+  // rather than in runTool_main.cc so it's reachable from the Python/SWIG
+  // binding too, not just the CLI.
+  std::string flagsJson();
   RunInfo::RunVec listRuns(const RunSelect& runsel, bool configs = false,
                            bool transitions = false, bool subruns = false);
   void printRun(const RunInfo& info);
+  // Same content as printRun, as a JSON object (serialized text, not a
+  // nlohmann::json return type -- this class is SWIG-wrapped and
+  // nlohmann::json isn't a SWIG-recognized type, same reason
+  // RunInfo::dbTables2/3() and RunConfig::dbTables2/3() return std::string).
+  std::string runJson(const RunInfo& info);
 
  private:
   // read the database via query_engine

--- a/DbService/src/RunConfig.cc
+++ b/DbService/src/RunConfig.cc
@@ -1,11 +1,13 @@
 #include "Offline/DbService/inc/RunConfig.hh"
+
 #include "cetlib_except/exception.h"
-#include "nlohmann/json.hpp"
+
+#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>
-#include <iostream>
 
+#include "nlohmann/json.hpp"
 
 namespace {
 
@@ -68,7 +70,7 @@ void walkCID(const json& node,
   }
 }
 
-}
+}  // namespace
 
 // ---------------------------------------------------------------------------
 // mu2e::RunConfig::dbTables2

--- a/DbService/src/RunInfo.cc
+++ b/DbService/src/RunInfo.cc
@@ -3,10 +3,11 @@
 #include "Offline/GeneralUtilities/inc/TimeUtility.hh"
 
 #include "cetlib_except/exception.h"
-#include "nlohmann/json.hpp"
 
 #include <ctime>
 #include <string>
+
+#include "nlohmann/json.hpp"
 
 using namespace mu2e;
 
@@ -36,10 +37,23 @@ std::string RunInfo::dbTables2(bool qjson) const {
 // requested the individual per-config objects are merged into a single JSON
 // object (an empty object "{}" if nothing is found).
 std::string RunInfo::dbTables3(bool qjson) const {
+  // TRG/Gateway/CFO/DQM configs are excluded from the cat-3 merge -- they
+  // don't carry relevant DBServiceTables content, and including them is what
+  // originally produced colliding keys across configs (see
+  // RUNINFO_DUPLICATE_TABLE below). Shared by both branches deliberately:
+  // this used to live only in the qjson branch below, which meant `runTool
+  // -q` (text) and `runTool -q -j` (JSON) silently reported different table
+  // sets for the same run -- a single predicate used by both means that
+  // can't happen again by the two conditions drifting apart.
+  auto excluded = [](const RunConfig& config) {
+    return config.subsystem() == "TRG" || config.subsystem() == "Gateway" ||
+           config.subsystem() == "CFO" || config.subsystem() == "DQM";
+  };
+
   if (qjson) {
     nlohmann::json merged = nlohmann::json::object();
     for (auto const& config : _configs) {
-      if (config.subsystem() == "TRG" || config.subsystem() == "Gateway" || config.subsystem() == "CFO" || config.subsystem() == "DQM") {
+      if (excluded(config)) {
         continue;
       }
       std::string tables = config.dbTables3(qjson);
@@ -53,8 +67,8 @@ std::string RunInfo::dbTables3(bool qjson) const {
       for (auto it = part.begin(); it != part.end(); ++it) {
         if (merged.contains(it.key())) {
           throw cet::exception("RUNINFO_DUPLICATE_TABLE")
-              << "RunInfo::dbTables3() found duplicate table key \""
-              << it.key() << "\" across run configs\n";
+              << "RunInfo::dbTables3() found duplicate table key \"" << it.key()
+              << "\" across run configs\n";
         }
         merged[it.key()] = it.value();
       }
@@ -65,6 +79,9 @@ std::string RunInfo::dbTables3(bool qjson) const {
   // Non-JSON: concatenate the per-config values, one per line.
   std::string result;
   for (auto const& config : _configs) {
+    if (excluded(config)) {
+      continue;
+    }
     std::string tables = config.dbTables3(qjson);
     if (!tables.empty()) {
       result += tables;

--- a/DbService/src/RunInfo.cc
+++ b/DbService/src/RunInfo.cc
@@ -39,6 +39,9 @@ std::string RunInfo::dbTables3(bool qjson) const {
   if (qjson) {
     nlohmann::json merged = nlohmann::json::object();
     for (auto const& config : _configs) {
+      if (config.subsystem() == "TRG" || config.subsystem() == "Gateway" || config.subsystem() == "CFO" || config.subsystem() == "DQM") {
+        continue;
+      }
       std::string tables = config.dbTables3(qjson);
       if (tables.empty()) {
         continue;

--- a/DbService/src/RunTool.cc
+++ b/DbService/src/RunTool.cc
@@ -6,10 +6,11 @@
 #include "Offline/GeneralUtilities/inc/splitString.hh"
 
 #include "cetlib_except/exception.h"
-#include "nlohmann/json.hpp"
 
 #include <algorithm>
 #include <iomanip>
+
+#include "nlohmann/json.hpp"
 
 using namespace mu2e;
 
@@ -23,6 +24,14 @@ RunTool::RunTool() {
 
 //**************************************************
 std::map<int, std::string> RunTool::flags(FlagType ftype) {
+  // Memoized -- see the cache members' comment in RunTool.hh for why.
+  if (ftype == FlagType::run && _runFlagsCached) {
+    return _runFlagsCache;
+  }
+  if (ftype == FlagType::transition && _transitionFlagsCached) {
+    return _transitionFlagsCache;
+  }
+
   std::map<int, std::string> flags;
   // run query url, answer returned in csv
   int rc;
@@ -55,6 +64,15 @@ std::map<int, std::string> RunTool::flags(FlagType ftype) {
                     sv[1]});  // Fallback to description if name not available
     }
   }
+
+  if (ftype == FlagType::run) {
+    _runFlagsCache = flags;
+    _runFlagsCached = true;
+  } else if (ftype == FlagType::transition) {
+    _transitionFlagsCache = flags;
+    _transitionFlagsCached = true;
+  }
+
   return flags;
 }
 

--- a/DbService/src/RunTool.cc
+++ b/DbService/src/RunTool.cc
@@ -6,6 +6,7 @@
 #include "Offline/GeneralUtilities/inc/splitString.hh"
 
 #include "cetlib_except/exception.h"
+#include "nlohmann/json.hpp"
 
 #include <algorithm>
 #include <iomanip>
@@ -55,6 +56,35 @@ std::map<int, std::string> RunTool::flags(FlagType ftype) {
     }
   }
   return flags;
+}
+
+//**************************************************
+// Both flag types as one JSON object: {"run_flags": [{"id":.., "name":..}, ..],
+// "transition_flags": [...]}. A single object, not an array -- this is a
+// fixed pair of categories, not a list of independent records (compare
+// runJson(), where an array is right because a run listing is a list).
+std::string RunTool::flagsJson() {
+  nlohmann::json out = nlohmann::json::object();
+
+  nlohmann::json runFlags = nlohmann::json::array();
+  for (auto const& pp : flags(FlagType::run)) {
+    nlohmann::json f = nlohmann::json::object();
+    f["id"] = pp.first;
+    f["name"] = pp.second;
+    runFlags.push_back(f);
+  }
+  out["run_flags"] = runFlags;
+
+  nlohmann::json transitionFlags = nlohmann::json::array();
+  for (auto const& pp : flags(FlagType::transition)) {
+    nlohmann::json f = nlohmann::json::object();
+    f["id"] = pp.first;
+    f["name"] = pp.second;
+    transitionFlags.push_back(f);
+  }
+  out["transition_flags"] = transitionFlags;
+
+  return out.dump(1, ' ');
 }
 
 //**************************************************
@@ -384,4 +414,70 @@ void RunTool::printRun(const RunInfo& info) {
     }
     tzset();
   }
+}
+
+//**************************************************
+// Same content as printRun, as a serialized JSON object. configs/
+// transitions/subruns are always present as arrays (empty if not fetched/
+// not present) rather than omitted, so a consumer can rely on a fixed
+// schema shape regardless of which of -c/-a/-s were passed -- unlike the
+// text format, which only prints a section when it's non-empty.
+//
+// Unlike printRun's text format, this decodes run type_name in addition to
+// transition type_name (printRun only decodes the latter) -- both are one
+// flags() lookup away, and a JSON consumer benefits from not having to
+// separately call -f and cross-reference run/transition type ids by hand.
+//
+// Subrun start/stop times are emitted as the raw Unix timestamps rather
+// than the fixed America/Chicago-localized strings printRun renders --
+// unambiguous for a machine reader, and avoids that function's global TZ
+// environment-variable save/set/restore dance entirely.
+std::string RunTool::runJson(const RunInfo& info) {
+  const RunRecord& runRecord = info.runRecord();
+
+  std::map<int, std::string> runTypes = flags(FlagType::run);
+  std::map<int, std::string> transitionTypes = flags(FlagType::transition);
+
+  nlohmann::json out = nlohmann::json::object();
+  out["run"] = runRecord.runNumber();
+  out["type_id"] = runRecord.runTypeId();
+  auto rit = runTypes.find(runRecord.runTypeId());
+  out["type_name"] = (rit != runTypes.end()) ? rit->second : "";
+  out["create_time"] = runRecord.createTime();
+
+  nlohmann::json configs = nlohmann::json::array();
+  for (auto const& config : info.configs()) {
+    nlohmann::json c = nlohmann::json::object();
+    c["subsystem"] = config.subsystem();
+    c["version"] = config.version();
+    c["create_time"] = config.createTime();
+    configs.push_back(c);
+  }
+  out["configs"] = configs;
+
+  nlohmann::json transitions = nlohmann::json::array();
+  for (auto const& trans : info.transitions()) {
+    nlohmann::json t = nlohmann::json::object();
+    t["type_id"] = trans.typeId();
+    auto tit = transitionTypes.find(trans.typeId());
+    t["type_name"] = (tit != transitionTypes.end()) ? tit->second : "";
+    t["transition_time"] = trans.transitionTime();
+    transitions.push_back(t);
+  }
+  out["transitions"] = transitions;
+
+  nlohmann::json subruns = nlohmann::json::array();
+  for (auto const& subrun : info.subruns()) {
+    nlohmann::json s = nlohmann::json::object();
+    s["subrun"] = subrun.subrunNumber();
+    s["events"] = subrun.nEvents();
+    s["min_ewt"] = subrun.minEwt();
+    s["max_ewt"] = subrun.maxEwt();
+    s["start_time_unix"] = subrun.startTimeUnix();
+    s["stop_time_unix"] = subrun.stopTimeUnix();
+    subruns.push_back(s);
+  }
+  out["subruns"] = subruns;
+
+  return out.dump(1, ' ');
 }

--- a/DbService/src/pywrap.i
+++ b/DbService/src/pywrap.i
@@ -9,6 +9,25 @@
 %include "std_map.i"
 %include "stdint.i"
 
+// Without this, any uncaught C++ exception (cet::exception and friends all
+// derive from std::exception) crossing back into Python from a wrapped call
+// aborts the interpreter instead of raising a catchable Python exception --
+// e.g. RunInfo::dbTables3()'s RUNINFO_DUPLICATE_TABLE throw on a duplicate
+// key. %exception here applies to every wrapped function/method in this
+// module, translating any such throw into a Python RuntimeError carrying the
+// original what() text.
+%include "exception.i"
+
+%exception {
+  try {
+    $action
+  } catch (const std::exception& e) {
+    SWIG_exception(SWIG_RuntimeError, e.what());
+  } catch (...) {
+    SWIG_exception(SWIG_UnknownError, "unknown C++ exception");
+  }
+}
+
 %apply const std::string& {std::string* foo};
 %template(vec_str) std::vector<std::string>;
 %template(map_int_str) std::map<int, std::string>;

--- a/DbService/src/runTool_main.cc
+++ b/DbService/src/runTool_main.cc
@@ -111,11 +111,26 @@ int main(int argc, char** argv) {
   // printed as formatted JSON; otherwise the values are printed one per line
   // for machine reading (no labels or adornment).
   if (dbtables) {
-    for (auto const& rr : runvec) {
-      std::string tables = rr.dbTables3(json);
-      if (!tables.empty()) {
-        std::cout << tables << "\n";
+    // RunInfo::dbTables3()/RunConfig::dbTables3() throw (RUNINFO_DUPLICATE_TABLE /
+    // RUNCONFIG_DUPLICATE_KEY) when a run's configs disagree on a table key --
+    // a rare user misconfiguration, but still a fatal condition: merging past
+    // it would silently drop data. Left uncaught, that throw escapes as an
+    // unhandled exception and aborts the process (core dump). Catch it here,
+    // narrowly, and report it the way every other error path in this tool
+    // does: a message on stderr and a non-zero exit, not a crash. Still fails
+    // fast on the first bad run in the selection, same as before -- dbtables
+    // isn't meant to be queried over many runs at once, so partial-result
+    // handling across runs isn't worth the complexity here.
+    try {
+      for (auto const& rr : runvec) {
+        std::string tables = rr.dbTables3(json);
+        if (!tables.empty()) {
+          std::cout << tables << "\n";
+        }
       }
+    } catch (std::exception const& e) {
+      std::cerr << e.what() << std::endl;
+      return 1;
     }
     return 0;
   }

--- a/DbService/src/runTool_main.cc
+++ b/DbService/src/runTool_main.cc
@@ -15,285 +15,328 @@
 using namespace mu2e;
 
 int main(int argc, char** argv) {
-  ParseCLI cli("Run database query tool");
+  // Single handler for the whole body: RunTool/RunInfo/RunConfig throw
+  // cet::exception on a range of conditions (DB unreachable, a run's configs
+  // disagreeing on a table key, malformed flag-table content, ...), and
+  // std::stoi below throws std::invalid_argument on non-numeric --last/--days
+  // input (e.g. a typo'd CLI arg). All derive from std::exception (verified
+  // directly, including nlohmann::json::parse_error), so one catch here
+  // covers every throw site in this file instead of the narrower per-branch
+  // handling this used to have -- left uncaught, any of them aborts the
+  // process with a core dump instead of a clean, parseable error.
+  try {
+    ParseCLI cli("Run database query tool");
 
-  // Add the global subcommand (no subcommands in this tool)
-  cli.addSubcommand("", "");
+    // Add the global subcommand (no subcommands in this tool)
+    cli.addSubcommand("", "");
 
-  // Add switches
-  cli.addSwitch("", "flags", "f", "flags", false,
-                "print run and transition types");
-  cli.addSwitch("", "run", "r", "run", true,
-                "run range (e.g., 100000 or 100000-101000)");
-  cli.addSwitch("", "last", "n", "last", true, "last N runs");
-  cli.addSwitch("", "type", "y", "type", true,
-                "comma-separated list of run types");
-  cli.addSwitch("", "time", "t", "time", true,
-                "time restriction (ISO8601 format)\n         since: "
-                "2026-06-05T18:38:20-05:00 or range: 2026-06-01/2026-06-05");
-  cli.addSwitch("", "days", "d", "days", true, "since N days ago to now");
-  cli.addSwitch("", "configs", "c", "configs", false,
-                "also print configuration records");
-  cli.addSwitch("", "transitions", "a", "transitions", false,
-                "also print transitions");
-  cli.addSwitch("", "subruns", "s", "subruns", false, "also print subruns");
-  cli.addSwitch("", "blob", "b", "blob", true,
-                "print formatted JSON blob for specified subsystem");
-  cli.addSwitch("", "dbtables", "q", "dbtables", false,
-                "print the cat 3 DbService tables");
-  cli.addSwitch("", "cidtables", "e", "cidtables", false,
-                "print the cat 2 DbService CID tables (cid name)");
-  cli.addSwitch("", "json", "j", "json", false,
-                "output content in JSON format");
+    // Add switches
+    cli.addSwitch("", "flags", "f", "flags", false,
+                  "print run and transition types");
+    cli.addSwitch("", "run", "r", "run", true,
+                  "run range (e.g., 100000 or 100000-101000)");
+    cli.addSwitch("", "last", "n", "last", true, "last N runs");
+    cli.addSwitch("", "type", "y", "type", true,
+                  "comma-separated list of run types");
+    cli.addSwitch("", "time", "t", "time", true,
+                  "time restriction (ISO8601 format)\n         since: "
+                  "2026-06-05T18:38:20-05:00 or range: 2026-06-01/2026-06-05");
+    cli.addSwitch("", "days", "d", "days", true, "since N days ago to now");
+    cli.addSwitch("", "configs", "c", "configs", false,
+                  "also print configuration records");
+    cli.addSwitch("", "transitions", "a", "transitions", false,
+                  "also print transitions");
+    cli.addSwitch("", "subruns", "s", "subruns", false, "also print subruns");
+    cli.addSwitch("", "blob", "b", "blob", true,
+                  "print formatted JSON blob for specified subsystem");
+    cli.addSwitch("", "dbtables", "q", "dbtables", false,
+                  "print the cat 3 DbService tables");
+    cli.addSwitch("", "cidtables", "e", "cidtables", false,
+                  "print the cat 2 DbService CID tables (cid name)");
+    cli.addSwitch("", "json", "j", "json", false,
+                  "output content in JSON format");
 
 
-  // Parse command line
-  int rc = cli.setArgs(argc, argv);
-  if (rc != 0) {
-    return rc;
-  }
+    // Parse command line
+    int rc = cli.setArgs(argc, argv);
+    if (rc != 0) {
+      return rc;
+    }
 
-  // Check for help (autohelp handles this, but we return after)
-  if (cli.getBool("", "help")) {
-    return 0;
-  }
-
-  RunTool tool;
-
-  // Handle flags request
-  if (cli.getBool("", "flags")) {
-    // JSON shaping lives on RunTool::flagsJson(), not here, so it's callable
-    // from the Python/SWIG binding too, not just this CLI -- see its comment.
-    if (cli.getBool("", "json")) {
-      std::cout << tool.flagsJson() << "\n";
+    // Check for help (autohelp handles this, but we return after)
+    if (cli.getBool("", "help")) {
       return 0;
     }
 
-    std::map<int, std::string> flags;
+    RunTool tool;
 
-    flags = tool.flags(RunTool::FlagType::run);
-    std::cout << "run flags:" << std::endl;
-    for (auto pp : flags) {
-      std::cout << std::setw(4) << pp.first << "  " << pp.second << std::endl;
+    // Handle flags request
+    if (cli.getBool("", "flags")) {
+      // JSON shaping lives on RunTool::flagsJson(), not here, so it's callable
+      // from the Python/SWIG binding too, not just this CLI -- see its comment.
+      if (cli.getBool("", "json")) {
+        std::cout << tool.flagsJson() << "\n";
+        return 0;
+      }
+
+      std::map<int, std::string> flags;
+
+      flags = tool.flags(RunTool::FlagType::run);
+      std::cout << "run flags:" << std::endl;
+      for (auto pp : flags) {
+        std::cout << std::setw(4) << pp.first << "  " << pp.second << std::endl;
+      }
+
+      flags = tool.flags(RunTool::FlagType::transition);
+      std::cout << "transition flags:" << std::endl;
+      for (auto pp : flags) {
+        std::cout << std::setw(4) << pp.first << "  " << pp.second << std::endl;
+      }
+
+      return 0;
     }
 
-    flags = tool.flags(RunTool::FlagType::transition);
-    std::cout << "transition flags:" << std::endl;
-    for (auto pp : flags) {
-      std::cout << std::setw(4) << pp.first << "  " << pp.second << std::endl;
-    }
+    // Build RunSelect from command line arguments
+    std::string run = cli.getString("", "run");
+    std::string last_str = cli.getString("", "last");
+    int last = last_str.empty() ? 0 : std::stoi(last_str);
+    std::string type = cli.getString("", "type");
+    std::string time = cli.getString("", "time");
+    std::string days_str = cli.getString("", "days");
+    int days = days_str.empty() ? 0 : std::stoi(days_str);
 
-    return 0;
-  }
+    RunSelect runsel(run, last, type, time, days);
 
-  // Build RunSelect from command line arguments
-  std::string run = cli.getString("", "run");
-  std::string last_str = cli.getString("", "last");
-  int last = last_str.empty() ? 0 : std::stoi(last_str);
-  std::string type = cli.getString("", "type");
-  std::string time = cli.getString("", "time");
-  std::string days_str = cli.getString("", "days");
-  int days = days_str.empty() ? 0 : std::stoi(days_str);
+    // Get print options
+    bool configs = cli.getBool("", "configs");
+    bool transitions = cli.getBool("", "transitions");
+    bool subruns = cli.getBool("", "subruns");
+    std::string blob_subsystem = cli.getString("", "blob");
+    bool dbtables = cli.getBool("", "dbtables");
+    bool cidtables = cli.getBool("", "cidtables");
+    bool json = cli.getBool("", "json");
 
-  RunSelect runsel(run, last, type, time, days);
-
-  // Get print options
-  bool configs = cli.getBool("", "configs");
-  bool transitions = cli.getBool("", "transitions");
-  bool subruns = cli.getBool("", "subruns");
-  std::string blob_subsystem = cli.getString("", "blob");
-  bool dbtables = cli.getBool("", "dbtables");
-  bool cidtables = cli.getBool("", "cidtables");
-  bool json = cli.getBool("", "json");
-
-  // If blob subsystem or dbtables is specified, we need to fetch configs
-  bool need_configs =
-      configs || !blob_subsystem.empty() || dbtables || cidtables;
+    // If blob subsystem or dbtables is specified, we need to fetch configs
+    bool need_configs =
+        configs || !blob_subsystem.empty() || dbtables || cidtables;
 
 
-  // Query and print runs
-  RunInfo::RunVec runvec =
-      tool.listRuns(runsel, need_configs, transitions, subruns);
+    // Query and print runs
+    RunInfo::RunVec runvec =
+        tool.listRuns(runsel, need_configs, transitions, subruns);
 
-  // Handle dbtables output: cat-3 DbService table values, collected across all
-  // configs of each run by RunInfo::dbTables3.  With -j the merged content is
-  // printed as formatted JSON; otherwise the values are printed one per line
-  // for machine reading (no labels or adornment).
-  if (dbtables) {
-    // RunInfo::dbTables3()/RunConfig::dbTables3() throw (RUNINFO_DUPLICATE_TABLE /
-    // RUNCONFIG_DUPLICATE_KEY) when a run's configs disagree on a table key --
-    // a rare user misconfiguration, but still a fatal condition: merging past
-    // it would silently drop data. Left uncaught, that throw escapes as an
-    // unhandled exception and aborts the process (core dump). Catch it here,
-    // narrowly, and report it the way every other error path in this tool
-    // does: a message on stderr and a non-zero exit, not a crash. Still fails
-    // fast on the first bad run in the selection, same as before -- dbtables
-    // isn't meant to be queried over many runs at once, so partial-result
-    // handling across runs isn't worth the complexity here.
-    try {
+    // Handle dbtables output: cat-3 DbService table values, collected across all
+    // configs of each run by RunInfo::dbTables3.  With -j the merged content is
+    // printed as formatted JSON; otherwise the values are printed one per line
+    // for machine reading (no labels or adornment).
+    if (dbtables) {
+      // dbTables3() output carries no per-run label, and in JSON mode is one
+      // dump() per run with no enclosing array -- concatenating more than
+      // one is not valid JSON (or, in text mode, an unlabeled jumble no
+      // reader could attribute back to a run). This is only meaningful for
+      // a single run, and that's enforced here rather than just assumed --
+      // a selection matching more than one run is rejected outright instead
+      // of silently emitting output nothing downstream can parse.
+      if (runvec.size() > 1) {
+        std::cerr << "ERROR - -q/--dbtables requires a selection matching "
+                     "exactly one run (matched "
+                  << runvec.size()
+                  << "); narrow with --run, --last 1, or a tighter "
+                     "--time/--days window.\n";
+        return 1;
+      }
+
+      // RunInfo::dbTables3()/RunConfig::dbTables3() throw
+      // (RUNINFO_DUPLICATE_TABLE / RUNCONFIG_DUPLICATE_KEY) when a run's
+      // configs disagree on a table key -- a rare user misconfiguration, but
+      // still a fatal condition: merging past it would silently drop data.
+      // Caught by the single handler around this whole function, same as
+      // every other error path here.
       for (auto const& rr : runvec) {
         std::string tables = rr.dbTables3(json);
         if (!tables.empty()) {
           std::cout << tables << "\n";
         }
       }
-    } catch (std::exception const& e) {
-      std::cerr << e.what() << std::endl;
-      return 1;
+      return 0;
     }
-    return 0;
-  }
 
-  // Handle cidtables output: cat-2 DbService CID table entries, collected by
-  // RunInfo::dbTables2 (which restricts to the "TRG" config that holds them).
-  // With -j the content is fetched in JSON format and printed as formatted
-  // JSON; otherwise it is printed as "cid name" one pair per line.
-  if (cidtables) {
-    for (auto const& rr : runvec) {
-      std::string tables = rr.dbTables2(json);
-      if (!tables.empty()) {
-        std::cout << tables << "\n";
+    // Handle cidtables output: cat-2 DbService CID table entries, collected by
+    // RunInfo::dbTables2 (which restricts to the "TRG" config that holds them).
+    // With -j the content is fetched in JSON format and printed as formatted
+    // JSON; otherwise it is printed as "cid name" one pair per line.
+    if (cidtables) {
+      // Same single-run constraint as dbtables above and for the same
+      // reason -- dbTables2() output carries no per-run label. Worth noting
+      // this isn't only a JSON-mode concern: "[]" (no TRG config, or none
+      // with CID entries) still counts as non-empty per the check below, so
+      // even the JSON array case can emit multiple concatenated documents.
+      if (runvec.size() > 1) {
+        std::cerr << "ERROR - -e/--cidtables requires a selection matching "
+                     "exactly one run (matched "
+                  << runvec.size()
+                  << "); narrow with --run, --last 1, or a tighter "
+                     "--time/--days window.\n";
+        return 1;
       }
+
+      for (auto const& rr : runvec) {
+        std::string tables = rr.dbTables2(json);
+        if (!tables.empty()) {
+          std::cout << tables << "\n";
+        }
+      }
+      return 0;
     }
-    return 0;
-  }
 
 
-  // Handle JSON blob output for specific subsystem
-  if (!blob_subsystem.empty()) {
-    // Two separate output paths, not a shared one -- see below for why.
-    nlohmann::json blobArr = nlohmann::json::array();  // used only when json
+    // Handle JSON blob output for specific subsystem
+    if (!blob_subsystem.empty()) {
+      // Two separate output paths, not a shared one -- see below for why.
+      nlohmann::json blobArr = nlohmann::json::array();  // used only when json
 
-    for (auto const& rr : runvec) {
-      if (!json) {
-        std::cout << "Run " << rr.runNumber() << ":\n";
-      }
-      bool found = false;
-      for (const auto& config : rr.configs()) {
-        if (config.subsystem() == blob_subsystem) {
-          found = true;
-          // Get the settings string (already cleaned in RunTool.cc)
-          std::string settings = config.settings();
+      for (auto const& rr : runvec) {
+        if (!json) {
+          std::cout << "Run " << rr.runNumber() << ":\n";
+        }
+        bool found = false;
+        for (const auto& config : rr.configs()) {
+          if (config.subsystem() == blob_subsystem) {
+            found = true;
+            // Get the settings string (already cleaned in RunTool.cc)
+            std::string settings = config.settings();
 
+            if (json) {
+              // settings is already valid JSON text (a jsonb column) -- parse
+              // and re-dump it through a real JSON library rather than the
+              // human-readable formatter below. That formatter intentionally
+              // unescapes \n into real newlines for readability, which is a
+              // deliberate choice for the human-facing default, but it means
+              // that output is NOT valid JSON (an unescaped control character
+              // inside a JSON string isn't legal) -- hence a genuinely
+              // separate path here rather than reusing/tweaking it.
+              nlohmann::json entry = nlohmann::json::object();
+              entry["run"] = rr.runNumber();
+              entry["subsystem"] = blob_subsystem;
+              entry["found"] = true;
+              // Non-throwing overload, matching how RunConfig::dbTables2/3()
+              // and RunInfo already parse this exact same settings column --
+              // empty/malformed content degrades to a discarded (null) value
+              // instead of an uncaught parse_error aborting the process (a
+              // real, reachable case: DbUtil::simplfyQeString() passes empty/
+              // single-character content through unvalidated).
+              nlohmann::json parsed =
+                  nlohmann::json::parse(settings, nullptr, false);
+              entry["settings"] = parsed.is_discarded() ? nlohmann::json(nullptr) : parsed;
+              blobArr.push_back(entry);
+              break;
+            }
+
+            // Replace literal \n with actual newlines
+            size_t pos = 0;
+            while ((pos = settings.find("\\n", pos)) != std::string::npos) {
+              settings.replace(pos, 2, "\n");
+              pos += 1;
+            }
+
+            // Simple JSON pretty-printing: add indentation after { [ and newlines
+            // after , ; :
+            std::string formatted;
+            int indent = 0;
+            bool in_string = false;
+            char prev_char = '\0';
+
+            for (size_t i = 0; i < settings.length(); ++i) {
+              char c = settings[i];
+
+              // Track if we're inside a string
+              if (c == '"' && prev_char != '\\') {
+                in_string = !in_string;
+              }
+
+              if (!in_string) {
+                // Add newline and indent after opening braces/brackets
+                if (c == '{' || c == '[') {
+                  formatted += c;
+                  formatted += '\n';
+                  indent += 2;
+                  formatted += std::string(indent, ' ');
+                  prev_char = c;
+                  continue;
+                }
+                // Add newline and unindent before closing braces/brackets
+                else if (c == '}' || c == ']') {
+                  formatted += '\n';
+                  indent -= 2;
+                  formatted += std::string(indent, ' ');
+                  formatted += c;
+                  prev_char = c;
+                  continue;
+                }
+                // Add newline and indent after commas
+                else if (c == ',') {
+                  formatted += c;
+                  formatted += '\n';
+                  formatted += std::string(indent, ' ');
+                  prev_char = c;
+                  continue;
+                }
+                // Skip extra whitespace
+                else if (c == ' ' && (prev_char == ',' || prev_char == '{' ||
+                                      prev_char == '[')) {
+                  continue;
+                }
+              }
+
+              formatted += c;
+              prev_char = c;
+            }
+
+            std::cout << formatted << "\n";
+            break;
+          }
+        }
+        if (!found) {
           if (json) {
-            // settings is already valid JSON text (a jsonb column) -- parse
-            // and re-dump it through a real JSON library rather than the
-            // human-readable formatter below. That formatter intentionally
-            // unescapes \n into real newlines for readability, which is a
-            // deliberate choice for the human-facing default, but it means
-            // that output is NOT valid JSON (an unescaped control character
-            // inside a JSON string isn't legal) -- hence a genuinely
-            // separate path here rather than reusing/tweaking it.
             nlohmann::json entry = nlohmann::json::object();
             entry["run"] = rr.runNumber();
             entry["subsystem"] = blob_subsystem;
-            entry["found"] = true;
-            entry["settings"] = nlohmann::json::parse(settings);
+            entry["found"] = false;
+            entry["settings"] = nullptr;
             blobArr.push_back(entry);
-            break;
+          } else {
+            std::cout << "  Subsystem '" << blob_subsystem
+                      << "' not found in configs\n";
           }
-
-          // Replace literal \n with actual newlines
-          size_t pos = 0;
-          while ((pos = settings.find("\\n", pos)) != std::string::npos) {
-            settings.replace(pos, 2, "\n");
-            pos += 1;
-          }
-
-          // Simple JSON pretty-printing: add indentation after { [ and newlines
-          // after , ; :
-          std::string formatted;
-          int indent = 0;
-          bool in_string = false;
-          char prev_char = '\0';
-
-          for (size_t i = 0; i < settings.length(); ++i) {
-            char c = settings[i];
-
-            // Track if we're inside a string
-            if (c == '"' && prev_char != '\\') {
-              in_string = !in_string;
-            }
-
-            if (!in_string) {
-              // Add newline and indent after opening braces/brackets
-              if (c == '{' || c == '[') {
-                formatted += c;
-                formatted += '\n';
-                indent += 2;
-                formatted += std::string(indent, ' ');
-                prev_char = c;
-                continue;
-              }
-              // Add newline and unindent before closing braces/brackets
-              else if (c == '}' || c == ']') {
-                formatted += '\n';
-                indent -= 2;
-                formatted += std::string(indent, ' ');
-                formatted += c;
-                prev_char = c;
-                continue;
-              }
-              // Add newline and indent after commas
-              else if (c == ',') {
-                formatted += c;
-                formatted += '\n';
-                formatted += std::string(indent, ' ');
-                prev_char = c;
-                continue;
-              }
-              // Skip extra whitespace
-              else if (c == ' ' && (prev_char == ',' || prev_char == '{' ||
-                                    prev_char == '[')) {
-                continue;
-              }
-            }
-
-            formatted += c;
-            prev_char = c;
-          }
-
-          std::cout << formatted << "\n";
-          break;
         }
       }
-      if (!found) {
-        if (json) {
-          nlohmann::json entry = nlohmann::json::object();
-          entry["run"] = rr.runNumber();
-          entry["subsystem"] = blob_subsystem;
-          entry["found"] = false;
-          entry["settings"] = nullptr;
-          blobArr.push_back(entry);
-        } else {
-          std::cout << "  Subsystem '" << blob_subsystem
-                    << "' not found in configs\n";
-        }
+
+      if (json) {
+        std::cout << blobArr.dump(1, ' ') << "\n";
+      }
+    } else if (json) {
+      // Normal run listing, JSON: one array of per-run objects.
+      // RunTool::runJson() returns std::string (not nlohmann::json -- see its
+      // own comment for why), so each run's JSON text is parsed back in here
+      // to assemble a single valid array, rather than concatenating one
+      // document per run the way -q/-e do (fine there since dbtables isn't
+      // meant to be queried as a list; not fine here, since a run listing
+      // routinely is).
+      nlohmann::json arr = nlohmann::json::array();
+      for (auto const& rr : runvec) {
+        arr.push_back(nlohmann::json::parse(tool.runJson(rr)));
+      }
+      std::cout << arr.dump(1, ' ') << "\n";
+    } else {
+      // Normal print
+      for (auto const& rr : runvec) {
+        tool.printRun(rr);
       }
     }
 
-    if (json) {
-      std::cout << blobArr.dump(1, ' ') << "\n";
-    }
-  } else if (json) {
-    // Normal run listing, JSON: one array of per-run objects.
-    // RunTool::runJson() returns std::string (not nlohmann::json -- see its
-    // own comment for why), so each run's JSON text is parsed back in here
-    // to assemble a single valid array, rather than concatenating one
-    // document per run the way -q/-e do (fine there since dbtables isn't
-    // meant to be queried as a list; not fine here, since a run listing
-    // routinely is).
-    nlohmann::json arr = nlohmann::json::array();
-    for (auto const& rr : runvec) {
-      arr.push_back(nlohmann::json::parse(tool.runJson(rr)));
-    }
-    std::cout << arr.dump(1, ' ') << "\n";
-  } else {
-    // Normal print
-    for (auto const& rr : runvec) {
-      tool.printRun(rr);
-    }
+    return 0;
+  } catch (std::exception const& e) {
+    std::cerr << e.what() << std::endl;
+    return 1;
   }
-
-  return 0;
 }

--- a/DbService/src/runTool_main.cc
+++ b/DbService/src/runTool_main.cc
@@ -7,6 +7,8 @@
 #include "Offline/DbService/inc/RunTool.hh"
 #include "Offline/GeneralUtilities/inc/ParseCLI.hh"
 
+#include "nlohmann/json.hpp"
+
 #include <iomanip>
 #include <iostream>
 
@@ -42,7 +44,7 @@ int main(int argc, char** argv) {
   cli.addSwitch("", "cidtables", "e", "cidtables", false,
                 "print the cat 2 DbService CID tables (cid name)");
   cli.addSwitch("", "json", "j", "json", false,
-                "with -q or -e, fetch content in JSON format");
+                "output content in JSON format");
 
 
   // Parse command line
@@ -60,6 +62,13 @@ int main(int argc, char** argv) {
 
   // Handle flags request
   if (cli.getBool("", "flags")) {
+    // JSON shaping lives on RunTool::flagsJson(), not here, so it's callable
+    // from the Python/SWIG binding too, not just this CLI -- see its comment.
+    if (cli.getBool("", "json")) {
+      std::cout << tool.flagsJson() << "\n";
+      return 0;
+    }
+
     std::map<int, std::string> flags;
 
     flags = tool.flags(RunTool::FlagType::run);
@@ -152,14 +161,37 @@ int main(int argc, char** argv) {
 
   // Handle JSON blob output for specific subsystem
   if (!blob_subsystem.empty()) {
+    // Two separate output paths, not a shared one -- see below for why.
+    nlohmann::json blobArr = nlohmann::json::array();  // used only when json
+
     for (auto const& rr : runvec) {
-      std::cout << "Run " << rr.runNumber() << ":\n";
+      if (!json) {
+        std::cout << "Run " << rr.runNumber() << ":\n";
+      }
       bool found = false;
       for (const auto& config : rr.configs()) {
         if (config.subsystem() == blob_subsystem) {
           found = true;
           // Get the settings string (already cleaned in RunTool.cc)
           std::string settings = config.settings();
+
+          if (json) {
+            // settings is already valid JSON text (a jsonb column) -- parse
+            // and re-dump it through a real JSON library rather than the
+            // human-readable formatter below. That formatter intentionally
+            // unescapes \n into real newlines for readability, which is a
+            // deliberate choice for the human-facing default, but it means
+            // that output is NOT valid JSON (an unescaped control character
+            // inside a JSON string isn't legal) -- hence a genuinely
+            // separate path here rather than reusing/tweaking it.
+            nlohmann::json entry = nlohmann::json::object();
+            entry["run"] = rr.runNumber();
+            entry["subsystem"] = blob_subsystem;
+            entry["found"] = true;
+            entry["settings"] = nlohmann::json::parse(settings);
+            blobArr.push_back(entry);
+            break;
+          }
 
           // Replace literal \n with actual newlines
           size_t pos = 0;
@@ -226,10 +258,36 @@ int main(int argc, char** argv) {
         }
       }
       if (!found) {
-        std::cout << "  Subsystem '" << blob_subsystem
-                  << "' not found in configs\n";
+        if (json) {
+          nlohmann::json entry = nlohmann::json::object();
+          entry["run"] = rr.runNumber();
+          entry["subsystem"] = blob_subsystem;
+          entry["found"] = false;
+          entry["settings"] = nullptr;
+          blobArr.push_back(entry);
+        } else {
+          std::cout << "  Subsystem '" << blob_subsystem
+                    << "' not found in configs\n";
+        }
       }
     }
+
+    if (json) {
+      std::cout << blobArr.dump(1, ' ') << "\n";
+    }
+  } else if (json) {
+    // Normal run listing, JSON: one array of per-run objects.
+    // RunTool::runJson() returns std::string (not nlohmann::json -- see its
+    // own comment for why), so each run's JSON text is parsed back in here
+    // to assemble a single valid array, rather than concatenating one
+    // document per run the way -q/-e do (fine there since dbtables isn't
+    // meant to be queried as a list; not fine here, since a run listing
+    // routinely is).
+    nlohmann::json arr = nlohmann::json::array();
+    for (auto const& rr : runvec) {
+      arr.push_back(nlohmann::json::parse(tool.runJson(rr)));
+    }
+    std::cout << arr.dump(1, ' ') << "\n";
   } else {
     // Normal print
     for (auto const& rr : runvec) {


### PR DESCRIPTION
- allow json output for all switches, preferred for agents
- gate dbtables3 to subdetector configs only
- put a catch in the main so that agents can parse a throw more easily
Merge is very low stakes - only occasional use exists anywhere. CI and Validation are not sensitive to changes
