### PR TITLE
TimeoutService: keep TimeoutWatchdog state per art schedule

### DIFF
--- a/CalPatRec/src/AgnosticHelixFinder_module.cc
+++ b/CalPatRec/src/AgnosticHelixFinder_module.cc
@@ -466,6 +466,7 @@ namespace mu2e {
     if (_enableTimeout && _timeoutService) {
       _timeoutGuard.emplace(*(*_timeoutService),
                             event,
+                            scheduleID(),
                             moduleDescription().moduleLabel(),
                             _timeoutMs);
     }

--- a/CalPatRec/src/TZClusterFinder_module.cc
+++ b/CalPatRec/src/TZClusterFinder_module.cc
@@ -291,6 +291,7 @@ namespace mu2e {
     if (_enableTimeout && _timeoutService) {
       _timeoutGuard.emplace(*(*_timeoutService),
                             event,
+                            scheduleID(),
                             moduleDescription().moduleLabel(),
                             _timeoutMs);
     }

--- a/TimeoutService/CMakeLists.txt
+++ b/TimeoutService/CMakeLists.txt
@@ -4,6 +4,7 @@ cet_make_library(
     LIBRARIES PUBLIC
       art::Framework_Principal
       art::Framework_Services_Registry
+      art::Utilities
       fhiclcpp::fhiclcpp
       fhiclcpp::types
 )

--- a/TimeoutService/inc/TimeoutWatchdog.hh
+++ b/TimeoutService/inc/TimeoutWatchdog.hh
@@ -1,6 +1,9 @@
 //
 // An art service to provide cooperative timeout checks for event/module processing.
 //
+// Deadlines and cancellation state are kept per art schedule: every call names the
+// schedule it acts on, so concurrent schedules never touch the same state.
+//
 
 #ifndef TimeoutService_TimeoutWatchdog_hh
 #define TimeoutService_TimeoutWatchdog_hh
@@ -8,6 +11,8 @@
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Services/Registry/ServiceDeclarationMacros.h"
 #include "art/Framework/Services/Registry/ServiceTable.h"
+#include "art/Utilities/PerScheduleContainer.h"
+#include "art/Utilities/ScheduleID.h"
 #include "fhiclcpp/types/Atom.h"
 
 #include <chrono>
@@ -56,20 +61,23 @@ public:
   TimeoutWatchdog& operator=(TimeoutWatchdog&&) = delete;
 
   // --- called by modules (cooperative) ---
-  void startEvent(art::Event const& e);
-  void startModule(std::string const& moduleLabel,
+  // sid is the schedule processing the event: scheduleID() in a legacy module,
+  // ProcessingFrame::scheduleID() in a shared one.
+  void startEvent(art::Event const& e, art::ScheduleID sid);
+  void startModule(art::ScheduleID sid,
+                   std::string const& moduleLabel,
                    std::optional<double> allowedTimeMs = std::nullopt);
-  void endModule();
+  void endModule(art::ScheduleID sid);
 
   // Returns true once the current event/module has exceeded a configured budget.
-  bool check();
+  bool check(art::ScheduleID sid);
 
   // Stop token that can be used in downstream cooperative cancellation points.
-  std::stop_token stopToken() const;
+  std::stop_token stopToken(art::ScheduleID sid) const;
 
   // helpers
-  std::optional<std::chrono::steady_clock::time_point> eventDeadline() const;
-  std::optional<std::chrono::steady_clock::time_point> moduleDeadline() const;
+  std::optional<std::chrono::steady_clock::time_point> eventDeadline(art::ScheduleID sid) const;
+  std::optional<std::chrono::steady_clock::time_point> moduleDeadline(art::ScheduleID sid) const;
 
   // RAII guard declaration (defined below)
   class ModuleGuard;
@@ -103,7 +111,9 @@ private:
 
   double moduleBudgetFor_(std::optional<double> allowedTimeMs) const;
 
-  State tls_;
+  // One State per schedule, sized at construction and never resized, so each
+  // schedule reads and writes only its own element.
+  art::PerScheduleContainer<State> states_;
 
   double eventTimeoutMs_;
   double moduleTimeoutMs_;
@@ -114,25 +124,28 @@ class TimeoutWatchdog::ModuleGuard {
 public:
   ModuleGuard(TimeoutWatchdog& svc,
               art::Event const& e,
+              art::ScheduleID sid,
               std::string const& moduleLabel,
               std::optional<double> allowedTimeMs = std::nullopt)
     : svc_{svc}
+    , sid_{sid}
   {
-    svc_.startEvent(e); // Only necessary if the service is configured with registerPreEventCallback=false
-    svc_.startModule(moduleLabel, allowedTimeMs);
+    svc_.startEvent(e, sid_); // Only necessary if the service is configured with registerPreEventCallback=false
+    svc_.startModule(sid_, moduleLabel, allowedTimeMs);
   }
 
   ~ModuleGuard() noexcept {
     // Never throw from destructor
-    svc_.endModule();
+    svc_.endModule(sid_);
   }
 
-  bool check() const { return svc_.check(); }
+  bool check() const { return svc_.check(sid_); }
 
-  std::stop_token stopToken() const { return svc_.stopToken(); }
+  std::stop_token stopToken() const { return svc_.stopToken(sid_); }
 
 private:
   TimeoutWatchdog& svc_;
+  art::ScheduleID sid_;
 };
 
 } // namespace mu2e

--- a/TimeoutService/src/TimeoutWatchdog.cc
+++ b/TimeoutService/src/TimeoutWatchdog.cc
@@ -1,6 +1,7 @@
 #include "Offline/TimeoutService/inc/TimeoutWatchdog.hh"
 
 #include "art/Framework/Services/Registry/ActivityRegistry.h"
+#include "art/Persistency/Provenance/ScheduleContext.h"
 
 #include <cstdio>
 #include <sstream>
@@ -13,39 +14,43 @@ namespace mu2e {
     , moduleTimeoutMs_(config().moduleTimeoutMs())
     , debugLevel_(config().debugLevel())
   {
+    states_.expand_to_num_schedules();
+
     if(config().registerPreEventCallback()) {
-      registry.sPreProcessEvent.watch([this](art::Event const& e, art::ScheduleContext) {
-        this->startEvent(e);
+      registry.sPreProcessEvent.watch([this](art::Event const& e, art::ScheduleContext const sc) {
+        this->startEvent(e, sc.id());
       });
     }
   }
 
-  void TimeoutWatchdog::startEvent(art::Event const& e) {
-    if (tls_.event != e.event() || tls_.subRun != e.subRun() || tls_.run != e.run()) {
+  void TimeoutWatchdog::startEvent(art::Event const& e, art::ScheduleID const sid) {
+    State& state = states_.at(sid);
+    if (state.event != e.event() || state.subRun != e.subRun() || state.run != e.run()) {
       // New event: reset cancellation state and apply event-level deadline.
-      tls_.run = e.run();
-      tls_.subRun = e.subRun();
-      tls_.event = e.event();
-      tls_.moduleLabel.clear();
-      tls_.stopSource = std::stop_source{};
-      tls_.stopToken = tls_.stopSource.get_token();
+      state.run = e.run();
+      state.subRun = e.subRun();
+      state.event = e.event();
+      state.moduleLabel.clear();
+      state.stopSource = std::stop_source{};
+      state.stopToken = state.stopSource.get_token();
 
       if (eventTimeoutMs_ > 0.0) {
         Clock::time_point const now = Clock::now();
-        tls_.eventDeadline = now + std::chrono::duration_cast<Clock::duration>(
-                                                                               std::chrono::duration<double, std::milli>(eventTimeoutMs_));
+        state.eventDeadline = now + std::chrono::duration_cast<Clock::duration>(
+                                                                                std::chrono::duration<double, std::milli>(eventTimeoutMs_));
       } else {
-        tls_.eventDeadline.reset();
+        state.eventDeadline.reset();
       }
 
-      tls_.moduleDeadline.reset();
+      state.moduleDeadline.reset();
 
       if (debugLevel_ > 1) {
-        std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u eventTimeoutMs=%.3f\n",
+        std::printf("[TimeoutWatchdog::%s] schedule %u Event %u:%u:%u eventTimeoutMs=%.3f\n",
                     __func__,
-                    tls_.run,
-                    tls_.subRun,
-                    tls_.event,
+                    static_cast<unsigned>(sid.id()),
+                    state.run,
+                    state.subRun,
+                    state.event,
                     eventTimeoutMs_);
       }
     }
@@ -57,18 +62,21 @@ namespace mu2e {
     return moduleTimeoutMs_;
   }
 
-  void TimeoutWatchdog::startModule(std::string const& moduleLabel,
+  void TimeoutWatchdog::startModule(art::ScheduleID const sid,
+                                    std::string const& moduleLabel,
                                     std::optional<double> allowedTimeMs) {
-    // Module scope starts a fresh stop token so checks are local to this invocation.
-    tls_.moduleLabel = moduleLabel;
-    if (tls_.stopToken.stop_requested()) { //FIXME: Need to decide if a previous module was timed out but the event wasn't, do we allow next modules to continue anyway
+    // A stop request is sticky for the rest of the event: if an earlier module
+    // timed out, check() returns true for this module immediately.
+    State& state = states_.at(sid);
+    state.moduleLabel = moduleLabel;
+    if (state.stopToken.stop_requested()) { //FIXME: Need to decide if a previous module was timed out but the event wasn't, do we allow next modules to continue anyway
       if (debugLevel_ > 0) {
         std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u stop already requested when starting module=%s\n",
                     __func__,
-                    tls_.run,
-                    tls_.subRun,
-                    tls_.event,
-                    tls_.moduleLabel.c_str());
+                    state.run,
+                    state.subRun,
+                    state.event,
+                    state.moduleLabel.c_str());
       }
       // add source reset here if we want to ignore previous module's stop
     }
@@ -76,71 +84,73 @@ namespace mu2e {
     double const budget = moduleBudgetFor_(allowedTimeMs);
     if (budget > 0.0) {
       Clock::time_point const now = Clock::now();
-      tls_.moduleDeadline = now + std::chrono::duration_cast<Clock::duration>(
-                                                                              std::chrono::duration<double, std::milli>(budget));
+      state.moduleDeadline = now + std::chrono::duration_cast<Clock::duration>(
+                                                                               std::chrono::duration<double, std::milli>(budget));
     } else {
-      tls_.moduleDeadline.reset();
+      state.moduleDeadline.reset();
     }
 
     if (debugLevel_ > 1) {
       std::printf("[TimeoutWatchdog::%s] module=%s moduleTimeoutMs=%.3f\n",
                   __func__,
-                  tls_.moduleLabel.c_str(),
+                  state.moduleLabel.c_str(),
                   budget);
     }
   }
 
-  void TimeoutWatchdog::endModule() {
-    if (debugLevel_ > 1 && !tls_.moduleLabel.empty()) {
+  void TimeoutWatchdog::endModule(art::ScheduleID const sid) {
+    State& state = states_.at(sid);
+    if (debugLevel_ > 1 && !state.moduleLabel.empty()) {
       std::printf("[TimeoutWatchdog::%s] module=%s\n",
                   __func__,
-                  tls_.moduleLabel.c_str());
+                  state.moduleLabel.c_str());
     }
 
     // Clear module-only state; event-level deadline remains active.
-    tls_.moduleDeadline.reset();
-    tls_.moduleLabel.clear();
+    state.moduleDeadline.reset();
+    state.moduleLabel.clear();
   }
 
   std::optional<TimeoutWatchdog::Clock::time_point>
-  TimeoutWatchdog::eventDeadline() const { return tls_.eventDeadline; }
+  TimeoutWatchdog::eventDeadline(art::ScheduleID const sid) const { return states_.at(sid).eventDeadline; }
 
   std::optional<TimeoutWatchdog::Clock::time_point>
-  TimeoutWatchdog::moduleDeadline() const { return tls_.moduleDeadline; }
+  TimeoutWatchdog::moduleDeadline(art::ScheduleID const sid) const { return states_.at(sid).moduleDeadline; }
 
-  bool TimeoutWatchdog::check() {
+  bool TimeoutWatchdog::check(art::ScheduleID const sid) {
+    State& state = states_.at(sid);
     // Once cancellation is requested, preserve sticky behavior for callers.
-    if (tls_.stopToken.stop_requested()) {
+    if (state.stopToken.stop_requested()) {
       if (debugLevel_ > 0) {
         std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u stop already requested module=%s\n",
                     __func__,
-                    tls_.run,
-                    tls_.subRun,
-                    tls_.event,
-                    tls_.moduleLabel.c_str());
+                    state.run,
+                    state.subRun,
+                    state.event,
+                    state.moduleLabel.c_str());
       }
       return true;
     }
 
     Clock::time_point const now = Clock::now();
 
-    bool const timedOutEvent = tls_.eventDeadline && (now > *tls_.eventDeadline);
-    bool const timedOutModule = tls_.moduleDeadline && (now > *tls_.moduleDeadline);
+    bool const timedOutEvent = state.eventDeadline && (now > *state.eventDeadline);
+    bool const timedOutModule = state.moduleDeadline && (now > *state.moduleDeadline);
 
     if (!timedOutEvent && !timedOutModule) {
       return false;
     }
 
     // Transition to cancelled state so subsequent checks can short-circuit quickly.
-    tls_.stopSource.request_stop();
+    state.stopSource.request_stop();
 
     if (debugLevel_ > 0) {
       std::printf("[TimeoutWatchdog::%s] Event %u:%u:%u timeout module=%s eventExceeded=%d moduleExceeded=%d\n",
                   __func__,
-                  tls_.run,
-                  tls_.subRun,
-                  tls_.event,
-                  tls_.moduleLabel.c_str(),
+                  state.run,
+                  state.subRun,
+                  state.event,
+                  state.moduleLabel.c_str(),
                   timedOutEvent ? 1 : 0,
                   timedOutModule ? 1 : 0);
     }
@@ -148,8 +158,8 @@ namespace mu2e {
     return true;
   }
 
-  std::stop_token TimeoutWatchdog::stopToken() const {
-    return tls_.stopToken;
+  std::stop_token TimeoutWatchdog::stopToken(art::ScheduleID const sid) const {
+    return states_.at(sid).stopToken;
   }
 
 } // namespace mu2e


### PR DESCRIPTION
## Intent

`TimeoutWatchdog` is declared `SHARED`, but all of its per-event state lived in a single member, `State tls_`. The name is left over from the `thread_local` version in #1777; that storage was removed when the service moved from `LEGACY` to `SHARED` to pass the MT test. In a job with more than one schedule, the `sPreProcessEvent` callback runs on every schedule at once. Each call rewrites that one member, including a move-assignment of the same `std::stop_source`. That is a data race, and it happens in any multi-schedule job that loads `Services.Reco` or `Services.SimAndReco`, even with every budget at 0. `Mu2eG4/fcl/g4test_03MT.fcl` (5 schedules, `Services.SimAndReco`) is one such job. Once a budget is enabled, it gets worse: one schedule starting a new event would replace the deadline and stop token of a module still running on another schedule.

## Change

- The state now lives in an `art::PerScheduleContainer<State>`. It is sized with `expand_to_num_schedules()` in the constructor and never resized, so each schedule reads and writes only its own element and no lock is needed.
- Every entry point (`startEvent`, `startModule`, `endModule`, `check`, `stopToken`, `eventDeadline`, `moduleDeadline`) takes the `art::ScheduleID` it acts on, and access goes through the bounds-checked `at()`.
  - The pre-event callback passes `ScheduleContext::id()`.
  - `ModuleGuard` takes the ID once at construction and stores it, so code calling `guard.check()` / `guard.stopToken()` does not change.
- The two in-tree consumers, `TZClusterFinder` and `AgnosticHelixFinder`, now pass their legacy-module `scheduleID()` to `ModuleGuard`. A GitHub code search finds no other user of the service in Offline, Production or mu2e-trig-config.
- `art::Utilities` is added to the library's link list, since the library now uses it directly.
- Two small changes on lines the patch already touches:
  - The `startModule` comment said each module starts with a fresh stop token. The code does the opposite: a stop request is sticky for the rest of the event. The comment now says so, and the existing `FIXME` is unchanged.
  - The `debugLevel > 1` event print now includes the schedule number.

Single-schedule jobs behave exactly as before.

## Validation

- Compiled `TimeoutWatchdog.cc`, `TimeoutWatchdog_service.cc`, `TZClusterFinder_module.cc` and `AgnosticHelixFinder_module.cc` with the buildtest flags (`-std=c++20 -Wall -Werror -pedantic -O3 ...`, envset `p106`). Linked the library and service plugin with `-Wl,--no-undefined`.
- Ran a job with the patched service and no modules: `EmptyEvent`, 200 events, `@table::Services.Reco`, `eventTimeoutMs : 1000`, `debugLevel : 2`.
  - `num_schedules : 5` gives exit 0, with events on all five schedules (41/38/43/37/41). No `at()` threw, so the container is sized correctly when the service is constructed.
  - `num_schedules : 1` gives exit 0.
  - The same 5-schedule job with the service built under AddressSanitizer gives exit 0 and no reports.
- Not run: a ThreadSanitizer build of art. The race is inferred from the code, not observed. I also did not exercise the two consumer modules with real input, only compiled them.

## Deliberately not in this PR

These came out of the same package review, but each one needs a decision from the trigger group, not a mechanical fix:

- A timeout makes the consumers `put()` a truncated collection, and nothing in the event records that it happened.
- A module-level timeout is sticky for the rest of the event (the `FIXME`), so a later module in the same event also sees `check() == true`.
- The service-level `moduleTimeoutMs` has no effect, because both consumers create the guard only when their own `timeoutMs > 0` and always pass it. `eventTimeoutMs` is checked only by modules that have a guard.
- Moving the diagnostics from `printf` to message-facility, and removing the vestigial `SConscript`.

@michaelmackenzie, this changes the `ModuleGuard` constructor signature. It is worth a look if you have trigger-side code outside Offline that constructs one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DZynGvjEZXCiW6Ag6y5vG
