### PR TITLE
Fix sign error truncating saturated-waveform sampling window in StrawWaveform

### DIFF
--- a/TrackerMC/src/StrawWaveform.cc
+++ b/TrackerMC/src/StrawWaveform.cc
@@ -199,7 +199,7 @@ namespace mu2e {
           volts.push_back(0);
         }
 
-        int num_steps = (int)ceil((times[times.size()-1]-iclust->time()-strawele.clusterLookbackTime())/strawele.saturationTimeStep());
+        int num_steps = (int)ceil((times[times.size()-1]-iclust->time()+strawele.clusterLookbackTime())/strawele.saturationTimeStep());
 
         for (int i=0;i<num_steps;i++){
           double time = iclust->time()-strawele.clusterLookbackTime() + i*strawele.saturationTimeStep();


### PR DESCRIPTION
## Intent

Fix a sign error in `StrawWaveform::sampleADCWaveform` (saturation branch) that truncates the saturated-waveform stepping loop before the end of the ADC window.

## The bug

`TrackerMC/src/StrawWaveform.cc:202` computes the step count as

```cpp
int num_steps = (int)ceil((times[times.size()-1]-iclust->time()-strawele.clusterLookbackTime())/strawele.saturationTimeStep());
```

while the loop body it controls evaluates the response at

```cpp
double time = iclust->time()-strawele.clusterLookbackTime() + i*strawele.saturationTimeStep();
```

Walking that time up to `times.back()` requires the numerator `times.back() - iclust->time() + clusterLookbackTime()`; the code subtracts `clusterLookbackTime()` a second time instead of adding it, so the loop stops `2*clusterLookbackTime()` early — about 10 ns at production defaults (`clusterLookbackTime = 5.0` ns, `saturationTimeStep = 2.5` ns), i.e. 4 missing steps.

## Effect

The truncated loop is the one that sums the saturated impulse response into the ADC samples, so ion clusters arriving in the final ~10 ns of the digitization window contribute nothing: the last ADC sample(s) of every saturating straw waveform are systematically underestimated. The branch is gated only on `max_possible_voltage > saturationVoltage()`, so this is reachable in standard production digitization (`makeSD`).

## Scope

One line; only the saturation branch of `sampleADCWaveform` is affected. Non-saturating waveforms take the other branch and are untouched.

## Validation

Found by a static review sweep of TrackerMC at `f6e43507b`; the arithmetic was re-derived by hand against the loop's own time formula. Not built or run locally — requesting the standard build test on this PR, which exercises the digitization path (`ceDigi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
