### PR TITLE
Sources: fail loudly on bad CORSIKA and PBI input files

### DIFF
--- a/Sources/src/CosmicCORSIKA.cc
+++ b/Sources/src/CosmicCORSIKA.cc
@@ -51,6 +51,10 @@ namespace mu2e {
         throw std::runtime_error("Error: reclen too small");
       }
 
+      if(reclen > 4*_fbsize_words) {
+        throw std::runtime_error("Error: reclen too big");
+      }
+
       // Read the full record
       if(!input->read(_buf.ch, reclen)) {
         break;
@@ -87,6 +91,9 @@ namespace mu2e {
 
       break;
 
+    }
+    if(_infmt == Format::UNDEFINED) {
+      throw std::runtime_error("Error: could not read the RUNH record at the start of the file");
     }
     input->clear();
     input->seekg(0, ios::beg);
@@ -241,7 +248,7 @@ namespace mu2e {
         }
 
       } // loop over records
-      return true;
+      throw std::runtime_error("Error: file ended before the RUNE record");
   }
 
   bool CosmicCORSIKA::generate( GenParticleCollection& genParts, unsigned long long &primaries)

--- a/Sources/src/FromCorsikaBinary_source.cc
+++ b/Sources/src/FromCorsikaBinary_source.cc
@@ -125,6 +125,10 @@ namespace mu2e {
       currentEventNumber_ = 0;
 
       currentFile_ = new ifstream(currentFileName_);
+      if (!currentFile_->is_open()) {
+        throw cet::exception("FILEOPEN", " FromCorsikaBinary: ")
+          << " cannot open input file " << currentFileName_ << "\n";
+      }
 
       unsigned subrun = 0;
       float lowE, highE;

--- a/Sources/src/PBISequence_source.cc
+++ b/Sources/src/PBISequence_source.cc
@@ -28,6 +28,7 @@
 //   So long as we do not write multiple subruns to same output file it is also moot.
 //
 
+#include <cmath>
 #include <iostream>
 #include <fstream>
 #include <boost/utility.hpp>
@@ -63,6 +64,32 @@ using namespace std;
 
 namespace mu2e {
   using namespace boost::accumulators;
+
+  namespace {
+    void throwIfNotOpen(std::ifstream const& in, std::string const& fileName) {
+      if (!in.is_open()) {
+        throw cet::exception("FILEOPEN", " PBISequence: ")
+          << " cannot open input file " << fileName << "\n";
+      }
+    }
+
+    // Read the next proton count.  Returns false only at a clean end of file;
+    // a malformed, negative or non-finite value throws.
+    bool readProtons(std::istream& in, std::string const& fileName, unsigned long long& nprotons) {
+      double protons = 0.;
+      if (!(in >> protons)) {
+        if (in.eof() && !in.bad()) return false;
+        throw cet::exception("BADINPUT", " PBISequence: ")
+          << " malformed proton count in file " << fileName << "\n";
+      }
+      if (!std::isfinite(protons) || protons < 0.) {
+        throw cet::exception("BADINPUT", " PBISequence: ")
+          << " invalid proton count " << protons << " in file " << fileName << "\n";
+      }
+      nprotons = static_cast<unsigned long long>(llrint(protons));
+      return true;
+    }
+  }
 
   struct Config
   {
@@ -163,20 +190,15 @@ namespace mu2e {
     using namespace boost::accumulators;
     currentFileName_ = filename;
     currentFile_ = new ifstream(currentFileName_,std::ifstream::in);
+    throwIfNotOpen(*currentFile_, currentFileName_);
     // reset counters
     subRunNumber_++;
     if(subRunNumber_ != firstSubRunNumber_) currentEventNumber_ = 0; // only reset after the first sub run
     // compute statistics on protons in this file
     nprotAcc_ = {};
-    double protons;
-    unsigned long long nprotons;
-    while(true) {
-      *currentFile_ >> protons;
-      if ( currentFile_->good()) {
-        nprotons = static_cast<unsigned long long>(llrint(protons));
-        nprotAcc_(double(nprotons));
-      } else
-        break;
+    unsigned long long nprotons = 0;
+    while (readProtons(*currentFile_, currentFileName_, nprotons)) {
+      nprotAcc_(double(nprotons));
     }
     if ( verbosity_ > 0 ){
       std::cout << "Read " << extract_result<tag::count>(nprotAcc_) << " events with " << extract_result<tag::mean>(nprotAcc_) << " <protons> " << extract_result<tag::variance>(nprotAcc_) << " variance from file " << currentFileName_ << std::endl;
@@ -202,11 +224,8 @@ namespace mu2e {
       art::SubRunPrincipal*& outSR,
       art::EventPrincipal*& outE)
   {
-    double protons;
-    unsigned long long nprotons;
-    (*currentFile_) >>  protons;
-    if (!currentFile_->good()) return false;
-    nprotons = static_cast<unsigned long long>(llrint(protons));
+    unsigned long long nprotons = 0;
+    if (!readProtons(*currentFile_, currentFileName_, nprotons)) return false;
     managePrincipals(runNumber_, subRunNumber_, ++currentEventNumber_, outR, outSR, outE);
     std::unique_ptr<ProtonBunchIntensity> pbi(new ProtonBunchIntensity(nprotons));
     art::put_product_in_principal(std::move(pbi), *outE, myModuleLabel_);
@@ -262,16 +281,10 @@ namespace mu2e {
   void PBISequenceDetail::computeRunDataProducts( std::vector<std::string> const& inputFiles ){
     for ( auto const& file : inputFiles){
       std::ifstream in(file,std::ifstream::in);
-      double protons;
-      unsigned long long nprotons;
-      while (in){
-        in >> protons;
-        if ( in.good()) {
-          nprotons = static_cast<unsigned long long>(llrint(protons));
-          runNprotAcc_(double(nprotons));
-        } else {
-          break;
-        }
+      throwIfNotOpen(in, file);
+      unsigned long long nprotons = 0;
+      while (readProtons(in, file, nprotons)) {
+        runNprotAcc_(double(nprotons));
       }
     }
   } // end computeRunDataProducts


### PR DESCRIPTION
## Intent

Make the CORSIKA and PBI input sources fail loudly and clearly on bad input files, instead of crashing through undefined behaviour or silently producing a short or corrupted sequence. Clean input produces identical output to `main`.

Both sources are used in production: `FromCorsikaBinary` in `Production/JobConfig/cosmic/prolog.fcl`, and `PBISequence` in `JobConfig/mixing/CreatePBISequence.fcl` and `JobConfig/primary/NoPrimaryPBISequence.fcl`.

## Changes

**`CosmicCORSIKA.cc` / `FromCorsikaBinary_source.cc`**
- `genEvent()` now throws when the file ends before its `RUNE` record. It used to fall through to `return true` with an empty particle map, and `generate()` then read `_particles_map.begin()->second` from that empty map.
- `openFile()` throws if it could not read a `RUNH` record (empty or unreadable file), and `readFile()` throws if the stream did not open.
- `openFile()` now applies the same `reclen > 4*_fbsize_words` bound that `genEvent()` already applies. Without it, an oversized first length word overflowed the 22940-byte record buffer.

**`PBISequence_source.cc`**
- One helper, `readProtons()`, replaces the three copies of the read loop. It returns false only at a clean end of file, and throws on a malformed token or on a negative or non-finite count. A negative count used to wrap to about 1.8e19 through the `unsigned long long` cast and feed the run-integrated `ProtonBunchIntensitySummary`.
- `throwIfNotOpen()` checks both places the file is opened.
- Behaviour change: the loop tests the extraction itself rather than `good()`, so the last value of a file with no trailing newline is no longer dropped. The production file I checked (`PBI_33344_a`, CRLF line endings) ends with a newline, and its output is unchanged.

## Validation

- Full `muse build` of Offline at this branch (base `329c10038`), prof, `-Werror`: clean. `$MUSE_ENVSET_DIR/pre-commit` against the base: clean.
- I ran the same test jobs (`FromCorsikaBinary` or `PBISequence` source plus `PrintModule`) against the CI build of `329c10038` (old) and this branch (new). The CORSIKA files were synthesized in NORMAL format.

| Input | old | new |
|---|---|---|
| valid CORSIKA file | 1 event, 18 GenParticles | identical log |
| CORSIKA file with no `RUNE` record | rc=1, `std::bad_array_new_length` at ModuleEndJob | rc=1, `Error: file ended before the RUNE record` |
| CORSIKA file truncated mid-record | rc=1, `std::bad_array_new_length` | rc=1, `Error: file ended before the RUNE record` |
| empty CORSIKA file | rc=1, `std::bad_array_new_length` | rc=1, `Error: could not read the RUNH record ...` |
| CORSIKA first length word = 100000 | rc=139, segfault | rc=1, `Error: reclen too big` |
| real PBI file `PBI_33344_a` | 2000 events, SDF 0.967507 | identical log |
| PBI file with no trailing newline (3 values) | 2 events | 3 events |
| PBI file containing `-5` | rc=0, mean 6.1e18 | rc=9, `BADINPUT ... invalid proton count -5` |
| PBI file containing `abc` | rc=0, 1 event, rest ignored | rc=9, `BADINPUT ... malformed proton count` |

A missing input path was already rejected by art's catalog service for both sources (`CatalogServiceError`). For CORSIKA the new open check therefore only matters for files that exist but cannot be read. For PBISequence it now fires earlier, because the constructor pre-reads all files for the integrated summary.

No real CORSIKA binary was available on disk, so the valid-file case uses a synthesized NORMAL-format file. COMPACT format was not exercised.

## Deliberately not changed

- The new throws in `CosmicCORSIKA.cc` use `std::runtime_error`, to match every other throw in that file. Converting that file to `cet::exception` would be a separate cleanup.
- `FromCorsikaBinary::closeCurrentFile()` still never deletes its `ifstream`, which leaks one per input file. This is unrelated to input validation.
- Observed while testing, not changed: if the `RUNE` block shares a record with the last event's particle blocks, `genEvent()` returns false at `RUNE` and those particles are never emitted. The synthetic 2-event file produces 1 event on both `main` and this branch. I have not checked whether real CORSIKA output lays records out this way, so I'm raising it here rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtK75GTmT83CoNXRytdREj
