### PR TITLE
ServicesGeom Pipe: reject unknown flavors, store lengths per pipe

### DIFF
--- a/GeometryService/src/PipeMaker.cc
+++ b/GeometryService/src/PipeMaker.cc
@@ -37,20 +37,20 @@ namespace mu2e {
     // Qualities of types
     std::vector<int>                       nComponentsOfType;
     std::vector<int>                       nPipesOfType;
-    std::vector<double>                    lengthOfType;
-    std::vector<std::string>               flavorOfType;
+    std::vector<Pipe::Flavor>              flavorOfType;
     std::vector<std::string>               fillOfType;
     nComponentsOfType                      .reserve(nType);
     nPipesOfType                           .reserve(nType);
-    if (version == 1) lengthOfType         .reserve(nType);
     flavorOfType                           .reserve(nType);
     fillOfType                             .reserve(nType);
 
     // Qualities of Pipes, by type
     std::vector<std::vector<CLHEP::Hep3Vector> >         sites;
     std::vector<std::vector<std::string> >               orients;
+    std::vector<std::vector<double> >                    lengths;
     sites                                  .reserve(nType);
     orients                                .reserve(nType);
+    lengths                                .reserve(nType);
 
     // Collections by type of qualities of components.  Filled below
     std::vector<std::vector<double> >      rInOfCompByType;
@@ -83,10 +83,6 @@ namespace mu2e {
     std::string vOffsetBaseName  = "Pipe.vOffsetType";
 
 
-    // Some temporary holders
-    std::vector<double> tempDoubleVec;
-    int totPipes = 0; // Keep track of total number of pipes
-
     // *********************
     // Loop over the various pipe _types_ and fill the vectors with
     // information needed for the _types_.
@@ -105,21 +101,19 @@ namespace mu2e {
       int nComp = c.getInt(bCompNumberVarName.str(),1);
       nComponentsOfType.push_back(nComp);
 
-      totPipes += nComp;  // Track total pipes
-
-      // Get the length of this type of box - the w component.
-      // This is Full length - will be cut in half when making Tubs, not Tori
-      if ( version == 1 ){
-        std::ostringstream bLengthVarName;
-        bLengthVarName << lengthBaseName << iType;
-        lengthOfType.push_back(c.getDouble(bLengthVarName.str())*CLHEP::mm);
-      }
-
       // Get the flavor - straight or bend for this type
       std::ostringstream pFlavVarName;
       pFlavVarName << flavBaseName << iType;
       std::string theFlav = c.getString(pFlavVarName.str(),"straight");
-      flavorOfType.push_back(theFlav);
+      if ( theFlav == "straight" ) {
+        flavorOfType.push_back(Pipe::Flavor::straight);
+      } else if ( theFlav == "bend" ) {
+        flavorOfType.push_back(Pipe::Flavor::bend);
+      } else {
+        throw cet::exception("GEOM")
+          << pFlavVarName.str() << " must be \"straight\" or \"bend\"."
+          << "\nYou specified: " << theFlav;
+      }
 
       // Get the fill material for the type of pipe
       std::ostringstream pFillVarName;
@@ -129,16 +123,16 @@ namespace mu2e {
 
     } // End of collecting Type information
 
-    if ( version > 1 ) lengthOfType.reserve(totPipes);
-
     // ****************
     // Now collect individual pipe information
     // ****************
     std::vector<CLHEP::Hep3Vector> tmpVecHep3V;
     std::vector<std::string> tmpVecOri;
+    std::vector<double> tmpVecLen;
     for ( int it = 0; it < nType; it++ ) {
       tmpVecHep3V.clear();
       tmpVecOri.clear();
+      tmpVecLen.clear();
       for ( int ip = 0; ip < nPipesOfType[it]; ip++ ) {
         // Location of the center of the pipe in Mu2e coords
         // Use our now-familiar trick for variable names
@@ -158,23 +152,27 @@ namespace mu2e {
             << "\nentered as a string.You specified: " << orientation;
         }
         tmpVecOri.push_back(orientation);
-        if ( version > 1 ) {
-          // We will cheat and collect a length for each pipe rather than
-          // each type (which rhymes).
-          std::ostringstream aLengthVarName;
-          aLengthVarName << lengthBaseName << it+1 << "Pipe" << ip+1;
-          std::ostringstream altLengthVarName;
-          altLengthVarName << lengthBaseName << it+1;
 
-          double tmpVal = c.getDouble( aLengthVarName.str(), -1.0 );
-          if ( tmpVal < 0.0 ) tmpVal = c.getDouble( altLengthVarName.str() );
-          lengthOfType.push_back(tmpVal);
+        // Full length of the pipe - will be cut in half when making Tubs,
+        // not Tori.  Version 1 gives one length per type.  Version 2 allows
+        // a length per pipe, falling back to the length of the type.
+        std::ostringstream pipeLengthVarName;
+        pipeLengthVarName << lengthBaseName << it+1 << "Pipe" << ip+1;
+        std::ostringstream typeLengthVarName;
+        typeLengthVarName << lengthBaseName << it+1;
 
+        double pipeLength = 0.0;
+        if ( version > 1 && c.hasName(pipeLengthVarName.str()) ) {
+          pipeLength = c.getDouble(pipeLengthVarName.str());
+        } else {
+          pipeLength = c.getDouble(typeLengthVarName.str());
         }
+        tmpVecLen.push_back(pipeLength*CLHEP::mm);
 
       }
       orients.push_back(tmpVecOri);
       sites.push_back(tmpVecHep3V);
+      lengths.push_back(tmpVecLen);
     }
 
     // ****************
@@ -247,14 +245,13 @@ namespace mu2e {
     } // end loop over types...
 
     // Now make the pointer to the object itself.
-    std::unique_ptr<Pipe> res(new Pipe( version,
-                                        nComponentsOfType,
+    std::unique_ptr<Pipe> res(new Pipe( nComponentsOfType,
                                         nPipesOfType,
-                                        lengthOfType,
                                         flavorOfType,
                                         fillOfType,
                                         sites,
                                         orients,
+                                        lengths,
                                         rInOfCompByType,
                                         rOutOfCompByType,
                                         materialOfCompByType,

--- a/Mu2eG4/src/constructServicesGeom.cc
+++ b/Mu2eG4/src/constructServicesGeom.cc
@@ -83,17 +83,15 @@ namespace mu2e {
     // ==> Make Pipes <========
     // *******************************************************
 
-    int                        version = pipeSet->getVersion();
-
     // Load up the vectors needed for building.
     std::vector<int>            nPipes = pipeSet->getNPipes();
     std::vector<int>            nComps = pipeSet->getNComponentsInPipe();
-    std::vector<double>         pLeng  = pipeSet->getLengths();
-    std::vector<std::string>    pFlav  = pipeSet->getFlavor();
+    std::vector<Pipe::Flavor>   pFlav  = pipeSet->getFlavor();
     std::vector<std::string>    pFill  = pipeSet->getFillMaterialNames();
 
     std::vector<std::vector<CLHEP::Hep3Vector> > pCent = pipeSet->getCentersOfPipes();
     std::vector<std::vector<std::string> > pOrient = pipeSet->getOrientations();
+    std::vector<std::vector<double> > pLeng = pipeSet->getLengths();
 
     std::vector<std::vector<double> > cInRad = pipeSet->getInnerRads();
     std::vector<std::vector<double> > cOutRad = pipeSet->getOuterRads();
@@ -105,26 +103,18 @@ namespace mu2e {
     // *** Loop over the types and construct all *********
     // ***************************************************
 
-    int whichPipe = 0;
     for ( unsigned int it = 0; it < nPipes.size(); it++ ) {
 
       int nPipe = nPipes[it];
       int nComp = nComps[it];
-      double len = 0.0;
-      if (version == 1) len = pLeng[it];
-      std::string flav = pFlav[it];
-      bool isBend = false;
-      if ( flav != "straight" ) {
-        isBend = true;
-      } // end of if not straight
+      bool isBend = ( pFlav[it] == Pipe::Flavor::bend );
 
       std::string fillMat = pFill[it];
 
       // *** Now loop over the individual pipes ***
       for ( int ip = 0; ip < nPipe; ip++ ) {
 
-        if ( version > 1 ) len = pLeng[whichPipe];
-        whichPipe++;
+        double len = pLeng[it][ip];
         // Make the container ("mother") volume for the type.
         TubsParams  pipeParams(0.0,cOutRad[it][0],len/2.0);
         TorusParams bendParams(0.0,cOutRad[it][0],len);

--- a/ServicesGeom/inc/Pipe.hh
+++ b/ServicesGeom/inc/Pipe.hh
@@ -1,5 +1,5 @@
-#ifndef ExternalShieldingGeom_Pipe_hh
-#define ExternalShieldingGeom_Pipe_hh
+#ifndef ServicesGeom_Pipe_hh
+#define ServicesGeom_Pipe_hh
 
 //
 //
@@ -36,23 +36,17 @@ namespace mu2e {
     // can add a "bendAngle" parameter which will be meaningless for a
     // straight section.
 
+    enum class Flavor { straight, bend };
+
     // ***
     // These represet type-level information
     // ***
 
-    const int &                           getVersion() const
-    { return _version; }
     const std::vector<int> &              getNComponentsInPipe() const
     { return _nComponentsInPipe; }
     const std::vector<int> &              getNPipes() const
     { return _nPipes; }
-    // If the flavor (see below) is "bend", then the length is really
-    // the toroidal radius of the containing pipe
-    // In version 2, length is not a property of a type, but of an individual
-    // pipe.  Use the same vector for code simplicity.
-    const std::vector<double> &           getLengths() const
-    { return _lengths; }
-    const std::vector<std::string> &      getFlavor() const
+    const std::vector<Flavor> &           getFlavor() const
     { return _flavors; }
     const std::vector<std::string> &      getFillMaterialNames() const
     { return _fillMaterialNames; }
@@ -68,6 +62,10 @@ namespace mu2e {
     { return _centerPositions; }
     const std::vector<std::vector<std::string> >&          getOrientations() const
     { return _orientations; }
+    // Full length of each pipe.  If the flavor is bend, this is the
+    // toroidal radius of the containing pipe.
+    const std::vector<std::vector<double> >&               getLengths() const
+    { return _lengths; }
 
     // The following are component-level information
     const std::vector<std::vector<double> >&  getInnerRads() const
@@ -86,27 +84,25 @@ namespace mu2e {
     friend class PipeMaker;
 
     // Private ctr: the class should only be constructed via Pipe::PipeMaker.
-    Pipe(const int&                               version,
-         const std::vector<int>&                  nComponentsInPipe,
+    Pipe(const std::vector<int>&                  nComponentsInPipe,
          const std::vector<int>&                  nPipes,
-         const std::vector<double>&               lengths,
-         const std::vector<std::string>&          flavs,
+         const std::vector<Flavor>&               flavs,
          const std::vector<std::string>&          fillMats,
          const std::vector<std::vector<CLHEP::Hep3Vector> >&    sites,
          const std::vector<std::vector<std::string> >&          orients,
+         const std::vector<std::vector<double> >&               lengths,
          const std::vector<std::vector<double> >& innerRads,
          const std::vector<std::vector<double> >& outerRads,
          const std::vector<std::vector<std::string> >&          mats,
          const std::vector<std::vector<double> >& uOffsets,
          const std::vector<std::vector<double> >& vOffsets)
-      : _version          (version),
-        _nComponentsInPipe (nComponentsInPipe),
+      : _nComponentsInPipe (nComponentsInPipe),
         _nPipes           (nPipes),
-        _lengths          (lengths),
         _flavors          (flavs),
         _fillMaterialNames     (fillMats),
         _centerPositions  (sites),
         _orientations     (orients),
+        _lengths          (lengths),
         _innerRads        (innerRads),
         _outerRads        (outerRads),
         _materialNames    (mats),
@@ -122,17 +118,16 @@ namespace mu2e {
     // Current description based on Geometry 14, adapted by
     // David Norvil Brown,
 
-    int                                  _version;
     // The following vectors hold information about the pipes
-    // The first five are type-level information
+    // The first four are type-level information
     std::vector< int >                   _nComponentsInPipe;
     std::vector< int >                   _nPipes;
-    std::vector< double >                _lengths;
-    std::vector< std::string >           _flavors;
+    std::vector< Flavor >                _flavors;
     std::vector< std::string >           _fillMaterialNames;
-    // The next two are pipe-level information
+    // The next three are pipe-level information
     std::vector< std::vector<CLHEP::Hep3Vector > >     _centerPositions;
     std::vector< std::vector<std::string > >           _orientations;
+    std::vector< std::vector< double > >               _lengths;
     // The last five are component-level information
     std::vector< std::vector< double > > _innerRads;
     std::vector< std::vector< double > > _outerRads;
@@ -145,4 +140,4 @@ namespace mu2e {
 
 }
 
-#endif/*ExternalShieldingGeom_Pipe_hh*/
+#endif/*ServicesGeom_Pipe_hh*/


### PR DESCRIPTION
## Intent

This PR fixes three issues in `ServicesGeom/Pipe` and the code that fills and reads it (`GeometryService/src/PipeMaker.cc`, `Mu2eG4/src/constructServicesGeom.cc`).

1. **A misspelled pipe flavor silently became a bend.** `constructServicesGeom` built a 90-degree torus for any flavor that was not exactly `"straight"`. With `Pipe.flavorType1 = "Straight"`, the current geometry turned a 3.6 m straight pipe into a torus with a toroidal radius of 3632 mm, and the job ran normally. `PipeMaker` now throws on anything other than `straight` or `bend`, and `Pipe` stores the flavor as an enum:
   ```
   ---- GEOM BEGIN
     Pipe.flavorType1 must be "straight" or "bend".
     You specified: Straight
   ```
2. **`Pipe` lengths changed their index space with `Pipe.version`.** Version 1 stored one length per type. Version 2 stored one per pipe, flattened across types. The builder had to branch on the version and walk a `whichPipe` counter. Lengths are now stored `[type][pipe]`, the same way as the centers and orientations. For version 1 files, the maker copies each type's length to every pipe of that type. `Pipe` no longer carries the version. Version 2 lengths now get the same `CLHEP::mm` factor as version 1, which has no numerical effect. The per-pipe length is now looked up with `hasName`, replacing the `-1` sentinel.
3. **Include guard.** `Pipe.hh` used `ExternalShieldingGeom_Pipe_hh`. It is now `ServicesGeom_Pipe_hh`.

## Behavior change

None for any valid geometry file. The only new behavior is that an unknown flavor now throws instead of building a torus. Every flavor in `Pipe_v01.txt` through `Pipe_v04.txt` is `straight` or `bend`.

One requirement is relaxed. A version 1 file previously had to give `Pipe.lengthType<N>` even for a type with zero pipes. It is now read only for types that have pipes.

## Validation

- I built the three changed files with the exact flags from `compile_commands.json` (including `-Werror`) against an Offline build at `0ef02a66d`. None of these files, nor the headers they use, differ between that commit and the base of this PR. The build produced a preload library.
- I then ran `Mu2eG4/fcl/gdmldump.fcl` with and without that library and compared the GDML after stripping pointer addresses:
  - Default geometry (`geom_common.txt`, which includes `Pipe_v04.txt`, version 2): identical, covering 2071 pipe entries.
  - The same geometry with `Pipe.version = 1` and the missing type lengths supplied: identical. This dump differs from the version 2 dump in 224 lines, so the version 1 path really ran.
  - Misspelled flavor: the unpatched build exits 0 with the torus described above. The patched build throws the message above.
- The 2017-era geometry files that include `Pipe_v01.txt` could not be used for this, because they no longer load in either build (`Can't find file "Offline/Mu2eG4/geom/bldg/backfillTSarea-W1UpperNotchLower.txt"`).

## Scope

Nothing outside the three files above. I deliberately did not touch two related things:

- The unused `art::Wrapper` friend declarations and default constructors in `ServicesGeom`. The same code exists in `ExternalShieldingGeom` and is better removed from both packages in one change.
- `OrientationResolver`, which treats unknown orientation digits as "no rotation". It is shared with other geometry builders.

Found during a static review of the `ServicesGeom` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL4jFRGq1ub5r3owcE6Ria
