### PR TITLE
Per-event deterministic reseeding for seeded modules downstream of G4MT (issue #849)

### DIFF
--- a/CRVResponse/src/CrvPhotonGenerator_module.cc
+++ b/CRVResponse/src/CrvPhotonGenerator_module.cc
@@ -4,6 +4,7 @@
 //
 // Original Author: Ralf Ehrlich
 
+#include "Offline/SeedService/inc/PerEventReseed.hh"
 #include "Offline/CRVConditions/inc/CRVDigitizationPeriod.hh"
 #include "Offline/CRVConditions/inc/CRVPhotonYield.hh"
 #include "Offline/CRVResponse/inc/MakeCrvPhotons.hh"
@@ -257,6 +258,7 @@ namespace mu2e
 
   void CrvPhotonGenerator::produce(art::Event& event)
   {
+    perEventReseed(_engine, event.id(), "CrvPhotonGenerator");
     std::unique_ptr<CrvPhotonsCollection> crvPhotonsCollection(new CrvPhotonsCollection);
 
     std::map<std::pair<mu2e::CRSScintillatorBarIndex,int>,std::vector<CrvPhotons::SinglePhoton> > photonMap;

--- a/CRVResponse/src/CrvSiPMChargeGenerator_module.cc
+++ b/CRVResponse/src/CrvSiPMChargeGenerator_module.cc
@@ -4,6 +4,7 @@
 //
 // Original Author: Ralf Ehrlich
 
+#include "Offline/SeedService/inc/PerEventReseed.hh"
 #include "Offline/CRVConditions/inc/CRVDigitizationPeriod.hh"
 #include "Offline/CRVConditions/inc/CRVStatus.hh"
 #include "Offline/CRVResponse/inc/MakeCrvSiPMCharges.hh"
@@ -158,6 +159,7 @@ namespace mu2e
 
   void CrvSiPMChargeGenerator::produce(art::Event& event)
   {
+    perEventReseed(_engine, event.id(), "CrvSiPMChargeGenerator");
     std::unique_ptr<CrvSiPMChargesCollection> crvSiPMChargesCollection(new CrvSiPMChargesCollection);
 
     art::Handle<CrvPhotonsCollection> crvPhotonsCollection;

--- a/CRVResponse/src/CrvWaveformsGenerator_module.cc
+++ b/CRVResponse/src/CrvWaveformsGenerator_module.cc
@@ -4,6 +4,7 @@
 //
 // Original Author: Ralf Ehrlich
 
+#include "Offline/SeedService/inc/PerEventReseed.hh"
 #include "Offline/CRVResponse/inc/MakeCrvWaveforms.hh"
 #include "Offline/CosmicRayShieldGeom/inc/CosmicRayShield.hh"
 #include "Offline/CRVConditions/inc/CRVCalib.hh"
@@ -151,6 +152,7 @@ namespace mu2e
 
   void CrvWaveformsGenerator::produce(art::Event& event)
   {
+    perEventReseed(_engine, event.id(), "CrvWaveformsGenerator");
     art::Handle<EventWindowMarker> eventWindowMarker;
     event.getByLabel(_eventWindowMarkerTag,eventWindowMarker);
     EventWindowMarker::SpillType spillType = eventWindowMarker->spillType();

--- a/CaloMC/src/CaloDigiMaker_module.cc
+++ b/CaloMC/src/CaloDigiMaker_module.cc
@@ -4,6 +4,7 @@
 // Simulate digitization procedure and produce CaloDigis.
 //
 //
+#include "Offline/SeedService/inc/PerEventReseed.hh"
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Services/Optional/RandomNumberGenerator.h"
@@ -143,6 +144,7 @@ namespace mu2e {
   //---------------------------------------------------------
   void CaloDigiMaker::produce(art::Event& event)
   {
+    perEventReseed(engine_, event.id(), "CaloDigiMaker");
 
       if ( diagLevel_ > 0 ) std::cout<<"[CaloDigiMaker::produce] begin" << std::endl;
 

--- a/CaloMC/src/CaloShowerROMaker_module.cc
+++ b/CaloMC/src/CaloShowerROMaker_module.cc
@@ -3,6 +3,7 @@
 // Includes corrections from Birks law, longitudinal response uniformity and photo-statistics fluctuations.
 // The PE are generated individually and corrected for transit time.
 //
+#include "Offline/SeedService/inc/PerEventReseed.hh"
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
 #include "canvas/Utilities/InputTag.h"
@@ -159,6 +160,7 @@ namespace mu2e {
   //---------------------------------------------------------------
   void CaloShowerROMaker::produce(art::Event& event)
   {
+    perEventReseed(engine_, event.id(), "CaloShowerROMaker");
       if (diagLevel_ > 0) std::cout << "[CaloShowerROMaker::produce] begin" << std::endl;
 
       const EventWindowMarker& ewMarker = *event.getValidHandle(ewMarkerToken_);

--- a/CommonMC/src/EventWindowMarkerProducer_module.cc
+++ b/CommonMC/src/EventWindowMarkerProducer_module.cc
@@ -5,6 +5,7 @@
 //
 // ======================================================================
 
+#include "Offline/SeedService/inc/PerEventReseed.hh"
 #include "art/Framework/Core/EDProducer.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -98,6 +99,7 @@ namespace mu2e {
   }
 
   void EventWindowMarkerProducer::produce(art::Event& event) {
+    perEventReseed(_engine, event.id(), "EventWindowMarkerProducer");
     unique_ptr<EventWindowMarker> marker(new EventWindowMarker);
     unique_ptr<ProtonBunchTimeMC> pbtmc(new ProtonBunchTimeMC);
     unique_ptr<ProtonBunchTime> pbt(new ProtonBunchTime);

--- a/EventMixing/src/ProtonBunchIntensityLogNormal_module.cc
+++ b/EventMixing/src/ProtonBunchIntensityLogNormal_module.cc
@@ -9,6 +9,7 @@
 // Original author: David Brown (LBNL) 19 May 2015
 // Revamp: Andrei Gaponenko, 2018
 
+#include "Offline/SeedService/inc/PerEventReseed.hh"
 #include <random>
 #include <numbers>
 //#include "gsl/gsl_sf_erf.h"
@@ -53,6 +54,7 @@ namespace mu2e {
 
   private:
     art::InputTag pp_;
+    art::RandomNumberGenerator::base_engine_t& engine_;
     artURBG urbg_;
     std::lognormal_distribution<double> lognd_;
     std::uniform_real_distribution<double> unitflatd_;
@@ -68,7 +70,8 @@ namespace mu2e {
   ProtonBunchIntensityLogNormal::ProtonBunchIntensityLogNormal(const Parameters& conf)
     : art::EDProducer{conf}
     , pp_(conf().PP())
-    , urbg_(createEngine(art::ServiceHandle<SeedService>()->getSeed()))
+    , engine_(createEngine(art::ServiceHandle<SeedService>()->getSeed()))
+    , urbg_(engine_)
     , unitflatd_(0.0,1.0)
     , debug_(conf().debug())
     , mean_(conf().extendedMean())
@@ -120,6 +123,7 @@ namespace mu2e {
   }
 
   void ProtonBunchIntensityLogNormal::produce(art::Event& event) {
+    perEventReseed(engine_, event.id(), "ProtonBunchIntensityLogNormal");
     // determine the event type
     auto pph = event.getValidHandle<PrimaryParticle>(pp_);
     auto const& pp = *pph;

--- a/SeedService/inc/PerEventReseed.hh
+++ b/SeedService/inc/PerEventReseed.hh
@@ -1,0 +1,43 @@
+#ifndef SeedService_PerEventReseed_hh
+#define SeedService_PerEventReseed_hh
+//
+// Per-event deterministic reseeding of a CLHEP engine (Offline issue #849).
+//
+// Under Mu2eG4MT, events reach the legacy modules downstream of g4run in a
+// scheduler-dependent order, so any module consuming a sequential random
+// stream is irreproducible run-to-run.  G4 itself is immune because
+// Mu2eG4WorkerRunManager reseeds per event from a hash of the EventID; this
+// header applies the identical recipe to any seeded module.
+//
+// Gated on the environment variable MU2E_RESEED_PER_EVENT so that default
+// behavior (and reproducibility of existing single-threaded productions) is
+// completely unchanged unless explicitly enabled.
+//
+#include "CLHEP/Random/RandomEngine.h"
+#include "canvas/Persistency/Provenance/EventID.h"
+#include <cstdlib>
+#include <functional>
+#include <string>
+
+namespace mu2e {
+
+  inline bool perEventReseedEnabled() {
+    static const bool on = (std::getenv("MU2E_RESEED_PER_EVENT") != nullptr);
+    return on;
+  }
+
+  // Same construction as Mu2eG4WorkerRunManager::initializeRun: hash a
+  // string of run/subrun/event plus a per-module salt, mask to 31 bits.
+  inline void perEventReseed(CLHEP::HepRandomEngine& engine,
+                             art::EventID const& id,
+                             std::string const& salt) {
+    if (!perEventReseedEnabled()) return;
+    std::string const msg = "r" + std::to_string(id.run())
+                          + "s" + std::to_string(id.subRun())
+                          + "e" + std::to_string(id.event()) + salt;
+    std::hash<std::string> hf;
+    engine.setSeed(static_cast<long>(hf(msg) & 0x7FFFFFFFUL), 0);
+  }
+
+} // namespace mu2e
+#endif

--- a/TrackerMC/src/StrawDigisFromStrawGasSteps_module.cc
+++ b/TrackerMC/src/StrawDigisFromStrawGasSteps_module.cc
@@ -5,6 +5,7 @@
 // Original author David Brown, LBNL
 //
 // framework
+#include "Offline/SeedService/inc/PerEventReseed.hh"
 #include "art/Framework/Principal/Event.h"
 #include "fhiclcpp/ParameterSet.h"
 #include "art/Framework/Principal/Handle.h"
@@ -454,6 +455,7 @@ namespace mu2e {
     }
 
     void StrawDigisFromStrawGasSteps::produce(art::Event& event) {
+    perEventReseed(_engine, event.id(), "StrawDigisFromStrawGasSteps");
       if ( _printLevel > 1 ) cout << "StrawDigisFromStrawGasSteps: produce() begin; event " << event.id().event() << endl;
       static int ncalls(0);
       ++ncalls;


### PR DESCRIPTION
## Motivation

Under `Mu2eG4MT`, events reach the legacy modules downstream of `g4run` in a scheduler-dependent order, so any module consuming a sequential random stream is irreproducible run-to-run — issue #849. G4 itself is immune because `Mu2eG4WorkerRunManager` reseeds each event deterministically from a hash of the EventID.

Demonstrated on `Production/Validation/ceSimReco.fcl` (100 events, `baseSeed 8`, two identical runs per configuration): with 2-thread/2-schedule `Mu2eG4MT`, the two runs wrote **16 vs 12 events with only 9 in common**, and on those 9 the `g4run` tracker StepPointMCs hashed identical while the StrawDigis differed on all of them — the break is exactly the seeded digitizers, not G4.

## Change

`SeedService/inc/PerEventReseed.hh` applies the identical recipe to any seeded module: hash `run/subrun/event` plus a per-module salt, `setSeed` at the top of `produce()`. Wired into the eight seeded modules downstream of `g4run` in the digitization chain:

`StrawDigisFromStrawGasSteps`, `CaloDigiMaker`, `CaloShowerROMaker`, `CrvPhotonGenerator`, `CrvSiPMChargeGenerator`, `CrvWaveformsGenerator`, `EventWindowMarkerProducer`, `ProtonBunchIntensityLogNormal` (this one keeps an engine reference beside its `artURBG` wrapper, which hides the engine).

**Gated on the environment variable `MU2E_RESEED_PER_EVENT`** — default behavior, and bit-reproducibility of existing single-threaded productions, is completely unchanged unless explicitly enabled. Happy to convert the gate to a fcl parameter if that is preferred.

## Validation

Same 2×2 harness, patched plugins confirmed loaded, gate enabled:

| pair | before | after |
|---|---|---|
| single-threaded ×2 | identical | identical (no regression) |
| `Mu2eG4MT` 2×2 ×2 | divergent (16 vs 12 events; digis differ 9/9) | **bit-identical** (15/15 events; g4 0/15, digi 0/15 differ) |

Estimated cost of the reseed itself is ~26 µs/engine/event (`HepJamesRandom::setSeed`, measurement from the #849 thread), i.e. ~0.25% of a 0.2 s/event job — and zero when the gate is off.

Notes:
- ST and MT outputs remain different realizations of the same physics (per-event g4 tracker steps are identical; the residual enters via intermediates not persisted in the validation output). Each configuration now reproduces itself exactly, which is the #849 requirement.
- A separate MT teardown fatal (`G4CacheReference<V>::Destroy`, Cache001, after the output file closes) was observed in 1 of 2 MT runs before and after this change; it is out of scope here.
- The patched-module builds and validation ran against `v13_12_10`/`SimJob Run1Bak`; the two CaloMC modules were reworked on `main` since, so the change was re-applied on `main` at the same anchors (`engine_`, `produce(art::Event& event)`). CI is the compile check for `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5HnfdYMwXXrJGAkYVE48c
