### PR TITLE
Use the configured electronicsTimeDelay in StrawResponse::calibrateTimes

### DIFF
--- a/TrackerConditions/src/StrawResponse.cc
+++ b/TrackerConditions/src/StrawResponse.cc
@@ -169,12 +169,11 @@ namespace mu2e {
 
   void StrawResponse::calibrateTimes(TrkTypes::TDCValues const& tdc,
       TrkTypes::TDCTimes &times, const StrawId &id) const {
-    double electronicsTimeDelay = _strawElectronics->electronicsTimeDelay();
     times[StrawEnd::hv] = tdc[StrawEnd::hv]*_strawElectronics->tdcLSB()
-      - electronicsTimeDelay + _timeOffsetPanel[id.uniquePanel()]
+      - _electronicsTimeDelay + _timeOffsetPanel[id.uniquePanel()]
       + _timeOffsetStrawHV[id.uniqueStraw()];
     times[StrawEnd::cal] = tdc[StrawEnd::cal]*_strawElectronics->tdcLSB()
-      - electronicsTimeDelay + _timeOffsetPanel[id.uniquePanel()]
+      - _electronicsTimeDelay + _timeOffsetPanel[id.uniquePanel()]
       + _timeOffsetStrawCal[id.uniqueStraw()];
   }
 


### PR DESCRIPTION
## Intent

`StrawResponse` accepts an optional `electronicsTimeDelay` override (`StrawResponseConfig.hh`, documented in `TrackerConditions/fcl/prolog.fcl` as "if not defined here, the code will get values from StrawElectronics"). `StrawResponseMaker.cc:29-30` applies it and stores the result in `StrawResponse::_electronicsTimeDelay`. However, `StrawResponse::calibrateTimes` never uses that member. It reads `_strawElectronics->electronicsTimeDelay()` directly, so the override has no effect on reco times. The only place the member was read was `print()`.

This PR makes `calibrateTimes` use `_electronicsTimeDelay`.

## Behavior change

None for any existing configuration. When the override is not set, `_electronicsTimeDelay` is initialized from `StrawElectronics::electronicsTimeDelay()`, which is the value used before this change. The override is not set in Offline, Production (main) or mu2e-trig-config, and both defaults are 0.0. The change matters only for a job that sets `strawResponse.electronicsTimeDelay` to differ from `strawElectronics.electronicsTimeDelay`. Until now, such a job was silently ignored.

## Scope

`StrawResponse::calibrateTimes` in `TrackerConditions/src/StrawResponse.cc`, and nothing else. This is kept separate from #1980 (the panel index fix in `StrawElectronics::uncalibrateTimes`) because it is a different defect.

## Validation

- The changed file passes `g++ -std=c++20 -Wall -Werror -fsyntax-only` against the current spack view. A full build is left to CI.
- I did not run a reco job. The default path is numerically unchanged by construction.

Found during a static review of the `TrackerConditions` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL4jFRGq1ub5r3owcE6Ria
