### PR TITLE
Mu2eG4: fix the S0/S1 findings from the static-review audit (#1947)

### DIFF
--- a/Mu2eG4/src/ConstructMaterials.cc
+++ b/Mu2eG4/src/ConstructMaterials.cc
@@ -448,7 +448,7 @@ namespace mu2e {
     mat = uniqueMaterialOrThrow( "RackSteel" );
     {
       G4Material* RackSteel = new G4Material( mat.name, 8.05*CLHEP::g/CLHEP::cm3, 2);
-      RackSteel->AddMaterial(findMaterialOrThrow("G4_Al"),0.985);
+      RackSteel->AddMaterial(findMaterialOrThrow("G4_Fe"),0.985);
       RackSteel->AddMaterial(findMaterialOrThrow("G4_C"), 0.015);
     }
 

--- a/Mu2eG4/src/Mu2eG4TrackingAction.cc
+++ b/Mu2eG4/src/Mu2eG4TrackingAction.cc
@@ -607,7 +607,7 @@ namespace mu2e {
   // Append end of track information to the existing SimParticle.
   void Mu2eG4TrackingAction::saveSimParticleEnd(const G4Track* trk){
 
-    if( _sizeLimit>0 && _currentSize>=_sizeLimit ) return;
+    if( _sizeLimit>0 && _currentSize>_sizeLimit ) return;
 
     G4int trackingVerbosityLevel = fpTrackingManager->GetVerboseLevel();
 

--- a/Mu2eG4/src/constructExtMonFNALInfrastructure.cc
+++ b/Mu2eG4/src/constructExtMonFNALInfrastructure.cc
@@ -62,8 +62,7 @@ namespace mu2e {
     //----------------------------------------------------------
     // Pixel Chiller Mother Volume
 
-    // finishNesting() uses the backwards interpretation of rotations
-    G4RotationMatrix* pixelChillerRotationInParentG4 = reg.add(G4RotationMatrix(pixelChillerRotationInParent.inverse()));
+    G4RotationMatrix* pixelChillerRotationInParentG4 = reg.add(G4RotationMatrix(pixelChillerRotationInParent));
     std::vector<double> extMonFNALPixelChillerHalfSize;
     config.getVectorDouble("extMonFNAL.pixelChiller.halfSize", extMonFNALPixelChillerHalfSize);
     const std::string pixelChillerNum = "pixelChiller"+std::to_string(chillerNum);

--- a/Mu2eG4/src/constructExtMonFNALInfrastructure.cc
+++ b/Mu2eG4/src/constructExtMonFNALInfrastructure.cc
@@ -62,7 +62,8 @@ namespace mu2e {
     //----------------------------------------------------------
     // Pixel Chiller Mother Volume
 
-    G4RotationMatrix* pixelChillerRotationInParentG4 = reg.add(G4RotationMatrix(pixelChillerRotationInParent));
+    // finishNesting() uses the backwards interpretation of rotations
+    G4RotationMatrix* pixelChillerRotationInParentG4 = reg.add(G4RotationMatrix(pixelChillerRotationInParent.inverse()));
     std::vector<double> extMonFNALPixelChillerHalfSize;
     config.getVectorDouble("extMonFNAL.pixelChiller.halfSize", extMonFNALPixelChillerHalfSize);
     const std::string pixelChillerNum = "pixelChiller"+std::to_string(chillerNum);

--- a/Mu2eG4/src/constructProtonAbsorber.cc
+++ b/Mu2eG4/src/constructProtonAbsorber.cc
@@ -739,7 +739,7 @@ namespace mu2e {
 
             //extend the box so that it notches through at either end, not just the center
             const double notchExtension = (opaVersion > 2) ?
-              (rin - sqrt(rin*rin-notchWidth*notchWidth)) : 0.;
+              (rin - sqrt(rin*rin-(notchWidth/2.)*(notchWidth/2.))) : 0.;
 
             G4Box* notch = new G4Box("notch", notchWidth/2.*CLHEP::mm,
                                      (notchHeight+notchExtension)/2.*CLHEP::mm, hl*1.1 );

--- a/Mu2eG4/src/constructTargetPS.cc
+++ b/Mu2eG4/src/constructTargetPS.cc
@@ -1231,7 +1231,7 @@ namespace mu2e {
           //next remove overlap at rod
           //
           double wireRodAngle = std::abs((rodCenterToWire).angle(spokeAxis));
-          deltaLength = std::abs(std::tan(wireRodAngle)/tgt->spokeRadius());
+          deltaLength = std::abs(tgt->spokeRadius()*std::cos(wireRodAngle)/std::sin(wireRodAngle));
           wheelPos -= (deltaLength+1.)*spokeAxis;
           if(verbosityLevel > 0)
             std::cout << "wire rod angle " << wireRodAngle << " delta L " << deltaLength

--- a/Mu2eG4/src/constructVirtualDetectors.cc
+++ b/Mu2eG4/src/constructVirtualDetectors.cc
@@ -1266,7 +1266,7 @@ namespace mu2e {
               VolumeInfo vdInfo = nestTubs(VirtualDetector::volumeName(vdIdDiskEdge),
                                            vdParamsInnerDisk,downstreamVacuumMaterial,0,
                                            posInnerDisk,caloDisk,
-                                           vdIdDiskSurf,vdIsVisible,G4Color::Red(),vdIsSolid,forceAuxEdgeVisible,
+                                           vdIdDiskEdge,vdIsVisible,G4Color::Red(),vdIsSolid,forceAuxEdgeVisible,
                                            placePV,false);
               ++vdIdDiskEdge;
 
@@ -1274,7 +1274,7 @@ namespace mu2e {
               VolumeInfo vdInfo2 = nestTubs(VirtualDetector::volumeName(vdIdDiskEdge),
                                             vdParamsOuterDisk,downstreamVacuumMaterial,0,
                                             posInnerDisk,caloDisk,
-                                            vdIdDiskSurf,1,G4Color::Red(),vdIsSolid,forceAuxEdgeVisible,
+                                            vdIdDiskEdge,vdIsVisible,G4Color::Red(),vdIsSolid,forceAuxEdgeVisible,
                                             placePV,false);
               ++vdIdDiskEdge;
 

--- a/Mu2eG4/src/validPolyCones.cc
+++ b/Mu2eG4/src/validPolyCones.cc
@@ -29,10 +29,9 @@ namespace {
     }
 
     bool operator<(pConePlane const& a) const{
-      if ( z    < a.z    ) return true;
-      if ( rmin < a.rmin ) return true;
-      if ( rmax < a.rmax ) return true;
-      return false;
+      if ( z    != a.z    ) return z    < a.z;
+      if ( rmin != a.rmin ) return rmin < a.rmin;
+      return rmax < a.rmax;
     }
   };
 


### PR DESCRIPTION
Fixes the S0 and all six S1 findings from #1947 (static-review audit of `Mu2eG4/`). Seven commits, one per finding, so each can be reviewed and reverted on its own. Every finding was hand-verified at the source before fixing; the issue carries the full evidence and arithmetic.

| commit | finding | what changes in output |
| --- | --- | --- |
| EMC disk-edge VD copy number | #1947 S0 | The four `EMC_Disk_*_Edge*` VD planes now write their own volumeId (77–80) instead of 75/77; the contaminated Disk_1_SurfIn / Disk_0_EdgeIn streams become pure. Any analysis that "used" edge-VD hits before was reading mislabeled data. |
| `saveSimParticleEnd` boundary | #1947 S1 | In events that hit `maxSimParticleCollectionSize`, the last admitted SimParticle now carries real end-of-track info instead of `endDefined()==false`. |
| RackSteel Fe/Al | #1947 S1 | STM shielding house and electronics racks become steel instead of aluminum-at-steel-density. **This shifts STM background rates — explicit STM-group sign-off requested; happy to drop this commit into its own PR if preferred.** |
| Hayman spoke rod-side offset | #1947 S1 | Back-ports the corrected expression `constructStickmanTarget` already uses (its comment: "seems to be a typo in the hayman"). Rod-side spoke-wire endpoints move by the tan²θ error factor; only the +1 mm padding is kept as-is. |
| OPA notch sagitta | #1947 S1 | The notch cut into OPA support ring 2 shrinks from 15.18 mm to the intended 3.76 mm extension (live v04 values). |
| `pConePlane::operator<` | #1947 S1 | The polycone duplicate-plane gate becomes a valid strict weak ordering. A geometry with genuine duplicate planes that previously slipped through will now fail loudly — that is the point. |
| ExtMon chiller rotation | #1947 S1 | The three hall pixel chillers get the `.inverse()` every sibling call site applies; their rotation flips to the intended sign. |

### Validation

- All seven touched files compile warning-free under `g++ -std=c++20 -Wall -Wextra -fsyntax-only` against the Musing include paths (the two `-Wunused-parameter` warnings in `constructExtMonFNALInfrastructure.cc:570` are in an untouched function and present on `main`).
- **Not run:** no art job, no GDML diff, no before/after geometry rendering. The behavioural claims come from the audited arithmetic. The geometry commits (VD, Hayman, OPA, chiller) deserve a `gdmldump` + overlap-check pass in CI, and the RackSteel commit a before/after STM rate check by someone with a suitable setup.
- No FHiCL or SimpleConfig key changes anywhere, so no companion `Production` or `mu2e-trig-config` PR is required.

### Deliberately not in this PR

The 29 S2 / 2 S3 findings from #1947 (dead code, dormant guards, hand-run-path bugs). Several want maintainer decisions (e.g. whether `sourceProfileReader`, `DuplicateLogicalVolumeChecker` and `constructStudyEnv_v00*` should exist at all) and none affects live production output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
