### PR TITLE
TrackerConditions: reject fcl lists whose length the makers cannot use

### DIFF
--- a/TrackerConditions/src/StrawDriftMaker.cc
+++ b/TrackerConditions/src/StrawDriftMaker.cc
@@ -26,7 +26,8 @@ namespace mu2e {
 
     std::vector<double> dataEField = _config.kVcm();
     std::vector<double> dataVInst = _config.cmus();
-    if ( dataEField.size()==0 || dataEField.size()!=dataVInst.size() ) {
+    // the table is interpolated between neighbouring points, so it needs at least 2
+    if ( dataEField.size()<2 || dataEField.size()!=dataVInst.size() ) {
       throw cet::exception("STRAW_DRIFT_BADMODEL")
         << "input drift model don't make sense, sizes:"<< dataEField.size()
         << " " << dataVInst.size()  << "\n";

--- a/TrackerConditions/src/StrawElectronicsMaker.cc
+++ b/TrackerConditions/src/StrawElectronicsMaker.cc
@@ -14,9 +14,37 @@ using namespace std;
 namespace mu2e {
   using namespace TrkTypes;
 
+  namespace {
+    // a per-channel fcl list is either empty (no override) or covers every channel
+    void checkChannelListLength(char const* name, size_t size, size_t nchannels) {
+      if (size != 0 && size != nchannels)
+        throw cet::exception("BADCONFIG")
+          << "StrawElectronics fcl parameter " << name << " has " << size
+          << " entries; it must be empty or have " << nchannels << "\n";
+    }
+  }
+
   StrawElectronics::ptr_t StrawElectronicsMaker::fromFcl(EventTiming::cptr_t eventTiming) {
 
     unsigned maxTDC = (0x1<<_config.numTDCbits())-1;
+
+    // the wire distance points are interpolated between neighbours, so there must be at least 2
+    auto const wireDistances = _config.wireDistances();
+    auto const currentMeans = _config.currentMeans();
+    auto const currentNormalizations = _config.currentNormalizations();
+    auto const currentSigmas = _config.currentSigmas();
+    auto const currentT0s = _config.currentT0s();
+    if (wireDistances.size() < 2
+        || currentMeans.size() != wireDistances.size()
+        || currentNormalizations.size() != wireDistances.size()
+        || currentSigmas.size() != wireDistances.size()
+        || currentT0s.size() != wireDistances.size()) {
+      throw cet::exception("BADCONFIG")
+        << "StrawElectronics fcl parameters wireDistances, currentMeans, currentNormalizations,"
+        << " currentSigmas and currentT0s must have the same length, at least 2; lengths are "
+        << wireDistances.size() << " " << currentMeans.size() << " " << currentNormalizations.size()
+        << " " << currentSigmas.size() << " " << currentT0s.size() << "\n";
+    }
 
     // creat this at the beginning since it must be used,
     // partially constructed, to complete the construction
@@ -37,25 +65,34 @@ namespace mu2e {
         _config.ADCPoles(), _config.ADCZeros(),
         _config.preampToAdc1Poles(), _config.preampToAdc1Zeros(),
         _config.preampToAdc2Poles(), _config.preampToAdc2Zeros(),
-        _config.wireDistances(), _config.currentMeans(),
-        _config.currentNormalizations(), _config.currentSigmas(),
-        _config.currentT0s(), _config.reflectionTimeShift(),
+        wireDistances, currentMeans,
+        currentNormalizations, currentSigmas,
+        currentT0s, _config.reflectionTimeShift(),
         _config.reflectionVelocity(), _config.reflectionALength(),
         _config.reflectionFrac(), _config.triggerHysteresis(),
         _config.clusterLookbackTime());
 
+    auto const timeOffsetPanelFcl = _config.timeOffsetPanel();
+    auto const timeOffsetStrawHVFcl = _config.timeOffsetStrawHV();
+    auto const timeOffsetStrawCalFcl = _config.timeOffsetStrawCal();
+    checkChannelListLength("timeOffsetPanel", timeOffsetPanelFcl.size(), StrawId::_nupanels);
+    checkChannelListLength("timeOffsetStrawHV", timeOffsetStrawHVFcl.size(), StrawId::_nustraws);
+    if (timeOffsetStrawCalFcl.size() != timeOffsetStrawHVFcl.size())
+      throw cet::exception("BADCONFIG")
+        << "StrawElectronics fcl parameters timeOffsetStrawHV and timeOffsetStrawCal must have the same length, not "
+        << timeOffsetStrawHVFcl.size() << " and " << timeOffsetStrawCalFcl.size() << "\n";
     std::array<double, StrawId::_nupanels> timeOffsetPanel;
     std::array<double, StrawId::_nustraws> timeOffsetStrawHV, timeOffsetStrawCal;
-    if (_config.timeOffsetPanel().size() > 0){
+    if (timeOffsetPanelFcl.size() > 0){
       for (size_t i=0;i<timeOffsetPanel.size();i++)
-        timeOffsetPanel[i] = _config.timeOffsetPanel()[i];
+        timeOffsetPanel[i] = timeOffsetPanelFcl[i];
     }else{
       timeOffsetPanel.fill(0);
     }
-    if (_config.timeOffsetStrawHV().size() > 0){
+    if (timeOffsetStrawHVFcl.size() > 0){
       for(size_t i=0;i<timeOffsetStrawHV.size();i++){
-        timeOffsetStrawHV[i] = _config.timeOffsetStrawHV()[i];
-        timeOffsetStrawCal[i] = _config.timeOffsetStrawCal()[i];
+        timeOffsetStrawHV[i] = timeOffsetStrawHVFcl[i];
+        timeOffsetStrawCal[i] = timeOffsetStrawCalFcl[i];
       }
     }else{
       timeOffsetStrawHV.fill(0);
@@ -65,16 +102,20 @@ namespace mu2e {
         timeOffsetStrawHV,
         timeOffsetStrawCal );
 
+    auto const thresholddVdI = _config.thresholddVdI();
+    auto const adcdVdI = _config.adcdVdI();
+    checkChannelListLength("thresholddVdI", thresholddVdI.size(), StrawId::_nustraws);
+    checkChannelListLength("adcdVdI", adcdVdI.size(), StrawId::_nustraws);
     std::array<std::array<double, StrawId::_nustraws>,StrawElectronics::npaths> dVdI;
-    if(_config.thresholddVdI().size()>0) {
+    if(thresholddVdI.size()>0) {
       for (size_t i=0;i<dVdI[StrawElectronics::thresh].size();i++)
-        dVdI[StrawElectronics::thresh][i] = _config.thresholddVdI()[i];
+        dVdI[StrawElectronics::thresh][i] = thresholddVdI[i];
     } else {
       dVdI[StrawElectronics::thresh].fill(_config.defaultThresholddVdI());
     }
-    if(_config.adcdVdI().size()>0) {
+    if(adcdVdI.size()>0) {
       for (size_t i=0;i<dVdI[StrawElectronics::adc].size();i++)
-        dVdI[StrawElectronics::adc][i] = _config.adcdVdI()[i];
+        dVdI[StrawElectronics::adc][i] = adcdVdI[i];
     } else {
       dVdI[StrawElectronics::adc].fill(_config.defaultAdcdVdI());
     }
@@ -86,10 +127,12 @@ namespace mu2e {
     analognoise[StrawElectronics::adc]    = _config.adcAnalogNoise();
     ptr->setAnalogNoise(analognoise);
 
+    auto const discriminatorThreshold = _config.discriminatorThreshold();
+    checkChannelListLength("discriminatorThreshold", discriminatorThreshold.size(), StrawId::_nustrawends);
     std::array<double, StrawId::_nustrawends> vthresh;
-    if(_config.discriminatorThreshold().size()>0) {
+    if(discriminatorThreshold.size()>0) {
       for (size_t i=0;i<vthresh.size();i++)
-        vthresh[i] = _config.discriminatorThreshold()[i];
+        vthresh[i] = discriminatorThreshold[i];
     } else {
       vthresh.fill(_config.defaultDiscriminatorThreshold());
     }
@@ -126,13 +169,13 @@ namespace mu2e {
 
     const double pC_per_uA_ns{1000}; // unit conversion from pC/ns to microAmp
 
-    auto integral_normalization = log(responseBins/2/sampleRate + _config.currentT0s()[0]) - log(_config.currentT0s()[0]); // integral of 1/(t+t0) for 0 cm
+    auto integral_normalization = log(responseBins/2/sampleRate + currentT0s[0]) - log(currentT0s[0]); // integral of 1/(t+t0) for 0 cm
 
     std::vector<StrawElectronics::WireDistancePoint> wPoints;
-    for (size_t ai=0;ai<_config.wireDistances().size();ai++){
-      wPoints.emplace_back( _config.wireDistances()[ai],
-          _config.currentMeans()[ai],  _config.currentNormalizations()[ai],
-          _config.currentSigmas()[ai], _config.currentT0s()[ai]);
+    for (size_t ai=0;ai<wireDistances.size();ai++){
+      wPoints.emplace_back( wireDistances[ai],
+          currentMeans[ai],  currentNormalizations[ai],
+          currentSigmas[ai], currentT0s[ai]);
       wPoints[ai]._currentPulse = std::vector<double>(responseBins,0);
       double integral = 0;
       for (int i=0;i<responseBins;i++){

--- a/TrackerConditions/src/StrawResponseMaker.cc
+++ b/TrackerConditions/src/StrawResponseMaker.cc
@@ -16,6 +16,17 @@
 
 using namespace std;
 namespace mu2e {
+
+  namespace {
+    // a per-channel fcl list is either empty (no override) or covers every channel
+    void checkChannelListLength(char const* name, size_t size, size_t nchannels) {
+      if (size != 0 && size != nchannels)
+        throw cet::exception("BADCONFIG")
+          << "StrawResponse fcl parameter " << name << " has " << size
+          << " entries; it must be empty or have " << nchannels << "\n";
+    }
+  }
+
   StrawResponse::ptr_t StrawResponseMaker::fromFcl(
       StrawDrift::cptr_t strawDrift,
       StrawElectronics::cptr_t strawElectronics,
@@ -46,12 +57,14 @@ namespace mu2e {
     if(_config.ADCPedestal(x)) ADCped = x;
 
     double pmpEnergyScaleAvg = 0;
+    auto const peakMinusPedestalEnergyScale = _config.peakMinusPedestalEnergyScale();
+    checkChannelListLength("peakMinusPedestalEnergyScale", peakMinusPedestalEnergyScale.size(), StrawId::_nustraws);
     std::array<double, StrawId::_nustraws> pmpEnergyScale;
-    if (_config.peakMinusPedestalEnergyScale().size() == 0){
+    if (peakMinusPedestalEnergyScale.size() == 0){
       pmpEnergyScale.fill(_config.defaultPeakMinusPedestalEnergyScale());
     }else{
       for (size_t i=0;i<pmpEnergyScale.size();i++) {
-        pmpEnergyScale[i] = _config.peakMinusPedestalEnergyScale()[i];
+        pmpEnergyScale[i] = peakMinusPedestalEnergyScale[i];
       }
     }
     for (size_t i=0;i<pmpEnergyScale.size();i++) {
@@ -61,7 +74,11 @@ namespace mu2e {
 
     if ( _config.unsignedDriftRMS().size() != _config.signedDriftRMS().size()
         || _config.driftOffBins().size() != 2
-        || _config.driftRMSBins().size() != 2){
+        || _config.driftRMSBins().size() != 2
+        || _config.llDriftTimeOffBins().size() != 2
+        || _config.llDriftTimeRMSBins().size() != 2
+        || _config.llDriftTimeOffset().size() < 2
+        || _config.llDriftTimeRMS().size() < 2){
       throw cet::exception("BADCONFIG")
         << "StrawResponse drift res vector lengths incorrect" << "\n";
     }
@@ -117,19 +134,28 @@ namespace mu2e {
         pmpEnergyScaleAvg, strawHalfPropVelocity,
         _config.driftIgnorePhi());
 
+    auto const timeOffsetPanelFcl = _config.timeOffsetPanel();
+    auto const timeOffsetStrawHVFcl = _config.timeOffsetStrawHV();
+    auto const timeOffsetStrawCalFcl = _config.timeOffsetStrawCal();
+    checkChannelListLength("timeOffsetPanel", timeOffsetPanelFcl.size(), StrawId::_nupanels);
+    checkChannelListLength("timeOffsetStrawHV", timeOffsetStrawHVFcl.size(), StrawId::_nustraws);
+    if (timeOffsetStrawCalFcl.size() != timeOffsetStrawHVFcl.size())
+      throw cet::exception("BADCONFIG")
+        << "StrawResponse fcl parameters timeOffsetStrawHV and timeOffsetStrawCal must have the same length, not "
+        << timeOffsetStrawHVFcl.size() << " and " << timeOffsetStrawCalFcl.size() << "\n";
     std::array<double, StrawId::_nupanels> timeOffsetPanel;
     std::array<double, StrawId::_nustraws> timeOffsetStrawHV, timeOffsetStrawCal;
-    if (_config.timeOffsetPanel().size() > 0){
+    if (timeOffsetPanelFcl.size() > 0){
       for (size_t i=0;i<timeOffsetPanel.size();i++)
-        timeOffsetPanel[i] = _config.timeOffsetPanel()[i];
+        timeOffsetPanel[i] = timeOffsetPanelFcl[i];
     }else{
       for (size_t i=0;i<timeOffsetPanel.size();i++)
         timeOffsetPanel[i] = strawElectronics->getTimeOffsetPanel(i);
     }
-    if (_config.timeOffsetStrawHV().size() > 0){
+    if (timeOffsetStrawHVFcl.size() > 0){
       for(size_t i=0;i<timeOffsetStrawHV.size();i++){
-        timeOffsetStrawHV[i] = _config.timeOffsetStrawHV()[i];
-        timeOffsetStrawCal[i] = _config.timeOffsetStrawCal()[i];
+        timeOffsetStrawHV[i] = timeOffsetStrawHVFcl[i];
+        timeOffsetStrawCal[i] = timeOffsetStrawCalFcl[i];
       }
     }else{
       for (size_t i=0;i<timeOffsetStrawHV.size();i++){

--- a/TrackerConditions/src/TrackerPanelMapMaker.cc
+++ b/TrackerConditions/src/TrackerPanelMapMaker.cc
@@ -1,7 +1,7 @@
 // clang-format off
 #include "Offline/TrackerConditions/inc/TrackerPanelMap.hh"
 #include "Offline/TrackerConditions/inc/TrackerPanelMapMaker.hh"
-// #include "cetlib_except/exception.h"
+#include "cetlib_except/exception.h"
 // #include "TMath.h"
 // #include <cmath>
 // #include <complex>
@@ -26,8 +26,15 @@ namespace mu2e {
     std::vector<int> panel   = config_.panel  ();
     std::vector<int> zface   = config_.zface  ();
 
-    int npanels = mnid.size();
-    for (int i=0; i<npanels; i++) {
+    size_t npanels = mnid.size();
+    if (dtcid.size() != npanels || link.size() != npanels || uniquePlane.size() != npanels ||
+        ppid.size()  != npanels || panel.size() != npanels || zface.size() != npanels) {
+      throw cet::exception("BADCONFIG")
+        << "TrackerPanelMap fcl columns must all have the same length; mnid has " << npanels
+        << " entries, dtcid " << dtcid.size() << ", link " << link.size() << ", uniquePlane " << uniquePlane.size()
+        << ", ppid " << ppid.size() << ", panel " << panel.size() << ", zface " << zface.size() << "\n";
+    }
+    for (size_t i=0; i<npanels; i++) {
       TrkPanelMap::Row r(mnid[i],dtcid[i],link[i],uniquePlane[i],ppid[i],panel[i],zface[i]);
       ptr->add(r);
     }


### PR DESCRIPTION
### Intent

The tracker conditions makers accept per-channel fcl lists that override database or default values, for example `timeOffsetPanel`, `timeOffsetStrawHV`, `peakMinusPedestalEnergyScale` and `discriminatorThreshold`. Each list is meant to be either empty (no override) or one entry per channel. The makers only checked that the list was non-empty, then read it up to the full detector size (216 panels, 20736 straws, 41472 straw ends). A list that is shorter than that, for example an override of a few panels, was read past its end. That is undefined behaviour: in practice it quietly fills the conditions with whatever memory follows the vector, or crashes.

With this PR the maker throws a `cet::exception` for every such list, naming the parameter, its length and the length it needs. The checks:

| Maker | Parameters | Rule |
|---|---|---|
| `StrawElectronicsMaker` | `timeOffsetPanel` | empty or 216 |
| `StrawElectronicsMaker`, `StrawResponseMaker` | `timeOffsetStrawHV`, `timeOffsetStrawCal` | empty or 20736, and the same length as each other |
| `StrawResponseMaker` | `timeOffsetPanel` | empty or 216 |
| `StrawElectronicsMaker` | `thresholddVdI`, `adcdVdI` | empty or 20736 |
| `StrawElectronicsMaker` | `discriminatorThreshold` | empty or 41472 |
| `StrawResponseMaker` | `peakMinusPedestalEnergyScale` | empty or 20736 |
| `StrawElectronicsMaker` | `wireDistances`, `currentMeans`, `currentNormalizations`, `currentSigmas`, `currentT0s` | same length, at least 2 (the response is interpolated between neighbouring points, `StrawElectronics.cc:93,133,147`) |
| `StrawResponseMaker` | `llDriftTimeOffBins`, `llDriftTimeRMSBins` | exactly 2, like the existing `driftOffBins`/`driftRMSBins` check |
| `StrawResponseMaker` | `llDriftTimeOffset`, `llDriftTimeRMS` | at least 2 (`PieceLineDrift` reads `yvals[ibin+1]`) |
| `TrackerPanelMapMaker` | `mnid`, `dtcid`, `link`, `uniquePlane`, `ppid`, `panel`, `zface` | same length |
| `StrawDriftMaker` | `kVcm`, `cmus` | at least 2 (was: at least 1; a single point underflows `dataDistances.size()-2`) |

`timeOffsetStrawHV` and `timeOffsetStrawCal` are a special case worth calling out. `timeOffsetStrawCal` was read whenever `timeOffsetStrawHV` was non-empty, so setting only the HV offsets read from an empty vector, and setting only the Cal offsets was silently ignored. Both now have to be given together.

The same file already had the right pattern for one list: `strawHalfPropVelocity` in `StrawResponseMaker.cc` throws `BADCONFIG` on a bad length. This PR applies it to the rest.

Each list is now read into a local once. `fhicl::Sequence::operator()` returns the vector by value, so the old `_config.timeOffsetStrawHV()[i]` inside a 20736-iteration loop copied the whole list on every iteration. That only mattered when an override was actually set, and the local is needed for the length check anyway. This is from reading `fhiclcpp/types/Sequence.h`; I have not measured it.

### Scope

No committed configuration changes behaviour. Every one of these lists is empty in `TrackerConditions/fcl/prolog.fcl`, apart from the wire points (5 each), the `ll*` tables (2 bins, 26 values), the drift table (30 points) and the panel map (18 rows each), all of which pass. None of the parameters is set anywhere in Production or mu2e-trig-config at their current main. The checks run on the fcl path, and `StrawElectronicsMaker::fromDb` calls `fromFcl` first, so they also run in DB jobs.

A user fcl that sets one of these lists to a partial length will now stop at the first event with a clear message, instead of running with corrupted conditions.

### Validation

Built the full Offline at this branch point (`329c10038`) with muse, envset p107, prof, `-Werror`; clean.

I ran 12 one-event jobs (`EmptyEvent`, `Services.Reco`, `strawElectronics.useDb: false`) through a throwaway analyzer, not part of this PR, that fetches `StrawDrift`, `StrawPhysics`, `StrawElectronics`, `StrawResponse` and `TrackerPanelMap`. Each job overrides one list. I ran them on unpatched `main` and on this branch:

| Override | `main` | This branch |
|---|---|---|
| none | runs | runs |
| `strawElectronics.timeOffsetPanel`, 216 entries (and the same for `strawResponse`) | runs, offset applied | runs, offset applied |
| `strawElectronics.timeOffsetPanel`, 3 entries | runs; panel 5 offset reads `4.00193e-322` | `BADCONFIG`: has 3 entries; it must be empty or have 216 |
| `strawElectronics.timeOffsetStrawHV`, 20736 entries, no Cal | segfault | `BADCONFIG`: HV and Cal must have the same length, not 20736 and 0 |
| `strawResponse.timeOffsetStrawHV`/`Cal`, 1 entry each | runs | `BADCONFIG` |
| `strawResponse.peakMinusPedestalEnergyScale`, 2 entries | runs | `BADCONFIG` |
| `strawResponse.llDriftTimeOffBins`, 3 entries | runs | `BADCONFIG` |
| `strawElectronics.wireDistances`, 4 of 5 | runs | `BADCONFIG` |
| `strawElectronics.thresholddVdI`, 2 entries | runs | `BADCONFIG` |
| `strawElectronics.discriminatorThreshold`, 2 entries | runs | `BADCONFIG` |
| `strawDrift.kVcm`/`cmus`, 1 point | runs | `STRAW_DRIFT_BADMODEL` |
| `trackerPanelMap.dtcid`, 17 of 18 | segfault | `BADCONFIG`: lists all seven column lengths |

"Runs" on `main` means the job finished with exit code 0 after reading past the end of the vector.

Not covered: the valid full-length straw case (`timeOffsetStrawHV` and `timeOffsetStrawCal` at 20736 entries each). That job does not get past service construction within 15 minutes on either `main` or this branch. `fhicl-dump` of the same file takes 3 s, and a stack of the stuck process is inside `fhicl::ParameterSet`'s copy constructor, before any tracker code runs. So it is independent of this change, but it means the valid full-length straw path is only exercised at 216 entries (panels), not at 20736.

### Deliberately not in this PR

Found in the same audit, left for separate PRs so this one stays one topic: config parameters that are declared but never used (`driftIntegrationBins`, `bFieldOverride`, `clusterDriftPolynomial`, `Mu2eDetectorConfig`, `Mu2eMaterialConfig`), two wrong unit comments in `StrawElectronicsConfig.hh`, and count parameters declared as `double` (`eBins`, `nGainGauss`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtK75GTmT83CoNXRytdREj
