### PR TITLE
Use unique panel index for time offsets in StrawElectronics::uncalibrateTimes

### DIFF
--- a/TrackerConditions/src/StrawElectronics.cc
+++ b/TrackerConditions/src/StrawElectronics.cc
@@ -223,8 +223,8 @@ namespace mu2e {
 
   void StrawElectronics::uncalibrateTimes(TrkTypes::TDCTimes &times, const StrawId &id) const {
     if (!overrideDbTimeOffsets()){
-      times[StrawEnd::hv] -= _timeOffsetPanel[id.getPanel()] + _timeOffsetStrawHV[id.uniqueStraw()];
-      times[StrawEnd::cal] -= _timeOffsetPanel[id.getPanel()] + _timeOffsetStrawCal[id.uniqueStraw()];
+      times[StrawEnd::hv] -= _timeOffsetPanel[id.uniquePanel()] + _timeOffsetStrawHV[id.uniqueStraw()];
+      times[StrawEnd::cal] -= _timeOffsetPanel[id.uniquePanel()] + _timeOffsetStrawCal[id.uniqueStraw()];
     }
   }
 


### PR DESCRIPTION
## Intent

`StrawElectronics::uncalibrateTimes` subtracts the panel time offset using `id.getPanel()`, which is the panel number within its plane (0-5). The offset table `_timeOffsetPanel` has `StrawId::_nupanels` entries and is filled by unique panel index from `TrkDelayPanel` (`StrawElectronicsMaker.cc:279`). Its inverse in reco, `StrawResponse::calibrateTimes`, correctly uses `id.uniquePanel()` (`StrawResponse.cc:174,177`).

As a result, digitization shifts a hit in panel k of plane p by the delay of panel k in plane 0, and reco then removes the delay of panel 6p+k. Every plane except plane 0 is left with a per-panel time bias. The `TrkDelayPanel` table does have non-zero, panel-dependent values (for example cid 5 starts at -2.3 and -2.0 ns).

In 32055fb4e (2021), when these arrays were extended to all channels, the straw index on these two lines changed from `getStraw()` to `uniqueStraw()`, but the panel index was left as it was. This PR changes `getPanel()` to `uniquePanel()` on both lines.

## Who is affected

The code path runs only when `overrideDbTimeOffsets` is false. That is the default in `TrackerConditions/fcl/prolog.fcl`. Production's `JobConfig/digitize/epilog.fcl` sets it to true, so standard MC production is not affected. Any digitization job that does not include that epilog (`StrawDigisFromStrawGasSteps`, `PoissonTrackerNoise`) currently gets the bias.

## Scope

A two-line change in `TrackerConditions/src/StrawElectronics.cc`. Nothing else is touched.

## Validation

- The changed file passes `g++ -std=c++20 -Wall -Werror -fsyntax-only` against the current spack view. A full build is left to CI.
- The index spaces were checked by reading: the `StrawId::uniquePanel()` definition, how `_timeOffsetPanel` is filled in `StrawElectronicsMaker::fromDb`, and the reco counterpart in `StrawResponse::calibrateTimes`.
- I did not run a digitization job to measure the bias before and after.

Found during a static review of the `TrackerConditions` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL4jFRGq1ub5r3owcE6Ria
