### PR TITLE
zBinningForFoils: use detector-system z for single-foil targets

### DIFF
--- a/StoppingTargetGeom/src/zBinningForFoils.cc
+++ b/StoppingTargetGeom/src/zBinningForFoils.cc
@@ -26,11 +26,11 @@ namespace mu2e{
         << "zBinningForFoils: using a stopping target with no foils!\n";
     }
 
-    // Special case: set bin size to the foil thickness instead of basing it
+    // Special case: set bin size to the foil half-thickness instead of basing it
     // on the spacing between foils.
     if ( nfoils == 1 ){
       double dz = (nBinsDZ+0.5)*target.foil(0).halfThickness();
-      double z0 = target.foil(0).centerInMu2e().z();
+      double z0 = target.foil(0).centerInDetectorSystem().z();
       int nbins = 2*nBinsDZ + 1;
       return Binning( nbins, z0-dz, z0+dz );
     }


### PR DESCRIPTION
## What

`zBinningForFoils` builds the z binning for the generator summary histograms. Its single-foil branch took the foil center from `centerInMu2e()`, while the multi-foil branch and the header comment ("This uses the DetectorSystem coordinates") use `centerInDetectorSystem()`. This PR makes the single-foil branch use detector-system z as well.

It also corrects the comment above that branch: the single-foil bin width is `2*dz/nbins = halfThickness()`, the foil half-thickness rather than its thickness.

## Why

The only caller, `GeneratorSummaryHistograms::book` (`Mu2eUtilities`), fills `hz` and `hrzPos` with `detSys->toDetector(position).z()`. Run1B is the one geometry with a single foil: `geom_run1_b_v01.txt` has `stoppingTarget.radii = {600.00}` and `z0InMu2e = 4185`, and it inherits `mu2e.detectorSystemZ0 = 10171`. The histograms were therefore booked over z = 4185 ± 23.8 mm, while every entry sat near −5986 mm. Both histograms came out empty, with everything in underflow. `GenParticlesAnalyzer` (in `Mu2eG4/fcl/g4test_03.fcl` and `transportOnly.fcl`) is the path that books them.

Multi-foil geometries are unaffected. No data product depends on this function.

## Validation

- `g++ -std=c++20 -Wall -Wextra -Werror -fsyntax-only` on the changed file in the muse al9 prof environment: clean.
- The corrected range follows from the geometry values above: about −5986 ± 23.8 mm, which covers the filled values. I have not run a job to show the populated histograms.

## Deliberately not in this PR

These came up in a review of `StoppingTargetGeom` and will be handled separately:
- Foil tilt: `TargetFoil::normal()`, built from `stoppingTarget.xCos`/`yCos`, has no consumer, and `constructStoppingTarget` places every foil unrotated. No current geometry sets a tilt.
- In `GeometryService/src/StoppingTargetMaker.cc`, `PrintConfig` swaps its x/y/z variation labels, and `foilTarget_supportStructure_angleOffset` is read twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgCD6rzgTteUFTPsdvWcou
