### PR TITLE
Fixes for issue 1974

### DIFF
--- a/Mu2eKinKal/inc/ExtrapolateCRVRegion.hh
+++ b/Mu2eKinKal/inc/ExtrapolateCRVRegion.hh
@@ -125,8 +125,9 @@ namespace mu2e {
         if(!coincident(newinter.time_)) inters_.emplace_back(newinter,(int)isect,sector.whw_);
       } else if(newinter.onsurface_ && newinter.inbounds_) {
         retval |= trange.beyond(newinter.time_,tdir); // crossing just beyond this piece: keep extrapolating
-      } else if(!newinter.onsurface_ && tdir == TimeDir::backwards) {
-        if(time_to_sector > piece_span) retval = true; // far sector beyond this (short) piece: keep going
+      } else if(!newinter.onsurface_) {
+        // far sector beyond this (short) piece: keep going, in BOTH time directions.
+        if(time_to_sector > piece_span) retval = true;
       }
     }
     // --- strongback passive planes (minvnorm floor, like ExtrapolatePlanes) ---
@@ -140,8 +141,8 @@ namespace mu2e {
         if(!coincident(newinter.time_)) inters_.emplace_back(newinter,plane);
       } else if(newinter.onsurface_ && newinter.inbounds_) {
         retval |= trange.beyond(newinter.time_,tdir);
-      } else if(!newinter.onsurface_ && tdir == TimeDir::backwards) {
-        if(time_to_plane > piece_span) retval = true;
+      } else if(!newinter.onsurface_) {
+        if(time_to_plane > piece_span) retval = true; // as in the sector loop above
       }
     }
     // sort the crossings in the time direction so the KKExtrap loop adds them outermost-first

--- a/Mu2eKinKal/src/KKBField.cc
+++ b/Mu2eKinKal/src/KKBField.cc
@@ -26,9 +26,10 @@ namespace mu2e {
     SVEC3 dBdxv(dBdx.X(),dBdx.Y(), dBdx.Z());
     SVEC3 dBdyv(dBdy.X(),dBdy.Y(), dBdy.Z());
     SVEC3 dBdzv(dBdz.X(),dBdz.Y(), dBdz.Z());
-    retval.Place_in_row(dBdxv,0,0);
-    retval.Place_in_row(dBdyv,1,0);
-    retval.Place_in_row(dBdzv,2,0);
+    // Grad(i,j) = dB_i/dx_j, so the derivative along an axis fills a column, not a row
+    retval.Place_in_col(dBdxv,0,0);
+    retval.Place_in_col(dBdyv,0,1);
+    retval.Place_in_col(dBdzv,0,2);
     return retval;
   }
   // numerical derivatives for now: TODO!

--- a/Mu2eKinKal/src/KinematicLineFit_module.cc
+++ b/Mu2eKinKal/src/KinematicLineFit_module.cc
@@ -356,8 +356,17 @@ namespace mu2e {
     return seedtraj;
   }
   bool KinematicLineFit::goodFit(KKTRK const& ktrk) const {
-    // require physical consistency: fit can succeed but the result can have changed charge or helicity
-    return ktrk.fitStatus().usable();
+    bool retval = ktrk.fitStatus().usable();
+    // a usable fit can still have diverged from its hits: test the fit where the active straw hits are
+    if(retval){
+      for(auto const& shptr : ktrk.strawHits()) {
+        if(shptr->active() && !Mu2eKinKal::inDetector(ktrk.fitTraj().position3(shptr->time()))){
+          retval = false;
+          break;
+        }
+      }
+    }
+    return retval;
   }
 
   void KinematicLineFit::sampleFit(KKTRK& kktrk) const {


### PR DESCRIPTION
Issue #1974 

Tested against main, no significant differences for production jobs.

For CentralHelix extrapolation with bfcorr=true, the needsExtrapolation fix is necessary to recover some CRV crossings on the forward leg. It is still not possible to run stably with bfcorr=true without upstream modifications to KinKal, which are in a separate PR. This limited fix can safely be merged now.

Edit: no change in track numbers and CRV crossings across KL/CH, no measurable change in reco time (<0.1% CPU time difference before/after).

There are a few additional TT_Outer crossings for the CH bfcorr=false run. These represent helices that loop several times around the tracker volume, an unphysical trajectory that can be resolved by setting bfcorr=true. But that fix requires significant upstream changes.