### PR TITLE
CaloReco: fix stale nSiPM count and silent digi drop in CaloHitMakerFast::addPulse

### DIFF
--- a/CaloReco/src/CaloHitMakerFast_module.cc
+++ b/CaloReco/src/CaloHitMakerFast_module.cc
@@ -198,21 +198,23 @@ namespace mu2e {
    //--------------------------------------------------------------------------------------------------------------
    void CaloHitMakerFast::addPulse(pulseMapType& pulseMap, unsigned crystalID, float time, float eDep)
    {
-       bool addNewHit(true);
        for (auto& pulse : pulseMap[crystalID])
        {
            if (std::fabs(pulse.time_ - time) > deltaTPulses_) continue;
 
-           addNewHit    = false;
            float ratio  = (eDep-pulse.eDep_)/(eDep+pulse.eDep_);
            float eMean  = (eDep+pulse.eDep_)/2.0;
            float sigmaR = 0.707*sqrt(1.0/eMean/nPEperMeV_ + noise2_/eMean/eMean);
 
-           if (fabs(ratio) < nSigmaNoise_*sigmaR) {pulse.add(time,eDep);}
-           else if (eDep>pulse.eDep_)             {pulse.time_=time; pulse.eDep_=eDep;}
-           break;
+           // Two SiPM readings of the same energy deposit agree within noise: combine them.
+           if (fabs(ratio) < nSigmaNoise_*sigmaR) {pulse.add(time,eDep); return;}
+
+           // In time but incompatible in energy: not a reading of the same deposit.
+           // Keep scanning for a compatible pulse; if none exists the digi becomes its
+           // own hit below, and downstream selections (e.g. minSiPMPerHit) judge it on
+           // its own nSiPM count.
        }
-       if (addNewHit) pulseMap[crystalID].push_back(HitInfo(time, eDep));
+       pulseMap[crystalID].push_back(HitInfo(time, eDep));
    }
 }
 


### PR DESCRIPTION
Fixes the two S1 findings of the CaloReco static-review audit (#1944), both in `CaloHitMakerFast::addPulse` — the module that runs in every production reco job and in the trigger (`mu2e-trig-config/core/producers/trigCalProducers.fcl`, label `CaloHitFastMaker`).

### The two defects

**Stale `nSiPM_` after the replace branch.** `HitInfo::add()` is the only code that increments `nSiPM_`; the replace branch overwrote `time_`/`eDep_` wholesale but kept the old count. With the production defaults, two coincident ~5 MeV digis merge to `{nSiPM=2, eDep≈5.05}` and a third in-window 50 MeV digi fires the replace branch (ratio 0.82 against a 0.11 threshold), leaving `{nSiPM=2, eDep=50}` backed by one raw digi. Downstream, `CaloHit::energyDepTot()` returns `eDep_*nSiPMs_` — doubled from a single-digi energy — and `CaloClusterFast` cuts `nSiPMs() >= minSiPMPerHit` (2) on exactly this output, so the gate built to reject uncorroborated single-SiPM hits passed one, in both production reco and the trigger.

**Silent drop of the third outcome.** An in-window digi that failed the compatibility test and was *not* the larger one hit neither branch: `addNewHit` was already false and the loop broke — no CaloHit, no cluster-energy contribution, no diagnostic at any `diagLevel`. An 8 MeV pileup digi 0.5 ns after a 50 MeV pulse vanished entirely.

### The fix

The merge test exists to combine the two SiPM readings of one energy deposit (the `nSigmaNoise` fcl comment says so directly). A digi that is in time but incompatible in energy is therefore *not* a reading of the same deposit, and the fix treats it that way: compatible → merge as before; incompatible → keep scanning, and if no compatible pulse exists the digi becomes its own hit. No replace branch, so no stale count and nothing dropped.

Why this is the honest policy rather than a behavior patch:

- `pulseMap` already holds a `std::vector<HitInfo>` per crystal and `extractHits` already emits every entry — multiple pulses per crystal is the module's own data model, not something this PR introduces.
- A real deposit is read by **both** SiPMs of the crystal, so its two digis still merge into a legitimate `nSiPM=2` hit and pass `minSiPMPerHit` as before. A lone incompatible digi now stays `nSiPM=1` and the downstream selection judges it honestly — which is precisely the corroboration that cut was written to demand.
- The old replace branch was arrival-order-dependent (`[8, 50]` replaced, `[50, 8]` dropped); the new logic gives the same answer in either order.
- The precise `CaloHitMaker` clusters by time only and keeps all sub-clusters — this aligns the fast maker with the policy the offline chain already uses.

### Expected behavior shifts, stated plainly

- Trigger/reco hits that previously passed `minSiPMPerHit: 2` only via the stale count will now (correctly) fail it.
- Energy that was previously discarded by the silent third outcome now appears as additional `nSiPM=1` hits, so `IntensityInfoCalo`'s summed calo energy can increase slightly and hit counts can grow. If the calo group prefers the old keep-the-dominant-pulse policy for rate reasons, the minimal alternative is an explicit, documented else-branch plus a `nSiPM_=1` reset in the replace — happy to rework to that; what should not survive is the stale count.

### Validation

- The module compiles warning-free under `g++ -std=c++20 -Wall -Wextra -fsyntax-only` against the Musing include paths (the warnings in the compile log are all from external headers and pre-date this branch).
- **Not run:** no art job was executed and no before/after rate comparison was made. The scenarios above are hand-computed from the production defaults in `CaloReco/fcl/prolog.fcl`. The CI job tests exercise the calo trigger paths and are the first real check; a before/after look at `CaloHitFastMaker` output on a standard ceMix sample by someone with a suitable setup would be the definitive one.
- No FHiCL key changes, so no companion PR is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
