### PR TITLE
Initialize TrkFilters members that FHiCL can leave unset

### DIFF
--- a/TrkFilters/src/HelixFilter_module.cc
+++ b/TrkFilters/src/HelixFilter_module.cc
@@ -31,6 +31,7 @@ using namespace CLHEP;
 #include <string>
 #include <vector>
 #include <iostream>
+#include <limits>
 #include <memory>
 
 namespace mu2e
@@ -163,31 +164,35 @@ namespace mu2e
         }
         return false;
       }
+      // Every threshold below is filled through fhicl::OptionalAtom::operator()(T&),
+      // which leaves its target untouched when the key is absent.  The initializers
+      // are therefore the values used when a key is not configured, and each one is
+      // chosen so that the corresponding comparison in checkHelix() is a no-op.
       bool          _configured;
-      bool          _hascc; // Calo Cluster
-      bool          _doHelicityCheck;
-      int           _hel;
-      int           _minnstrawhits;
-      double        _minHitRatio;
-      double        _minmom, _maxmom;
-      double        _maxpT;
-      double        _minpT;
-      double        _maxchi2XY;
-      double        _maxchi2PhiZ;
-      double        _maxd0;
-      double        _mind0;
-      double        _maxlambda;
-      double        _minlambda;
-      double        _maxnloops;
-      double        _minnloops;
-      bool          _useSlopeSigMin;
-      double        _slopeSigMin;
-      bool          _useSlopeSigMax;
-      double        _slopeSigMax;
+      bool          _hascc           = false; // Calo Cluster
+      bool          _doHelicityCheck = false;
+      int           _hel             = 0;
+      int           _minnstrawhits   = 0;
+      double        _minHitRatio     = 0.;
+      double        _minmom          = 0.;
+      double        _maxmom          = std::numeric_limits<double>::max();
+      double        _minpT           = 0.;
+      double        _maxchi2XY       = std::numeric_limits<double>::max();
+      double        _maxchi2PhiZ     = std::numeric_limits<double>::max();
+      double        _maxd0           = std::numeric_limits<double>::max();
+      double        _mind0           = std::numeric_limits<double>::lowest();
+      double        _maxlambda       = std::numeric_limits<double>::max();
+      double        _minlambda       = 0.;  // the cut is applied to |lambda|
+      double        _maxnloops       = std::numeric_limits<double>::max();
+      double        _minnloops       = 0.;
+      bool          _useSlopeSigMin  = false;
+      double        _slopeSigMin     = 0.;
+      bool          _useSlopeSigMax  = false;
+      double        _slopeSigMax     = 0.;
       TrkFitFlag    _goodh; // helix fit flag
-      bool          _prescaleUsingD0Phi;
+      bool          _prescaleUsingD0Phi = false;
       PhiPrescalingParams     _prescalerPar;
-      const Tracker*_myTracker;
+      const Tracker*_myTracker     = nullptr;
     };
 
     struct Config{

--- a/TrkFilters/src/MultiHelixFilter_module.cc
+++ b/TrkFilters/src/MultiHelixFilter_module.cc
@@ -266,7 +266,7 @@ namespace mu2e
     unsigned      _nevt, _npass;
 
     // histogram info
-    Hist_t* _hists[10];
+    Hist_t* _hists[10] = {nullptr};
   };
 
   //--------------------------------------------------------------------------------------
@@ -279,6 +279,7 @@ namespace mu2e
     , _timeWindow        (config().timeWindow())
     , _maxOverlap        (config().maxOverlap())
     , _minArcGap         (config().minArcGap())
+    , _doHistograms      (config().doHistograms())
     , _nevt              (0)
     , _npass             (0)
     {


### PR DESCRIPTION
### Intent

Two uninitialized-member reads in `TrkFilters`, both sourced from FHiCL and neither caught by validation.

`fhicl::OptionalAtom<T>::operator()(T& value)` assigns only when the key is present and leaves `value` untouched otherwise (`fhiclcpp/types/OptionalAtom.h:44-51`). `HelixFilter`'s `HelixCutsTool` fills fifteen cut thresholds through that form — `_hascc`, `_doHelicityCheck`, `_hel`, `_minnstrawhits`, `_minHitRatio`, `_minmom`, `_maxmom`, `_minpT`, `_maxchi2XY`, `_maxchi2PhiZ`, `_maxd0`, `_mind0`, `_maxlambda`, `_minlambda`, `_maxnloops`, `_minnloops` — with no in-class initializer and no entry in the constructor's initializer list, and then reads every one of them in the cut chain. Omitting a key from a menu therefore produces a silently wrong trigger rather than a configuration error. `_slopeSigMin`/`_slopeSigMax` in the same struct already do it correctly, by keeping the boolean return in `_useSlopeSigMin`/`_useSlopeSigMax` and guarding the comparison.

`MultiHelixFilter` declares a `doHistograms` parameter and a `_doHistograms` member but never assigns one from the other, so `beginJob` and `filter` decide whether to book and fill histograms by reading an uninitialized bool, and the configuration key does nothing.

### Scope

Each threshold gets an in-class initializer chosen so that an unconfigured cut is a no-op, `_myTracker` gets `nullptr`, `_doHistograms` is initialized from the configuration, and `_hists` defaults to null pointers. `_maxpT` is deleted rather than initialized — it is declared and never read anywhere in the file.

**No committed configuration changes behaviour.** All twenty `HelixFilter` instances in `mu2e-trig-config` (`trigTprFilters.fcl`, `trigAprFilters.fcl`, `trigCprFilters.fcl`, `trigMprFilters.fcl`), after expanding their `@table::` references, set all fifteen keys; `MultiHelixFilter` has no consumer in Offline, Production or mu2e-trig-config.

### Deliberately not in this PR

These came out of the same read-through and are each a separate topic:

- Making the fifteen keys required `fhicl::Atom`s instead of initialized `OptionalAtom`s. That is the stronger fix — an omitted cut would fail validation instead of silently disabling itself — and every committed instance would still validate. Happy to do that instead if the maintainers prefer it; it is a schema change, so it did not belong in the same commit.
- `prescaleUsingD0Phi` and `prescalerPar` are independent FHiCL entries, so enabling the flag without an amplitude leaves `PhiPrescalingParams` at its default of zero, `evalIPAPresc` returns 0, and `NEvt % prescaler` divides by zero. The one live user sets `amplitude: 6.2`, whose minimum over phase is exactly 1.0, so nothing crashes today. The fix is an `OptionalTable` so the pair validates as a unit.
- `HelixFilter` converts curvature to momentum with a bare `3./10.` and computes `_bz0` in `beginRun` without ever reading it, while `MultiHelixFilter` multiplies by `_bz0`. The two modules disagree by a factor of `Bz`, and the live thresholds are tuned against `HelixFilter`'s current scale, so correcting it shifts every momentum cut in the menu.
- The `maxDt0` timing cut is evaluated over the whole input collection rather than the helices that passed the selection. It is set in no committed configuration.
- `beginJob`/`beginRun` in both modules are `virtual` without `override`, which is what would have caught `_hists` never being booked at compile time.

### Validation

Compile and test coverage from CI only — I have not run an art job. The change is behaviour-preserving for every committed configuration, as described above.
