### PR TITLE
always get fresh run list

### DIFF
--- a/DbService/src/RunTool.cc
+++ b/DbService/src/RunTool.cc
@@ -116,11 +116,7 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
   select = "run_number,comment,create_time,run_type_id";
   table = "online.run";
   order = "-run_number";
-  // Bypass the web cache for this query. It is unfiltered (no WHERE), so the
-  // whole table is cached as one blob on the server and refreshed on its own
-  // schedule -- runs inserted since the last refresh are silently absent
-  // from it, which makes them invisible to every selection (-r, --last,
-  // plain listing) even though they're already in the database.
+  // Bypass the web cache for this query so we always get the latest runs
   _reader.setUseCache(false);
   int rc = _reader.query(tcsv, select, table, where, order);
   _reader.setUseCache(true);

--- a/DbService/src/RunTool.cc
+++ b/DbService/src/RunTool.cc
@@ -116,7 +116,14 @@ RunInfo::RunVec RunTool::listRuns(const RunSelect& runsel, bool configs,
   select = "run_number,comment,create_time,run_type_id";
   table = "online.run";
   order = "-run_number";
+  // Bypass the web cache for this query. It is unfiltered (no WHERE), so the
+  // whole table is cached as one blob on the server and refreshed on its own
+  // schedule -- runs inserted since the last refresh are silently absent
+  // from it, which makes them invisible to every selection (-r, --last,
+  // plain listing) even though they're already in the database.
+  _reader.setUseCache(false);
   int rc = _reader.query(tcsv, select, table, where, order);
+  _reader.setUseCache(true);
   if (rc != 0 || tcsv.empty()) {
     throw cet::exception("RUNTOOL_BAD_RUN_QUERY")
         << " RunTool::listRuns failed to retrieve runs \n";


### PR DESCRIPTION
The previous query was going to the web cache so wasn't always up to date.  Here we always get the latest list of runs directly from the db.