### PR TITLE
Fix integer truncation in cosmic livetime resampling scale factor

### DIFF
--- a/EventMixing/src/Mu2eProductMixer.cc
+++ b/EventMixing/src/Mu2eProductMixer.cc
@@ -236,7 +236,7 @@ namespace mu2e {
     }
     if (mixCosmicLivetimes_) {
       if(generatedEvents_ == 0)throw cet::exception("BADINPUT")<<"Mu2eProductMixer: generated event count =0; was the mixin file opened correctly?" << std::endl;
-      float scaling = resampledEvents_ / generatedEvents_;
+      float scaling = static_cast<float>(resampledEvents_) / static_cast<float>(generatedEvents_);
       auto livetime = std::make_unique<CosmicLivetime>(totalPrimaries_ * scaling,
                                                        area_, lowE_, highE_, fluxConstant_, livetime_ * scaling);
       sr.put(std::move(livetime), subrunLivetimeInstanceName_, art::fullSubRun());


### PR DESCRIPTION
## Problem

`Mu2eProductMixer::endSubRun` computes the cosmic livetime scale factor with integer division:

```cpp
float scaling = resampledEvents_ / generatedEvents_;
```

`resampledEvents_` and `generatedEvents_` are both `unsigned int`, so the ratio is truncated to its floor **before** the float assignment. The resampled `CosmicLivetime` product (instance `mixed`, the only livetime product `S2Resampler.fcl` keeps) is scaled by that floored value.

Consequences, measured against `sim.mu2e.CosmicDSStopsCRYAll.MDC2025ab` (GenEventCount = 128,783/subrun, S1 livetime 29.586 s/subrun):

| dataset | events/job | true scaling | stored | livetime/subrun stored (true) |
|---|---|---|---|---|
| `dts.mu2e.CosmicCRYAll.Run1Ban` | 100,000 | 0.776 | **0** | **0 s** (22.97 s) |
| `dts.mu2e.CosmicCRYAll.MDC2025ap` | 500,000 | 3.882 | 3 | 88.76 s (114.9 s, −23%) |

Any S2 cosmic resampling with events/job below the mixin subrun's generated count stores **exactly zero** livetime; above it, livetime is understated by up to `1/floor(ratio)`. Present since c30db7ecd (2021).

## Fix

Cast before dividing:

```cpp
float scaling = static_cast<float>(resampledEvents_) / static_cast<float>(generatedEvents_);
```

One line; no interface change. Existing datasets can be corrected offline since the true scaling is recomputable from events/job and the S1 subrun GenEventCount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
