### PR TITLE
SimBookkeeper: throw on a missing or duplicate efficiency tag

### DIFF
--- a/SimulationConditions/inc/SimBookkeeper.hh
+++ b/SimulationConditions/inc/SimBookkeeper.hh
@@ -14,6 +14,9 @@
 #include "Offline/Mu2eInterfaces/inc/ProditionsEntity.hh"
 #include "fhiclcpp/ParameterSet.h"
 
+#include <map>
+#include <string>
+
 namespace mu2e {
 
   class SimBookkeeper : public ProditionsEntity {
@@ -23,14 +26,8 @@ namespace mu2e {
 
     SimBookkeeper() : ProditionsEntity(cxname) {}
     // accessors
-    double const getEff(const std::string& name) const {
-      for (const auto& i_eff : _effs) {
-        if (i_eff.first == name) {
-          return i_eff.second;
-        }
-      }
-      return -1;
-    }
+    // throws if no efficiency with this tag was loaded
+    double getEff(const std::string& name) const;
 
     // setters
     void addEff(std::string name, double new_val) {

--- a/SimulationConditions/src/SimBookkeeper.cc
+++ b/SimulationConditions/src/SimBookkeeper.cc
@@ -1,7 +1,23 @@
 // Mu2e includes
 #include "Offline/SimulationConditions/inc/SimBookkeeper.hh"
+#include "cetlib_except/exception.h"
 
 namespace mu2e {
+
+  double SimBookkeeper::getEff(const std::string& name) const {
+    auto it = _effs.find(name);
+    if (it == _effs.end()) {
+      cet::exception ex("SIMBOOKKEEPER_MISSING_TAG");
+      ex << "SimBookkeeper has no efficiency with tag \"" << name
+         << "\". Available tags:";
+      for (const auto& i_eff : _effs) {
+        ex << " " << i_eff.first;
+      }
+      ex << "\n";
+      throw ex;
+    }
+    return it->second;
+  }
 
   const std::string SimBookkeeper::print() const {
     std::stringstream out;

--- a/SimulationConditions/src/SimBookkeeperMaker.cc
+++ b/SimulationConditions/src/SimBookkeeperMaker.cc
@@ -3,12 +3,21 @@
 //
 
 #include "Offline/SimulationConditions/inc/SimBookkeeperMaker.hh"
+#include "cetlib_except/exception.h"
+
+#include <set>
 
 namespace mu2e {
 
   SimBookkeeper::ptr_t SimBookkeeperMaker::fromFcl() {
     auto ptr = std::make_shared<SimBookkeeper>();
+    std::set<std::string> fclTags;
     for (const auto& i_effConf : _config.simStageEfficiencies()) {
+      if (!fclTags.insert(i_effConf.tag()).second) {
+        throw cet::exception("SIMBOOKKEEPER_DUPLICATE_FCL_TAG")
+          << "Efficiency tag \"" << i_effConf.tag()
+          << "\" appears more than once in simStageEfficiencies\n";
+      }
       ptr->addEff(i_effConf.tag(), i_effConf.eff());
     }
     return ptr;
@@ -18,7 +27,13 @@ namespace mu2e {
     // fill the SimBookkeeper with initial values
     auto ptr = fromFcl();
     // now overwrite with values from database
+    std::set<std::string> dbTags;
     for (const auto& i_row : effDb->rows()) {
+      if (!dbTags.insert(i_row.tag()).second) {
+        throw cet::exception("SIMBOOKKEEPER_DUPLICATE_DB_TAG")
+          << "Efficiency tag \"" << i_row.tag()
+          << "\" appears more than once in table " << effDb->name() << "\n";
+      }
       ptr->addEff(i_row.tag(), i_row.eff());
     }
     return ptr;


### PR DESCRIPTION
## What

`SimBookkeeper::getEff` returned `-1` for an unknown tag. It now throws `SIMBOOKKEEPER_MISSING_TAG`, and the message names the tag and lists the tags that were loaded. The function moves from the header into `SimBookkeeper.cc`.

`SimBookkeeperMaker` now throws when a tag appears twice in the same source: `SIMBOOKKEEPER_DUPLICATE_FCL_TAG` for the fcl `simStageEfficiencies` list and `SIMBOOKKEEPER_DUPLICATE_DB_TAG` for the `SimEfficiencies2` table. Before this change the last value was kept without any message. A DB row that overrides an fcl value for the same tag is still allowed, as before.

## Why

The only caller of `getEff`, `MixBackgroundFrames::startEvent`, multiplies the efficiencies of its `simStageEfficiencyTags` chain to set the mean number of mixed secondaries. When a SimEfficiencies2 table lacks one stage of that chain, the job dies with `Unphysical SimStageEfficiency value -1`. That message reads like a bad value rather than a missing row, and it does not say which tag is missing. This happened with a Run1Ban mixing table that lacked `NeutralsCat`. `fhicl-dump` cannot catch it; only a real run does.

A duplicate tag feeds the same normalization, so it should fail rather than silently pick one row.

## Compatibility

- The missing-tag case already ended the job through the mixer's `< 0` check. It still ends the job, now with a clearer message. The mixer's check is unchanged and still catches a negative value stored in a table.
- No existing table contains a duplicate tag. `dbTool print-content --name SimEfficiencies2` shows 11 cids with 123 rows and no repeated tag within a cid. The published text tables `SimEfficiencies2_Run1Bai.txt`, `SimEfficiencies2_Run1Bai-007.txt` and `SimEfficiencies2_Run1Ban.txt` have none either. No repository other than Offline sets `simStageEfficiencies`.
- The class layout of `SimBookkeeper` is unchanged.

## Validation

- Built SimulationConditions and EventMixing with muse (`-Werror`, al9 prof e29 p107) against `Musings/Offline/v13_38_00`, which is the current `main` (`329c1003`). The build was clean.
- A standalone test linked against the built library covers:
  - a known tag;
  - a missing tag;
  - a duplicate fcl tag;
  - a DB value overriding an fcl value;
  - an fcl-only tag kept in DB mode;
  - a DB-only tag;
  - a duplicate DB tag.

  All 7 cases pass with this change. Against the unpatched v13_38_00 library, 3 cases show the old behaviour: a missing tag returns `-1`, and the duplicate fcl and DB tags each resolve to the last value.
- I have not run a full mixing job.

## Deliberately not in this PR

- `SimulationConditions/fcl/prolog.fcl` contains four default efficiencies ("some default values from small-scale tests") whose tags nothing uses. `fromDb` starts from these fcl values, so they appear in every DB-mode entity. Whether DB mode should start from the fcl values at all is a question for the package owners, so I have left it alone.
- The package also has unrelated cleanup: an unused SConscript link list, unused includes, and the `_tqDb_p` naming. That belongs in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DZynGvjEZXCiW6Ag6y5vG
