### PR TITLE
Fix for Invalid Time Range exception in regrow_kl.fcl

### DIFF
--- a/Mu2eKinKal/inc/KKExtrap.hh
+++ b/Mu2eKinKal/inc/KKExtrap.hh
@@ -152,7 +152,7 @@ namespace mu2e {
     // first. Anchor the range and time origin on the tracker interior, and intersect the whole trajectory:
     // a calo-cluster track is already extrapolated to the calo, so its end piece lies beyond TT_Back.
     double tref = midinter.good() ? midinter.time_ : ftraj.t0();
-    if(!midinter.good()) ftraj.range().forceRange(tref);
+    ftraj.range().forceRange(tref);
     auto recordFace = [&](TimeDir tdir){
       if(!ktrk.extrapolate(tdir,toPerim)) return;
       double const sgn = KinKal::timeDirSign(tdir);

--- a/Mu2eKinKal/inc/KKExtrap.hh
+++ b/Mu2eKinKal/inc/KKExtrap.hh
@@ -151,7 +151,8 @@ namespace mu2e {
     // The track meets the perimeter at both ends; extend each time direction and keep the face crossed
     // first. Anchor the range and time origin on the tracker interior, and intersect the whole trajectory:
     // a calo-cluster track is already extrapolated to the calo, so its end piece lies beyond TT_Back.
-    double const tref = midinter.good() ? midinter.time_ : ftraj.t0();
+    double tref = midinter.good() ? midinter.time_ : ftraj.t0();
+    if(!midinter.good()) ftraj.range().forceRange(tref);
     auto recordFace = [&](TimeDir tdir){
       if(!ktrk.extrapolate(tdir,toPerim)) return;
       double const sgn = KinKal::timeDirSign(tdir);


### PR DESCRIPTION
Clamp to valid time range (using t0) to address Invalid Time Range exception in regrow_kl.fcl.

Addresses issue #1958 

Tested as bit-identical for standard LoopHelix, CentralHelix jobs. No exception raised in regrow_kl.fcl.