### PR TITLE
Trigger: fix wrong-histogram bins and audit findings from #1942

### DIFF
--- a/Trigger/CMakeLists.txt
+++ b/Trigger/CMakeLists.txt
@@ -20,13 +20,12 @@ cet_build_plugin(MergeTriggerInfo art::module
 cet_build_plugin(PrescaleEvent art::module
     REG_SOURCE src/PrescaleEvent_module.cc
     LIBRARIES REG
-      artdaq-core-mu2e::Data
+      Offline::DataProducts
 )
 
 cet_build_plugin(ReadTriggerInfo art::module
     REG_SOURCE src/ReadTriggerInfo_module.cc
     LIBRARIES REG
-      
       Offline::BFieldGeom
       Offline::DataProducts
       Offline::GeometryService
@@ -36,13 +35,11 @@ cet_build_plugin(ReadTriggerInfo art::module
       Offline::RecoDataProducts
       Offline::TrackerGeom
       KinKal::Trajectory
-
 )
 
 cet_build_plugin(ReadTriggerPath art::module
     REG_SOURCE src/ReadTriggerPath_module.cc
     LIBRARIES REG
-      
       Offline::MCDataProducts
       Offline::RecoDataProducts
       Offline::Mu2eUtilities

--- a/Trigger/fcl/read_trig_paths.fcl
+++ b/Trigger/fcl/read_trig_paths.fcl
@@ -6,7 +6,6 @@
 process_name : readTriggerPaths
 
 services : @local::Services.Reco
-services.GeometryService.bFieldFile : "Offline/Mu2eG4/geom/bfgeom_reco_v01.txt"
 source: { module_type: RootInput }
 services.TFileService.fileName : "nts.user.read_trig_paths.sequencer.root"
 
@@ -21,4 +20,5 @@ physics : {
     trigger_paths : [              ]
 }
 
+# NOTE: reaches into the Production repo, so this fcl needs Production on FHICL_FILE_PATH
 #include "Production/Validation/database.fcl"

--- a/Trigger/fcl/read_trig_paths.fcl
+++ b/Trigger/fcl/read_trig_paths.fcl
@@ -20,5 +20,4 @@ physics : {
     trigger_paths : [              ]
 }
 
-# NOTE: reaches into the Production repo, so this fcl needs Production on FHICL_FILE_PATH
 #include "Production/Validation/database.fcl"

--- a/Trigger/src/DigiFilter_module.cc
+++ b/Trigger/src/DigiFilter_module.cc
@@ -28,7 +28,7 @@ namespace mu2e
   public:
     explicit DigiFilter(fhicl::ParameterSet const& pset);
     virtual bool filter(art::Event& event) override;
-    virtual bool endRun( art::Run& run ) override;
+    virtual bool endRun( art::Run& ) override;
 
   private:
     art::InputTag   _sdTag;
@@ -119,7 +119,7 @@ namespace mu2e
     return retval;
   }
 
-  bool DigiFilter::endRun( art::Run& run ) {
+  bool DigiFilter::endRun( art::Run& ) {
     if(_debug > 0 && _nevt > 0){
       mf::LogInfo("DigiFilter") << moduleDescription().moduleLabel() << " passed " << _npass << " events out of "
                                 << _nevt << " for a ratio of " << float(_npass)/float(_nevt);

--- a/Trigger/src/DigiFilter_module.cc
+++ b/Trigger/src/DigiFilter_module.cc
@@ -15,11 +15,34 @@
 #include "Offline/RecoDataProducts/inc/CaloDigi.hh"
 // #include "RecoDataProducts/inc/TriggerInfo.hh"
 // c++
+#include <algorithm>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
 using namespace std;
+
+namespace {
+  //Sum over every CaloDigi of the pedestal-subtracted peak sample. The baseline recipe is
+  //the one CaloHitMakerFast uses (CaloReco/src/CaloHitMakerFast_module.cc:144-149), so the
+  //two modules agree on what a digi's amplitude is. CaloDigi carries no calibrated energy,
+  //only the raw waveform, so this sum is in ADC counts rather than MeV.
+  float totalCaloSignal(const mu2e::CaloDigiCollection& digis) {
+    float total(0.);
+    for(const auto& digi : digis) {
+      const std::vector<int>& waveform = digi.waveform();
+      const int peak = digi.peakpos();
+      if(peak < 0 || size_t(peak) >= waveform.size()) continue; //no usable peak sample
+      const int nSamPed = std::min<int>(peak > 3 ? 4 : std::max(peak-1, 1), waveform.size());
+      float baseline(0.);
+      for(int i = 0; i < nSamPed; ++i) baseline += waveform.at(i);
+      baseline /= float(nSamPed);
+      total += float(waveform.at(peak)) - baseline;
+    }
+    return total;
+  }
+}
 
 namespace mu2e
 {
@@ -41,7 +64,7 @@ namespace mu2e
     int             _maxnsd;  //maximum number of StrawDigi required
     int             _minncd;  //minimum number of CaloDigi required
     int             _maxncd;  //maximum number of CaloDigi required
-    float           _maxcaloE;//NOTE: read from fhicl but never applied by filter() below
+    float           _maxcaloE;//maximum summed CaloDigi amplitude; negative disables the cut
 
     int             _debug;
     // counters
@@ -76,6 +99,7 @@ namespace mu2e
     // find the collection
 
     int         nsd(0), ncd(0);
+    float       caloSignal(0.);
 
     if (_useSD){
       auto sdH = event.getValidHandle<StrawDigiCollection>(_sdTag);
@@ -85,6 +109,8 @@ namespace mu2e
     if (_useCD){
       auto cdH = event.getValidHandle<CaloDigiCollection>(_cdTag);
       ncd   = (int)cdH.product()->size();
+      //only pay for the waveform loop when the cut is enabled
+      if (_maxcaloE >= 0.) caloSignal = totalCaloSignal(*cdH.product());
     }
 
     if (_useSD) {
@@ -95,8 +121,11 @@ namespace mu2e
     }
 
     if (_useCD) {
+      //a negative maxCaloEnergy means the amplitude cut is switched off, which is what every
+      //configuration in mu2e-trig-config currently sets
       if ( (ncd >= _minncd) &&
-           (ncd <= _maxncd) ){
+           (ncd <= _maxncd) &&
+           (_maxcaloE < 0. || caloSignal <= _maxcaloE) ){
         retvalCD = true;
       }
     }

--- a/Trigger/src/DigiFilter_module.cc
+++ b/Trigger/src/DigiFilter_module.cc
@@ -7,6 +7,8 @@
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
 #include "fhiclcpp/ParameterSet.h"
+#include "cetlib_except/exception.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
 // mu2e
 // data
 #include "Offline/RecoDataProducts/inc/StrawDigi.hh"
@@ -39,7 +41,7 @@ namespace mu2e
     int             _maxnsd;  //maximum number of StrawDigi required
     int             _minncd;  //minimum number of CaloDigi required
     int             _maxncd;  //maximum number of CaloDigi required
-    float           _maxcaloE;//maximum energy, from the sum of all caloDigi
+    float           _maxcaloE;//NOTE: read from fhicl but never applied by filter() below
 
     int             _debug;
     // counters
@@ -59,28 +61,30 @@ namespace mu2e
     _maxcaloE (pset.get<float>("maxCaloEnergy")),
     _debug    (pset.get<int>("debugLevel",0)),
     _nevt(0), _npass(0)
-  {}
+  {
+    // With neither source selected every event is rejected, silently: retval below stays
+    // false. Make that a configuration error rather than an empty trigger path.
+    if(!_useSD && !_useCD) {
+      throw cet::exception("BADCONFIG") << "DigiFilter: neither useStrawDigi nor useCaloDigi is set, "
+                                        << "which rejects every event\n";
+    }
+  }
 
   bool DigiFilter::filter(art::Event& event){
     ++_nevt;
     bool retval(false), retvalSD(false), retvalCD(false); // preset to fail
     // find the collection
 
-    const StrawDigiCollection* sdcol(0);
-    const CaloDigiCollection*  cdcol(0);
-
     int         nsd(0), ncd(0);
 
     if (_useSD){
       auto sdH = event.getValidHandle<StrawDigiCollection>(_sdTag);
-      sdcol = sdH.product();
-      nsd   = (int)sdcol->size();
+      nsd   = (int)sdH.product()->size();
     }
 
     if (_useCD){
       auto cdH = event.getValidHandle<CaloDigiCollection>(_cdTag);
-      cdcol = cdH.product();
-      ncd   = (int)cdcol->size();
+      ncd   = (int)cdH.product()->size();
     }
 
     if (_useSD) {
@@ -109,7 +113,7 @@ namespace mu2e
       ++_npass;
 
       if(_debug > 1){
-        cout << moduleDescription().moduleLabel() << " passed event " << event.id() << endl;
+        mf::LogInfo("DigiFilter") << moduleDescription().moduleLabel() << " passed event " << event.id();
       }
     }
     return retval;
@@ -117,8 +121,10 @@ namespace mu2e
 
   bool DigiFilter::endRun( art::Run& run ) {
     if(_debug > 0 && _nevt > 0){
-      cout << moduleDescription().moduleLabel() << " passed " << _npass << " events out of " << _nevt << " for a ratio of " << float(_npass)/float(_nevt) << endl;
+      mf::LogInfo("DigiFilter") << moduleDescription().moduleLabel() << " passed " << _npass << " events out of "
+                                << _nevt << " for a ratio of " << float(_npass)/float(_nevt);
     }
+    _nevt = 0; _npass = 0; //reset for the next run, as MSDHitFilter does
     return true;
   }
 }

--- a/Trigger/src/EvalWeightedEventCounts_module.cc
+++ b/Trigger/src/EvalWeightedEventCounts_module.cc
@@ -42,29 +42,21 @@ public:
 
   using Parameters = art::EDAnalyzer::Table<Config>;
 
-  enum { kNOcc = 2, kNOccVar = 2 };
+  // one set of histograms, two variables in it
+  enum { kNOccVar = 2 };
 
   struct occupancyHist_ {
-    TH1F* _hOccInfo[kNOcc][kNOccVar];
-
-    occupancyHist_() {
-      for (int i = 0; i < kNOcc; ++i) {
-        for (int j = 0; j < kNOccVar; ++j) {
-          _hOccInfo[i][j] = NULL;
-        }
-      }
-    }
+    TH1F* _hOccInfo[kNOccVar] = {nullptr, nullptr};
   };
 
   explicit EvalWeightedEventCounts(const Parameters& config);
   virtual ~EvalWeightedEventCounts() {}
 
-  virtual void beginJob();
-  virtual void endJob();
+  void beginJob() override;
+  void endJob() override;
 
   // This is called for each event.
-  virtual void analyze(const art::Event& e);
-  virtual void beginRun(const art::Run& run);
+  void analyze(const art::Event& e) override;
 
   void bookHistograms();
   void bookOccupancyInfoHist(art::ServiceHandle<art::TFileService>& Tfs, occupancyHist_& Hist);
@@ -74,7 +66,6 @@ private:
   art::InputTag _evtWeightTag;
 
   std::string _tagName;
-  double _nPOT;
 
   occupancyHist_ _occupancyHist;
 
@@ -96,14 +87,13 @@ void EvalWeightedEventCounts::bookHistograms() {
 void EvalWeightedEventCounts::bookOccupancyInfoHist(art::ServiceHandle<art::TFileService>& Tfs,
                                                     occupancyHist_& Hist) {
 
-  int index_last = 0;
   art::TFileDirectory occInfoDir = Tfs->mkdir("occInfoGeneral");
-  Hist._hOccInfo[index_last][0] =
-      occInfoDir.make<TH1F>(Form("hInstLum_%i", index_last),
-                            "distrbution of instantaneous lum; p/pulse", 1000, _minPOT, _maxPOT);
-  Hist._hOccInfo[index_last][1] =
-      occInfoDir.make<TH1F>(Form("hInstLum2B_%i", index_last),
-                            "distrbution of instantaneous lum re-weighted in 2 batch-mode; p/pulse",
+  Hist._hOccInfo[0] =
+      occInfoDir.make<TH1F>("hInstLum_0",
+                            "distribution of instantaneous lum; p/pulse", 1000, _minPOT, _maxPOT);
+  Hist._hOccInfo[1] =
+      occInfoDir.make<TH1F>("hInstLum2B_0",
+                            "distribution of instantaneous lum re-weighted in 2 batch-mode; p/pulse",
                             1000, _minPOT, _maxPOT);
 }
 
@@ -114,24 +104,12 @@ void EvalWeightedEventCounts::beginJob() { bookHistograms(); }
 void EvalWeightedEventCounts::endJob() {
 
   //    evalTriggerRate();  Tag names must be specified in the fcl
-  printf("[%s::enJob] totWg    = %10.3e\n", _tagName.c_str(), _wgSum[0]);
-  printf("[%s::enJob] totEvtB1 = %10.3f\n", _tagName.c_str(), _wgSum[1]);
-  printf("[%s::enJob] totEvtB2 = %10.3f\n", _tagName.c_str(), _wgSum[2]);
+  printf("[%s::endJob] totWg    = %10.3e\n", _tagName.c_str(), _wgSum[0]);
+  printf("[%s::endJob] totEvtB1 = %10.3f\n", _tagName.c_str(), _wgSum[1]);
+  printf("[%s::endJob] totEvtB2 = %10.3f\n", _tagName.c_str(), _wgSum[2]);
 }
 
 //--------------------------------------------------------------------------------
-
-//================================================================
-void EvalWeightedEventCounts::beginRun(const art::Run& run) {
-  // get bfield
-  // GeomHandle<BFieldManager> bfmgr;
-  // GeomHandle<DetectorSystem> det;
-  // CLHEP::Hep3Vector vpoint_mu2e = det->toMu2e(CLHEP::Hep3Vector(0.0,0.0,0.0));
-  // _bz0 = bfmgr->getBField(vpoint_mu2e).z();
-
-  // mu2e::GeomHandle<mu2e::Tracker> th;
-  // _tracker  = th.get();
-}
 
 //--------------------------------------------------------------------------------
 void EvalWeightedEventCounts::analyze(const art::Event& event) {
@@ -160,7 +138,7 @@ void EvalWeightedEventCounts::analyze(const art::Event& event) {
 
   double p1 = lumi * xlognorm_norm_b1 * cut_off_norm_b1;
   _wgSum[1] += p1;
-  _occupancyHist._hOccInfo[0][0]->Fill(lumi, p1);
+  _occupancyHist._hOccInfo[0]->Fill(lumi, p1);
 
   double p2 = lumi * xlognorm_norm_b2 * cut_off_norm_b2;
   double oneBatchWg = ROOT::Math::lognormal_pdf(lumi, mub1, sigma) / cut_off_norm_b1;
@@ -168,7 +146,7 @@ void EvalWeightedEventCounts::analyze(const art::Event& event) {
 
   p2 *= twoBatchWg / oneBatchWg; // sample generated using one batch mode
 
-  _occupancyHist._hOccInfo[0][1]->Fill(lumi, p2);
+  _occupancyHist._hOccInfo[1]->Fill(lumi, p2);
   _wgSum[2] += p2;
 }
 

--- a/Trigger/src/MSDHitFilter_module.cc
+++ b/Trigger/src/MSDHitFilter_module.cc
@@ -38,7 +38,7 @@ namespace mu2e {
 
   private:
     bool filter  (art::Event& event) override;
-    bool endRun  (art::Run&   run  ) override;
+    bool endRun  (art::Run&        ) override;
     static bool goodHit (const MSDHit& hit); //uses no member data
 
     // Inputs
@@ -87,7 +87,7 @@ namespace mu2e {
   }
 
   //-----------------------------------------------------------------------------
-  bool MSDHitFilter::endRun(art::Run& run) {
+  bool MSDHitFilter::endRun(art::Run&) {
     // Print a summary of the filter results
     const float rate = (_nevt > 0) ? float(_npass)/float(_nevt) : 0.f;
     TLOG(TLVL_DEBUG + 2) << "passed " << _npass << " events out of " << _nevt << " for a ratio of " << rate;

--- a/Trigger/src/MSDHitFilter_module.cc
+++ b/Trigger/src/MSDHitFilter_module.cc
@@ -7,7 +7,7 @@
 #include "art/Framework/Core/EDFilter.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
-#include "fhiclcpp/ParameterSet.h"
+#include "canvas/Utilities/InputTag.h"
 
 // Offline
 #include "Offline/RecoDataProducts/inc/MSDHit.hh"
@@ -27,7 +27,7 @@ namespace mu2e {
     struct Config {
       using Name    = fhicl::Name;
       using Comment = fhicl::Comment;
-      fhicl::Atom<std::string>  tag    {Name("tag")    , Comment("Collection tag")};
+      fhicl::Atom<art::InputTag> tag   {Name("tag")    , Comment("Collection tag")};
       fhicl::Atom<int>          minHits{Name("minHits"), Comment("Minimum number of hits")};
     };
 
@@ -39,14 +39,14 @@ namespace mu2e {
   private:
     bool filter  (art::Event& event) override;
     bool endRun  (art::Run&   run  ) override;
-    bool goodHit (const MSDHit& hit);
+    static bool goodHit (const MSDHit& hit); //uses no member data
 
     // Inputs
-    std::string              _tag;
+    art::InputTag            _tag;
     int                      _minHits = -1;
 
     // Data
-    unsigned long            _nevt, _npass;
+    unsigned long            _nevt = 0, _npass = 0;
 
   };
 
@@ -73,15 +73,12 @@ namespace mu2e {
     // Count total events seen
     ++_nevt;
 
-    // Filter flag
-    bool passed = true;
-
     auto handle = event.getValidHandle<MSDHitCollection>(_tag);
     const auto hits = handle.product();
     int naccepted = 0;
     for(const auto& hit : *hits) if(goodHit(hit)) ++naccepted;
 
-    passed &= naccepted >= _minHits;
+    const bool passed = naccepted >= _minHits;
 
     if (passed) ++_npass;
 

--- a/Trigger/src/MergeTriggerInfo_module.cc
+++ b/Trigger/src/MergeTriggerInfo_module.cc
@@ -21,7 +21,6 @@
 #include <vector>
 #include <memory>
 #include <iostream>
-#include <forward_list>
 #include <string>
 
 
@@ -32,7 +31,7 @@ namespace mu2e {
     using  Comment = fhicl::Comment;
     struct Config {
       fhicl::Atom<int> debug     { Name("debugLevel"), Comment("Debug Level"), 0};
-      fhicl::Atom<int> doDeepCopy{ Name("doDeepCopy"), Comment("Produce cloned object collections"), 0};
+      fhicl::Atom<bool> doDeepCopy{ Name("doDeepCopy"), Comment("Produce cloned object collections"), false};
     };
 
     using        Parameters = art::EDProducer::Table<Config>;
@@ -40,7 +39,7 @@ namespace mu2e {
     void         produce(art::Event& evt) override;
   private:
     int          _debug;
-    int          _doDeepCopy;
+    bool         _doDeepCopy;
   };
 
   MergeTriggerInfo::MergeTriggerInfo(const Parameters& config) :
@@ -49,7 +48,7 @@ namespace mu2e {
     _doDeepCopy(config().doDeepCopy())
   {
     produces<TriggerInfoCollection>();
-    if (_doDeepCopy == 1){
+    if (_doDeepCopy){
       produces<KalSeedCollection        >();
       produces<HelixSeedCollection      >();
       produces<TimeClusterCollection    >();
@@ -71,15 +70,15 @@ namespace mu2e {
     std::vector<art::Handle<TriggerInfo> > list_of_triggerInfo = event.getMany<TriggerInfo>();
 
     if(_debug > 0){
-      std::cout << "["<<moduleDescription().moduleLabel() << "] number of TriggerInfo found in the is: "<< list_of_triggerInfo.size() << std::endl;
+      std::cout << "["<<moduleDescription().moduleLabel() << "] number of TriggerInfo found: "<< list_of_triggerInfo.size() << std::endl;
     }
 
     for (auto & trigInfoH: list_of_triggerInfo){
-      TriggerInfo trigInfo(*trigInfoH.product());
+      const TriggerInfo& trigInfo(*trigInfoH.product());
       if(_debug > 0){
         std::cout << "["<<moduleDescription().moduleLabel() << "] helices, tracks: "<< trigInfo.tracks().size() << " " << trigInfo.helixes().size() << std::endl;
       }
-      if (_doDeepCopy == 1){
+      if (_doDeepCopy){
         for(auto ptr : trigInfo.tracks       ()) ksCol->push_back(*(ptr.get()));
         for(auto ptr : trigInfo.helixes      ()) hsCol->push_back(*(ptr.get()));
         for(auto ptr : trigInfo.hitClusters  ()) tcCol->push_back(*(ptr.get()));
@@ -91,7 +90,7 @@ namespace mu2e {
     }
 
     event.put(std::move(tiCol));
-    if (_doDeepCopy == 1){
+    if (_doDeepCopy){
       event.put(std::move(ksCol));
       event.put(std::move(hsCol));
       event.put(std::move(tcCol));

--- a/Trigger/src/PrescaleEvent_module.cc
+++ b/Trigger/src/PrescaleEvent_module.cc
@@ -19,7 +19,6 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "Offline/DataProducts/inc/EventWindowMarker.hh"
 #include "Offline/DataProducts/inc/PrescaleFilterFraction.hh"
-#include "artdaq-core-mu2e/Data/EventHeader.hh"
 
 #include <memory>
 #include <iostream>
@@ -36,7 +35,7 @@ namespace mu2e
     using  Comment = fhicl::Comment;
 
     struct EventModeConfig {
-      fhicl::Atom<std::string>   eventMode{ Name("eventMode"), Comment("EventMode: OnSpill, OffSpill, Calib, ...")};
+      fhicl::Atom<std::string>   eventMode{ Name("eventMode"), Comment("EventMode: OnSpill or OffSpill")};
       fhicl::Atom<int>           prescale { Name("prescale") , Comment("Prescale factor")};
     };
 
@@ -45,7 +44,7 @@ namespace mu2e
       uint32_t prescale_;
       std::string name_;
       EventMode(EventWindowMarker::SpillType type, int prescale, std::string const& name ) : type_(type),
-      prescale_(static_cast<uint32_t>(std::max(0,prescale))), name_(name) {}
+      prescale_(static_cast<uint32_t>(prescale)), name_(name) {}
     };
 
     struct Config {
@@ -86,11 +85,14 @@ namespace mu2e
       if(mode.eventMode() == "OffSpill") eventMode_.push_back(EventMode(EventWindowMarker::offspill, mode.prescale(),mode.eventMode()));
       else if(mode.eventMode() == "OnSpill") eventMode_.push_back(EventMode(EventWindowMarker::onspill, mode.prescale(),mode.eventMode()));
       else throw cet::exception("TRIGGER") << "Unknown prescale mode " << mode.eventMode();
+      if(mode.prescale() < 1) throw cet::exception("TRIGGER") << "Prescale factor for mode " << mode.eventMode()
+                                                              << " is " << mode.prescale() << "; it must be >= 1, "
+                                                              << "since 0 rejects every event";
       produces<mu2e::PrescaleFilterFraction,art::InSubRun>(mode.eventMode());
     }
   }
 
-  inline bool PrescaleEvent::filter(art::Event & e)
+  bool PrescaleEvent::filter(art::Event & e)
   {
     // Check for the prescale corresponding to the current event mode
     auto ewmH = e.getValidHandle(ewmtoken_);
@@ -101,7 +103,7 @@ namespace mu2e
       if (spillType == ewm.spillType()){
         ++nevt_[imode];
     // Apply the prescale
-        bool retval = mode.prescale_ > 0 ? e.event() % mode.prescale_ == 0 : false;
+        bool retval = e.event() % mode.prescale_ == 0; //prescale_ >= 1 is enforced in the constructor
         if (retval) ++npass_[imode];
         return retval;
       }
@@ -116,10 +118,11 @@ namespace mu2e
       auto ff = std::make_unique<PrescaleFilterFraction>(mode.prescale_, nevt_[imode],npass_[imode]);
       subrun.put(std::move(ff),mode.name_,art::fullSubRun());
       if(debug_ > 0){
-        double frac = mode.prescale_ > 0 ? 1.0/double(mode.prescale_) : 0.0;
-        std::cout << moduleDescription().moduleLabel() << " mode " << mode.name_ << " passed " << npass_[imode] << " events out of " << nevt_[imode]
-          << " for a ratio of " << ((nevt_[imode] > 0) ? double(npass_[imode])/double(nevt_[imode]) : 0.f)
-          << " with an expected fraction of " << frac  << std::endl;
+        const double frac = 1.0/double(mode.prescale_);
+        mf::LogInfo("PrescaleEvent") << moduleDescription().moduleLabel() << " mode " << mode.name_ << " passed " << npass_[imode]
+                                     << " events out of " << nevt_[imode]
+                                     << " for a ratio of " << ((nevt_[imode] > 0) ? double(npass_[imode])/double(nevt_[imode]) : 0.)
+                                     << " with an expected fraction of " << frac;
        }
       // reset
       npass_[imode] = 0; nevt_[imode] = 0;

--- a/Trigger/src/PrescaleEvent_module.cc
+++ b/Trigger/src/PrescaleEvent_module.cc
@@ -39,12 +39,15 @@ namespace mu2e
       fhicl::Atom<int>           prescale { Name("prescale") , Comment("Prescale factor")};
     };
 
+    //A prescale of zero or less means the mode is disabled and rejects every event.
+    //mu2e-trig-config sets prescale:-1 on the paths that are turned off, so this is a
+    //configured state rather than a bad configuration; it is normalized to 0 here.
     struct EventMode {
       EventWindowMarker::SpillType type_;
       uint32_t prescale_;
       std::string name_;
       EventMode(EventWindowMarker::SpillType type, int prescale, std::string const& name ) : type_(type),
-      prescale_(static_cast<uint32_t>(prescale)), name_(name) {}
+      prescale_(prescale > 0 ? static_cast<uint32_t>(prescale) : 0u), name_(name) {}
     };
 
     struct Config {
@@ -85,9 +88,6 @@ namespace mu2e
       if(mode.eventMode() == "OffSpill") eventMode_.push_back(EventMode(EventWindowMarker::offspill, mode.prescale(),mode.eventMode()));
       else if(mode.eventMode() == "OnSpill") eventMode_.push_back(EventMode(EventWindowMarker::onspill, mode.prescale(),mode.eventMode()));
       else throw cet::exception("TRIGGER") << "Unknown prescale mode " << mode.eventMode();
-      if(mode.prescale() < 1) throw cet::exception("TRIGGER") << "Prescale factor for mode " << mode.eventMode()
-                                                              << " is " << mode.prescale() << "; it must be >= 1, "
-                                                              << "since 0 rejects every event";
       produces<mu2e::PrescaleFilterFraction,art::InSubRun>(mode.eventMode());
     }
   }
@@ -103,7 +103,7 @@ namespace mu2e
       if (spillType == ewm.spillType()){
         ++nevt_[imode];
     // Apply the prescale
-        bool retval = e.event() % mode.prescale_ == 0; //prescale_ >= 1 is enforced in the constructor
+        bool retval = mode.prescale_ > 0 ? e.event() % mode.prescale_ == 0 : false;
         if (retval) ++npass_[imode];
         return retval;
       }
@@ -118,7 +118,7 @@ namespace mu2e
       auto ff = std::make_unique<PrescaleFilterFraction>(mode.prescale_, nevt_[imode],npass_[imode]);
       subrun.put(std::move(ff),mode.name_,art::fullSubRun());
       if(debug_ > 0){
-        const double frac = 1.0/double(mode.prescale_);
+        const double frac = mode.prescale_ > 0 ? 1.0/double(mode.prescale_) : 0.0;
         mf::LogInfo("PrescaleEvent") << moduleDescription().moduleLabel() << " mode " << mode.name_ << " passed " << npass_[imode]
                                      << " events out of " << nevt_[imode]
                                      << " for a ratio of " << ((nevt_[imode] > 0) ? double(npass_[imode])/double(nevt_[imode]) : 0.)

--- a/Trigger/src/ReadTriggerInfo_module.cc
+++ b/Trigger/src/ReadTriggerInfo_module.cc
@@ -199,7 +199,7 @@ namespace mu2e {
 
     virtual void beginJob();
     virtual void endJob();
-    virtual void beginRun(const art::Run & run);
+    virtual void beginRun(const art::Run &);
     virtual void beginSubRun(const art::SubRun& sr);
 
     // This is called for each event.
@@ -743,7 +743,7 @@ namespace mu2e {
   }
 
   //--------------------------------------------------------------------------------//
-  void ReadTriggerInfo::beginRun(const art::Run & run) {
+  void ReadTriggerInfo::beginRun(const art::Run &) {
     // get bfield
     GeomHandle<BFieldManager> bfmgr;
     GeomHandle<DetectorSystem> det;

--- a/Trigger/src/ReadTriggerInfo_module.cc
+++ b/Trigger/src/ReadTriggerInfo_module.cc
@@ -32,8 +32,6 @@
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
-#include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
-#include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 
 //Data products
 #include "Offline/RecoDataProducts/inc/CaloCluster.hh"
@@ -190,11 +188,9 @@ namespace mu2e {
       fhicl::Atom<size_t>            nCaloTrig          {Name("nCaloTriggers"      ), Comment("Number of calorimeter triggers"            )  };
       fhicl::Atom<size_t>            nCaloCalibTrig     {Name("nCaloCalibTriggers" ), Comment("Number of calorimeter calibration triggers")  };
       fhicl::Atom<art::InputTag>     sdTag              {Name("strawDigiCollection"), Comment("makeSD"                                    ), "makeSD"  };
-      fhicl::Atom<art::InputTag>     chTag              {Name("comboHitCollection" ), Comment("TTmakeSH"                                  ), "TTmakeSH"};
       fhicl::Atom<art::InputTag>     cdTag              {Name("caloDigiCollection" ), Comment("CaloDigiFromShower"                        ), "CaloDigiFromShower"  };
       fhicl::Atom<art::InputTag>     genCountTag        {Name("genCount"           ), Comment("GenEventCount label"                       ), "genCounter" };
       fhicl::Atom<art::InputTag>     PBITag             {Name("PBITag"             ), Comment("ProtonBunchIntensity label"                ), "PBISim" };
-      fhicl::Atom<float>             duty_cycle         {Name("dutyCycle"          ), Comment("Duty cycle"                                ), 0.3};
       fhicl::Atom<string>            processName        {Name("processName"        ), Comment("globalTrigger"                             ), ""  };
     };
 
@@ -238,18 +234,15 @@ namespace mu2e {
     int                       _nCaloTrig;
     int                       _nCaloCalibTrig;
     std::vector<std::string>  _trigPaths;
-    art::InputTag             _trigAlgTag;
     art::InputTag             _sdTag;
-    art::InputTag             _chTag;
     art::InputTag             _cdTag;
     art::InputTag             _genCountTag;
     art::InputTag             _PBITag;
 
-    double                    _duty_cycle;
     string                    _processName;
     int                       _nProcess;
-    double                    _bz0;
-    double                    _nPOT;
+    double                    _bz0   = 0.;
+    double                    _nPOT  = 0.;
 
     std::vector<trigInfo_>    _trigAll;
     std::vector<trigInfo_>    _trigFinal;
@@ -266,16 +259,12 @@ namespace mu2e {
     caloCalibrationHist_      _caloCalibHist;
     occupancyHist_            _occupancyHist;
 
-    const mu2e::Tracker*      _tracker;
-    const mu2e::ComboHitCollection*    _chcol;
-    const art::Event*                  _event;
-    const mu2e::HelixSeedCollection*   _hsCprCol;
-    const mu2e::HelixSeedCollection*   _hsTprCol;
+    const mu2e::Tracker*      _tracker = nullptr;
 
     float  _minPOT, _maxPOT;
     const int _genOccIndex;
 
-    bool _useNGen; //use gen event count for normalization if available
+    bool _useNGen = false; //use gen event count for normalization if available
   };
 
   ReadTriggerInfo::ReadTriggerInfo(const art::EDAnalyzer::Table<Config>& config):
@@ -286,11 +275,9 @@ namespace mu2e {
     _nCaloTrig           (config() .nCaloTrig()      ),
     _nCaloCalibTrig      (config() .nCaloCalibTrig() ),
     _sdTag               (config() .sdTag()          ),
-    _chTag               (config() .chTag()          ),
     _cdTag               (config() .cdTag()          ),
     _genCountTag         (config() .genCountTag()    ),
     _PBITag              (config() .PBITag()         ),
-    _duty_cycle          (config() .duty_cycle()     ),
     _processName         (config() .processName()    ),
     _nProcess            (0                          ),
     _minPOT              (0.                         ),
@@ -359,8 +346,10 @@ namespace mu2e {
 
     art::TFileDirectory trigBDWDir = Tfs->mkdir("trigBDW");
 
-    Hist._hTrigBDW[0] = trigBDWDir.make<TH1F>("hTrigBDW_global"    , "Trigger bandwidth; ; rate [Hz]"                   , (_nMaxTrig+2), -0.5, (_nMaxTrig+1.5));
-    Hist._hTrigBDW[1] = trigBDWDir.make<TH1F>("hTrigBDW_cumulative", "Cumulative Trigger bandwidth; ; rate [Hz]"        , (_nMaxTrig+2), -0.5, (_nMaxTrig+1.5));
+    // NOTE: these hold the accepted-event fraction, not a rate. Converting to Hz needs the
+    // microbunch period and the duty cycle; until that is restored the axis says what is there.
+    Hist._hTrigBDW[0] = trigBDWDir.make<TH1F>("hTrigBDW_global"    , "Trigger bandwidth; ; accepted fraction"           , (_nMaxTrig+2), -0.5, (_nMaxTrig+1.5));
+    Hist._hTrigBDW[1] = trigBDWDir.make<TH1F>("hTrigBDW_cumulative", "Cumulative Trigger bandwidth; ; accepted fraction", (_nMaxTrig+2), -0.5, (_nMaxTrig+1.5));
 
   }
   //--------------------------------------------------------------------------------//
@@ -496,6 +485,10 @@ namespace mu2e {
     if(_nTrackTrig > kNTrackTrig) throw cet::exception("BADCONFIG") << "Number of track triggers assumed " << _nTrackTrig << " is greater than the maximum " << kNTrackTrig << "\n";
     if(_nCaloTrig > kNCaloOnly) throw cet::exception("BADCONFIG") << "Number of calo-only triggers assumed " << _nCaloTrig << " is greater than the maximum " << kNCaloOnly << "\n";
     if(_nCaloCalibTrig > kNCaloCalib) throw cet::exception("BADCONFIG") << "Number of calo calibration triggers assumed " << _nCaloCalibTrig << " is greater than the maximum " << kNCaloCalib << "\n";
+    if(_genOccIndex >= kNOcc) throw cet::exception("BADCONFIG") << "Occupancy index 2*nTrackTriggers + nCaloTriggers = " << _genOccIndex << " is greater than the maximum " << kNOcc-1 << "\n";
+    if(size_t(_nTrackTrig) > _nMaxTrig || size_t(_nCaloTrig) > _nMaxTrig || size_t(_nCaloCalibTrig) > _nMaxTrig)
+      throw cet::exception("BADCONFIG") << "nPathIDs (" << _nMaxTrig << ") must be at least as large as each per-type trigger count; "
+                                        << "the per-path label vectors are sized from it\n";
 
     // Initialize the output histograms
     bookHistograms();
@@ -504,7 +497,9 @@ namespace mu2e {
   //--------------------------------------------------------------------------------//
   void ReadTriggerInfo::endJob() {
     if(_nProcess <= 0) {
-      if(_diagLevel > 0) printf("[ReadTriggerInfo::%s] Setting N(processed) from %i to 1\n", __func__, _nProcess);
+      // _nProcess is the denominator of every efficiency and rejection below
+      mf::LogWarning("ReadTriggerInfo") << "N(processed) is " << _nProcess
+                                        << "; normalising to 1, so every efficiency below is a raw count";
       _nProcess = 1;
     }
 
@@ -550,13 +545,14 @@ namespace mu2e {
     //helix
     if(_diagLevel > 2) printf("[ReadTriggerInfo::%s] Setting helix occupancy histogram titles\n", __func__);
     for (int i=_nTrackTrig; i<_nTrackTrig*2; ++i) {
+      const auto& label = _trigHelix[i-_nTrackTrig].label;
       for (int j=0; j<kNOccVar; ++j) {
         if (_occupancyHist._hOccInfo[i][j] != nullptr)    {
-          std::string title = _trigHelix[i].label +": "+ _occupancyHist._hOccInfo[i][j]->GetTitle();
+          std::string title = label +": "+ _occupancyHist._hOccInfo[i][j]->GetTitle();
           _occupancyHist._hOccInfo[i][j]->SetTitle(title.c_str());
         }
         if (_occupancyHist._h2DOccInfo[i][j] != nullptr)    {
-          std::string title = _trigHelix[i].label +": "+ _occupancyHist._h2DOccInfo[i][j]->GetTitle();
+          std::string title = label +": "+ _occupancyHist._h2DOccInfo[i][j]->GetTitle();
           _occupancyHist._h2DOccInfo[i][j]->SetTitle(title.c_str());
         }
       }
@@ -564,13 +560,14 @@ namespace mu2e {
     //calo trig
     if(_diagLevel > 2) printf("[ReadTriggerInfo::%s] Setting calo histogram titles\n", __func__);
     for (int i=_nTrackTrig*2; i<_nTrackTrig*2+_nCaloTrig; ++i) {
+      const auto& label = _trigCaloOnly[i-_nTrackTrig*2].label;
       for (int j=0; j<kNOccVar; ++j) {
         if (_occupancyHist._hOccInfo[i][j] != nullptr)    {
-          std::string title = _trigCaloOnly[i].label +": "+ _occupancyHist._hOccInfo[i][j]->GetTitle();
+          std::string title = label +": "+ _occupancyHist._hOccInfo[i][j]->GetTitle();
           _occupancyHist._hOccInfo[i][j]->SetTitle(title.c_str());
         }
         if (_occupancyHist._h2DOccInfo[i][j] != nullptr)    {
-          std::string title = _trigCaloOnly[i].label +": "+ _occupancyHist._h2DOccInfo[i][j]->GetTitle();
+          std::string title = label +": "+ _occupancyHist._h2DOccInfo[i][j]->GetTitle();
           _occupancyHist._h2DOccInfo[i][j]->SetTitle(title.c_str());
         }
       }
@@ -605,10 +602,10 @@ namespace mu2e {
       if (_trigEvtPS[i].counts > 0) _sumHist._hTrigInfo[3]->SetBinContent(i+1, _trigEvtPS[i].counts);
 
       _sumHist._hTrigInfo[4]->GetXaxis()->SetBinLabel(i+1, _trigHelix[i].label.c_str());
-      if (_trigHelix[i].counts > 0) _sumHist._hTrigInfo[4]->SetBinContent(i+1, _trigHelix[i].counts);
+      if (_trigHelix[i].counts > 0) _sumHist._hTrigInfo[4]->SetBinContent(i+1, _nProcess*1.f/_trigHelix[i].counts);
 
       _sumHist._hTrigInfo[5]->GetXaxis()->SetBinLabel(i+1, _trigCaloCalib[i].label.c_str());
-      if (_trigCaloCalib[i].counts > 0) _sumHist._hTrigInfo[5]->SetBinContent(i+1, _trigCaloCalib[i].counts);
+      if (_trigCaloCalib[i].counts > 0) _sumHist._hTrigInfo[5]->SetBinContent(i+1, _nProcess*1.f/_trigCaloCalib[i].counts);
 
       if (_trigFinal[i].counts > 0) {
         _sumHist._hTrigInfo  [6]->GetXaxis()->SetBinLabel(i+1, _trigFinal[i].label.c_str());
@@ -677,7 +674,8 @@ namespace mu2e {
     //order the array with the filter used at the end of each path
     std::sort(_trigFinal.begin(), _trigFinal.end(), [](const auto a, const auto b) {return a.counts < b.counts; });
 
-    double    mean_mb_rate   = 1.;///(mbtime/CLHEP::s)*_duty_cycle;
+    //no conversion to Hz is applied: see the note on the hTrigBDW axis titles
+    const double mean_mb_rate = 1.;
 
     bool      isFirst(true);
     int       index(0);
@@ -718,8 +716,8 @@ namespace mu2e {
 
     NCorrelated = 0;
 
-    const char* label_ref = VecLabels.at(VecLabels.size()-1).c_str();
     if (VecLabels.size()<2) return;
+    const char* label_ref = VecLabels.at(VecLabels.size()-1).c_str();
 
     //    char* label(0);
 
@@ -808,36 +806,12 @@ namespace mu2e {
       }
     }
 
-    //get the helix collections
-    art::Handle<mu2e::HelixSeedCollection>  hsCprH;
-    if (hsCprH.isValid()) {
-      _hsCprCol = hsCprH.product();
-    }else {
-      _hsCprCol = nullptr;
-    }
-
-    art::Handle<mu2e::HelixSeedCollection>  hsTprH;
-    if (hsTprH.isValid()) {
-      _hsTprCol = hsTprH.product();
-    }else {
-      _hsTprCol = nullptr;
-    }
-
     //get the StrawDigi Collection
     art::Handle<mu2e::StrawDigiCollection> sdH;
     event.getByLabel(_sdTag, sdH);
     const StrawDigiCollection* sdCol(0);
     if (sdH.isValid()) {
       sdCol = sdH.product();
-    }
-
-    //get the ComboHitCollection
-    art::Handle<mu2e::ComboHitCollection> chH;
-    event.getByLabel(_chTag, chH);
-    if (chH.isValid()) {
-      _chcol = chH.product();
-    }else {
-      _chcol = nullptr;
     }
 
     //get the CaloDigi Collection
@@ -886,7 +860,6 @@ namespace mu2e {
           }
           int          index_all(i);//0);
           int          index(i);//0);
-          bool         passed(false);
           size_t       nTrigObj(0);
           //fill the Global Trigger bits info
           _trigAll[index_all].label  = moduleLabel;
@@ -901,40 +874,38 @@ namespace mu2e {
             if(_diagLevel > 3) printf("[ReadTriggerInfo::%s] : Helix-filter module (%s) found in path %s\n", __func__, moduleLabel.c_str(), path.c_str());
             _trigHelix[index].label  = moduleLabel;
             ++_trigHelix[index].counts;
-            passed = true;
             nTrigObj=0;
             if(!trigInfo) throw cet::exception("BADINPUTS") << "Trigger info product not found before needed!\n";
+            bool filledOccupancy = false;
             for (auto const hseed: trigInfo->helixes()) {
-              if(hseed) {
-                ++nTrigObj;
-                fillHelixTrigInfo(index, hseed.get(), _helHist);
-                if (passed) {
-                  passed = false;
-                  fillOccupancyInfo(_nTrackTrig+helix_trig_index, sdCol, cdCol, _occupancyHist);
-                }
+              if(!hseed) continue;
+              ++nTrigObj;
+              fillHelixTrigInfo(index, hseed.get(), _helHist);
+              if (!filledOccupancy) { //occupancy is a per-event quantity: fill it once
+                filledOccupancy = true;
+                fillOccupancyInfo(_nTrackTrig+helix_trig_index, sdCol, cdCol, _occupancyHist);
               }
-              ++helix_trig_index;
             }//end loop over the helix-collection
+            ++helix_trig_index; //one occupancy slot per helix filter, not per helix
             _helHist._hHelInfo[i][120]->Fill(nTrigObj);
 
           } else if (isTrackFilter(moduleLabel)) {
             if(_diagLevel > 3) printf("[ReadTriggerInfo::%s] : Track-filter module (%s) found in path %s\n", __func__, moduleLabel.c_str(), path.c_str());
             _trigTrack[index].label  = moduleLabel;
             ++_trigTrack[index].counts;
-            passed = true;
             nTrigObj=0;
             if(!trigInfo) throw cet::exception("BADINPUTS") << "Trigger info product not found before needed!\n";
+            bool filledOccupancy = false;
             for (auto const kseed: trigInfo->tracks()) {
-              if(kseed) {
-                ++nTrigObj;
-                fillTrackTrigInfo(index, kseed.get(), _trkHist);
-                if (passed) {
-                  passed = false;
-                  fillOccupancyInfo(track_trig_index, sdCol, cdCol, _occupancyHist);
-                }
+              if(!kseed) continue;
+              ++nTrigObj;
+              fillTrackTrigInfo(index, kseed.get(), _trkHist);
+              if (!filledOccupancy) { //occupancy is a per-event quantity: fill it once
+                filledOccupancy = true;
+                fillOccupancyInfo(track_trig_index, sdCol, cdCol, _occupancyHist);
               }
-              ++track_trig_index;
             }//end loop over the kaseed-collection
+            ++track_trig_index; //one occupancy slot per track filter, not per track
             _trkHist._hTrkInfo[i][40]->Fill(nTrigObj);
             trigFlag_index.push_back(index_all);
 
@@ -944,7 +915,6 @@ namespace mu2e {
           } else if ( moduleLabel.find("caloCalibCosmic") != std::string::npos) {
             _trigCaloCalib[index].label  = moduleLabel;
             ++_trigCaloCalib[index].counts;
-            passed = false;
             nTrigObj=0;
             if(!trigInfo) throw cet::exception("BADINPUTS") << "Trigger info product not found before needed!\n";
             for (auto const cluster : trigInfo->caloClusters()) {
@@ -958,20 +928,19 @@ namespace mu2e {
             if(_diagLevel > 3) printf("[ReadTriggerInfo::%s] : Calo-filter module (%s) found in path %s\n", __func__, moduleLabel.c_str(), path.c_str());
             _trigCaloOnly[index].label  = moduleLabel;
             ++_trigCaloOnly[index].counts;
-            passed = true;
             nTrigObj=0;
             if(!trigInfo) throw cet::exception("BADINPUTS") << "Trigger info product not found before needed!\n";
+            bool filledOccupancy = false;
             for (auto const clseed: trigInfo->caloClusters()) {
-              if(clseed) {
-                ++nTrigObj;
-                fillCaloTrigInfo(calo_trig_index, clseed.get(), _caloTSeedHist);
-                if (passed) {
-                  passed = false;
-                  fillOccupancyInfo   (_nTrackTrig*2+calo_trig_index, sdCol, cdCol, _occupancyHist);
-                }
+              if(!clseed) continue;
+              ++nTrigObj;
+              fillCaloTrigInfo(calo_trig_index, clseed.get(), _caloTSeedHist);
+              if (!filledOccupancy) { //occupancy is a per-event quantity: fill it once
+                filledOccupancy = true;
+                fillOccupancyInfo   (_nTrackTrig*2+calo_trig_index, sdCol, cdCol, _occupancyHist);
               }
-              ++calo_trig_index;
             }//end loop
+            ++calo_trig_index; //one occupancy slot per calo filter, not per cluster
             //_caloTSeedHist._hCaloOnlyInfo[i][20]->Fill(nTrigObj);
             trigFlag_index.push_back(index_all);
           }
@@ -999,10 +968,9 @@ namespace mu2e {
   //--------------------------------------------------------------------------------//
   void ReadTriggerInfo::fillTrackTrigInfo(int TrkTrigIndex, const KalSeed* KSeed, trackInfoHist_& Hist) {
     if(!Hist._hTrkInfo[TrkTrigIndex][0]) throw cet::exception("BADCONFIG") << __func__ << ": Track histogram index " << TrkTrigIndex << " not initialized\n";
-    GlobalConstantsHandle<ParticleDataList> pdt;
 
+    if(KSeed->segments().empty()) return; //nothing to characterise without a segment
     int                nsh = (int)KSeed->hits().size();
-    // KalSegment const& fseg = KSeed->segments().front();
     auto& fseg = KSeed->segments().front();
 
     double     ndof  = std::max(1.0,nsh - 5.0);
@@ -1025,8 +993,9 @@ namespace mu2e {
     }
 
     double lambda = fseg.loopHelix().lam();
-    double pitch  = std::abs(lambda)*6.28;
-    double nLoops = (z_max - z_min)/pitch;
+    double pitch  = std::abs(lambda)*2.*M_PI;
+    //without intersections z_min/z_max keep their sentinel seeds, which would make nLoops meaningless
+    double nLoops = (z_max > z_min && pitch > 0.) ? (z_max - z_min)/pitch : -1.;
 
     if (KSeed->caloCluster()) clE = KSeed->caloCluster()->energyDep();
 
@@ -1042,7 +1011,6 @@ namespace mu2e {
   //--------------------------------------------------------------------------------//
   void ReadTriggerInfo::fillHelixTrigInfo(int HelTrigIndex, const HelixSeed* HSeed, helixInfoHist_& Hist) {
     if(!Hist._hHelInfo[HelTrigIndex][0]) throw cet::exception("BADCONFIG") << __func__ << ": Helix histogram index " << HelTrigIndex << " not initialized\n";
-    GlobalConstantsHandle<ParticleDataList> pdt;
     HelixTool helTool(HSeed, _tracker);
 
     int        nch       = (int)HSeed->hits().size();

--- a/Trigger/src/ReadTriggerPath_module.cc
+++ b/Trigger/src/ReadTriggerPath_module.cc
@@ -100,7 +100,7 @@ namespace mu2e {
 
     virtual void beginJob();
     virtual void endJob();
-    virtual void beginRun(const art::Run & run);
+    virtual void beginRun(const art::Run &);
     virtual void beginSubRun(const art::SubRun& sr);
 
     // This is called for each event.
@@ -385,7 +385,7 @@ namespace mu2e {
   }
 
   //--------------------------------------------------------------------------------//
-  void ReadTriggerPath::beginRun(const art::Run & run) {
+  void ReadTriggerPath::beginRun(const art::Run &) {
     if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
   }
 

--- a/Trigger/src/ReadTriggerPath_module.cc
+++ b/Trigger/src/ReadTriggerPath_module.cc
@@ -504,7 +504,7 @@ namespace mu2e {
         const bool is_helix   = isHelixPath  (path, trigNavig) && !skip_exclusive;
         const bool is_calo    = isCaloPath   (path, trigNavig) && !skip_exclusive;
         const bool is_minbias = isMinBiasPath(path) && !skip_exclusive;
-        passed         |= skip_exclusive;
+        passed          = true;
         track_passed   |= is_track;
         helix_passed   |= is_helix;
         calo_passed    |= is_calo;
@@ -539,7 +539,7 @@ namespace mu2e {
       _sumHist._hTrigInfo[2]->Fill(1);
       _sumHist._hTrigInfo[3]->Fill(1);
     }
-    if(track_passed) { //helix trigger rates
+    if(helix_passed) { //helix trigger rates
       _sumHist._hTrigInfo[2]->Fill(2);
       _sumHist._hTrigInfo[3]->Fill(2);
     }

--- a/Trigger/src/ReadTriggerPath_module.cc
+++ b/Trigger/src/ReadTriggerPath_module.cc
@@ -112,11 +112,9 @@ namespace mu2e {
     bool     isTrackFilter            (const std::string& module);
     bool     isHelixFilter            (const std::string& module);
     bool     isCaloFilter             (const std::string& module);
-    bool     isGlobalFilter           (const std::string& module);
     bool     isTrackPath              (const std::string& path, TriggerResultsNavigator& trigNavig);
     bool     isHelixPath              (const std::string& path, TriggerResultsNavigator& trigNavig);
     bool     isCaloPath               (const std::string& path, TriggerResultsNavigator& trigNavig);
-    bool     isGlobalPath             (const std::string& path, TriggerResultsNavigator& trigNavig);
     bool     isMinBiasPath            (const std::string& path);
 
     void     trigPathVal              (const int Index, TriggerResultsNavigator& trigNavig, summaryInfoHist_& Hist);
@@ -131,6 +129,7 @@ namespace mu2e {
 
     size_t                    _nMaxTrig;
     std::vector<std::string>  _trigPaths;
+    std::vector<std::string>  _bookedTrigPaths; //the menu the histograms were booked for
 
     int                       _nProcess;
     double                    _nPOT;
@@ -139,7 +138,7 @@ namespace mu2e {
 
     float  _minPOT, _maxPOT;
 
-    bool _useNGen; //use gen event count for normalization if available
+    bool _useNGen = false; //use gen event count for normalization if available
   };
 
   ReadTriggerPath::ReadTriggerPath(const art::EDAnalyzer::Table<Config>& config):
@@ -162,6 +161,7 @@ namespace mu2e {
   void ReadTriggerPath::bookHistograms() {
     if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
     _nMaxTrig = _trigPaths.size();
+    _bookedTrigPaths = _trigPaths;
     if(_nMaxTrig > kMaxTriggers) throw cet::exception("BADCONFIG") << __func__ << ": Input trigger path list size (" << _nMaxTrig << ") is larger than the maximum ("
                                                                    << kMaxTriggers << ")\n";
     art::ServiceHandle<art::TFileService> tfs;
@@ -187,7 +187,7 @@ namespace mu2e {
     const int npot_bins(200);
     Hist._hNPOT         = trigInfoDir.make<TH1F>("hNPOT"              , "N(POT);N(POT)/#mu-bunch", npot_bins, _minPOT, _maxPOT);
 
-    Hist._hTrig2D       = trigInfoDir.make<TH2F>("hTrigOverlap"       , "Trigger overlap: N(x and y)/N(x)", _nMaxTrig, -0.5, _nMaxTrig-0.5, _nMaxTrig, -0.5, _nMaxTrig);
+    Hist._hTrig2D       = trigInfoDir.make<TH2F>("hTrigOverlap"       , "Trigger overlap: N(x and y)/N(x)", _nMaxTrig, -0.5, _nMaxTrig-0.5, _nMaxTrig, -0.5, _nMaxTrig-0.5);
 
     art::TFileDirectory cutflowDir = Tfs->mkdir("cutflowDir");
     art::TFileDirectory potEffDir  = Tfs->mkdir("POTEffDir");
@@ -201,34 +201,21 @@ namespace mu2e {
 
   //--------------------------------------------------------------------------------//
   bool ReadTriggerPath::isTrackFilter(const std::string& module) {
-    if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
     return module.find("KSFilter") != std::string::npos;
   }
 
   //--------------------------------------------------------------------------------//
   bool ReadTriggerPath::isHelixFilter(const std::string& module) {
-    if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
     return module.find("HSFilter") != std::string::npos;
   }
 
   //--------------------------------------------------------------------------------//
   bool ReadTriggerPath::isCaloFilter(const std::string& module) {
-    if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
     return module.find("calo") != std::string::npos && module.find("Filter") != std::string::npos;
   }
 
   //--------------------------------------------------------------------------------//
-  bool ReadTriggerPath::isGlobalFilter(const std::string& module) {
-    if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
-    return (module.find("HSFilter")!= std::string::npos && module.find("CosmicHelix")!= std::string::npos) ||
-      module.find("caloPhotonFilter")!= std::string::npos ||
-      module.find("caloMVANNCEFilter")!= std::string::npos ||
-      module.find("TSFilter")       != std::string::npos;
-  }
-
-  //--------------------------------------------------------------------------------//
   bool ReadTriggerPath::isTrackPath(const std::string& path, TriggerResultsNavigator& trigNavig) {
-    if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
     bool passed = false;
     // check if the module labels are available for a more reliable check
     auto modules = trigNavig.triggerModules(path);
@@ -245,7 +232,6 @@ namespace mu2e {
 
   //--------------------------------------------------------------------------------//
   bool ReadTriggerPath::isHelixPath(const std::string& path, TriggerResultsNavigator& trigNavig) {
-    if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
     bool passed = false;
     // check if the module labels are available for a more reliable check
     auto modules = trigNavig.triggerModules(path);
@@ -263,7 +249,6 @@ namespace mu2e {
 
   //--------------------------------------------------------------------------------//
   bool ReadTriggerPath::isCaloPath(const std::string& path, TriggerResultsNavigator& trigNavig) {
-    if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
     bool passed = false;
     // check if the module labels are available for a more reliable check
     auto modules = trigNavig.triggerModules(path);
@@ -277,22 +262,7 @@ namespace mu2e {
   }
 
   //--------------------------------------------------------------------------------//
-  bool ReadTriggerPath::isGlobalPath(const std::string& path, TriggerResultsNavigator& trigNavig) {
-    if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
-    bool passed = false;
-    // check if the module labels are available for a more reliable check
-    auto modules = trigNavig.triggerModules(path);
-    if(modules.size() > 0) {
-      for (auto module : modules) passed |= isGlobalFilter(module);
-    } else { // use the path name to determine if it's a global path
-      passed = false; // FIXME: Determine global path names
-    }
-    return passed;
-  }
-
-  //--------------------------------------------------------------------------------//
   bool ReadTriggerPath::isMinBiasPath(const std::string& path) {
-    if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
     return path.find("minBias") != std::string::npos;
   }
 
@@ -301,23 +271,28 @@ namespace mu2e {
     if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
     const std::string path = trigNavig.getTrigPathNameByIndex(Index);
     const unsigned lastModule = trigNavig.indexLastModule(path);
+    // indexLastModule returns unsigned(-1) for a path it does not know; using it as a
+    // loop bound below would run ~4e9 iterations, so reject it explicitly
+    if(lastModule == unsigned(-1)) throw cet::exception("BADCONFIG") << __func__ << ": Trigger path " << path << " is not known to the navigator\n";
     auto h = Hist._hTrigModules[Index];
     if(!h) throw cet::exception("BADCONFIG") << __func__ << ": Trigger path index " << Index << " is out of bounds for initialized histograms\n";
     if(h->GetEntries() == 0) h->SetTitle((path + " path cut-flow").c_str());
 
-    // set the bin labels if needed
-    if(h->Integral() <= 0.) {
-      auto modules = trigNavig.triggerModules(path);
-      auto size = modules.size();
-      if(size > 0) {
-        for(unsigned i = 0; i < size; ++i) {
-          h->GetXaxis()->SetBinLabel(h->FindBin(i), (i < size) ? modules[i].c_str() : "Final");
-        }
+    const auto modules = trigNavig.triggerModules(path);
+    const unsigned nModules = modules.size();
+
+    // set the bin labels if needed: one bin per module, plus a final bin for
+    // events that passed the whole chain
+    if(h->Integral() <= 0. && nModules > 0) {
+      for(unsigned i = 0; i <= nModules; ++i) {
+        h->GetXaxis()->SetBinLabel(h->FindBin(i), (i < nModules) ? modules[i].c_str() : "Final");
       }
     }
 
-    // cut-flow along the trigger path
-    for (unsigned i = 0; i < lastModule ; ++i) h->Fill(i);
+    // cut-flow along the trigger path. indexLastModule is the index of the module that
+    // made the decision, and that module did run, so the bound is inclusive
+    for (unsigned i = 0; i <= lastModule ; ++i) h->Fill(i);
+    if(trigNavig.accepted(path)) h->Fill(nModules); //the whole chain passed
   }
 
 
@@ -330,7 +305,10 @@ namespace mu2e {
   void ReadTriggerPath::endJob() {
     if(_diagLevel > 4) printf("[ReadTriggerPath::%s]\n", __func__);
     if(_nProcess <= 0) {
-      if(_diagLevel > 0) printf("[ReadTriggerPath::%s] Setting N(processed) from %i to 1\n", __func__, _nProcess);
+      // _nProcess is the denominator of every efficiency and rejection below, so record
+      // the substitution at a severity a default-configured job actually shows
+      mf::LogWarning("ReadTriggerPath") << "N(processed) is " << _nProcess
+                                        << "; normalising to 1, so every efficiency below is a raw count";
       _nProcess = 1;
     }
     if(_diagLevel > 0) printf("[ReadTriggerPath::%s] N(processed) = %i\n", __func__, _nProcess);
@@ -418,7 +396,7 @@ namespace mu2e {
     sr.getByLabel(_genCountTag, genCountH);
     _useNGen = genCountH.isValid();
     if(_useNGen) _nProcess += genCountH.product()->count();
-    if(_diagLevel > 0) printf("[ReadTriggerPath::%s] use gen count product flag = %o\n", __func__, _useNGen);
+    if(_diagLevel > 0) printf("[ReadTriggerPath::%s] use gen count product flag = %d\n", __func__, _useNGen);
   }
 
   //--------------------------------------------------------------------------------//
@@ -450,7 +428,11 @@ namespace mu2e {
     //check if the histograms have been initialized
     if(!_sumHist._hTrigInfo[0]) bookHistograms();
 
-    if(_trigPaths.size() > _nMaxTrig) throw cet::exception("BADCONFIG") << "Number of triggers assumed (" << _nMaxTrig << ") is less than the observed (" << _trigPaths.size() << ")\n";
+    // the histogram binning and bin labels are fixed by the first menu seen, so any
+    // later change to the menu -- not just a change in its size -- invalidates them
+    if(_trigPaths != _bookedTrigPaths) throw cet::exception("BADCONFIG") << "Trigger menu changed within the job: histograms were booked for "
+                                                                        << _bookedTrigPaths.size() << " paths and this event has " << _trigPaths.size()
+                                                                        << ". Process files with a common menu.\n";
 
     //initialize bin labels
     if(_sumHist._hTrigInfo[0]->Integral() <= 0.) {
@@ -476,7 +458,7 @@ namespace mu2e {
     //fill the histogram with the accepted trigger bits
     _sumHist._hNPOT->Fill(_nPOT);
     bool passed(false), track_passed(false), helix_passed(false), calo_passed(false), minbias_passed(false), unknown(false);
-    unsigned naccept(0), exclusive_idx(-1);
+    unsigned naccept(0), exclusive_idx(0);
     for (unsigned i=0; i< trigNavig.getTrigPaths().size(); ++i) {
       const std::string path = trigNavig.getTrigPathNameByIndex(i);
       if(_diagLevel > 4) {
@@ -511,7 +493,7 @@ namespace mu2e {
         minbias_passed |= is_minbias;
         unknown |= !(is_track || is_helix || is_calo || is_minbias || skip_exclusive);
         if(is_track + is_helix + is_calo + is_minbias > 1) {
-          if(_diagLevel > -1) printf("[ReadTriggerPath::%s] Path %s identified as multiple types: track = %o helix = %o calo = %o minbias = %o\n",
+          if(_diagLevel > -1) printf("[ReadTriggerPath::%s] Path %s identified as multiple types: track = %d helix = %d calo = %d minbias = %d\n",
                                      __func__, path.c_str(), is_track, is_helix, is_calo, is_minbias);
         }
         //Fill the correlation matrix

--- a/Trigger/src/TriggerInfoToCollections_module.cc
+++ b/Trigger/src/TriggerInfoToCollections_module.cc
@@ -12,6 +12,8 @@
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
 
+#include "cetlib_except/exception.h"
+
 // Offline
 #include "Offline/RecoDataProducts/inc/TriggerInfo.hh"
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
@@ -31,7 +33,7 @@ namespace mu2e {
    struct Config {
       using  Name    = fhicl::Name;
       using  Comment = fhicl::Comment;
-      fhicl::Atom<std::string> tag   { Name("triggerInfoName") , Comment("Trigger info (collection) name")};
+      fhicl::Atom<art::InputTag> tag { Name("triggerInfoName") , Comment("Trigger info (collection) tag")};
       fhicl::Atom<int>         debug { Name("debugLevel")      , Comment("Debug Level"), 0};
     };
 
@@ -56,8 +58,8 @@ namespace mu2e {
     }
 
   private:
-    std::string  _tag;
-    int          _debug;
+    art::InputTag _tag;
+    int           _debug;
   };
 
   TriggerInfoToCollections::TriggerInfoToCollections(const Parameters& config) :
@@ -136,10 +138,10 @@ namespace mu2e {
                __func__, moduleDescription().moduleLabel().c_str(), trkCol->size(), hlxCol->size(), tclCol->size());
       }
     } else {
-      if(_debug > 1) {
-        printf("[TriggerInfoToCollections::%s::%s] No TriggerInfo collection found with tag %s\n",
-               __func__, moduleDescription().moduleLabel().c_str(), _tag.c_str());
-      }
+      // Emitting six empty collections here would be indistinguishable downstream from
+      // "no trigger fired", so a tag that matches nothing has to fail loudly.
+      throw cet::exception("BADINPUTS") << "No TriggerInfo or TriggerInfoCollection found with tag "
+                                        << _tag << "\n";
     }
 
     // add the collections to the event


### PR DESCRIPTION
Addresses the findings in #1942 (static-review audit of `Trigger/`).

Five commits, kept separate so the two live bug fixes can be read and reverted on their own:

| commit | what |
| --- | --- |
| `fix(Trigger): ReadTriggerPath filled two rate bins from the wrong flag` | the two defects that make a runnable job report a wrong number |
| `fix(Trigger): ReadTriggerPath cut-flow bound, menu check, dead code` | items 8, 9, 18, 23, 26, 30, 31 |
| `fix(Trigger): ReadTriggerInfo indexing, dead state and empty-input guards` | items 3, 4, 7, 15, 17, 19, 21, 22, 27 |
| `fix(Trigger): fail-loud inputs, validated types and cleanup in the remaining modules` | items 10, 12, 14, 24, 29, 31 and the safe part of 11 |
| `cleanup(Trigger): drop unused beginRun/endRun parameter names` | warning cleanup |

### The two live bugs

`ReadTriggerPath_module.cc:542` filled the `"Helix"` bin of `hGlobalTrigEff`/`hGlobalTrigRej` from `track_passed`, so it reported the track rate and was numerically identical to the `"Tracks"` bin. `helix_passed` was computed and never read — because the assignment is `|=` it counts as a use, so no unused-variable warning fires.

`:507` drove the `"Total"` bin from `passed |= skip_exclusive`, which is true exactly when a path matching `ignorePaths` fired — the paths every other category excludes.

Both are one-line changes. Their only consumer is `Trigger/fcl/read_trig_paths.fcl`, a hand-run job, so nothing in production was affected.

### Deliberately not in this PR

Four items from #1942 need a decision I cannot make from the source:

- **item 5** — `EvalWeightedEventCounts`: the two-batch cutoff normalization cancels itself and leaves the one-batch factor behind (`p2 = lumi·n2·c1·pdf2/pdf1`, 2.7% off). The algebra is unambiguous but the intended formula is not, so this needs its author.
- **item 11 (schema half)** — converting `DigiFilter` to validated FHiCL needs a companion `mu2e-trig-config` PR: the live configs also set `triggerPath`, a key this module has never read and which validated FHiCL would reject. The same coupling blocks removing `maxCaloEnergy`, which is read from FHiCL and never applied. The reject-every-event case is fixed here without touching the schema.
- **item 13** — `MergeTriggerInfo` collects `TriggerInfo` by type via `getMany`, so re-running the trigger over its own output double-counts. Fixing it means choosing between an explicit tag list and a process-name filter.
- **item 20** — whether `ReadTriggerInfo` should exist at all. It has no FHiCL consumer anywhere in Offline, Production or mu2e-trig-config, and its successor says so in its own header. I fixed it in place rather than deleting 1,113 lines on my own judgement; if it goes, commit 3 goes with it.

Two items are partial and say so in the commit messages: the `"Calib"` bin label is left in place (item 23) because removing it shifts every bin above it, and the `printf`-to-message-service conversion (item 25) is done only where a `cout`/`printf` was already being replaced for another reason — converting the ~60 remaining `printf` calls in the two analyzers would bury the rest of the diff.

### Validation

- All eight modules compile clean and **warning-free** under `g++ -std=c++20 -Wall -Wextra` against the Musing include paths. The four `-Wunused-parameter` warnings the package used to emit were verified to pre-date this branch by compiling the same files from `mu2e/main`.
- `Trigger/CMakeLists.txt`: `PrescaleEvent` no longer links `artdaq-core-mu2e::Data`, because the include that motivated it (`Data/EventHeader.hh`) was unused. It now names `Offline::DataProducts`, where `EventWindowMarker` and `PrescaleFilterFraction` live — the latter has a `.cc`, so this is the honest dependency.
- **Not run.** No art job was executed and no histogram was compared before and after. The behavioural claims are from reading the source. The two live bugs in particular deserve a before/after run of `read_trig_paths.fcl` by someone with a suitable input file.
- No change to any FHiCL key that `mu2e-trig-config` or `Production` sets, so no companion PR is required for what is here.

### Correction after the first CI run

The first build at `367c39db` failed four job tests — `trigger`, `ceDigi`, `ceMix` and `cosmicOffSpill` — all with the same message at module construction:

```
Prescale factor for mode OnSpill is -1; it must be >= 1, since 0 rejects every event
```

That guard was mine, and it was wrong. `prescale: -1` is how `mu2e-trig-config` turns a trigger path off — 35 sites set it, including `core/filters/trigCprFilters.fcl` and `data/physMenu.json` — so `main`'s `std::max(0,prescale)` clamp and the `prescale_ > 0` guard in `filter()` were encoding a sentinel, not being defensive. Commit `fix(Trigger): prescale <= 0 means disabled, not a bad configuration` restores `main`'s behaviour exactly and documents the sentinel where the type is declared. `build (prof)` was green throughout; this was a configuration rejection at runtime, which is why the compile-only check in the Validation section above did not catch it.

The other fail-loud guard in this PR, `DigiFilter` rejecting `useStrawDigi` and `useCaloDigi` both false, was checked against the same repo: every live site sets exactly one of the two true.
