### PR TITLE
Fix Tracker copy semantics: re-point panels and planes at the copy

### DIFF
--- a/TrackerGeom/inc/Panel.hh
+++ b/TrackerGeom/inc/Panel.hh
@@ -17,8 +17,13 @@
 
 namespace mu2e {
 
+  class Tracker;
+
   class Panel{
     using xyzVec = CLHEP::Hep3Vector; // switch to XYZVec TODO
+
+    // Tracker re-points the straw pointers when it is copied
+    friend class Tracker;
 
     public:
     using StrawCollection = std::array<const Straw*, StrawId::_nstraws>;
@@ -85,6 +90,11 @@ namespace mu2e {
     std::string name( std::string const& base ) const;
 
     private:
+    // Fill the straw pointers from the given collection.  This is used both when
+    // building a panel and when a Tracker is copied, since the pointers must then
+    // refer to the straws owned by the copy and not to those of the original.
+    void rebindStraws( TrackerStrawCollection const& straws );
+
     StrawId _id; // only the plane and panel fields are used to define a panel
     xyzVec _udir, _vdir, _wdir; // direction vectors in DS frame
     HepTransform  _UVWtoDS; // transform from this panel's frame to the DS frame

--- a/TrackerGeom/inc/Plane.hh
+++ b/TrackerGeom/inc/Plane.hh
@@ -21,10 +21,15 @@
 #include "CLHEP/Vector/ThreeVector.h"
 
 namespace mu2e {
+  class Tracker;
+
   class Plane{
     using PanelCollection = std::array<const Panel*,StrawId::_npanels>;
     using TrackerPanelCollection = std::array<Panel,StrawId::_nupanels>;
     using xyzVec = CLHEP::Hep3Vector;
+
+    // Tracker re-points the panel pointers when it is copied
+    friend class Tracker;
 
     public:
 
@@ -78,6 +83,11 @@ namespace mu2e {
     }
 
     private:
+    // Fill the panel pointers from the given collection.  This is used both when
+    // building a plane and when a Tracker is copied, since the pointers must then
+    // refer to the panels owned by the copy and not to those of the original.
+    void rebindPanels( TrackerPanelCollection const& panels );
+
     StrawId             _id;
     HepTransform        _PlanetoDS; // transform from plane coordinates to DS (just a translation)
     xyzVec _udir, _vdir, _wdir; // direction vectors in DS frame

--- a/TrackerGeom/inc/Tracker.hh
+++ b/TrackerGeom/inc/Tracker.hh
@@ -46,6 +46,16 @@ namespace mu2e {
     // construct from a set of straws and their global properties.
     Tracker(StrawCollection const& straws, StrawProperties const& sprops,const TrackerG4InfoPtr& g4tracker, PEType const& pexists);
 
+    // The panels and planes hold pointers into this object's own straw and panel
+    // arrays, so the compiler-generated copy would leave the copy referring to the
+    // straws and panels of the original.  This copy constructor re-points them at
+    // the content of the copy.  Note that the TrackerG4Info is deliberately shared
+    // with the original: it describes the nominal G4 model and does not depend on
+    // the (possibly aligned) straw positions.
+    Tracker(Tracker const& other);
+    // ProditionsEntity deletes assignment, so a Tracker can be copy constructed but
+    // not assigned.  Accept the compiler generated destructor.
+
     // accessors
     // origin in nominal tracker coordinate system
     const xyzVec& origin() const { return _origin; }
@@ -94,6 +104,9 @@ namespace mu2e {
     bool planeExists(StrawId const& id) const { return _planeExists[id.plane()]; }
 
     private:
+    // Re-point the panel and plane pointers at this object's own content.
+    void rebindConstituents();
+
     xyzVec _origin;
     // global straw properties
     StrawProperties _strawprops;

--- a/TrackerGeom/src/Panel.cc
+++ b/TrackerGeom/src/Panel.cc
@@ -26,23 +26,22 @@ namespace mu2e {
     return os.str();
   }
 
-  Panel::Panel( const StrawId& id, TrackerStrawCollection const& straws, HepTransform const& panelToDS ) : _id(id) {
+  void Panel::rebindStraws( TrackerStrawCollection const& straws ) {
     for(auto const& straw : straws ) {
       // pick out all the straws belonging to this panel.
       if(_sidmask.equal(_id,straw.id())){
         _straws[straw.id().straw()] = &straw;
       }
     }
+  }
+
+  Panel::Panel( const StrawId& id, TrackerStrawCollection const& straws, HepTransform const& panelToDS ) : _id(id) {
+    rebindStraws(straws);
     setPanelToDS(panelToDS);
   }
 
   Panel::Panel( const StrawId& id, TrackerStrawCollection const& straws ) : _id(id) {
-    for(auto const& straw : straws ) {
-      // pick out all the straws belonging to this panel.
-      if(_sidmask.equal(_id,straw.id())){
-        _straws[straw.id().straw()] = &straw;
-      }
-    }
+    rebindStraws(straws);
     // compute the panel coordinate axes based on the straw content
     // U points along the straw (Cal to HV), V is radially outward, W is given by right-handedness
     _udir = _straws.front()->wireDirection();

--- a/TrackerGeom/src/Plane.cc
+++ b/TrackerGeom/src/Plane.cc
@@ -24,13 +24,17 @@ namespace mu2e {
     return os.str();
   }
 
-  Plane::Plane( const StrawId& id, TrackerPanelCollection const& panels) : _id(id) {
+  void Plane::rebindPanels( TrackerPanelCollection const& panels ) {
     for(auto const& panel : panels ) {
       // pick out all the panels belonging to this plane.  This code relies on the Tracker collection being in order.
       if(_sidmask.equal(_id,panel.id())){
         _panels[panel.id().panel()] = &panel;
       }
     }
+  }
+
+  Plane::Plane( const StrawId& id, TrackerPanelCollection const& panels) : _id(id) {
+    rebindPanels(panels);
     // define the origin (in the tracker nominal frame) as the geometric average of the panel origins
     xyzVec origin;
     for(auto const& panel : _panels) origin += panel->origin();

--- a/TrackerGeom/src/Tracker.cc
+++ b/TrackerGeom/src/Tracker.cc
@@ -32,4 +32,22 @@ namespace mu2e {
 
     }
 
+  Tracker::Tracker(Tracker const& other) :
+    Detector(other), ProditionsEntity(other),
+    _origin(other._origin),
+    _strawprops(other._strawprops),
+    _planes(other._planes),
+    _panels(other._panels),
+    _straws(other._straws),
+    _planeExists(other._planeExists),
+    _g4tracker(other._g4tracker) {
+      // the copied panels and planes still point into 'other': re-point them here
+      rebindConstituents();
+    }
+
+  void Tracker::rebindConstituents() {
+    for(auto& panel : _panels) panel.rebindStraws(_straws);
+    for(auto& plane : _planes) plane.rebindPanels(_panels);
+  }
+
 } // namespace mu2e


### PR DESCRIPTION
### Intent

`Panel` holds `std::array<const Straw*, 96>` pointing into the `Tracker`'s own straw array, and `Plane` holds `std::array<const Panel*, 6>` pointing into its panel array. `Tracker` declares no copy constructor, so the compiler-generated one gives the copy fresh straw and panel storage while every `Panel` and `Plane` inside it still points at the *original* object's storage.

The only copy site in Offline today, `AlignedTrackerMaker::fromFcl`/`fromDb` (`TrackerConditions/src/AlignedTrackerMaker.cc:93,123`), is correct only because `alignTracker` subsequently rebuilds every panel and plane from the copy's own straws. Nothing in `TrackerGeom` makes that requirement discoverable, so any other copy would silently read another tracker's geometry, and a copy outliving its source would dangle.

### Change

* `Tracker` gets a copy constructor that copies the members and then re-points the constituents at its own content.
* New private helpers `Panel::rebindStraws` and `Plane::rebindPanels` do the re-pointing. The two `Panel` constructors and the `Plane` constructor now call them instead of repeating the fill loop, so that logic has a single home.
* `Tracker` is a `friend` of `Panel` and `Plane` for those two helpers; nothing else gains access.

No behavior changes for existing callers: `ProditionsEntity` deletes assignment, so `Tracker` stays copy constructible and non-assignable, and the only `std::move` involving a tracker (`TrackerMaker::getTrackerPtr`) moves a `unique_ptr`, not a `Tracker`.

Deliberately not changed: the `TrackerG4Info` `shared_ptr` is still shared with the original rather than deep copied. It describes the nominal G4 model and does not depend on the (possibly aligned) straw positions.

### Validation

Compiled the changed translation units, plus the three main consumers, with the Muse spack toolchain (gcc 13.3, `-std=c++20 -Wall -Werror`): all of `TrackerGeom/src/*.cc`, `TrackerConditions/src/AlignedTrackerMaker.cc`, `GeometryService/src/TrackerMaker.cc` and `Mu2eG4/src/ConstructTrackerDetail5.cc` pass.

Wrote a throwaway program that builds a `Tracker` from a synthetic straw set, copies it, and counts constituent pointers that do not fall inside the copy's own arrays. Against `main`:

```
straw pointers not owned by the copy: 20736 / 20736
panel pointers not owned by the copy: 216 / 216
```

With this branch:

```
straw pointers not owned by the copy: 0 / 20736
panel pointers not owned by the copy: 0 / 216
```

The program is not included here; `TrackerGeom` has no test directory and I did not want to add one in this PR. Happy to contribute it wherever the collaboration would want such a check to live.

I have not run a full build or the physics validation jobs locally; leaving that to CI.

### Related, not addressed here

While reading the package I noticed a few adjacent items that are separate topics and are deliberately left out to keep this PR to one thing: the `Panel`/`Plane` pointer arrays are not value initialised in the value constructors and no check catches an unfilled slot; `Panel.cc` hardcodes straws 47/48 as the panel middle while `Plane.cc` divides by a literal 6; `Tracker::_origin` is never assigned; and `Manifold`/`ManifoldId` appear to be dead but are still built. I can open follow-ups if they are wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138sWPyeSCDFbbn2cB9JBDy