### PR TITLE
TrkHitReco: fix defects found by a static sweep of the package

### DIFF
--- a/TrkHitReco/src/CombineStrawHits_module.cc
+++ b/TrkHitReco/src/CombineStrawHits_module.cc
@@ -21,6 +21,8 @@
 #include "TMath.h"
 
 #include <iostream>
+#include <numeric>
+#include <vector>
 
 namespace mu2e {
 
@@ -61,7 +63,10 @@ namespace mu2e {
       void produce( art::Event& e);
 
     private:
-      void combine(EventWindowMarker const& ewm, ComboHitCollection const& chcOrig, ComboHitCollection& chcol);
+      // origIndex maps a position in chcOrig to the corresponding index in chcol's parent
+      // collection; it is the identity unless the input was re-sorted first
+      void combine(EventWindowMarker const& ewm, ComboHitCollection const& chcOrig, ComboHitCollection& chcol,
+                   std::vector<uint16_t> const& origIndex);
       void combineHits(const ComboHitCollection& chcOrig, ComboHit& combohit);
 
       int           _debug;
@@ -143,20 +148,29 @@ namespace mu2e {
         // select hits based on flag
         panels[ch.strawId().uniquePanel()].push_back(ish);
       }
+      // chcolNew's parent is chcH (the unsorted input), so record where each sorted hit came
+      // from: without this the ComboHits would store positions in chcolsort while resolving
+      // them against chcOrig, silently corrupting per-hit provenance
+      std::vector<uint16_t> origIndex;
+      origIndex.reserve(nsh);
       for (uint16_t ipanel=0;ipanel<StrawId::_nupanels;ipanel++){
         for (uint16_t ish=0;ish<panels[ipanel].size();ish++){
           chcolsort.push_back(chcOrig.at(panels[ipanel][ish]));
+          origIndex.push_back(panels[ipanel][ish]);
         }
       }
-      combine(ewm, chcolsort, *chcolNew);
+      combine(ewm, chcolsort, *chcolNew, origIndex);
     }else{
-      combine(ewm, chcOrig, *chcolNew);
+      std::vector<uint16_t> origIndex(chcOrig.size());
+      std::iota(origIndex.begin(), origIndex.end(), 0);
+      combine(ewm, chcOrig, *chcolNew, origIndex);
     }
     event.put(std::move(chcolNew));
   }
 
 
-  void CombineStrawHits::combine(EventWindowMarker const& ewm, ComboHitCollection const& chcOrig, ComboHitCollection& chcol)
+  void CombineStrawHits::combine(EventWindowMarker const& ewm, ComboHitCollection const& chcOrig, ComboHitCollection& chcol,
+                                 std::vector<uint16_t> const& origIndex)
   {
 
     float minT = _minT;
@@ -175,7 +189,7 @@ namespace mu2e {
       if ( _testflag && hit1.flag().hasAnyProperty(StrawHitFlag::dead)) continue;
       if ( _testflag && (!hit1.flag().hasAllProperties(_shsel) || hit1.flag().hasAnyProperty(_shmask))) continue;
       ComboHit combohit;
-      combohit.init(hit1,ich);
+      combohit.init(hit1,origIndex[ich]);
       int panel1 = hit1.strawId().uniquePanel();
 
       for (size_t jch=ich+1;jch<chcOrig.size();++jch) {
@@ -194,7 +208,7 @@ namespace mu2e {
         float wdchi = fabs(hit1.wireDist() - hit2.wireDist())/wderr;
         if (wdchi > _maxwdchi) continue;
 
-        bool ok = combohit.addIndex(jch);
+        bool ok = combohit.addIndex(origIndex[jch]);
         if (!ok){
           std::cout << "CombineStrawHits past limit" << std::endl;
         } else {
@@ -206,7 +220,7 @@ namespace mu2e {
       combohit._flag = initialFlag;
       int nch = combohit.nCombo();
       if(nch  < _minN || nch > _maxN){
-        if(_filter)break;
+        if(_filter)continue;
       } else
         combohit._flag.merge(StrawHitFlag::nhitsel);
       // actually combine the hits if necessar, and make the cuts
@@ -214,19 +228,19 @@ namespace mu2e {
 
       auto time = _useTOT ? combohit.correctedTime() : combohit.time();
       if (time < minT || time > maxT ){
-        if(_filter)break;
+        if(_filter)continue;
       } else
         combohit._flag.merge(StrawHitFlag::timesel);
 
       auto energy = combohit.energyDep();
       if( energy > _maxE || energy < _minE ) {
-        if(_filter)break;
+        if(_filter)continue;
       } else
         combohit._flag.merge(StrawHitFlag::energysel);
 
       auto r2 = combohit.pos().Perp2();
       if( r2 < _minR2 || r2 > _maxR2 ) {
-        if(_filter)break;
+        if(_filter)continue;
       } else
         combohit._flag.merge(StrawHitFlag::radsel);
       combohit._mask = _mask;

--- a/TrkHitReco/src/CombineStrawHits_module.cc
+++ b/TrkHitReco/src/CombineStrawHits_module.cc
@@ -190,6 +190,10 @@ namespace mu2e {
       if ( _testflag && (!hit1.flag().hasAllProperties(_shsel) || hit1.flag().hasAnyProperty(_shmask))) continue;
       ComboHit combohit;
       combohit.init(hit1,origIndex[ich]);
+      // TimeDivision is a quality tag: StrawHitRecoUtils sets it only when the longitudinal
+      // position was actually measured, and leaves it off when StrawResponse had to clamp the
+      // position to the straw end.  It must therefore be propagated from the constituents.
+      bool tdiv = hit1.flag().hasAllProperties(StrawHitFlag::tdiv);
       int panel1 = hit1.strawId().uniquePanel();
 
       for (size_t jch=ich+1;jch<chcOrig.size();++jch) {
@@ -213,11 +217,12 @@ namespace mu2e {
           std::cout << "CombineStrawHits past limit" << std::endl;
         } else {
           isUsed[jch]= true;
+          tdiv &= hit2.flag().hasAllProperties(StrawHitFlag::tdiv);
         }
       }
-      // clear the flag bits; they are reset later
-      const static StrawHitFlag initialFlag("TimeDivision");
-      combohit._flag = initialFlag;
+      // clear the flag bits; they are reset below
+      combohit._flag = StrawHitFlag();
+      if(tdiv) combohit._flag.merge(StrawHitFlag::tdiv);
       int nch = combohit.nCombo();
       if(nch  < _minN || nch > _maxN){
         if(_filter)continue;
@@ -263,7 +268,7 @@ namespace mu2e {
     {
       size_t index = combohit.index(ich);
       if (_debug > 3)std::cout << index << ", ";
-      if (index > chcOrig.size())
+      if (index >= chcOrig.size())
         throw cet::exception("RECO")<<"mu2e::CombineStrawHits: inconsistent index "<<std::endl;
 
       const ComboHit& ch = chcOrig[index];

--- a/TrkHitReco/src/StereoLineTest_main.cc
+++ b/TrkHitReco/src/StereoLineTest_main.cc
@@ -77,7 +77,7 @@ int main(int argc, char** argv) {
   double dz = deltaz/(npts-1);
   std::random_device r;
   std::default_random_engine eng(r());
-  std::uniform_int_distribution<int> phirange(-M_PI,M_PI);
+  std::uniform_real_distribution<double> phirange(-M_PI,M_PI);
   std::normal_distribution urand{0.0, ures};
   std::normal_distribution vrand{0.0, vres};
 

--- a/TrkHitReco/src/StrawHitReco_module.cc
+++ b/TrkHitReco/src/StrawHitReco_module.cc
@@ -5,6 +5,7 @@
 // Merged with flag and position creation B. Echenard, CalTech
 //
 // framework
+#include "cetlib_except/exception.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
@@ -147,6 +148,9 @@ namespace mu2e {
     produces<ComboHitCollection>();
     produces<IntensityInfoTrackerHits>();
     if (_writesh) produces<StrawHitCollection>();
+    // flagCrossTalk reads the StrawHitCollection, which is only created when it is written out
+    if (_flagXT && !_writesh)
+      throw cet::exception("RECO")<<"mu2e::StrawHitReco: FlagCrossTalk requires WriteStrawHitCollection"<<std::endl;
     if (_printLevel > 0) std::cout << "In StrawHitReco constructor " << std::endl;
   }
 
@@ -213,10 +217,11 @@ namespace mu2e {
       _shrUtils.createComboHit(ewm, isd, chCol, shCol, caloClusters, pbtOffset,
           digi.strawId(), digi.TDC(), digi.TOT(), pmp,
           trackerStatus,  srep, tt);
-      //flag straw and electronic cross-talk
-      if(_flagXT){
-        _shrUtils.flagCrossTalk(shCol, chCol);
-      }
+    }
+    //flag straw and electronic cross-talk: this scans the whole collection, so it must run once
+    //per event, not once per digi
+    if(_flagXT){
+      _shrUtils.flagCrossTalk(shCol, chCol);
     }
     if(_writesh)event.put(std::move(shCol));
     intInfo->setNTrackerHits(chCol->size());


### PR DESCRIPTION
Six defects found by a static review of `TrkHitReco` at `0ef02a66d`. **I have not built this locally — relying on `mu2e/buildtest`.**

---

### 1. 🔴 `CombineStrawHits`: ComboHit parent and stored indices reference two different collections

`src/CombineStrawHits_module.cc:131` binds the output to the original input handle:

```cpp
chcolNew->setParent(chcH);
```

but the `Unsorted:true` branch (`:133-151`) permutes the hits into a local `chcolsort` and then calls `combine(ewm, chcolsort, *chcolNew)`. Inside, `combohit.init(hit1,ich)` and `combohit.addIndex(jch)` store `ich`/`jch` — positions in the **permutation** — while every consumer resolves them against `chcOrig`. Per-hit provenance is silently wrong, and wrong precisely when the permutation is non-trivial, which is the only reason the branch exists.

**Live** via `Production/Processing/vstdata_epilog.fcl:5` (`physics.producers.makePH.Unsorted : true`). The prolog default is `false` (`prolog.fcl:116`, *"sim data are sorted, VST currently not"*), so **MC reconstruction is unaffected — this is VST data processing only.**

Fixed by threading the original-index mapping into `combine()` and storing original-collection indices in both branches. Which hits get combined is unchanged; only the recorded provenance index changes.

### 2. 🟡 `FilterHits` abandons the event instead of dropping the hit

The four cuts at `:209,217,223,229` are `if(_filter)break;` inside the per-event `for (size_t ich...)` loop, so one failed cut discards every later panel's hits rather than the hit that failed. `continue` is what the surrounding code means. Dormant — no committed fcl sets `makePH.FilterHits:true`.

### 3. 🟡 `StrawHitReco`: `flagCrossTalk` runs per digi, and null-dereferences when `WriteStrawHitCollection` is false

Two problems at the same call site (`:217-219`):

- It sits **inside** the per-digi loop, but `flagCrossTalk` rescans the entire collection (`StrawHitRecoUtils.cc:44-62`), so it runs N times per event instead of once.
- It dereferences `shCol`, which `:190-193` only allocates when `_writesh` is true. `FlagCrossTalk:true` with `WriteStrawHitCollection:false` null-dereferences a `unique_ptr`.

Hoisted the call out of the loop, and rejected the impossible configuration in the constructor rather than silently skipping the flagging. Both are dormant: every committed config sets `FlagCrossTalk : false`.

### 4. 🟡 `StereoLineTest`: integer distribution over `[-M_PI, M_PI]`

`src/StereoLineTest_main.cc:80` — `std::uniform_int_distribution<int> phirange(-M_PI,M_PI)`. `M_PI` truncates to `3`, so the stereo stress test only ever sampled 7 discrete orientations instead of a continuous angle. Changed to `uniform_real_distribution<double>`.

---

### Validation

- **Build: not run locally.** Everything above is static. Please let `buildtest` be the arbiter.
- **No art job was run**, so finding 1 is a predicted failure, not an observed one. The cheapest confirmation is one VST job through `vstdata_epilog.fcl`, comparing a ComboHit's resolved parent hit against the straw it actually came from.
- **Deliberately not included**, and offered as follow-ups:
  - The ComboHit quality chi-square at `:296`, `chisq = wacc2 - wacc/wwtsum`, looks dimensionally inconsistent — `_qual` is frequently negative so `TMath::Prob` returns 0 for every multi-hit ComboHit. I did not touch it because the intended formula needs a physics sign-off, and the confirmed consumers are diagnostic.
  - Six defects in `FlagBkgHits`, `TNTClusterer`, `Chi2Clusterer` and `DBSClusterer` (unclamped writes into a fixed 256-bucket array; an unsigned underflow defeating an `imin=0` clamp; a `tbin_==0.0` divide-by-zero path; per-event bounds held in never-reset members; a dead `cperr2_`; `std::prev` on an empty vector). **No committed configuration reaches any of it** — `PrepareHits` ends in `flagPH`, which `Production/JobConfig/reco/prolog.fcl:34` and `mu2e-trig-config/core/producers/trigTrkProducers.fcl:70` both bind to CalPatRec `DeltaFinder`, with the `FlagBkgHits` alternative commented out; the trigger CI reference log confirms `TrigFlagPH:DeltaFinder` is what runs. Whether ~1300 lines of unreached code should be fixed, deleted or revived is a maintainer call, not one for this PR.
  - Four defects in the `PeakFit` family, which `StrawHitRecoUtils.cc:29-30` makes unreachable (it throws unless `FitType` ∈ {1,2,5}; every committed config sets 1 or 5, never `combopeakfit(3)` or `peakfit(4)`).
- **`MakeStereoHits` and `ProtonBunchTimeFromStrawDigis` produced no findings** that survived adversarial verification. Read that as "nothing found", not "verified clean".


---

## Added after the first round: two more findings

A second, independent pass over the same commit — one reviewer covering the whole package rather than chunked units — turned up a live-path defect the first sweep missed. Both new fixes are in the follow-up commit.

### 5. 🟠 `CombineStrawHits` asserts `TimeDivision` on every output ComboHit, making `HitSelectionBits: ["TimeDivision"]` a no-op

⚠️ **This one changes which hits pass the helix-finder hit selection, in reco and in the trigger.** It wants sign-off from TrkPatRec before merging — happy to split it into its own PR if you'd rather take the rest first.

`src/CombineStrawHits_module.cc:204-206` seeded the flag word with a hard-coded bit:

```cpp
// clear the flag bits; they are reset later
const static StrawHitFlag initialFlag("TimeDivision");
combohit._flag = initialFlag;
```

Nothing re-derives it. `combineHits()` never touches the flag word, and the `nCombo()==1` path never calls `combineHits()` at all — so the comment's "they are reset later" is true of `nhitsel`/`timesel`/`energysel`/`radsel`, but not of this bit.

`TimeDivision` is a quality tag, not a formality. `StrawHitRecoUtils.cc:201` sets it as `if (td) ch._flag.merge(StrawHitFlag::tdiv)`, where `td` is the return of `StrawResponse::wireDistance()`. That returns `false` in exactly one case (`TrackerConditions/src/StrawResponse.cc:136-142`): the longitudinal position exceeded the straw length, so it was clamped to `±slen*_slfac` and its error inflated by `_errfac` — *"these come from missing a cluster on one end"*.

Consumers select on the bit:

| Config | Value | Tested at |
|---|---|---|
| `TrkPatRec/fcl/prolog.fcl:167` | `HitSelectionBits : ["TimeDivision"]` | `RobustHelixFinder_module.cc:841` |
| `mu2e-trig-config trigTprProducers.fcl:114,300` | `HitSelectionBits: ["TimeDivision"]` | same |

Both read `makePH`. Because `makePH` asserted the bit unconditionally, `ch.flag().hasAnyProperty(_hsel)` admitted **100%** of hits, and the clamped-position hits entered the helix fit indistinguishable from hits with a real longitudinal measurement.

(`CalPatRec` `DeltaFinder` also declares `goodHitMask : ["TimeDivision"]`, but with `testHitMask : false` at `CalPatRec/fcl/prolog.fcl:239,253`, so that consumer is not currently affected.)

The fix seeds the flag empty and propagates `tdiv` from the constituents: kept for a single-straw ComboHit, and for a multi-straw one only if every hit actually combined carries it. The all-must-agree rule is the conservative reading; if the intended semantics is any-of, that is a one-character change.

If instead the unconditional assertion was deliberate, then the right fix is the opposite one — delete `HitSelectionBits: ["TimeDivision"]` from both repos rather than leave a dead filter standing. Either way the current state is not what the configuration claims.

### 6. ⚪ Off-by-one in the `combineHits()` index guard

```cpp
if (index > chcOrig.size())   // index == size() passes, then reads one past the end
```

Now `>=`. Unreachable today, since the indices come from `addIndex()` on the same collection — but the check exists to catch exactly the case it let through.

### Companion PR

Finding 4 of the second pass is a config defect in the other repo and ships separately: **Mu2e/mu2e-trig-config#167** — `TrigMakePH` and `TrigOffSpMakePH` each repeat a `Minimum` key where they mean `Maximum`, so the OffSpill time windows are never applied.

### Still not built locally

Unchanged from above: no local build, no art job. `mu2e/buildtest` is the arbiter.
