### PR TITLE
CRVResponse: fix defects found by a static sweep of the package

### DIFF
--- a/CRVResponse/CMakeLists.txt
+++ b/CRVResponse/CMakeLists.txt
@@ -66,6 +66,7 @@ cet_build_plugin(CrvPlot art::module
       Offline::CRVConditions
       Offline::DataProducts
       Offline::GeometryService
+      Offline::GlobalConstantsService
       Offline::MCDataProducts
       Offline::ProditionsService
       Offline::RecoDataProducts

--- a/CRVResponse/src/CrvPhotonGenerator_module.cc
+++ b/CRVResponse/src/CrvPhotonGenerator_module.cc
@@ -198,7 +198,10 @@ namespace mu2e
       bool tableLoaded=false;
       for(size_t j=0; j<i; ++j)
       {
-        if(_lookupTableFileNames[i]==_lookupTableFileNames[j])
+        // the scintillation yield is state held on the shared MakeCrvPhotons instance, so two
+        // sectors may only share an instance if they agree on the yield as well as the table
+        if(_lookupTableFileNames[i]==_lookupTableFileNames[j] &&
+           _scintillationYields[i]==_scintillationYields[j])
         {
            tableLoaded=true;
            _makeCrvPhotons.emplace_back(_makeCrvPhotons[j]);

--- a/CRVResponse/src/CrvPlot_module.cc
+++ b/CRVResponse/src/CrvPlot_module.cc
@@ -7,6 +7,7 @@
 #include "Offline/CosmicRayShieldGeom/inc/CosmicRayShield.hh"
 #include "Offline/DataProducts/inc/CRSScintillatorBarIndex.hh"
 
+#include "cetlib_except/exception.h"
 #include "Offline/GlobalConstantsService/inc/GlobalConstantsHandle.hh"
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/CRVConditions/inc/CRVDigitizationPeriod.hh"
@@ -122,6 +123,18 @@ namespace mu2e
     art::Handle<CrvRecoPulseCollection> crvRecoPulseCollection;
     event.getByLabel(_crvRecoPulsesModuleLabel,"",crvRecoPulseCollection);
 
+    // any of these products can legitimately be absent from a file whose intermediate CRV
+    // collections were dropped, so say which one is missing instead of dereferencing an
+    // invalid handle (CrvMCHelper.cc and CrvCoincidenceClusterMatchMC_module.cc guard the same way)
+    if(!crvPhotonsCollection.isValid())
+      throw cet::exception("SIM")<<"mu2e::CrvPlot: no CrvPhotonsCollection with label "<<_crvPhotonsModuleLabel<<std::endl;
+    if(!crvSiPMChargesCollection.isValid())
+      throw cet::exception("SIM")<<"mu2e::CrvPlot: no CrvSiPMChargesCollection with label "<<_crvSiPMChargesModuleLabel<<std::endl;
+    if(!crvDigiCollection.isValid())
+      throw cet::exception("SIM")<<"mu2e::CrvPlot: no CrvDigiCollection with label "<<_crvDigiModuleLabel<<std::endl;
+    if(!crvRecoPulseCollection.isValid())
+      throw cet::exception("SIM")<<"mu2e::CrvPlot: no CrvRecoPulseCollection with label "<<_crvRecoPulsesModuleLabel<<std::endl;
+
     auto const& calib = _calib_h.get(event.id());
 
     GeomHandle<CosmicRayShield> CRS;
@@ -233,8 +246,10 @@ namespace mu2e
 //waveforms
       std::vector<std::vector<double> > ADCs[4];  //there can be multiple disconnected ADC waveforms per SiPM
       std::vector<std::vector<double> > times[4];
-      double scale[4]={NAN};
-      double maxADC[4]={NAN};
+      // NB: `double x[4]={NAN};` would set only element 0 to NAN and value-initialize 1-3 to 0.0,
+      // which silently defeats the isnan() "no digis" guard below for SiPMs 1-3
+      double scale[4]={NAN,NAN,NAN,NAN};
+      double maxADC[4]={NAN,NAN,NAN,NAN};
       CrvDigiCollection::const_iterator digis;
       for(digis=crvDigiCollection->begin(); digis!=crvDigiCollection->end(); ++digis)
       {

--- a/CRVResponse/src/CrvWidebandTest_module.cc
+++ b/CRVResponse/src/CrvWidebandTest_module.cc
@@ -241,8 +241,23 @@ namespace mu2e
   CrvWidebandTest::~CrvWidebandTest()
   {
     delete[] _recoPEs;
+    delete[] _recoTime;
+    delete[] _fitStatus;
     delete[] _depositedEnergy;
     delete[] _coincidencePDGid;
+    delete[] _coincidenceTime;
+    delete[] _coincidencePosX;
+    delete[] _coincidencePosY;
+    delete[] _coincidencePosZ;
+    delete[] _trackSlope;
+    delete[] _trackIntercept;
+    delete[] _trackPoints;
+    delete[] _trackPEs;
+    delete[] _trackChi2;
+    delete[] _summaryPEs;
+    delete[] _summaryFWHMs;
+    delete[] _summarySignals;
+    delete[] _summaryChi2s;
   }
 
   void CrvWidebandTest::beginJob()
@@ -396,6 +411,15 @@ namespace mu2e
     //fits for the entire stack of modules/sectors (sectorType=0) and for individual modules/sectors (sectorType=1,...)
     for(int iSectorType=0; iSectorType<_nSectorTypes; ++iSectorType)
     {
+     //reset the per-event track variables for EVERY sector type, including the trigger sectors
+     //skipped below: these arrays are branched into the tree at dimension _nSectorTypes and are
+     //filled every event, so an un-reset trigger-sector entry would persist whatever new[] left there
+     _trackSlope[iSectorType]    =0;
+     _trackIntercept[iSectorType]=0;
+     _trackPEs[iSectorType]      =0;
+     _trackPoints[iSectorType]   =0;
+     _trackChi2[iSectorType]     =-1;
+
      if(std::find(_triggerSectorTypes.begin(),_triggerSectorTypes.end(), iSectorType) != _triggerSectorTypes.end()) continue;
 
      //initialize track variables
@@ -403,11 +427,6 @@ namespace mu2e
      float sumY     =0;
      float sumXY    =0;
      float sumYY    =0;
-     _trackSlope[iSectorType]    =0;
-     _trackIntercept[iSectorType]=0;
-     _trackPEs[iSectorType]      =0;
-     _trackPoints[iSectorType]   =0;
-     _trackChi2[iSectorType]     =-1;
 
       double counterWidth = counters.at(0)->getBarDetail().getHalfWidth()*2.0;
       int widthDirection = counters.at(0)->getBarDetail().getWidthDirection();  //assumes that all counters are oriented in the same way

--- a/CRVResponse/src/MakeCrvDigis.cc
+++ b/CRVResponse/src/MakeCrvDigis.cc
@@ -9,10 +9,12 @@ void MakeCrvDigis::SetWaveform(const std::vector<double> &waveform, double ADCco
   _ADCs.resize(waveform.size());
   for(size_t i=0; i<waveform.size(); i++)
   {
-    int16_t ADC = static_cast<int16_t>(waveform[i]*ADCconversionFactor+pedestal+0.5);
-    if(ADC<minADC) ADC=minADC;
-    if(ADC>maxADC) ADC=maxADC;
-    _ADCs.at(i)=ADC;
+    // clamp before narrowing: an extreme sample cast to int16_t first would wrap around and
+    // land back inside [minADC,maxADC], so the saturation clamp would never see it
+    double ADCd = waveform[i]*ADCconversionFactor+pedestal+0.5;
+    if(ADCd<minADC) ADCd=minADC;
+    if(ADCd>maxADC) ADCd=maxADC;
+    _ADCs.at(i)=static_cast<int16_t>(ADCd);
   }
 
   int TDCtmp=lrint(startTime/digitizationPrecision);

--- a/CRVResponse/src/MakeCrvPhotons.cc
+++ b/CRVResponse/src/MakeCrvPhotons.cc
@@ -275,6 +275,10 @@ void LookupBin::Read(std::ifstream &lookupfile, const unsigned int &i)
   for(unsigned int i=0; i<nScintillatorScintillationBins; i++) _bins[0][i].Read(lookupfile,i);
   for(unsigned int i=0; i<nScintillatorCerenkovBins; i++)      _bins[1][i].Read(lookupfile,i);
   for(unsigned int i=0; i<nFiberCerenkovBins; i++)             _bins[2][i].Read(lookupfile,i);
+  // a truncated table would otherwise leave the bin boundaries and yield curves holding
+  // whatever was in the buffers, and the job would continue with silently wrong photon yields
+  if(!lookupfile) throw std::logic_error("Error while reading CRV lookup table file "+filename+
+                                         " (truncated or corrupt).");
   if(debug>0) std::cout<<"Done."<<std::endl;
 
   lookupfile.close();

--- a/CRVResponse/src/MakeCrvSiPMCharges.cc
+++ b/CRVResponse/src/MakeCrvSiPMCharges.cc
@@ -45,7 +45,11 @@ std::pair<int,int> MakeCrvSiPMCharges::FindFiberPhotonsPixelId()
 {
   double x,y;
   _photonMap->GetRandom2(x,y);
-  return std::pair<int,int>(lrint(x),lrint(y));
+  // GetRandom2 samples the full width of the outermost bin, so lrint can return _nPixelsX/Y,
+  // one past the last pixel; that phantom pixel would carry its own discharge state
+  int ix=std::min(std::max(static_cast<int>(lrint(x)),0),_nPixelsX-1);
+  int iy=std::min(std::max(static_cast<int>(lrint(y)),0),_nPixelsY-1);
+  return std::pair<int,int>(ix,iy);
 }
 
 bool MakeCrvSiPMCharges::IsInactivePixelId(const std::pair<int,int> &pixelId)

--- a/CRVResponse/src/MakeCrvWaveforms.cc
+++ b/CRVResponse/src/MakeCrvWaveforms.cc
@@ -48,6 +48,8 @@ void MakeCrvWaveforms::LoadSinglePEWaveform(const std::string &filename, double 
   }
   f.close();
 
+  if(_singlePEWaveform.empty())
+    throw std::logic_error("Could not read any single PE waveform points from "+filename);
   _singlePEMaxVoltage = *std::max_element(_singlePEWaveform.begin(), _singlePEWaveform.end());
 }
 


### PR DESCRIPTION
Nine defects found by a static review of `CRVResponse` at `0ef02a66d`. **I have not built this locally — relying on `mu2e/buildtest`.**

⚠️ **Finding 1 changes CRV simulation output.** Please read it first and decide whether you want it fixed forward or handled some other way — I have no view on which, and I am happy to drop that commit and keep the rest.

---

### 1. 🟠 CRV sector T5 is simulated at +30.5% light yield — and has been since `prolog_v11`

`src/CrvPhotonGenerator_module.cc:198-210` dedups `MakeCrvPhotons` instances by lookup-table **filename**. On a hit it shares the existing `shared_ptr` and `continue`s, so `SetScintillationYield` — which only runs on the first-load branch at `:223` — is never called for the second sector. The shared instance keeps the *first* sector's yield.

In `prolog_v12.fcl`, T3/T4/T5 all name `CRVConditions/v6_0/LookupTable_6000_0` with `scintillationYields` `39794, 39794, 30482`:

| sector | configured yield | yield actually used |
|---|---|---|
| T3 | 39794 | 39794 (loads first) |
| T4 | 39794 | 39794 (correct by coincidence) |
| T5 | **30482** | **39794** ← +30.5% |

It is the only mismatched filename group in the file — every other duplicate group (R1/R2/R5/L1… on `4550_0`, T1/T2 on `6000_1`) has identical yields. The `_debug>0` line at `:205` prints `_scintillationYields[i]`, the *configured* value rather than the one in use, so the log actively conceals the substitution.

**Scope beyond the current prolog:** `prolog_v11.fcl` carries the identical filenames and yields. `v10`/`v09` list only T1–T4, all at 39400, so no mismatch existed. The defect entered when T5 was added at v11 and is therefore in already-produced datasets, not only future ones.

Fixed by requiring the yields to agree as well as the filename before sharing an instance.

### 2. 🟠 SiPM pixel id can be one past the last pixel

`src/MakeCrvSiPMCharges.cc:44-49` returned `lrint` of an unbounded `GetRandom2` sample. The outermost `[39,40)` bin yields pixel id 40 in a 40×40 array — a phantom pixel with its own discharge state, inflating simulated SiPM charge. Clamped to the array.

### 3. 🟠 `LoadLookupTable` never checks stream state

`src/MakeCrvPhotons.cc:275-280` reads the Cerenkov map and all three bin arrays with no check afterwards. A truncated table leaves bin boundaries and yield curves holding whatever was in the buffers and the job continues with silently wrong photon yields. Now throws.

### 4. 🟠 `CrvWidebandTest` persists indeterminate track-fit values for trigger sectors

`src/CrvWidebandTest_module.cc:397-410`: the `continue` that skips `triggerSectorTypes` fires *before* the reset block, so for every index in `triggerSectorTypes` (`[5,6]` in `wideband4modules.fcl`, `[2,3,4,5]` in `widebandMuonTaggers.fcl`) `trackSlope`/`trackIntercept`/`trackPEs`/`trackPoints`/`trackChi2` hold whatever `new[]` returned on event 1 — and `_tree->Fill()` persists them every event, where the adjacent lines clearly intend the `0`/`-1` "no fit" sentinel. Moved the resets above the `continue`.

### 5. 🟡 `MakeCrvDigis` narrows before it saturates

`src/MakeCrvDigis.cc:12-14` cast to `int16_t` and *then* applied the `[minADC,maxADC]` clamp, so an extreme sample wraps around and lands back inside the range instead of saturating. Clamp in `double`, then narrow.

### 6. 🟡 `max_element` on a possibly-empty vector

`src/MakeCrvWaveforms.cc:51` — `LoadSinglePEWaveform` opens the file and checks `good()`, but a file that opens and yields no points reaches `max_element` on an empty vector.

### 7. 🟡 `CrvPlot`: `{NAN}` initializes only element 0

`src/CrvPlot_module.cc:236-237` — `double scale[4]={NAN};` sets element 0 to NAN and **value-initializes 1–3 to 0.0**. The `isnan(scale[SiPM])` "no digis" guard at `:305` therefore fails open for SiPM 1–3 and a flat y=0 curve is drawn; SiPM 0 conversely builds a `TGaxis` with a NaN bound at `:287`. Same bug in `maxADC[4]`.

### 8. 🟡 `CrvPlot`: four unchecked `art::Handle`s

`:113-124` uses `getByLabel` and never checks `isValid()`. `CrvMCHelper.cc:12` and `CrvCoincidenceClusterMatchMC_module.cc:119` guard the same case. Now throws naming the missing product.

### 9. 🟡 `CrvPlot`'s CMakeLists omits `Offline::GlobalConstantsService`

Despite `GlobalConstantsHandle<PhysicsParams>` at `:102`. It resolves transitively today, so this is hygiene, not a build break.

Also fixed alongside 4: `CrvWidebandTest`'s destructor freed 3 of its 18 `new[]` arrays.

---

### Validation

- **Build: not run locally.** Everything above is static — read from the source, `Production` and `mu2e-trig-config`, plus grep. Please let `buildtest` be the arbiter.
- **No art job was run.** Finding 1 is the cheapest to confirm empirically: run any CRV sim job with `debug > 0` and compare the printed T5 yield against `GetScintillationYield()` on the instance actually used — the print is the very line that hides it.
- **Lookup-table contents were not reviewed.** `CRVConditions/v6_0/*` and `data/singlePEWaveform*.txt` were taken as given; finding 3 is about the absent read check, not the data.
- **`prolog_v03..v11` were not audited** except where finding 1 required it — they are frozen history for reproducing old datasets.
- **Not included, deliberately:** `triggerSectorTypes` is a mandatory key with no default and is unset in the Production wideband config — that fix belongs in `Production`, not here. Two `CRVTest` issues (mandatory keys absent from 5 of its 6 `test/` fcl; unguarded division filling NaN into two histograms) are hand-run-only and left out to keep this PR to code that production runs. Happy to open an issue with the full 16.
